### PR TITLE
windy.com integration: animated wind, global webcams, Windy hand-off

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,16 @@ layer draws its own scale and units.
 - Listen to a **NOAA Weather Radio** relay while you watch (bring your county's
   stream URL — NOAA broadcasts on VHF and streams nothing itself).
 - Draw on the map freehand to circle the storm you're talking about, and look
-  through FAA airport webcams to see what the sky actually looks like.
+  through webcams to see what the sky actually looks like. The FAA's ~2,600
+  airport cameras need no key but stop at the US border; a free **Windy** key in
+  Settings adds their global network, which returns the 50 most popular cameras
+  in view rather than every one of them.
+- **Animated wind**: HRRR 10 m wind drawn as drifting particles, coloured by
+  speed — the Windy look, built from NOAA's own free GRIB grids rather than
+  licensed, so it needs no key and works offline of any paid API. CONUS only,
+  because HRRR is. Model output, not observation, and the layer says so.
+- **Open this view in Windy** from the command palette when you want their
+  models next to ours — same place, same zoom, matching overlay.
 - **Live station cards**: click a surface station and get a floating,
   draggable card — a live highway camera on top, then the station's local clock
   and how stale its reading is, temperature with humidity and dewpoint, a wind

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -754,6 +754,8 @@ pub(crate) enum PaletteAction {
     Reload,
     InstantReplay,
     GoLive,
+    /// Hand the current view off to windy.com in the browser.
+    OpenInWindy,
 }
 
 /// A placefile label/marker the egui painter draws over the map.
@@ -976,6 +978,22 @@ struct ChasePack {
     done: u64,
     errors: u64,
     bytes: u64,
+}
+
+/// Build a windy.com permalink for a map position.
+///
+/// Grammar, from Windy's own URL-parameters documentation and matching the share links their
+/// satellite view produces: `https://www.windy.com/?{overlay},{lat},{lon},{zoom}`. `lat,lon,zoom`
+/// are required and must appear in that order; the overlay is optional and goes first. Two rules
+/// worth keeping: **latitude comes before longitude** (the opposite of this codebase's own
+/// `(lon, lat)` convention, which is exactly how that gets written backwards), and coordinates
+/// must carry a decimal part or Windy ignores them.
+///
+/// Windy's zoom tops out at 18 and its overlay names are its own — `radar`, `satellite` and `cape`
+/// all resolve, alongside the documented `wind`, `temp`, `rain` and friends.
+fn windy_url(overlay: &str, lon: f64, lat: f64, zoom: f64) -> String {
+    let z = zoom.round().clamp(3.0, 18.0) as u32;
+    format!("https://www.windy.com/?{overlay},{lat:.3},{lon:.3},{z}")
 }
 
 /// How a lightning flash looks at `age_secs`: bright white-hot when it just happened, fading to a
@@ -5214,6 +5232,14 @@ impl HookEchoApp {
             None,
         );
         push(
+            "Open this view in Windy",
+            "Reference",
+            "Open windy.com in your browser, looking at the same place",
+            true,
+            PaletteAction::OpenInWindy,
+            None,
+        );
+        push(
             "Mute audio alerts",
             "Alerts",
             "Silence every chime and spoken warning without changing your sound choices",
@@ -5492,6 +5518,33 @@ impl HookEchoApp {
             PaletteAction::Reload => self.trigger_reload(ctx),
             PaletteAction::InstantReplay => self.instant_replay(),
             PaletteAction::GoLive => self.views[self.active].timeline.go_head(),
+            PaletteAction::OpenInWindy => {
+                let v = &self.views[self.active];
+                let c = v.camera.center;
+                let (lon, lat) = crate::render::mercator::world_to_lonlat(c.0, c.1);
+                // Pick the layer the user deliberately turned on, not the one that is always
+                // there: radar is the default state, so leading with it would make every other
+                // branch dead code and always land people on the same Windy page.
+                let overlay = if self.show_wind {
+                    "wind"
+                } else if self
+                    .fields
+                    .get(&crate::render::FieldLayer::Cape)
+                    .is_some_and(|s| s.show)
+                {
+                    "cape"
+                } else if v.basemap.slug().starts_with("goes") {
+                    "satellite"
+                } else if v.show_radar && v.volume.is_some() {
+                    "radar"
+                } else {
+                    "wind"
+                };
+                let url = windy_url(overlay, lon, lat, v.camera.zoom);
+                if let Err(e) = crate::platform::open_url(&url) {
+                    log::warn!("could not open {url}: {e}");
+                }
+            }
             PaletteAction::OpenWindow(w) => match w {
                 W::Site => {
                     if self.site_dialog.is_none() {
@@ -11778,7 +11831,7 @@ mod warning_scope_tests {
 
 #[cfg(test)]
 mod field_lut_tests {
-    use super::{categorical_lut, distinct_tilts, glm_style, ramp_lut, ramp_lut_a};
+    use super::{categorical_lut, distinct_tilts, glm_style, ramp_lut, ramp_lut_a, windy_url};
 
     #[test]
     fn distinct_tilts_skips_sails_repeats() {
@@ -11798,6 +11851,19 @@ mod field_lut_tests {
     fn distinct_tilts_clamps_to_what_exists() {
         assert_eq!(distinct_tilts(&[0.5, 0.5], 4), vec![0]);
         assert!(distinct_tilts(&[], 4).is_empty());
+    }
+
+    #[test]
+    fn windy_url_puts_latitude_first() {
+        // KTLX, zoom 7.4. Windy wants lat,lon — this codebase says (lon, lat) everywhere else,
+        // so a swap here would silently send people to the Indian Ocean.
+        let u = windy_url("radar", -97.3, 35.4, 7.4);
+        assert_eq!(u, "https://www.windy.com/?radar,35.400,-97.300,7");
+        // Decimals are mandatory: Windy ignores a whole-number coordinate.
+        assert!(windy_url("wind", -97.0, 35.0, 5.0).contains("35.000,-97.000"));
+        // Zoom is clamped into Windy's own range rather than passed through.
+        assert!(windy_url("wind", 0.0, 0.0, 2.0).ends_with(",3"));
+        assert!(windy_url("wind", 0.0, 0.0, 18.9).ends_with(",18"));
     }
 
     #[test]

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -228,8 +228,9 @@ enum OverlaySource {
     /// Run an external-process plugin: `(key, command, args, context)`. The key is the synthetic
     /// `plugin:<name>` id it shares with the placefile pipeline it feeds.
     Plugin(String, String, Vec<String>, crate::plugins::Context),
-    /// FAA camera sites within a lon/lat bbox `(min_lon, min_lat, max_lon, max_lat)`.
-    Webcams(f64, f64, f64, f64),
+    /// Camera sites within a lon/lat bbox `(min_lon, min_lat, max_lon, max_lat)`, plus the user's
+    /// Windy API key — empty for FAA-only, which is the keyless default.
+    Webcams(f64, f64, f64, f64, String),
     /// Live stations in a lat/lon bbox, plus the view centre the keyed networks are asked around
     /// and the keys themselves (empty = that network stays off).
     Stations {
@@ -404,9 +405,26 @@ impl OverlaySource {
             OverlaySource::Metar(lat0, lon0, lat1, lon1) => {
                 OverlayMsg::Metar(wxdata::metar::fetch_bbox(http, lat0, lon0, lat1, lon1).await?)
             }
-            OverlaySource::Webcams(min_lon, min_lat, max_lon, max_lat) => OverlayMsg::Webcams(
-                wxdata::webcams::fetch_bbox(http, min_lon, min_lat, max_lon, max_lat).await?,
-            ),
+            OverlaySource::Webcams(min_lon, min_lat, max_lon, max_lat, windy_key) => {
+                // Both networks, merged: the FAA is keyless but US-only, Windy covers the rest of
+                // the world for anyone who has supplied a key. Nothing for the user to choose.
+                let mut sites =
+                    wxdata::webcams::fetch_bbox(http, min_lon, min_lat, max_lon, max_lat)
+                        .await
+                        .unwrap_or_default();
+                if !windy_key.is_empty() {
+                    // A bad or throttled key must not take the FAA cameras down with it.
+                    match wxdata::webcams::fetch_windy_bbox(
+                        http, &windy_key, min_lon, min_lat, max_lon, max_lat,
+                    )
+                    .await
+                    {
+                        Ok(w) => sites.extend(w),
+                        Err(e) => log::warn!("windy webcams: {e}"),
+                    }
+                }
+                OverlayMsg::Webcams(sites)
+            }
             OverlaySource::Stations {
                 bbox,
                 center,
@@ -5110,8 +5128,9 @@ impl HookEchoApp {
             (
                 T::Webcams,
                 "Obs",
-                "Airport webcams (FAA)",
-                "Look at the sky through an airport's camera",
+                "Webcams (FAA + Windy)",
+                "Look at the sky through a real camera \u{2014} FAA airports, plus the Windy \
+                 network worldwide with a key in Settings",
                 false,
             ),
             (
@@ -5738,7 +5757,13 @@ impl HookEchoApp {
                     }
                 }
                 OverlayMsg::Metar(obs) => self.metars = obs,
-                OverlayMsg::Webcams(sites) => self.webcams = sites,
+                OverlayMsg::Webcams(sites) => {
+                    // Drop the cached stills with the list they belonged to. Windy's free-tier
+                    // image URLs expire after ten minutes, and a kept texture would otherwise
+                    // show the same frame until the layer was toggled off and on.
+                    self.pf_icon_tex.retain(|k, _| !k.starts_with("cam:"));
+                    self.webcams = sites;
+                }
                 OverlayMsg::Stations(obs) => self.stations.ingest(obs),
                 OverlayMsg::Ppef(p) => self.stations.ppef = Some(p),
                 OverlayMsg::DotCams(cams) => self.stations.cams = cams,
@@ -6017,9 +6042,11 @@ impl HookEchoApp {
             return; // zoomed out past the point where individual cameras mean anything
         }
         let (clon, clat) = ((min_lon + max_lon) * 0.5, (min_lat + max_lat) * 0.5);
+        // Under ten minutes on purpose: Windy's free-tier image URLs carry a token that expires at
+        // exactly ten, so a 600 s clock would race it and serve 401s.
         let stale = self
             .webcam_last_fetch
-            .is_none_or(|t| t.elapsed().as_secs() >= 600);
+            .is_none_or(|t| t.elapsed().as_secs() >= 480);
         let drifted = self.webcam_bounds.is_none_or(|(lo0, la0, lo1, la1)| {
             let (mlon, mlat) = ((lo0 + lo1) * 0.5, (la0 + la1) * 0.5);
             let (hw, hh) = ((lo1 - lo0) * 0.25, (la1 - la0) * 0.25);
@@ -6036,7 +6063,10 @@ impl HookEchoApp {
             );
             self.webcam_last_fetch = Some(Instant::now());
             self.webcam_bounds = Some(b);
-            self.spawn_overlay(ctx, OverlaySource::Webcams(b.0, b.1, b.2, b.3));
+            self.spawn_overlay(
+                ctx,
+                OverlaySource::Webcams(b.0, b.1, b.2, b.3, self.settings.windy_key.clone()),
+            );
         }
     }
 
@@ -6149,7 +6179,14 @@ impl HookEchoApp {
             let state = if c.out_of_order { "  (out of order)" } else { "" };
             body.push_str(&format!("{}  {}{}\n", c.name, c.direction, state));
         }
-        body.push_str("\nFAA WeatherCams");
+        // Which network this came from, and the credit each one is owed. Windy's terms require a
+        // visible "Webcams provided by Windy.com" wherever their cameras appear.
+        let from_windy = site.link.is_some();
+        body.push_str(if from_windy {
+            "\nWebcams provided by Windy.com"
+        } else {
+            "\nFAA WeatherCams"
+        });
         // The first working camera is the one we show; the rest are listed above.
         let cam = site.cameras.iter().find(|c| !c.out_of_order);
         let key = cam.map(|c| format!("cam:{}", c.id));
@@ -6158,8 +6195,14 @@ impl HookEchoApp {
             body,
             color: [110, 180, 240, 255],
             image: key.clone(),
+            // Not decoration: the link back to the camera's own page is a condition of using
+            // Windy's images at all.
+            link: site
+                .link
+                .clone()
+                .map(|u| ("View on Windy.com".to_string(), u)),
         });
-        let (Some(key), Some(cam_id)) = (key, cam.map(|c| c.id)) else {
+        let (Some(key), Some(cam)) = (key, cam) else {
             return;
         };
         if self.pf_icon_tex.contains_key(&key) {
@@ -6169,17 +6212,30 @@ impl HookEchoApp {
         let http = self.http.clone();
         let tx = self.pf_icon_tx.clone();
         let ctx2 = ctx.clone();
+        // Windy hands back the still's URL inline, so only the FAA needs a second round trip.
+        let inline = cam.image_url.clone();
+        let cam_id = cam.id;
         self._rt.spawn(async move {
-            match wxdata::webcams::latest_image(&http, cam_id).await {
-                Ok(Some(url)) => match fetch_icon_sheet(&http, &url).await {
-                    Ok(image) => {
-                        let _ = tx.send((key, image));
-                        ctx2.request_repaint();
+            let url = match inline {
+                Some(u) => Some(u),
+                None => match wxdata::webcams::latest_image(&http, cam_id).await {
+                    Ok(u) => u,
+                    Err(e) => {
+                        log::warn!("webcam {cam_id} lookup failed: {e}");
+                        None
                     }
-                    Err(e) => log::warn!("webcam image {url} failed: {e}"),
                 },
-                Ok(None) => log::info!("camera {cam_id} has no recent image"),
-                Err(e) => log::warn!("webcam {cam_id} lookup failed: {e}"),
+            };
+            let Some(url) = url else {
+                log::info!("camera {cam_id} has no recent image");
+                return;
+            };
+            match fetch_icon_sheet(&http, &url).await {
+                Ok(image) => {
+                    let _ = tx.send((key, image));
+                    ctx2.request_repaint();
+                }
+                Err(e) => log::warn!("webcam image {url} failed: {e}"),
             }
         });
     }
@@ -6281,7 +6337,8 @@ impl HookEchoApp {
             body,
             color,
             image: key.clone(),
-        });
+            link: None,
+});
         let (Some(key), Some(url)) = (key, p.image.clone()) else {
             return;
         };
@@ -7598,7 +7655,8 @@ impl HookEchoApp {
                                 ),
                                 color: report_color(r.kind),
                                 image: None,
-                            });
+                                link: None,
+});
                         } else {
                             let cell_hit = self.filters.show_cells
                                 && self.cells_site.as_deref() == self.views[idx].site.as_deref()
@@ -7630,7 +7688,8 @@ impl HookEchoApp {
                                         body: c.summary(),
                                         color: cell_color(c.kind),
                                         image: None,
-                                    });
+                                        link: None,
+});
                                 }
                                 None => {
                                     // Warnings/watches open the warning window (deduped by alert id
@@ -7662,7 +7721,8 @@ impl HookEchoApp {
                                             body: f.detail.clone(),
                                             color: f.stroke,
                                             image: None,
-                                        });
+                                            link: None,
+});
                                     }
                                 }
                             }

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -131,6 +131,14 @@ enum OverlayMsg {
     ProbSevere(Vec<GeoFeature>),
     /// An HRRR composite-reflectivity forecast (regridded + run/valid metadata).
     Hrrr(wxdata::hrrr::HrrrForecast),
+    /// HRRR wind components for the particle layer.
+    ///
+    /// Deliberately not an [`OverlayMsg::Field`]: `spawn_overlay` runs `decimated` on every
+    /// `Field` message, and `decimated` **max-pools**. That is right for reflectivity and wrong
+    /// for a signed vector component — it would bias u and v independently toward positive, i.e.
+    /// a phantom northeasterly drift. Boxed because a pair of CONUS grids is ~11 MB and this enum
+    /// is moved by value through the channel.
+    Wind(Box<crate::wind_draw::WindField>),
     /// Nearest-station observations for a site (or an error string).
     Obs(String, Result<wxdata::obs::StationObs, String>),
     /// VAD wind profile for a site.
@@ -248,6 +256,8 @@ enum OverlaySource {
     Contours(ContourKind, wxdata::hrrr::Model),
     /// NHC tropical cyclones (feature V).
     Tropical,
+    /// HRRR wind components for the particle layer, at a level and forecast hour.
+    Wind(wxdata::hrrr::WindLevel, u8),
 }
 
 impl OverlaySource {
@@ -473,6 +483,16 @@ impl OverlaySource {
             OverlaySource::Tropical => {
                 OverlayMsg::Tropical(wxdata::tropical::fetch_active(http).await?)
             }
+            OverlaySource::Wind(level, fh) => {
+                let (run, u, v) = wxdata::hrrr::fetch_wind(http, level, fh).await?;
+                OverlayMsg::Wind(Box::new(crate::wind_draw::WindField {
+                    u,
+                    v,
+                    level,
+                    run,
+                    fcst_hour: fh,
+                }))
+            }
             OverlaySource::Aviation => {
                 OverlayMsg::Aviation(wxdata::aviation::fetch_airsigmet(http).await?)
             }
@@ -689,6 +709,7 @@ pub(crate) enum OverlayToggle {
     Mds,
     Fronts,
     GlmLightning,
+    Wind,
     LinkCameras,
 }
 
@@ -1397,6 +1418,24 @@ pub struct HookEchoApp {
     glm: std::sync::Arc<std::sync::Mutex<wxdata::glm::GlmFeed>>,
     glm_last_poll: Option<Instant>,
     glm_polling: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    /// Animated wind particles. The grids are shared; the particle sets are per pane, because each
+    /// pane has its own camera. Nothing here persists to settings — neither do fronts or GLM.
+    show_wind: bool,
+    wind: Option<crate::wind_draw::WindField>,
+    wind_level: wxdata::hrrr::WindLevel,
+    wind_particles: std::collections::HashMap<usize, crate::wind_draw::Particles>,
+    /// What the current grids are of, so a level or forecast-hour change refetches at once.
+    wind_fetched: Option<(wxdata::hrrr::WindLevel, u8)>,
+    wind_last_fetch: Option<Instant>,
+    /// When the in-flight fetch started, or `None` if none is. One at a time: 10 m u+v is 4.5 MB
+    /// an hour, and a fast scrub across the forecast tail would otherwise queue ~82 MB of GRIB
+    /// behind itself. A timestamp rather than a flag because `spawn_overlay` drops fetch errors
+    /// into the log — a plain flag would never be cleared on failure and would wedge the layer.
+    wind_inflight: Option<Instant>,
+    /// Previous frame's instant, and the clamped timestep derived from it. Computed once per
+    /// frame so every pane advects by the same amount.
+    wind_last_frame: Option<Instant>,
+    wind_dt: f32,
     hodo_site: Option<String>,
     hodo_last_fetch: Option<Instant>,
     /// Streamer/OBS mode: hide all chrome (drawer/pills/docks), leaving only the map.
@@ -1795,6 +1834,15 @@ impl HookEchoApp {
             glm: std::sync::Arc::new(std::sync::Mutex::new(wxdata::glm::GlmFeed::new(15))),
             glm_last_poll: None,
             glm_polling: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            show_wind: false,
+            wind: None,
+            wind_level: wxdata::hrrr::WindLevel::Surface,
+            wind_particles: std::collections::HashMap::new(),
+            wind_fetched: None,
+            wind_last_fetch: None,
+            wind_inflight: None,
+            wind_last_frame: None,
+            wind_dt: 0.0,
             hodo_site: None,
             hodo_last_fetch: None,
             obs_mode: false,
@@ -4704,6 +4752,7 @@ impl HookEchoApp {
             T::RangeRings => &mut self.show_range_rings,
             T::Fronts => &mut self.show_fronts,
             T::GlmLightning => &mut self.show_glm,
+            T::Wind => &mut self.show_wind,
             T::Sensors => &mut self.show_sensors,
             T::Hodo => &mut self.show_hodo,
             T::Cells => &mut self.filters.show_cells,
@@ -5108,6 +5157,13 @@ impl HookEchoApp {
                 "Reference",
                 "Radar sites",
                 "Show every NEXRAD site; click one to switch radars",
+                true,
+            ),
+            (
+                T::Wind,
+                "Models",
+                "Wind (animated)",
+                "HRRR 10 m wind as drifting particles \u{2014} forecast output, CONUS only",
                 true,
             ),
             (
@@ -5659,6 +5715,13 @@ impl HookEchoApp {
                     }
                 }
                 OverlayMsg::Tropical(data) => self.tropical = Some(data),
+                OverlayMsg::Wind(w) => {
+                    self.wind_inflight = None;
+                    // Keep only if the selection didn't change while the fetch was in flight.
+                    if self.wind_fetched == Some((w.level, w.fcst_hour)) {
+                        self.wind = Some(*w);
+                    }
+                }
             }
             changed = true;
         }
@@ -7831,6 +7894,45 @@ impl HookEchoApp {
             }
         }
 
+        // Animated wind particles.
+        //
+        // Painter shapes land ABOVE the radar and there is no cheap way under it — `record_pane`
+        // finishes the whole `MapCallback` before this runs, so getting beneath would need a new
+        // GPU draw slot. Thin lines and a low alpha instead, halved again over a reflectivity
+        // product; Windy layers over its own radar exactly this way.
+        if self.show_wind {
+            // Past zoom 12 the 0.04 degree regrid goes visibly piecewise-linear, so fade out
+            // rather than present interpolation artifacts as if they were eddies.
+            let zoom_fade = (13.0 - cam.zoom).clamp(0.0, 1.0) as f32;
+            let v = &self.views[idx];
+            let over_radar = v.show_radar
+                && matches!(v.moment, wxdata::level2::Moment::Reflectivity)
+                && v.volume.is_some();
+            // Scrubbed to a past frame, while these grids are for the current hour: the two layers
+            // now disagree about what time it is. Dim rather than lie confidently — the same
+            // treatment the HRRR field layers already get.
+            let off_live = !v.timeline.following;
+            let alpha = zoom_fade
+                * if over_radar { 0.7 } else { 1.0 }
+                * if off_live { 0.4 } else { 1.0 };
+            // Split borrow: the grids and the per-pane particle sets are disjoint fields, and the
+            // advection needs both at once.
+            let Self {
+                wind,
+                wind_particles,
+                wind_dt,
+                ..
+            } = self;
+            if let (Some(field), true) = (wind.as_ref(), alpha > 0.01) {
+                let ps = wind_particles.entry(idx).or_default();
+                ps.update(field, &cam, vp, *wind_dt);
+                let mesh = ps.build_mesh(&cam, vp, prect.left_top(), alpha);
+                if !mesh.is_empty() {
+                    painter.add(egui::Shape::mesh(mesh));
+                }
+            }
+        }
+
         // Surface analysis: fronts with their pips, plus H/L centers.
         if self.show_fronts {
             if let Some(a) = &self.fronts {
@@ -9206,7 +9308,17 @@ impl HookEchoApp {
                 .rev()
                 .find(|l| self.fields.get(l).is_some_and(|s| s.show))
             {
-                ui::legend::draw_field(&painter, prect, *top, y);
+                y += ui::legend::draw_field(&painter, prect, *top, y);
+            }
+            // Wind particles carry their own scale — it isn't a FieldLayer, so it needs its own
+            // call rather than a slot in DRAW_ORDER.
+            if self.show_wind && self.wind.is_some() {
+                ui::legend::draw_ramp(
+                    &painter,
+                    prect,
+                    &crate::render::field_ramps::WIND,
+                    y,
+                );
             }
         }
     }
@@ -10637,6 +10749,56 @@ impl eframe::App for HookEchoApp {
                 }
                 busy.store(false, std::sync::atomic::Ordering::Relaxed);
             });
+        }
+
+        // Wind particles. HRRR posts hourly, so this gets its own 15-minute clock rather than
+        // riding the 120 s overlay block — that would re-download 4.5 MB about thirty times per
+        // useful update. Doubled on a metered connection.
+        if self.show_wind {
+            // Advection timestep, shared by every pane so they stay in step. Clamped because a
+            // stalled frame or a resume from background would otherwise teleport the whole field.
+            let now = Instant::now();
+            self.wind_dt = self
+                .wind_last_frame
+                .map_or(0.0, |t| now.duration_since(t).as_secs_f32())
+                // Headroom above the 100 ms Android cadence, so a normal phone frame is never
+                // itself treated as a hitch and quietly slowed down.
+                .clamp(0.0, 0.15);
+            self.wind_last_frame = Some(now);
+            // The app is otherwise idle-driven; this is its first always-on animation, and the
+            // cost is not the particle mesh — it is re-rendering the whole map (radar warp,
+            // vector basemap) every frame instead of sitting idle. Measured on an S24 Ultra:
+            // 7% CPU idle, 78% animating at 20 fps, so the cadence is the battery knob. 10 fps on
+            // a phone reads fine because the trail is itself the motion blur.
+            if crate::platform::activity::is_active() {
+                let ms = if cfg!(target_os = "android") { 100 } else { 33 };
+                ctx.request_repaint_after(std::time::Duration::from_millis(ms));
+            }
+
+            // Panes come and go with the layout; their particle sets should not outlive them.
+            self.wind_particles.retain(|k, _| *k < self.views.len());
+
+            let want = (self.wind_level, self.hrrr_fcst_hour);
+            let interval = if crate::platform::is_metered() { 1800 } else { 900 };
+            let stale = self
+                .wind_last_fetch
+                .is_none_or(|t| t.elapsed().as_secs() >= interval);
+            // A level or forecast-hour change refetches at once — but the ~200 ms floor keeps a
+            // fast drag across the forecast tail from firing a request per frame.
+            let changed = self.wind_fetched != Some(want)
+                && self
+                    .wind_last_fetch
+                    .is_none_or(|t| t.elapsed().as_millis() >= 200);
+            // A dropped fetch (spawn_overlay only logs errors) expires rather than wedging.
+            let free = self
+                .wind_inflight
+                .is_none_or(|t| t.elapsed().as_secs() >= 60);
+            if (stale || changed) && free {
+                self.wind_last_fetch = Some(Instant::now());
+                self.wind_inflight = Some(Instant::now());
+                self.wind_fetched = Some(want);
+                self.spawn_overlay(ctx, OverlaySource::Wind(want.0, want.1));
+            }
         }
 
         // Surface analysis: WPC reissues it a few times an hour.

--- a/crates/hookecho/src/lib.rs
+++ b/crates/hookecho/src/lib.rs
@@ -16,6 +16,7 @@ pub mod dialog;
 pub mod digest;
 pub mod events;
 pub mod fronts_draw;
+pub mod wind_draw;
 pub mod geo;
 pub mod gps;
 pub mod cloud;

--- a/crates/hookecho/src/render/field_ramps.rs
+++ b/crates/hookecho/src/render/field_ramps.rs
@@ -108,6 +108,35 @@ static ROTATION: FieldRamp = ramp!(
     ]
 );
 
+/// Wind speed, for the animated particle layer.
+///
+/// Public and deliberately absent from [`ramp_for`]: wind is not a [`FieldLayer`] — nothing is
+/// uploaded to the GPU as a scalar grid — but the particles still need a value→color rule and the
+/// legend still needs to explain it. `input_scale` converts the model's m/s to the knots people
+/// actually read, so both get the same conversion for free.
+pub static WIND: FieldRamp = FieldRamp {
+    input_scale: 1.943_844,
+    ..ramp!(
+        "Wind",
+        "kt",
+        0.0,
+        // 50, not 80: surface wind is 5-20 kt almost everywhere almost always, and a scale topping
+        // out at jet speeds leaves every particle in the pale bottom tenth of the palette. The
+        // live decode test peaked at 39 kt over the whole of CONUS.
+        50.0,
+        RampScale::Linear,
+        255,
+        &[
+            (0.0, [120, 165, 205]),
+            (0.25, [95, 200, 175]),
+            (0.5, [235, 225, 120]),
+            (0.7, [240, 155, 70]),
+            (0.85, [225, 80, 70]),
+            (1.0, [230, 95, 200]),
+        ]
+    )
+};
+
 static MESH: FieldRamp = ramp!(
     "Hail size",
     "mm",

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -153,6 +153,10 @@ pub struct Settings {
     /// Weather Underground API key — adds nearby PWS stations to the live station cards.
     #[serde(default)]
     pub wu_key: String,
+    /// Windy API key — adds the Windy webcam network to the keyless FAA cameras, which is what
+    /// gives the layer any coverage outside the United States. Held locally, same as the rest.
+    #[serde(default)]
+    pub windy_key: String,
     /// A ground field mill publishing JSON (`{"time":…, "kv_per_m":…}`, or an array of those).
     /// When set, the station cards chart real kV/m instead of NOAA's ionospheric model.
     #[serde(default)]
@@ -463,6 +467,7 @@ impl Default for Settings {
             maptiler_key: String::new(),
             tempest_token: String::new(),
             wu_key: String::new(),
+            windy_key: String::new(),
             field_mill_url: String::new(),
             start_view: None,
             sync_client_id: String::new(),
@@ -658,6 +663,7 @@ mod tests {
             mapbox_key: "pk.test".to_string(),
             tempest_token: String::new(),
             wu_key: String::new(),
+            windy_key: String::new(),
             field_mill_url: String::new(),
             maptiler_key: "mt.test".to_string(),
             start_view: Some(StartView {

--- a/crates/hookecho/src/ui/detail_window.rs
+++ b/crates/hookecho/src/ui/detail_window.rs
@@ -8,6 +8,9 @@ pub struct Detail {
     /// Texture-cache key of a picture to show above the text (webcam stills). `None` for the
     /// text-only features this window was built for.
     pub image: Option<String>,
+    /// `(label, url)` for a "see this on its own site" button. Windy's webcam terms require every
+    /// image to link back to the camera's page, so for those this is not decoration.
+    pub link: Option<(String, String)>,
 }
 
 /// Show the detail window. Returns `false` when it should close. `image` is the resolved texture
@@ -30,8 +33,11 @@ pub fn show(ctx: &egui::Context, detail: &Detail, image: Option<&egui::TextureHa
             if detail.image.is_some() {
                 match image {
                     Some(tex) => {
-                        let w = ui.available_width();
                         let size = tex.size_vec2();
+                        // Never wider than the image really is. Windy's webcam terms allow their
+                        // stills at original size or smaller and forbid stretching, and their
+                        // previews are often narrower than this window.
+                        let w = ui.available_width().min(size.x);
                         let h = if size.x > 0.0 { w * size.y / size.x } else { 0.0 };
                         ui.add(egui::Image::new(tex).fit_to_exact_size(egui::vec2(w, h)));
                     }
@@ -46,6 +52,16 @@ pub fn show(ctx: &egui::Context, detail: &Detail, image: Option<&egui::TextureHa
                 // Monospace keeps L3 attribute-table columns aligned.
                 ui.add(egui::Label::new(egui::RichText::new(&detail.body).monospace()).wrap());
             });
+            // A button rather than `ui.hyperlink_to`: Android needs the JNI ACTION_VIEW path in
+            // platform::open_url, which egui's own hyperlink does not go through.
+            if let Some((label, url)) = &detail.link {
+                ui.add_space(6.0);
+                if ui.button(label).clicked() {
+                    if let Err(e) = crate::platform::open_url(url) {
+                        log::warn!("could not open {url}: {e}");
+                    }
+                }
+            }
         });
     open
 }

--- a/crates/hookecho/src/ui/legend.rs
+++ b/crates/hookecho/src/ui/legend.rs
@@ -189,10 +189,21 @@ pub fn draw_field(
     layer: crate::render::FieldLayer,
     y_offset: f32,
 ) -> f32 {
-    use crate::render::field_ramps::{ramp_for, FieldScale};
-    let Some(r) = ramp_for(layer) else {
-        return 0.0;
-    };
+    match crate::render::field_ramps::ramp_for(layer) {
+        Some(r) => draw_ramp(painter, map_rect, r, y_offset),
+        None => 0.0,
+    }
+}
+
+/// The same key, for a ramp that isn't a [`crate::render::FieldLayer`] — the wind particles carry
+/// their scale rather than uploading a grid, but they still owe the reader a legend.
+pub fn draw_ramp(
+    painter: &egui::Painter,
+    map_rect: Rect,
+    r: &crate::render::field_ramps::FieldRamp,
+    y_offset: f32,
+) -> f32 {
+    use crate::render::field_ramps::FieldScale;
     let font = FontId::proportional(10.0);
     let origin = map_rect.left_top() + Vec2::new(INSET, INSET + y_offset);
 

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -358,6 +358,15 @@ fn basemaps_tab(ui: &mut egui::Ui, settings: &mut Settings) {
     key_field(ui, "WeatherFlow Tempest token", &mut settings.tempest_token);
     ui.add_space(8.0);
     key_field(ui, "Weather Underground API key", &mut settings.wu_key);
+    ui.add_space(12.0);
+    ui.separator();
+    ui.label("Webcams");
+    ui.weak(
+        "Optional. The FAA's ~2,600 cameras need no key but stop at the US border; a free Windy \
+         key adds their global network. Windy returns the 50 most popular cameras in view.",
+    );
+    ui.add_space(6.0);
+    key_field(ui, "Windy API key", &mut settings.windy_key);
     ui.add_space(8.0);
     ui.label("Field mill URL (JSON, kV/m)");
     ui.text_edit_singleline(&mut settings.field_mill_url)

--- a/crates/hookecho/src/wind_draw.rs
+++ b/crates/hookecho/src/wind_draw.rs
@@ -318,7 +318,11 @@ mod tests {
         let expect = 10.0 * PX_PER_SEC_PER_MS * dt as f64;
         for (dx, dy) in moved {
             assert!(dy.abs() < 1e-6, "a westerly must not move north or south: {dy}");
-            assert!((dx - expect).abs() < 1e-6, "stepped {dx} px, expected {expect}");
+            // Relative: the speed is an f32 widened to f64, so the error scales with the answer.
+            assert!(
+                (dx - expect).abs() < expect * 1e-5,
+                "stepped {dx} px, expected {expect}"
+            );
         }
     }
 
@@ -330,7 +334,12 @@ mod tests {
         let vp = (800.0, 600.0);
         let wide = step_pixels(&field, &Camera::at_lonlat(-100.0, 40.0, 5.0), vp, 0.033);
         let close = step_pixels(&field, &Camera::at_lonlat(-100.0, 40.0, 10.0), vp, 0.033);
-        assert!((wide[0].0 - close[0].0).abs() < 1e-6, "{:?} vs {:?}", wide[0], close[0]);
+        assert!(
+            (wide[0].0 - close[0].0).abs() < wide[0].0.abs() * 1e-5,
+            "{:?} vs {:?}",
+            wide[0],
+            close[0]
+        );
     }
 
     #[test]

--- a/crates/hookecho/src/wind_draw.rs
+++ b/crates/hookecho/src/wind_draw.rs
@@ -1,0 +1,379 @@
+//! Animated wind particles: the "streaming" wind map, driven by our own HRRR grids.
+//!
+//! Particles are advected on the CPU and emitted as one `egui::Mesh` per frame, the same technique
+//! [`crate::fronts_draw`] uses for its pips. That is not a fallback for a compute shader — it is
+//! the only portable option here. When eframe picks a GL adapter it builds the device with
+//! `wgpu::Limits::downlevel_webgl2_defaults()`, which zeroes `max_storage_buffers_per_shader_stage`
+//! and the compute workgroup sizes outright, so compute is forbidden by the device regardless of
+//! what the driver supports. The app has no compute and no storage buffers today; this layer was
+//! not going to be the first thing constraining backend choice.
+//!
+//! The budget makes it a non-issue anyway. Readable density is about one trail per 40x40 px —
+//! ~1,500 particles on a phone, ~900 in a desktop pane, not 100,000. At the 3,000 ceiling with a
+//! 12-point trail that is ~130k vertices a frame, which `egui-wgpu` binds as `Uint32` indices in
+//! a single draw call.
+//!
+//! `// ponytail:` the ceiling is the mesh rebuild, and the upgrade path if it ever bites is NOT
+//! compute — it is the webgl-wind trick (advect positions in a fragment shader, ping-ponging two
+//! textures), which runs on GLES 3.0 with no storage buffers at all.
+
+use crate::render::field_ramps::{bake_ramp_lut, FieldScale, WIND};
+use crate::render::mercator::{world_to_lonlat, Camera};
+use egui::{Color32, Mesh, Pos2, Vec2};
+use wxdata::hrrr::WindLevel;
+use wxdata::mrms::MrmsField;
+
+/// Positions per trail. What the eye reads is the streak's length in *pixels*, and at the rate
+/// below a 10 m/s wind draws roughly 12 of these across ~30 px — about what Windy shows, which
+/// gets there with 30-60 much shorter steps.
+const TRAIL: usize = 12;
+
+/// **The calibration knob**: on-screen pixels per second, per m/s of wind. A 10 m/s wind moves
+/// 160 px/s, drawing a ~35 px streak; a 25 m/s jet core hits the clamp below.
+///
+/// This is deliberately calibrated in SCREEN space rather than as a model-time multiplier, and
+/// that was a correction made against a real screen. Model time cannot work: on-screen speed
+/// would scale with zoom, so any multiplier fast enough to be visible across CONUS (a 10 m/s wind
+/// at z=5 moves 0.09 px per frame at 900x, i.e. a half-pixel trail) pins every particle against
+/// the step clamp two zoom levels later. Fixed pixel speed is also what every wind map does, and
+/// the legend still carries the real knots.
+///
+/// Direction is unaffected by the change: web mercator's scale factor is isotropic, so the
+/// `cos(lat)` that converts m/s to world units cancels out of the normalised heading and only
+/// ever set the magnitude — which is now set here instead.
+const PX_PER_SEC_PER_MS: f64 = 16.0;
+
+/// Longest single step, in pixels, so a hitch or a jet core cannot fling a particle across the
+/// pane. At low zoom this is several grid cells, which makes the trajectory coarse where the
+/// whole country is on screen and nobody is tracing a parcel; at the zooms where the flow is
+/// being read at all, a step is a small fraction of a cell and forward Euler is plenty.
+const MAX_STEP_PX: f64 = 20.0;
+
+/// Particles per pixel of pane area, and the range to clamp the result into. Deriving the count
+/// from area rather than fixing it means a four-pane layout costs about what one pane does.
+const PX_PER_PARTICLE: f32 = 1200.0;
+const COUNT_RANGE: (f32, f32) = (400.0, 3000.0);
+
+/// A matched pair of wind component grids plus the run they came from.
+pub struct WindField {
+    pub u: MrmsField,
+    pub v: MrmsField,
+    pub level: WindLevel,
+    pub run: chrono::DateTime<chrono::Utc>,
+    pub fcst_hour: u8,
+}
+
+impl WindField {
+    pub fn valid(&self) -> chrono::DateTime<chrono::Utc> {
+        self.run + chrono::Duration::hours(self.fcst_hour as i64)
+    }
+
+    /// Eastward/northward components (m/s) at a point, or `None` off the HRRR domain. Both
+    /// components must resolve — half a vector points somewhere the wind isn't going.
+    pub fn sample(&self, lon: f64, lat: f64) -> Option<(f32, f32)> {
+        Some((self.u.sample_bilinear(lon, lat)?, self.v.sample_bilinear(lon, lat)?))
+    }
+}
+
+/// Speed (m/s) → color, through the shared [`WIND`] ramp so the legend and the particles cannot
+/// disagree. The LUT is baked once; `FieldRamp::index` already applies the m/s→kt conversion.
+fn speed_color(ms: f32) -> Color32 {
+    static LUT: std::sync::LazyLock<Vec<u8>> = std::sync::LazyLock::new(|| match &WIND.scale {
+        FieldScale::Ramp { stops, .. } => bake_ramp_lut(stops, 255),
+        FieldScale::Categorical(_) => vec![255; 256 * 4],
+    });
+    let i = WIND.index(ms) as usize * 4;
+    Color32::from_rgb(LUT[i], LUT[i + 1], LUT[i + 2])
+}
+
+struct Particle {
+    /// Trail head first. **World space**, not screen space: world coordinates stay valid through
+    /// any camera change, so pan and zoom need no reprojection pass and no resize fix-up, and the
+    /// trails stay pinned to the ground — which is what makes this read as a map layer.
+    trail: [(f64, f64); TRAIL],
+    /// How many entries of `trail` are real yet (a fresh particle has one).
+    n: usize,
+    age: u32,
+    /// Randomised per particle, redrawn on every respawn. **This is the whole anti-clumping
+    /// mechanism.** With a shared lifetime everything piles into the convergence lines within
+    /// about ten seconds and the rest of the map empties; decorrelated deaths keep the field even
+    /// without any density-feedback bookkeeping.
+    max_age: u32,
+    /// Speed at the head, m/s, kept for coloring.
+    speed: f32,
+}
+
+/// One pane's particles. Each pane has its own camera, so each needs its own set.
+pub struct Particles {
+    p: Vec<Particle>,
+    rng: u64,
+    /// Viewport the population was sized for, so a resize can be noticed.
+    vp: (f32, f32),
+}
+
+impl Default for Particles {
+    fn default() -> Self {
+        Self {
+            p: Vec::new(),
+            // `// ponytail:` a four-line xorshift, not the `rand` crate, for jittering particles.
+            // Seeded off the clock: nothing here is security-sensitive or needs reproducibility.
+            rng: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.subsec_nanos() as u64 | 1)
+                .unwrap_or(0x2545_F491_4F6C_DD1D),
+            vp: (0.0, 0.0),
+        }
+    }
+}
+
+impl Particles {
+    fn next_rand(&mut self) -> u64 {
+        self.rng ^= self.rng << 13;
+        self.rng ^= self.rng >> 7;
+        self.rng ^= self.rng << 17;
+        self.rng
+    }
+
+    fn unit(&mut self) -> f64 {
+        (self.next_rand() >> 11) as f64 / (1u64 << 53) as f64
+    }
+
+    /// Place a particle at a uniform random point of the pane.
+    ///
+    /// Seeding in **screen** space rather than geographically is deliberate: uniform in lon/lat
+    /// piles particles up at high latitude once mercator stretches the map, which is exactly the
+    /// artifact this layer exists to avoid. It also means a fast drag refills the newly exposed
+    /// band within one lifetime instead of leaving it bare.
+    fn respawn(&mut self, i: usize, cam: &Camera, vp: (f32, f32)) {
+        let (rx, ry) = (self.unit(), self.unit());
+        let w = cam.screen_to_world((rx as f32 * vp.0, ry as f32 * vp.1), vp);
+        let max_age = 30 + (self.next_rand() % 60) as u32;
+        let p = &mut self.p[i];
+        p.trail[0] = w;
+        p.n = 1;
+        p.age = 0;
+        p.max_age = max_age;
+        p.speed = 0.0;
+    }
+
+    /// Advect every particle one frame. `dt` is clamped by the caller's contract to a sane frame
+    /// time — a hitch or a resume from background must not teleport the whole field.
+    pub fn update(&mut self, field: &WindField, cam: &Camera, vp: (f32, f32), dt: f32) {
+        let want = ((vp.0 * vp.1 / PX_PER_PARTICLE).clamp(COUNT_RANGE.0, COUNT_RANGE.1)) as usize;
+        if self.p.len() != want || self.vp != vp {
+            self.vp = vp;
+            self.p.resize_with(want, || Particle {
+                trail: [(0.0, 0.0); TRAIL],
+                n: 0,
+                age: 0,
+                max_age: 0,
+                speed: 0.0,
+            });
+            for i in 0..want {
+                if self.p[i].n == 0 {
+                    self.respawn(i, cam, vp);
+                }
+            }
+        }
+
+        let wpp = cam.world_per_pixel();
+        let max_step = MAX_STEP_PX * wpp;
+        // Off-pane by this much in world units, i.e. ~20 px of slack so a trail can leave cleanly.
+        let margin = 20.0 * wpp;
+        let (w0, h0) = cam.screen_to_world((0.0, 0.0), vp);
+        let (w1, h1) = cam.screen_to_world((vp.0, vp.1), vp);
+        let dt = dt as f64;
+
+        for i in 0..self.p.len() {
+            let (wx, wy) = self.p[i].trail[0];
+            if wx < w0 - margin || wx > w1 + margin || wy < h0 - margin || wy > h1 + margin {
+                self.respawn(i, cam, vp);
+                continue;
+            }
+            let (lon, lat) = world_to_lonlat(wx, wy);
+            let Some((u, v)) = field.sample(lon, lat) else {
+                // Off the HRRR domain — CONUS-only, so this is most of the world.
+                self.respawn(i, cam, vp);
+                continue;
+            };
+            let speed = (u * u + v * v).sqrt();
+            if speed < 0.2 {
+                // Dead calm: the particle would sit still and burn a trail into the map.
+                self.respawn(i, cam, vp);
+                continue;
+            }
+            // Heading from the wind vector, magnitude from the screen calibration. y is negated
+            // because v is northward while world y grows southward.
+            let step = (speed as f64 * PX_PER_SEC_PER_MS * dt * wpp).min(max_step);
+            let inv = step / speed as f64;
+            let (dx, dy) = (u as f64 * inv, -(v as f64) * inv);
+
+            let p = &mut self.p[i];
+            p.trail.copy_within(0..TRAIL - 1, 1);
+            p.trail[0] = (wx + dx, wy + dy);
+            p.n = (p.n + 1).min(TRAIL);
+            p.speed = speed;
+            p.age += 1;
+            if p.age > p.max_age {
+                self.respawn(i, cam, vp);
+            }
+        }
+    }
+
+    /// Build this frame's mesh. `origin` is the pane's top-left; `alpha` scales the whole layer
+    /// (the zoom fade and the dimming over reflectivity both ride on it).
+    pub fn build_mesh(&self, cam: &Camera, vp: (f32, f32), origin: Pos2, alpha: f32) -> Mesh {
+        let mut mesh = Mesh::default();
+        if alpha <= 0.01 {
+            return mesh;
+        }
+        let mut pts = [Pos2::ZERO; TRAIL];
+        for p in &self.p {
+            if p.n < 2 {
+                continue;
+            }
+            for (k, slot) in pts.iter_mut().enumerate().take(p.n) {
+                let (sx, sy) = cam.world_to_screen(p.trail[k], vp);
+                *slot = origin + Vec2::new(sx, sy);
+            }
+            let col = speed_color(p.speed);
+            for k in 0..p.n - 1 {
+                let (a, b) = (pts[k], pts[k + 1]);
+                let seg = b - a;
+                let len = seg.length();
+                if len < 0.01 {
+                    continue;
+                }
+                // Taper and fade from head to tail; the fade IS the motion blur, which is why this
+                // still looks right well below 60 fps.
+                let t = k as f32 / (TRAIL - 1) as f32;
+                let half = (2.0 - 1.3 * t) * 0.5;
+                let a8 = (alpha * (1.0 - 0.85 * t) * 255.0) as u8;
+                let c = Color32::from_rgba_unmultiplied(col.r(), col.g(), col.b(), a8);
+                let n = Vec2::new(seg.y, -seg.x) / len * half;
+                let i = mesh.vertices.len() as u32;
+                for q in [a - n, a + n, b + n, b - n] {
+                    mesh.colored_vertex(q, c);
+                }
+                mesh.add_triangle(i, i + 1, i + 2);
+                mesh.add_triangle(i, i + 2, i + 3);
+            }
+        }
+        mesh
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wxdata::mrms::MrmsField;
+
+    /// A uniform field over CONUS: `u` m/s east, `v` m/s north, everywhere.
+    fn uniform(u: f32, v: f32) -> WindField {
+        let grid = |val: f32| MrmsField {
+            values: vec![val; 16],
+            nx: 4,
+            ny: 4,
+            lon_west: -110.0,
+            lon_east: -90.0,
+            lat_north: 45.0,
+            lat_south: 35.0,
+            time: chrono::Utc::now(),
+        };
+        WindField {
+            u: grid(u),
+            v: grid(v),
+            level: WindLevel::Surface,
+            run: chrono::Utc::now(),
+            fcst_hour: 0,
+        }
+    }
+
+    /// Per-particle screen-space displacement over one `update`, for particles that didn't respawn.
+    fn step_pixels(field: &WindField, cam: &Camera, vp: (f32, f32), dt: f32) -> Vec<(f64, f64)> {
+        let mut ps = Particles::default();
+        ps.update(field, cam, vp, dt);
+        let before: Vec<(f64, f64)> = ps.p.iter().map(|p| p.trail[0]).collect();
+        ps.update(field, cam, vp, dt);
+        let wpp = cam.world_per_pixel();
+        ps.p.iter()
+            .zip(&before)
+            .filter(|(p, _)| p.age > 0)
+            .map(|(p, b)| {
+                (
+                    (p.trail[0].0 - b.0) / wpp,
+                    (p.trail[0].1 - b.1) / wpp,
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn a_westerly_pushes_particles_east_at_the_calibrated_screen_speed() {
+        let field = uniform(10.0, 0.0);
+        let cam = Camera::at_lonlat(-100.0, 40.0, 7.0);
+        let dt = 0.033f32;
+        let moved = step_pixels(&field, &cam, (800.0, 600.0), dt);
+        assert!(!moved.is_empty());
+        let expect = 10.0 * PX_PER_SEC_PER_MS * dt as f64;
+        for (dx, dy) in moved {
+            assert!(dy.abs() < 1e-6, "a westerly must not move north or south: {dy}");
+            assert!((dx - expect).abs() < 1e-6, "stepped {dx} px, expected {expect}");
+        }
+    }
+
+    #[test]
+    fn screen_speed_does_not_depend_on_zoom() {
+        // The whole reason the rate is calibrated in pixels: the same wind must read the same
+        // whether the pane shows the country or a county.
+        let field = uniform(10.0, 0.0);
+        let vp = (800.0, 600.0);
+        let wide = step_pixels(&field, &Camera::at_lonlat(-100.0, 40.0, 5.0), vp, 0.033);
+        let close = step_pixels(&field, &Camera::at_lonlat(-100.0, 40.0, 10.0), vp, 0.033);
+        assert!((wide[0].0 - close[0].0).abs() < 1e-6, "{:?} vs {:?}", wide[0], close[0]);
+    }
+
+    #[test]
+    fn the_step_clamp_caps_pixel_speed() {
+        // A jet core and a long frame: the clamp, not the wind, must set the distance.
+        let field = uniform(100.0, 0.0);
+        let cam = Camera::at_lonlat(-100.0, 40.0, 10.0);
+        for (dx, _) in step_pixels(&field, &cam, (800.0, 600.0), 0.1) {
+            assert!(dx <= MAX_STEP_PX + 1e-6, "stepped {dx} px, cap is {MAX_STEP_PX}");
+        }
+    }
+
+    #[test]
+    fn particles_off_the_domain_respawn_instead_of_freezing() {
+        // Camera over the Atlantic: HRRR has nothing there, so every sample fails.
+        let field = uniform(10.0, 0.0);
+        let cam = Camera::at_lonlat(-40.0, 40.0, 7.0);
+        let vp = (400.0, 300.0);
+        let mut ps = Particles::default();
+        ps.update(&field, &cam, vp, 0.02);
+        ps.update(&field, &cam, vp, 0.02);
+        assert!(ps.p.iter().all(|p| p.n == 1), "off-domain particles must keep respawning");
+        // Nothing to draw is better than a frozen field of stale streaks.
+        let mesh = ps.build_mesh(&cam, vp, Pos2::ZERO, 1.0);
+        assert!(mesh.is_empty());
+    }
+
+    #[test]
+    fn respawn_lifetimes_are_decorrelated() {
+        let field = uniform(10.0, 0.0);
+        let cam = Camera::at_lonlat(-100.0, 40.0, 7.0);
+        let mut ps = Particles::default();
+        ps.update(&field, &cam, (800.0, 600.0), 0.02);
+        let ages: std::collections::HashSet<u32> = ps.p.iter().map(|p| p.max_age).collect();
+        // A shared lifetime is the clumping bug; anything near the full 60-value spread is fine.
+        assert!(ages.len() > 30, "only {} distinct lifetimes", ages.len());
+        assert!(ps.p.iter().all(|p| (30..90).contains(&p.max_age)));
+    }
+
+    #[test]
+    fn speed_color_tracks_the_ramp() {
+        // Calm and gale must not land on the same color, and the ramp is read in knots.
+        assert_ne!(speed_color(1.0), speed_color(30.0));
+        assert_eq!(speed_color(0.0), speed_color(-0.0));
+    }
+}

--- a/crates/wxdata/src/hrrr.rs
+++ b/crates/wxdata/src/hrrr.rs
@@ -628,6 +628,23 @@ mod tests {
             u.values.iter().zip(&v.values).any(|(a, b)| (a - b).abs() > 0.5),
             "u and v are the same field — submessage aliasing"
         );
+
+        // `fetch_wind` pops the pair off a `.buffered()` stream assuming input order. A silent
+        // swap there would point every vector 90 degrees wrong and still look like weather, so
+        // pin it against single-field fetches that cannot be reordered. Same run, same hour.
+        let lvl = WindLevel::Surface.idx_level();
+        let solo_u = fetch_run_field(&http, Model::Hrrr, run, 1, "UGRD", lvl, f64::NEG_INFINITY)
+            .await
+            .expect("solo UGRD");
+        assert_eq!((solo_u.nx, solo_u.ny), (u.nx, u.ny));
+        let diff = solo_u
+            .values
+            .iter()
+            .zip(&u.values)
+            .filter(|(a, b)| a.is_finite() && b.is_finite())
+            .filter(|(a, b)| (*a - *b).abs() > 0.01)
+            .count();
+        assert_eq!(diff, 0, "fetch_wind's `u` is not UGRD — the pair is swapped");
     }
 
     #[test]

--- a/crates/wxdata/src/hrrr.rs
+++ b/crates/wxdata/src/hrrr.rs
@@ -175,6 +175,85 @@ pub async fn fetch_fields_one_run(
     Err(last_err.unwrap_or_else(|| anyhow::anyhow!("no HRRR run found")))
 }
 
+/// Which wind the particle layer flies on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum WindLevel {
+    /// 10 m above ground — the wind you stand in, and what surface obs report.
+    #[default]
+    Surface,
+    /// 500 mb — mid-level flow, roughly what steers storms. A quarter the bytes of 10 m.
+    Steering,
+}
+
+impl WindLevel {
+    /// The `.idx` level string. Both live in `wrfsfc`, so neither needs the much larger `wrfprs`
+    /// file that [`crate::sounding`] pulls for a full profile.
+    fn idx_level(self) -> &'static str {
+        match self {
+            WindLevel::Surface => "10 m above ground",
+            WindLevel::Steering => "500 mb",
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            WindLevel::Surface => "10 m",
+            WindLevel::Steering => "500 mb",
+        }
+    }
+}
+
+/// Fetch the `u`/`v` wind components for `level` as a matched pair from one model cycle.
+///
+/// **HRRR only, deliberately — do not add a [`Model`] parameter.** RAP's `awp130pgrb` packs the two
+/// components as *submessages of a single GRIB2 message*, so its `.idx` lists them at one shared
+/// byte offset:
+///
+/// ```text
+/// 92.1:4703714:d=2026073012:UGRD:500 mb:anl:
+/// 92.2:4703714:d=2026073012:VGRD:500 mb:anl:      <- same offset
+/// ```
+///
+/// [`field_byte_range`] hands back the same range for both, and `gribberish`'s `Message::data()`
+/// decodes the *first* data section, so a RAP `VGRD` request quietly returns u-wind: every vector
+/// at 45° with `|u| == |v|`, wrong everywhere and plausible-looking for about three seconds. HRRR's
+/// `wrfsfc` stores them as separate messages, so this path is safe. The same trap waits for any
+/// future RAP-sourced vector field.
+///
+/// `min_valid` is `-∞` for both: wind components are signed, and the regrid's threshold is a drop
+/// test, so anything higher would silently delete every westward or southward vector.
+pub async fn fetch_wind(
+    http: &reqwest::Client,
+    level: WindLevel,
+    fcst_hour: u8,
+) -> anyhow::Result<(DateTime<Utc>, MrmsField, MrmsField)> {
+    let lvl = level.idx_level();
+    let (run, mut fields) = fetch_fields_one_run(
+        http,
+        Model::Hrrr,
+        fcst_hour,
+        &[
+            ("UGRD", lvl, f64::NEG_INFINITY),
+            ("VGRD", lvl, f64::NEG_INFINITY),
+        ],
+    )
+    .await?;
+    anyhow::ensure!(fields.len() == 2, "expected u and v, got {}", fields.len());
+    // `.buffered` preserves input order, but a wind field is unreadable if u and v ever swap, so
+    // pop them back-to-front explicitly rather than trusting that at a distance.
+    let v = fields.pop().unwrap();
+    let u = fields.pop().unwrap();
+    anyhow::ensure!(
+        u.nx == v.nx && u.ny == v.ny,
+        "u/v grid mismatch: {}x{} vs {}x{}",
+        u.nx,
+        u.ny,
+        v.nx,
+        v.ny
+    );
+    Ok((run, u, v))
+}
+
 /// Fetch one field across forecast hours `1..=through_hour` from a SINGLE model cycle and fold
 /// them into one grid by elementwise max — the "swath" a max-per-hour field is meant to be read as.
 ///
@@ -492,6 +571,69 @@ mod tests {
         eprintln!("peak CAPE — RAP {max:.0} vs HRRR {hmax:.0} J/kg");
         let ratio = (max as f64 / hmax.max(1.0) as f64).max(hmax as f64 / max.max(1.0) as f64);
         assert!(ratio < 3.0, "RAP {max} and HRRR {hmax} disagree wildly");
+    }
+
+    #[tokio::test]
+    #[ignore = "network"]
+    async fn hrrr_wind_decodes_as_a_matched_pair() {
+        let http = reqwest::Client::new();
+        let (run, u, v) = fetch_wind(&http, WindLevel::Surface, 1).await.expect("HRRR wind");
+        assert_eq!((u.nx, u.ny), (v.nx, v.ny));
+
+        let finite = u
+            .values
+            .iter()
+            .zip(&v.values)
+            .filter(|(a, b)| a.is_finite() && b.is_finite());
+        let (mut n, mut max_kt) = (0usize, 0.0f32);
+        let (mut neg_u, mut neg_v) = (0usize, 0usize);
+        for (a, b) in finite {
+            n += 1;
+            max_kt = max_kt.max((a * a + b * b).sqrt() * 1.943_844);
+            neg_u += (*a < 0.0) as usize;
+            neg_v += (*b < 0.0) as usize;
+        }
+        let holes = 1.0 - n as f64 / u.values.len() as f64;
+        // The whole-grid figure is dominated by the Lambert domain's corners, which fall outside
+        // the model entirely and are supposed to be empty. The middle third is all inside CONUS,
+        // so its empty fraction is the one that says whether the regrid leaves real holes.
+        let (mut inner, mut inner_empty) = (0usize, 0usize);
+        for y in u.ny / 3..u.ny * 2 / 3 {
+            for x in u.nx / 3..u.nx * 2 / 3 {
+                inner += 1;
+                inner_empty += !u.values[y * u.nx + x].is_finite() as usize;
+            }
+        }
+        eprintln!(
+            "interior (middle third) — {:.2}% empty of {inner} cells",
+            inner_empty as f64 / inner as f64 * 100.0
+        );
+        eprintln!(
+            "HRRR 10 m wind {}x{} run {run} — {n} paired cells, {:.1}% empty, max {max_kt:.0} kt, \
+             {:.0}% easterly, {:.0}% southerly",
+            u.nx,
+            u.ny,
+            holes * 100.0,
+            neg_u as f64 / n as f64 * 100.0,
+            neg_v as f64 / n as f64 * 100.0,
+        );
+
+        assert!(n > u.values.len() / 2, "coverage holes: {:.1}% empty", holes * 100.0);
+        // Both signs must survive `min_valid`: a CONUS-wide field always has wind blowing every way.
+        assert!(neg_u > n / 20 && neg_v > n / 20, "one sign got clipped");
+        // Surface wind peaks somewhere in the country, but not at jet-stream speeds.
+        assert!((10.0..120.0).contains(&max_kt), "implausible peak {max_kt} kt");
+        // The RAP trap, checked from the outside: identical components mean one field read twice.
+        assert!(
+            u.values.iter().zip(&v.values).any(|(a, b)| (a - b).abs() > 0.5),
+            "u and v are the same field — submessage aliasing"
+        );
+    }
+
+    #[test]
+    fn wind_levels_map_to_idx_strings() {
+        assert_eq!(WindLevel::Surface.idx_level(), "10 m above ground");
+        assert_eq!(WindLevel::Steering.idx_level(), "500 mb");
     }
 
     #[test]

--- a/crates/wxdata/src/mrms.rs
+++ b/crates/wxdata/src/mrms.rs
@@ -99,6 +99,53 @@ impl MrmsField {
         }
     }
 
+    /// Value at `(lon, lat)` by bilinear interpolation of the four surrounding cell centres, or
+    /// `None` outside the grid. Point sampling for things that walk the field continuously rather
+    /// than drawing it as pixels (wind advection); [`max_within_km`](Self::max_within_km) answers a
+    /// different question and answers it over a radius.
+    ///
+    /// NaN-aware: HRRR's scatter regrid leaves holes, so the weights of whichever corners are
+    /// finite are renormalised over the corners that survive. That makes an isolated empty cell
+    /// invisible and softens the domain edge by half a cell, instead of punching a hole through
+    /// every sample that touches one. All four NaN → `None`, same as being off the grid.
+    pub fn sample_bilinear(&self, lon: f64, lat: f64) -> Option<f32> {
+        if self.nx == 0 || self.ny == 0 {
+            return None;
+        }
+        if lon < self.lon_west || lon > self.lon_east || lat < self.lat_south || lat > self.lat_north
+        {
+            return None;
+        }
+        let dlon = (self.lon_east - self.lon_west) / self.nx as f64;
+        let dlat = (self.lat_north - self.lat_south) / self.ny as f64; // rows go north→south
+                                                                       // Cell *centres* sit half a cell in from the corners, as max_within_km also assumes.
+        let fx = (lon - self.lon_west) / dlon - 0.5;
+        let fy = (self.lat_north - lat) / dlat - 0.5;
+        let (x0, y0) = (fx.floor(), fy.floor());
+        let (tx, ty) = ((fx - x0) as f32, (fy - y0) as f32);
+        let (x0, y0) = (x0 as isize, y0 as isize);
+        let mut acc = 0.0f32;
+        let mut wsum = 0.0f32;
+        for (dx, dy, w) in [
+            (0, 0, (1.0 - tx) * (1.0 - ty)),
+            (1, 0, tx * (1.0 - ty)),
+            (0, 1, (1.0 - tx) * ty),
+            (1, 1, tx * ty),
+        ] {
+            let (x, y) = (x0 + dx, y0 + dy);
+            if x < 0 || y < 0 || x >= self.nx as isize || y >= self.ny as isize {
+                continue;
+            }
+            let v = self.values[y as usize * self.nx + x as usize];
+            if !v.is_finite() {
+                continue;
+            }
+            acc += v * w;
+            wsum += w;
+        }
+        (wsum > 0.0).then(|| acc / wsum)
+    }
+
     /// Max-pool the grid down so both dimensions are `<= max_dim` (GPU texture limits). Some MRMS
     /// products (rotation tracks, AzShear) are 14000×7000 — larger than the 8192 texture cap.
     /// Max-pooling keeps the strongest signal in each block (right for shear/reflectivity).
@@ -305,6 +352,53 @@ mod tests {
         assert_eq!(f.max_within_km(-97.0, 35.0, 500.0), 9.0);
         // A point far from the grid sees nothing.
         assert_eq!(f.max_within_km(-80.0, 40.0, 20.0), 0.0);
+    }
+
+    /// 4×4 grid of 1° cells; each cell holds its own centre longitude, so the field is exactly
+    /// linear and bilinear interpolation has an analytic answer everywhere.
+    fn linear_field() -> MrmsField {
+        let mut values = vec![0.0f32; 16];
+        for j in 0..4 {
+            for i in 0..4 {
+                values[j * 4 + i] = -100.0 + i as f32 + 0.5;
+            }
+        }
+        MrmsField {
+            values,
+            nx: 4,
+            ny: 4,
+            lon_west: -100.0,
+            lon_east: -96.0,
+            lat_north: 40.0,
+            lat_south: 36.0,
+            time: chrono::Utc::now(),
+        }
+    }
+
+    #[test]
+    fn sample_bilinear_is_exact_on_a_linear_field() {
+        let f = linear_field();
+        // On a cell centre, and halfway between two — both reproduce the underlying line.
+        assert!((f.sample_bilinear(-98.5, 38.5).unwrap() - -98.5).abs() < 1e-4);
+        assert!((f.sample_bilinear(-98.0, 38.0).unwrap() - -98.0).abs() < 1e-4);
+        // Outside the box in either axis is None, not a clamped edge value.
+        assert_eq!(f.sample_bilinear(-90.0, 38.0), None);
+        assert_eq!(f.sample_bilinear(-98.0, 10.0), None);
+    }
+
+    #[test]
+    fn sample_bilinear_renormalises_over_nan_corners() {
+        let mut f = linear_field();
+        // Midpoint of the four centres around (-98.0, 38.0): all corners weigh 0.25.
+        f.values[5] = f32::NAN; // row 1, col 1 — one of the four; the other three carry the sample
+        let v = f.sample_bilinear(-98.0, 38.0).unwrap();
+        // Surviving corners are -97.5 (twice, at x=2) and -98.5 (once), weights 0.25 each.
+        assert!((v - (-97.5 * 2.0 + -98.5) / 3.0).abs() < 1e-4, "got {v}");
+        // Every corner gone → None, indistinguishable from off-grid, which is what callers want.
+        for v in f.values.iter_mut() {
+            *v = f32::NAN;
+        }
+        assert_eq!(f.sample_bilinear(-98.0, 38.0), None);
     }
 
     #[test]

--- a/crates/wxdata/src/webcams.rs
+++ b/crates/wxdata/src/webcams.rs
@@ -1,19 +1,29 @@
-//! FAA WeatherCams: airport camera sites and their latest still images.
+//! Webcams from two networks, sharing one shape: FAA WeatherCams and Windy.
 //!
 //! The FAA runs ~2,600 cameras, thick in Alaska and thin but real across the lower 48, and serves
-//! them keyless — you get a bbox of sites, then the newest frame per camera. That's the whole
-//! appeal over Windy's webcam network, which needs an API key per user before a single image
-//! loads. Windy remains the documented upgrade path if coverage ever matters more than setup:
-//! swap [`fetch_bbox`] for their `/api/webcams/v2/list` and keep everything downstream.
+//! them keyless — you get a bbox of sites, then the newest frame per camera. Its API is the one
+//! the FAA's own map calls, and it 401s without a `Referer` from its own origin. That's an origin
+//! check on a public dataset, not authentication, so we send one.
 //!
-//! The API is the one the FAA's own map calls, and it 401s without a `Referer` from its own
-//! origin. That's an origin check on a public dataset, not authentication, so we send one.
+//! [`fetch_windy_bbox`] covers everywhere the FAA doesn't, which is most of the planet, at the
+//! cost of an API key the user supplies. Both produce [`CamSite`]s, so the marker drawing,
+//! hit-testing and detail window downstream never learn which network a camera came from. Two
+//! differences leak through and are handled at the call site rather than hidden:
+//!
+//! - Windy caps `limit` at 50 per request, so a Windy bbox is the 50 most popular cameras in
+//!   view, not all of them. The FAA returns everything in the box.
+//! - Windy's free-tier image URLs are token-secured and the tokens expire after **10 minutes**,
+//!   so those URLs must never be persisted or cached across a refresh.
 
 use crate::alerts::USER_AGENT;
 
 const API: &str = "https://weathercams.faa.gov/api";
 /// The site's own origin, which its API insists on seeing.
 const REFERER: &str = "https://weathercams.faa.gov/";
+
+const WINDY_API: &str = "https://api.windy.com/webcams/api/v3/webcams";
+/// Windy's own maximum; asking for more is rejected rather than clamped.
+const WINDY_LIMIT: usize = 50;
 
 /// One camera at a site: which way it points, and how to name it in a list.
 #[derive(Debug, Clone, PartialEq)]
@@ -24,6 +34,12 @@ pub struct Camera {
     pub direction: String,
     pub bearing: Option<f32>,
     pub out_of_order: bool,
+    /// Ready-to-use still image. Windy returns one inline, so there is no second round trip; FAA
+    /// cameras leave this `None` and go through [`latest_image`].
+    ///
+    /// On Windy's free tier this URL carries a token that dies after ten minutes. Never persist
+    /// it, and drop any decoded texture alongside the site list on refresh.
+    pub image_url: Option<String>,
 }
 
 /// A camera site — an airport or a remote strip — and the cameras standing on it.
@@ -38,6 +54,9 @@ pub struct CamSite {
     pub lat: f64,
     pub lon: f64,
     pub cameras: Vec<Camera>,
+    /// The camera's page on its own network. Windy's terms require every image to link back to
+    /// this; FAA cameras leave it `None`.
+    pub link: Option<String>,
 }
 
 /// Parse the `/sites` payload. Tolerant: skips sites with no usable position, and sites that are
@@ -70,6 +89,7 @@ pub fn parse_sites(json: &str) -> Vec<CamSite> {
                             bearing: num(c, "cameraBearing").map(|b| b as f32),
                             out_of_order: flag(c, "cameraOutOfOrder", false)
                                 || flag(c, "cameraInMaintenance", false),
+                            image_url: None,
                         })
                     })
                     .collect::<Vec<_>>()
@@ -87,6 +107,7 @@ pub fn parse_sites(json: &str) -> Vec<CamSite> {
             lat,
             lon,
             cameras,
+            link: None,
         });
     }
     out
@@ -98,6 +119,78 @@ pub fn parse_latest_image(json: &str) -> Option<String> {
     let first = v.get("payload")?.as_array()?.first()?;
     let uri = first.get("imageUri")?.as_str()?;
     (!uri.is_empty()).then(|| uri.to_string())
+}
+
+/// Parse a `/webcams/api/v3/webcams` payload into the shared [`CamSite`] shape.
+///
+/// Tolerant in the same way [`parse_sites`] is — every field is probed rather than deserialised
+/// into a struct, and a record missing a position or an image is skipped instead of failing the
+/// batch. That is deliberate: this parser is written against Windy's published V3 schema, and the
+/// nesting under `images` is the part most likely to differ in practice, so a surprise there
+/// should cost one camera rather than the layer.
+pub fn parse_windy(json: &str) -> Vec<CamSite> {
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(json) else {
+        return Vec::new();
+    };
+    let Some(arr) = v.get("webcams").and_then(|w| w.as_array()) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for w in arr {
+        let loc = w.get("location");
+        let (Some(lat), Some(lon)) = (
+            loc.and_then(|l| num(l, "latitude")),
+            loc.and_then(|l| num(l, "longitude")),
+        ) else {
+            continue;
+        };
+        // V3 renamed the identifier from a string `id` to a numeric `webcamId`.
+        let id = w.get("webcamId").and_then(|v| v.as_u64()).unwrap_or(0);
+        let title = text(w, "title");
+        // `images.current.preview` is the documented still. Fall back through the other sizes so
+        // a camera that only publishes a thumbnail still gets a marker.
+        let image_url = w.get("images").and_then(|im| {
+            let cur = im.get("current");
+            ["preview", "thumbnail", "icon"]
+                .iter()
+                .find_map(|k| cur.and_then(|c| c.get(*k)).and_then(|s| s.as_str()))
+                .map(|s| s.to_string())
+        });
+        out.push(CamSite {
+            id,
+            name: if title.is_empty() {
+                format!("Webcam {id}")
+            } else {
+                title.clone()
+            },
+            // Windy has no airport identifiers; the location's own labels are the nearest thing.
+            ident: String::new(),
+            icao: String::new(),
+            state: loc.map(|l| text(l, "country")).unwrap_or_default(),
+            lat,
+            lon,
+            cameras: vec![Camera {
+                id,
+                name: title,
+                // Windy does not report which way a camera faces.
+                direction: String::new(),
+                bearing: None,
+                // `status` is "active" for a live camera; anything else is not worth opening.
+                out_of_order: w
+                    .get("status")
+                    .and_then(|s| s.as_str())
+                    .is_some_and(|s| !s.eq_ignore_ascii_case("active")),
+                image_url,
+            }],
+            // Required by Windy's terms: every image links back to its own page.
+            link: w
+                .get("urls")
+                .and_then(|u| u.get("detail"))
+                .and_then(|s| s.as_str())
+                .map(|s| s.to_string()),
+        });
+    }
+    out
 }
 
 fn text(v: &serde_json::Value, k: &str) -> String {
@@ -136,6 +229,42 @@ pub async fn fetch_bbox(
         .text()
         .await?;
     Ok(parse_sites(&body))
+}
+
+/// Fetch Windy webcams inside a lon/lat box. Needs the user's own API key.
+///
+/// Two of Windy's rules shape this call. `bbox` is ordered **north, east, south, west** — not the
+/// west/south/east/north this codebase uses everywhere else — and `limit` cannot exceed 50, so
+/// this asks for the 50 most *popular* cameras in view rather than an arbitrary 50. A continental
+/// bbox therefore returns a sample, not a census; the layer's description says so.
+pub async fn fetch_windy_bbox(
+    client: &reqwest::Client,
+    key: &str,
+    min_lon: f64,
+    min_lat: f64,
+    max_lon: f64,
+    max_lat: f64,
+) -> anyhow::Result<Vec<CamSite>> {
+    anyhow::ensure!(!key.is_empty(), "no Windy API key");
+    let bbox = format!("{max_lat},{max_lon},{min_lat},{min_lon}");
+    let body = client
+        .get(WINDY_API)
+        .query(&[
+            ("bbox", bbox.as_str()),
+            ("include", "images,location,urls"),
+            ("limit", &WINDY_LIMIT.to_string()),
+            ("sortKey", "popularity"),
+            ("sortDirection", "desc"),
+        ])
+        .header("User-Agent", USER_AGENT)
+        .header("x-windy-api-key", key)
+        .header("Accept", "application/json")
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+    Ok(parse_windy(&body))
 }
 
 /// Fetch the URL of a camera's most recent still. `None` when the camera has posted nothing.
@@ -185,6 +314,47 @@ mod tests {
         assert_eq!(s.cameras[0].bearing, Some(295.0));
         // Out-of-order cameras are kept, flagged — the site still deserves a marker.
         assert!(s.cameras[1].out_of_order);
+    }
+
+    /// Shaped from Windy's published V3 schema: the envelope is `{total, webcams}`, the id is a
+    /// number, and `urls.detail` is the link-back their terms require.
+    const WINDY: &str = r#"{"total":3,"webcams":[
+      {"webcamId":1358084658,"title":"Zermatt: Matterhorn","status":"active",
+       "location":{"city":"Zermatt","country":"Switzerland","latitude":46.0207,"longitude":7.7491},
+       "images":{"current":{"preview":"https://images.windy.com/webcams/preview.jpg",
+                            "thumbnail":"https://images.windy.com/webcams/thumb.jpg"}},
+       "urls":{"detail":"https://www.windy.com/webcams/1358084658"}},
+      {"webcamId":2,"title":"Only a thumbnail","status":"inactive",
+       "location":{"latitude":40.0,"longitude":-3.0},
+       "images":{"current":{"thumbnail":"https://images.windy.com/webcams/t2.jpg"}},
+       "urls":{"detail":"https://www.windy.com/webcams/2"}},
+      {"webcamId":3,"title":"No position","status":"active","images":{"current":{}}}
+    ]}"#;
+
+    #[test]
+    fn parses_windy_webcams() {
+        let sites = parse_windy(WINDY);
+        assert_eq!(sites.len(), 2, "a camera with no position must drop");
+        let s = &sites[0];
+        assert_eq!(s.id, 1358084658);
+        assert_eq!(s.name, "Zermatt: Matterhorn");
+        assert_eq!(s.state, "Switzerland");
+        assert!((s.lat - 46.0207).abs() < 1e-6 && (s.lon - 7.7491).abs() < 1e-6);
+        // The link-back is not optional — Windy's terms require it beside every image.
+        assert_eq!(
+            s.link.as_deref(),
+            Some("https://www.windy.com/webcams/1358084658")
+        );
+        assert!(s.cameras[0].image_url.as_deref().unwrap().ends_with("preview.jpg"));
+        assert!(!s.cameras[0].out_of_order);
+
+        // Falls back down the size list, and a non-"active" status reads as out of order.
+        assert!(sites[1].cameras[0].image_url.as_deref().unwrap().ends_with("t2.jpg"));
+        assert!(sites[1].cameras[0].out_of_order);
+
+        // Garbage and an empty envelope are empty layers, not errors.
+        assert!(parse_windy("not json").is_empty());
+        assert!(parse_windy(r#"{"total":0,"webcams":[]}"#).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Builds the Windy *look* from our own free NOAA data, adds Windy's webcam network, and an honest one-click hand-off to windy.com. Windy's animated map overlays cannot be licensed or embedded into a native client (their Map Forecast is a Leaflet JS library with no fetchable raster or vector endpoint), so nothing here scrapes or embeds them.

## Commits

| | |
|---|---|
| `d7dc56d` | `feat(wind)`: HRRR wind vector field |
| `2b2a74b` | `feat(wind)`: animated wind particles |
| `0b0fe13` | `feat`: open the current view in Windy |
| `0bfd3ad` | `feat(webcams)`: Windy global webcam network |
| `e1c6884` | `docs` |

## Wind

`hrrr::fetch_wind` pulls 10 m UGRD/VGRD through the existing `fetch_fields_one_run`, which guarantees both components come from the same model cycle — `u` from one run and `v` from another is a physically wrong direction field. `min_valid` is `f64::NEG_INFINITY` for both: wind components are signed and the default threshold would clip every negative one.

**HRRR only, deliberately.** RAP's `awp130pgrb` packs u and v as two *submessages of one GRIB2 message sharing a byte offset*, and `gribberish`'s `Message::data()` returns the first data section — so a RAP VGRD request silently returns u-wind, and every vector comes out at 45 degrees with `|u| == |v|`. Verified live. There is a comment at the fetch site so nobody \"fixes\" it later.

Particles advect on the CPU and draw as one `egui::Mesh` per frame via `Painter`, the technique `fronts_draw.rs` already uses. Not a compute shader: when eframe picks a GL adapter it creates the device with `wgpu::Limits::downlevel_webgl2_defaults()`, which zeroes `max_compute_workgroup_size_*` and `max_storage_buffers_per_shader_stage`. That is a device restriction, not a capability we can probe around, and Android ships the `gles` feature.

Positions live in web-mercator world space, so pan and zoom need no reprojection pass and trails stay pinned to the ground.

## Three things found by running it

**The layer shipped invisible the first time.** A model-time advection rate (`TIME_LAPSE=900`) moves a 10 m/s wind 0.088 px/frame at z=5 — a half-pixel trail. The fix was not a bigger multiplier: a model-time rate makes on-screen speed scale with zoom, so anything visible across CONUS pins every particle against the step clamp two zoom levels in. Advection is now calibrated in screen space (`PX_PER_SEC_PER_MS`), which also deleted the `EQUATOR_M` and `cos(lat)` terms — mercator's scale factor is isotropic, so it cancels out of a normalized heading.

**Android cost 10x more than expected.** Measured on an S24 Ultra: 7% CPU idle, 78% animating at 20 fps. The cost is the whole map re-rendering instead of sitting idle, which any animated layer pays — not the particle mesh. Phones now repaint at 10 fps: 27%, trails still read. Thermals benign over 5 minutes (38-40 C zones, 27 C battery).

**Windy's webcam API is V3, not the V2 the module's own docs pointed at.** Filters moved from path segments to query params and `id` became numeric `webcamId`. Three constraints are load-bearing: `bbox` is north,east,south,west; `limit` caps at 50 (so it is the 50 most popular in view, not a census); free-tier image tokens expire in 10 minutes, not the 15 assumed — the refresh clock was 600 s, racing it, now 480 s.

## Two bugs in existing code

`detail_window.rs` was scaling webcam stills *up* to the window width. Windy's terms allow original size or smaller and forbid stretching; now clamped to native width. And an `AtomicBool` in-flight guard would have wedged the wind layer permanently on any fetch error, since `spawn_overlay` only logs them — it is a timestamped `Option<Instant>` that expires.

Terms compliance is in the same commit as the fetch, not a follow-up: credit line, link-back button on every image (a button, not `ui.hyperlink_to`, because Android needs the JNI ACTION_VIEW path), and image URLs never persisted.

## Verification

`cargo clippy --workspace --all-targets -- -D warnings` clean. `cargo test --workspace` 270 passed / 12 ignored, up from 259 on main. `scripts/shots/shoot.sh check` passes. Interior regrid hole fraction measured at 0.00%, which retires the moire risk the plan flagged. `fetch_wind`'s `u` is pinned byte-for-byte against an independent UGRD fetch — a `.buffered()` ordering swap was the one failure mode that would have looked entirely plausible on screen.

**Not verified live:** the Windy webcam parser has never run against the real API — no key available. It is covered by a fixture built from the documented schema and written tolerantly, so a schema surprise under `images` costs one camera rather than the layer. The `images.current.*` nesting is the part most likely to differ. The FAA path was re-checked on screen and is unregressed.

`windy_key` follows the `mapbox_key` handling: `#[serde(default)]`, entered in Settings, absent from the committed template. Note `cloud.rs:424 shareable()` syncs API keys to Drive by design, so it will sync as `mapbox_key` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)