### PR TITLE
Android performance overhaul: pinch, tiles, radar loop, site switch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,9 @@ anyhow = "1"
 thiserror = "2"
 # `process` + `io-util` are for the external-process plugin runner (crates/hookecho/src/plugins.rs).
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "process", "io-util"] }
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+# `http2`: tile CDNs all speak h2, and one multiplexed connection beats ~28 TLS handshakes for a
+# screenful of tiles. ALPN falls back to HTTP/1.1 where h2 isn't offered.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "http2"] }
 flate2 = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -8221,8 +8221,13 @@ impl HookEchoApp {
     /// stops being enough to tell a stutter from a stall.
     #[cfg(debug_assertions)]
     fn frame_time_overlay(&mut self, ctx: &egui::Context) {
-        let dt = ctx.input(|i| i.unstable_dt) * 1000.0;
-        let text = format!("{dt:.1} ms  ({:.0} fps)", 1000.0 / dt.max(0.001));
+        let (dt, pinching) = ctx.input(|i| (i.unstable_dt * 1000.0, i.multi_touch().is_some()));
+        let text = format!(
+            "{dt:.1} ms ({:.0} fps)  z{:.2}{}",
+            1000.0 / dt.max(0.001),
+            self.views[self.active].camera.zoom,
+            if pinching { "  pinch" } else { "" }
+        );
         egui::Area::new(egui::Id::new("frame_time_overlay"))
             .anchor(egui::Align2::LEFT_TOP, egui::vec2(6.0, 6.0))
             .order(egui::Order::Tooltip)

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -7845,9 +7845,10 @@ impl HookEchoApp {
             (
                 want,
                 v.site.clone(),
-                // The streamer needs its own mutable base to merge chunks into, so this is the
-                // one place a decoded volume is still deep-copied — once per stream start.
-                v.volume.as_ref().map(|vol| (*vol.scan).clone()),
+                // Shared with the pane: the streamer merges into a new Scan rather than mutating
+                // this one, so it only needs a refcount, not the tens of MB a deep copy cost on
+                // the UI thread at every stream start.
+                v.volume.as_ref().map(|vol| Arc::clone(&vol.scan)),
             )
         };
 
@@ -7879,7 +7880,7 @@ impl HookEchoApp {
         &self,
         view_idx: usize,
         site: String,
-        base: Scan,
+        base: Arc<Scan>,
         ctx: egui::Context,
     ) -> tokio::task::JoinHandle<()> {
         let tx = self.msg_tx.clone();

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1632,6 +1632,10 @@ pub struct HookEchoApp {
     /// off the raw input, which has no idea egui drew a sheet over the map, so the pane input
     /// block checks the gesture center against these.
     mobile_occlusion: Vec<egui::Rect>,
+    /// When the last two-finger gesture ended. Lifting one finger of a pinch leaves the other
+    /// one down, which egui immediately reads as a click and a fresh drag — an interrogate popup
+    /// and a jump for what was only the end of a zoom. A short cooldown eats both.
+    last_gesture_end: Option<std::time::Instant>,
     /// Spotter Network positions + toggle + refresh clock (filtered to active site at draw).
     show_spotters: bool,
     /// FAA WeatherCams: the toggle, the sites in view, and the bbox//time they were fetched for.
@@ -2134,6 +2138,7 @@ impl HookEchoApp {
             mobile_snap: Default::default(),
             mobile_sheet_drag: None,
             mobile_occlusion: Vec::new(),
+            last_gesture_end: None,
             show_spotters: false,
             show_webcams: false,
             webcams: Vec::new(),
@@ -2780,16 +2785,19 @@ impl HookEchoApp {
         }
         egui::Area::new(egui::Id::new("warning_banners"))
             .constrain_to(self.chrome_rect)
+            // Read-only banner that self-expires in 45 s. Interactable layers occlude the map's
+            // pinch test (`layer_id_at`), and a banner across the top of a phone screen is exactly
+            // where a two-finger gesture lands, so it must not take input.
+            .interactable(false)
             .anchor(
                 egui::Align2::CENTER_TOP,
                 egui::vec2(0.0, crate::ui::style::LANE_TOP_BANNER),
             )
             .show(ctx, |ui| {
-                let mut dismiss = false;
                 for (event, area, at) in &self.warning_banners {
                     // Fade out over the last two seconds instead of vanishing mid-read.
                     let a = ((45.0 - at.elapsed().as_secs_f32()) / 2.0).clamp(0.0, 1.0);
-                    let resp = egui::Frame::new()
+                    egui::Frame::new()
                         .fill(egui::Color32::from_rgb(150, 20, 20).gamma_multiply(a))
                         .stroke(egui::Stroke::new(
                             1.0,
@@ -2817,15 +2825,8 @@ impl HookEchoApp {
                                     }
                                 });
                             });
-                        })
-                        .response;
-                    if resp.interact(egui::Sense::click()).clicked() {
-                        dismiss = true;
-                    }
+                        });
                     ui.add_space(4.0);
-                }
-                if dismiss {
-                    self.warning_banners.clear();
                 }
             });
         // Fast enough for the fade-out; the banner is only up for 45 s.
@@ -5225,6 +5226,8 @@ impl HookEchoApp {
         };
         egui::Area::new(egui::Id::new("chase_hud"))
             .constrain_to(self.chrome_rect)
+            // Pure readout — never take input, or it kills pinch over its corner of the map.
+            .interactable(false)
             .anchor(egui::Align2::LEFT_BOTTOM, egui::vec2(14.0, dy))
             .show(ctx, |ui| {
                 let frame = mobile::glass(ui, 244).stroke(egui::Stroke::new(
@@ -7283,6 +7286,9 @@ impl HookEchoApp {
                 egui::Align2::RIGHT_TOP,
                 egui::vec2(crate::ui::style::LANE_RIGHT_BADGE_X, y),
             )
+            // Only the following state carries a button; the notice is a read-only badge and must
+            // not occlude the map's pinch test.
+            .interactable(following)
             .show(ctx, |ui| {
                 let fill = if following {
                     egui::Color32::from_rgba_unmultiplied(40, 90, 150, 220)
@@ -8302,9 +8308,19 @@ impl HookEchoApp {
         // would ALSO register as a drag and fight the zoom — the gesture block below owns both
         // pan and zoom while two fingers are down.
         let gesture = ui.input(|i| i.multi_touch());
+        if gesture.is_some() {
+            self.last_gesture_end = Some(std::time::Instant::now());
+        }
+        // A finger still down after the other lifted is the tail of a pinch, not a new drag or a
+        // tap on the map. 150 ms is long enough to cover a normal two-finger lift and short
+        // enough to be invisible when you really did mean to tap.
+        let gesture_tail = self
+            .last_gesture_end
+            .is_some_and(|t| t.elapsed().as_millis() < 150);
+        let quiet = gesture.is_none() && !gesture_tail;
         // The draw tool takes the drag away from the pan, the same deal the measure tool makes
         // with the click: while it's armed, a drag draws. Disarm it (Esc / another tool) to pan.
-        if self.tool == MapTool::Draw && gesture.is_none() {
+        if self.tool == MapTool::Draw && quiet {
             if response.dragged() {
                 self.active = idx;
                 if let Some(pos) = response.interact_pointer_pos() {
@@ -8320,7 +8336,7 @@ impl HookEchoApp {
                     );
                 }
             }
-        } else if response.dragged() && gesture.is_none() {
+        } else if response.dragged() && quiet {
             self.active = idx;
             let d = response.drag_delta();
             self.views[idx].camera.pan_pixels(d.x, d.y);
@@ -8366,11 +8382,9 @@ impl HookEchoApp {
                     .any(|r| r.contains(mt.center_pos));
             if prect.contains(mt.center_pos) && !occluded {
                 self.active = idx;
-                let t = mt.translation_delta;
-                if t != egui::Vec2::ZERO {
-                    self.views[idx].camera.pan_pixels(t.x, t.y);
-                    self.follow_cell = None; // a manual pan takes over the camera (pinch-zoom does not)
-                }
+                // Zoom first, then pan: the translation is in screen pixels, and applying it at
+                // the pre-zoom scale over-moves the map by the pinch's own scale factor — which is
+                // what made the anchor trail the fingers.
                 if (mt.zoom_delta - 1.0).abs() > f32::EPSILON {
                     let cursor = (
                         mt.center_pos.x - prect.left(),
@@ -8380,9 +8394,14 @@ impl HookEchoApp {
                         .camera
                         .zoom_at((mt.zoom_delta as f64).log2(), cursor, vp);
                 }
+                let t = mt.translation_delta;
+                if t != egui::Vec2::ZERO {
+                    self.views[idx].camera.pan_pixels(t.x, t.y);
+                    self.follow_cell = None; // a manual pan takes over the camera (pinch-zoom does not)
+                }
             }
         }
-        if response.clicked() {
+        if response.clicked() && quiet {
             self.active = idx;
             if let Some(pos) = response.interact_pointer_pos() {
                 let cam = self.views[idx].camera;
@@ -11083,7 +11102,8 @@ impl HookEchoApp {
             return;
         }
         let accent = crate::theme::accent(self.settings.theme);
-        let mut done = false;
+        // Any real interaction — a click, or a touch gesture — means the cards have been read.
+        let done = ctx.input(|i| i.pointer.any_click() || i.multi_touch().is_some());
         // Mobile has its own chrome (dock + sheets) and its own gestures, so it gets its own
         // three callouts rather than pointing at pills that aren't there.
         let marks: &[(&str, egui::Align2, egui::Vec2, &str)] = if cfg!(target_os = "android") {
@@ -11135,6 +11155,10 @@ impl HookEchoApp {
                 .constrain_to(self.chrome_rect)
                 .anchor(align, offset)
                 .order(egui::Order::Foreground)
+                // The map card sits dead center on a phone, and an interactable layer there makes
+                // every pinch a no-op until it's dismissed. The cards take no input at all; any
+                // tap or gesture anywhere dismisses the whole set (below).
+                .interactable(false)
                 .show(ctx, |ui| {
                     style::glass(ui, 240)
                         .stroke(egui::Stroke::new(1.5, accent))
@@ -11145,9 +11169,11 @@ impl HookEchoApp {
                                     .size(style::FONT_BASE)
                                     .color(egui::Color32::from_gray(238)),
                             );
-                            if ui.small_button("Got it").clicked() {
-                                done = true;
-                            }
+                            ui.label(
+                                egui::RichText::new("Tap anywhere to dismiss")
+                                    .size(style::FONT_SM)
+                                    .color(accent),
+                            );
                         });
                 });
         }
@@ -11310,6 +11336,9 @@ impl HookEchoApp {
                 egui::Align2::CENTER_BOTTOM,
                 egui::vec2(0.0, crate::ui::style::LANE_BOTTOM_CHASE),
             )
+            // Self-expires after HOLD_SECS, so it needs no dismiss click — and an interactable
+            // layer over the map blanks pinch wherever it sits.
+            .interactable(false)
             .show(ctx, |ui| {
                 crate::ui::style::glass(ui, 246)
                     .stroke(egui::Stroke::new(
@@ -11317,17 +11346,11 @@ impl HookEchoApp {
                         egui::Color32::from_rgb(230, 100, 100).gamma_multiply(0.8),
                     ))
                     .show(ui, |ui| {
-                        if ui
-                            .label(
-                                egui::RichText::new(&msg)
-                                    .size(crate::ui::style::FONT_BASE)
-                                    .color(egui::Color32::from_rgb(240, 150, 150)),
-                            )
-                            .on_hover_text("Click to dismiss")
-                            .clicked()
-                        {
-                            self.error_chip = None;
-                        }
+                        ui.label(
+                            egui::RichText::new(&msg)
+                                .size(crate::ui::style::FONT_BASE)
+                                .color(egui::Color32::from_rgb(240, 150, 150)),
+                        );
                     });
             });
     }

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1144,6 +1144,14 @@ enum DataMsg {
         view: usize,
         site: String,
     },
+    /// A loop frame fetched ahead of the playhead. Goes into the scan cache and nowhere else —
+    /// showing it would jump the display forward.
+    Prefetched {
+        view: usize,
+        site: String,
+        name: String,
+        scan: Scan,
+    },
     Error {
         view: usize,
         site: String,
@@ -1159,6 +1167,7 @@ impl DataMsg {
             | DataMsg::LiveEnded { view, .. }
             | DataMsg::Frames { view, .. }
             | DataMsg::UpToDate { view, .. }
+            | DataMsg::Prefetched { view, .. }
             | DataMsg::Error { view, .. } => *view,
         }
     }
@@ -1169,6 +1178,7 @@ impl DataMsg {
             | DataMsg::LiveEnded { site, .. }
             | DataMsg::Frames { site, .. }
             | DataMsg::UpToDate { site, .. }
+            | DataMsg::Prefetched { site, .. }
             | DataMsg::Error { site, .. } => site,
         }
     }
@@ -1342,6 +1352,9 @@ pub struct HookEchoApp {
     /// Decoded-volume LRU keyed by AWS object name, so scrubbing back and forth on the
     /// timeline doesn't re-download. ~10 volumes; each ~a few MB.
     scan_cache: LruCache<String, Arc<Scan>>,
+    /// Loop frames being fetched ahead of the playhead, with when they were kicked off. A fetch
+    /// whose result never arrives (site changed under it) ages out rather than blocking a retry.
+    prefetching: std::collections::HashMap<String, Instant>,
     // --- Overlays (severe-weather layers; geographic, shared across views) ---
     http: reqwest::Client,
     overlay_rx: Receiver<OverlayMsg>,
@@ -1879,6 +1892,11 @@ impl HookEchoApp {
         }
 
         let settings = Settings::load();
+        let scan_cache_cap = if cfg!(target_os = "android") {
+            settings.live_loop_frames.clamp(6, 16) + 2
+        } else {
+            30
+        };
         let mut tiles = TileManager::new(spawner.clone());
         let mut vtiles = crate::vector_tiles::VectorTileManager::new(spawner.clone());
         // Tile workers wake the UI the moment a tile is ready; without this a finished tile waits
@@ -1969,9 +1987,11 @@ impl HookEchoApp {
             // from RAM without re-downloading (~30 volumes ≈ 2.5 h at a 5-min cadence).
             // Phones can't hold a 2.5 h DVR buffer of decoded volumes — each is tens of MB and
             // Android kills the process long before the LRU fills.
-            scan_cache: LruCache::new(
-                NonZeroUsize::new(if cfg!(target_os = "android") { 6 } else { 30 }).unwrap(),
-            ),
+            // On Android the cap used to be 6 against a 10-frame loop window, so every wrap of the
+            // loop missed on every frame and re-downloaded the whole thing, forever. It has to
+            // hold the window plus the head and the frame being fetched.
+            prefetching: std::collections::HashMap::new(),
+            scan_cache: LruCache::new(NonZeroUsize::new(scan_cache_cap).unwrap()),
             http,
             overlay_rx,
             overlay_tx,
@@ -7779,6 +7799,11 @@ impl HookEchoApp {
                     self.pane_shown.remove(&view);
                 }
                 DataMsg::UpToDate { view, .. } => self.views[view].loading = false,
+                DataMsg::Prefetched { name, scan, .. } => {
+                    self.prefetching.remove(&name);
+
+                    self.scan_cache.put(name, Arc::new(scan));
+                }
                 DataMsg::Error { view, err, .. } => {
                     let v = &mut self.views[view];
                     v.loading = false;
@@ -8058,7 +8083,24 @@ impl HookEchoApp {
 
         // Advance playback (if playing) then reconcile the displayed volume with the timeline.
         self.views[idx].timeline.live_window = self.settings.live_loop_frames.max(1);
-        self.views[idx].timeline.tick();
+        // Hold the playhead while the next frame is still downloading. Advancing on the wall clock
+        // regardless meant playback skipped frames it hadn't got yet and the loop read as juddery;
+        // waiting reads as buffering, which is what it is. Only while there's a fetch to wait for,
+        // so a permanently-failed frame can't stall the loop.
+        let next_pending = {
+            let tl = &self.views[idx].timeline;
+            tl.playing
+                && tl
+                    .frames
+                    .get(tl.playhead + 1)
+                    .map(|id| id.name().to_string())
+                    .is_some_and(|n| {
+                        !self.scan_cache.contains(&n) && self.prefetching.contains_key(&n)
+                    })
+        };
+        if !next_pending {
+            self.views[idx].timeline.tick();
+        }
         // Playback paces itself rather than riding whatever the idle heartbeat happens to give
         // it: ask for a repaint exactly when the next frame is due.
         if let Some(dt) = self.views[idx].timeline.time_to_next_frame() {
@@ -8151,7 +8193,54 @@ impl HookEchoApp {
                         self.spawn_frame_fetch(idx, s, id, ctx.clone());
                     }
                 }
+                // Pull the next two frames in behind the playhead, on their own in-flight book
+                // so they never compete with the frame being shown or with the head poll. Without
+                // this, playback is a serial download per frame with the loop stalled between.
+                if self.views[idx].timeline.playing {
+                    self.prefetch_frames(idx, ctx);
+                }
             }
+        }
+    }
+
+    /// Fetch the two frames after the playhead into the scan cache, so playback isn't a serial
+    /// download-per-frame. At most two are in flight, and an entry that never comes back (its
+    /// site changed under it) ages out after a minute.
+    fn prefetch_frames(&mut self, idx: usize, ctx: &egui::Context) {
+        self.prefetching
+            .retain(|_, at| at.elapsed() < std::time::Duration::from_secs(60));
+        if self.prefetching.len() >= 2 {
+            return;
+        }
+        let Some(site) = self.views[idx].site.clone() else {
+            return;
+        };
+        let tl = &self.views[idx].timeline;
+        let next: Vec<Identifier> = (1..=2)
+            .filter_map(|d| tl.frames.get(tl.playhead + d))
+            .cloned()
+            .collect();
+        for id in next {
+            let name = id.name().to_string();
+            if self.scan_cache.contains(&name) || self.prefetching.contains_key(&name) {
+                continue;
+            }
+            self.prefetching.insert(name, Instant::now());
+            let tx = self.msg_tx.clone();
+            let (site, ctx) = (site.clone(), ctx.clone());
+            let view = idx;
+            self.spawner.spawn(async move {
+                let name = id.name().to_string();
+                if let Ok(scan) = level2::download_scan(id).await {
+                    let _ = tx.send(DataMsg::Prefetched {
+                        view,
+                        site,
+                        name,
+                        scan,
+                    });
+                    ctx.request_repaint();
+                }
+            });
         }
     }
 

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1331,7 +1331,13 @@ pub struct HookEchoApp {
     settings_checked: Option<Instant>,
     /// Frame counter, only used to invalidate within-frame memos.
     frame_nr: u64,
-    palette_cache: Option<(u64, Vec<PaletteEntry>)>,
+    palette_cache: Option<(u64, std::sync::Arc<[PaletteEntry]>)>,
+    /// Visible city/town labels, keyed by the visible tile ids and the label-set generation.
+    #[allow(clippy::type_complexity)]
+    vlabel_cache: Option<(
+        (Vec<crate::render::TileId>, u64),
+        Vec<crate::vector_tiles::PlaceLabel>,
+    )>,
     /// Last result of each per-volume detector, keyed by what it depends on (see `volume_key`).
     #[allow(clippy::type_complexity)]
     nowcast_cache: Option<(
@@ -1967,6 +1973,7 @@ impl HookEchoApp {
             settings_checked: None,
             frame_nr: 0,
             palette_cache: None,
+            vlabel_cache: None,
             nowcast_cache: None,
             tds_cache: None,
             couplet_cache: None,
@@ -5379,14 +5386,16 @@ impl HookEchoApp {
     /// frame (drawer, mobile sheets, legend, palette). Nothing can change it mid-frame — an
     /// action dispatched from one of those lists takes effect on the next one — so a per-frame
     /// memo is both free and honest.
-    pub(crate) fn palette_entries(&mut self) -> Vec<PaletteEntry> {
+    /// The command-palette action registry for this frame. Shared, not copied: the built list is
+    /// a few hundred owned Strings, and several call sites want it in the same frame.
+    pub(crate) fn palette_entries(&mut self) -> std::sync::Arc<[PaletteEntry]> {
         if let Some((frame, entries)) = &self.palette_cache {
             if *frame == self.frame_nr {
-                return entries.clone();
+                return std::sync::Arc::clone(entries);
             }
         }
-        let entries = self.palette_entries_build();
-        self.palette_cache = Some((self.frame_nr, entries.clone()));
+        let entries: std::sync::Arc<[PaletteEntry]> = self.palette_entries_build().into();
+        self.palette_cache = Some((self.frame_nr, std::sync::Arc::clone(&entries)));
         entries
     }
 
@@ -8856,12 +8865,24 @@ impl HookEchoApp {
             let vis = self.vtiles.visible(&cam, vp);
             self.vtiles.request_missing(&vis);
             let ids: Vec<crate::render::TileId> = vis.iter().map(|v| v.id).collect();
-            let labels: Vec<crate::vector_tiles::PlaceLabel> = self
-                .vtiles
-                .labels_for(ids.iter())
-                .into_iter()
-                .cloned()
-                .collect();
+            // Deep-copying every visible place name every frame (for every pane) showed up at the
+            // 4-10 fps the phone runs at. The set only changes when the visible tiles do, or when
+            // a tile's labels finish tessellating — both bump the key below.
+            let key = (ids.clone(), self.vtiles.label_generation());
+            if self.vlabel_cache.as_ref().is_none_or(|(k, _)| *k != key) {
+                let labels: Vec<crate::vector_tiles::PlaceLabel> = self
+                    .vtiles
+                    .labels_for(ids.iter())
+                    .into_iter()
+                    .cloned()
+                    .collect();
+                self.vlabel_cache = Some((key, labels));
+            }
+            let labels = self
+                .vlabel_cache
+                .as_ref()
+                .map(|(_, l)| l.clone())
+                .unwrap_or_default();
             (if is_vector { ids } else { Vec::new() }, labels, vis)
         };
         // Drain finished fetches once (on the first pane) — they upload into the shared cache.
@@ -12587,7 +12608,13 @@ impl eframe::App for HookEchoApp {
                 self.site_dialog = None;
             }
         }
-        let entries = self.palette_entries();
+        // Only the open settings window reads these; building the registry for a closed window
+        // was a few hundred String allocations every frame.
+        let entries = if self.settings_window.open {
+            self.palette_entries()
+        } else {
+            std::sync::Arc::from(Vec::new())
+        };
         let sync_view = ui::settings_window::SyncView {
             signed_in: self.sync_tokens.is_some(),
             status: &self.sync_status,
@@ -12619,14 +12646,18 @@ impl eframe::App for HookEchoApp {
             .show(ctx, &mut self.settings, &pf_status);
         // Names come from the action registry, so a layer reads the same here as in the layers
         // panel — the enum's Debug spelling ("Mrms") is not a label.
-        let names: std::collections::HashMap<crate::render::FieldLayer, String> = self
-            .palette_entries()
-            .into_iter()
-            .filter_map(|e| match e.action {
-                PaletteAction::ToggleField(l) => Some((l, e.label)),
-                _ => None,
-            })
-            .collect();
+        let names: std::collections::HashMap<crate::render::FieldLayer, String> =
+            if self.layer_window_open {
+                self.palette_entries()
+                    .iter()
+                    .filter_map(|e| match e.action {
+                        PaletteAction::ToggleField(l) => Some((l, e.label.clone())),
+                        _ => None,
+                    })
+                    .collect()
+            } else {
+                Default::default()
+            };
         let active_fields: Vec<(crate::render::FieldLayer, String)> =
             crate::render::FieldLayer::DRAW_ORDER
                 .into_iter()

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -8762,7 +8762,7 @@ impl HookEchoApp {
         // Always run the vector-tile pipeline for its city/town labels — raster basemaps (satellite)
         // bake in faint labels that are hard to read, so we overlay crisp haloed ones. Only the
         // *geometry* is basemap-specific: vector basemaps draw it, raster keeps its own imagery.
-        let (visible_vector, vlabels) = {
+        let (visible_vector, vlabels, visible_vector_tiles) = {
             let vis = self.vtiles.visible(&cam, vp);
             self.vtiles.request_missing(&vis);
             let ids: Vec<crate::render::TileId> = vis.iter().map(|v| v.id).collect();
@@ -8772,13 +8772,19 @@ impl HookEchoApp {
                 .into_iter()
                 .cloned()
                 .collect();
-            (if is_vector { ids } else { Vec::new() }, labels)
+            (if is_vector { ids } else { Vec::new() }, labels, vis)
         };
         // Drain finished fetches once (on the first pane) — they upload into the shared cache.
         // Eviction lives with the tile manager (it also owns `requested`/`uploaded`), and only
         // the first pane runs it so a multi-pane frame doesn't evict what a later pane needs.
         let drop_tiles = if first && is_raster {
             self.tiles.touch_visible(&visible)
+        } else {
+            Vec::new()
+        };
+        let drop_vector_tiles = if first {
+            self.vtiles.touch_visible(&visible_vector_tiles);
+            self.vtiles.take_evicted()
         } else {
             Vec::new()
         };
@@ -8847,6 +8853,7 @@ impl HookEchoApp {
             new_vector_tiles,
             visible_vector,
             clear_vector,
+            drop_vector_tiles,
         };
         ui.painter()
             .add(egui_wgpu::Callback::new_paint_callback(prect, cb));

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1110,6 +1110,13 @@ struct LoadedPlacefile {
 }
 
 /// A background fetch result routed back to a specific view.
+/// Loop frames a phone keeps decoded at once. Each volume is tens of MB; a longer loop than this
+/// pushes the process into the range Android kills.
+#[cfg(target_os = "android")]
+const ANDROID_LOOP_WINDOW: usize = 6;
+#[cfg(not(target_os = "android"))]
+const ANDROID_LOOP_WINDOW: usize = 6;
+
 enum DataMsg {
     Volume {
         view: usize,
@@ -1359,7 +1366,8 @@ pub struct HookEchoApp {
     /// timeline doesn't re-download. ~10 volumes; each ~a few MB.
     scan_cache: LruCache<String, Arc<Scan>>,
     /// Loop frames being fetched ahead of the playhead, with when they were kicked off. A fetch
-    /// whose result never arrives (site changed under it) ages out rather than blocking a retry.
+    /// whose result never arrives (it failed, or the site changed under it) ages out rather than
+    /// blocking a retry — nothing here is ever waited on indefinitely.
     prefetching: std::collections::HashMap<String, Instant>,
     // --- Overlays (severe-weather layers; geographic, shared across views) ---
     http: reqwest::Client,
@@ -1898,8 +1906,12 @@ impl HookEchoApp {
         }
 
         let settings = Settings::load();
+        // A decoded volume is tens of MB, so the phone's cache is sized to the loop window it can
+        // actually afford (see ANDROID_LOOP_WINDOW) plus the head and the frame in flight —
+        // enough that a loop stops re-downloading itself on every wrap, without the ~900 MB RSS
+        // that holding a full desktop-sized window cost.
         let scan_cache_cap = if cfg!(target_os = "android") {
-            settings.live_loop_frames.clamp(6, 16) + 2
+            ANDROID_LOOP_WINDOW + 2
         } else {
             30
         };
@@ -8092,7 +8104,11 @@ impl HookEchoApp {
         }
 
         // Advance playback (if playing) then reconcile the displayed volume with the timeline.
-        self.views[idx].timeline.live_window = self.settings.live_loop_frames.max(1);
+        self.views[idx].timeline.live_window = if cfg!(target_os = "android") {
+            self.settings.live_loop_frames.clamp(1, ANDROID_LOOP_WINDOW)
+        } else {
+            self.settings.live_loop_frames.max(1)
+        };
         // Hold the playhead while the next frame is still downloading. Advancing on the wall clock
         // regardless meant playback skipped frames it hadn't got yet and the loop read as juddery;
         // waiting reads as buffering, which is what it is. Only while there's a fetch to wait for,
@@ -8105,7 +8121,11 @@ impl HookEchoApp {
                     .get(tl.playhead + 1)
                     .map(|id| id.name().to_string())
                     .is_some_and(|n| {
-                        !self.scan_cache.contains(&n) && self.prefetching.contains_key(&n)
+                        !self.scan_cache.contains(&n)
+                            && self.prefetching.get(&n).is_some_and(|at| {
+                                // Bounded: a fetch that never answers must not park the loop.
+                                at.elapsed() < std::time::Duration::from_secs(8)
+                            })
                     })
         };
         if !next_pending {
@@ -8248,7 +8268,7 @@ impl HookEchoApp {
     /// site changed under it) ages out after a minute.
     fn prefetch_frames(&mut self, idx: usize, ctx: &egui::Context) {
         self.prefetching
-            .retain(|_, at| at.elapsed() < std::time::Duration::from_secs(60));
+            .retain(|_, at| at.elapsed() < std::time::Duration::from_secs(15));
         if self.prefetching.len() >= 2 {
             return;
         }

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -8346,10 +8346,20 @@ impl HookEchoApp {
             // The mobile chrome floats over the map, and `multi_touch()` is raw input with no
             // notion of which layer the fingers are on — so a pinch on the bottom sheet used to
             // zoom the map underneath it. The chrome publishes what it covers; skip those rects.
-            // Explicit rects cover the always-on chrome; `is_pointer_over_area` covers every
-            // window and popup on top of it, which is what keeps a pinch on a Skew-T or a
-            // full-screen settings surface from also zooming the map behind it.
-            let occluded = ui.ctx().is_pointer_over_egui()
+            // Explicit rects cover the always-on chrome; the layer test covers every window and
+            // popup on top of it, which is what keeps a pinch on a Skew-T or a full-screen
+            // settings surface from also zooming the map behind it.
+            // `is_pointer_over_egui()` cannot be used here: it tests egui's single pointer
+            // position, which during a two-finger gesture is one arbitrary finger, and it treats
+            // the map's own background layer as "over egui" once the central panel has consumed
+            // the root ui's available rect — so it answered true over bare map and killed every
+            // pinch. Ask about the gesture's own center instead: any layer above the background
+            // there is real chrome.
+            let over_layer = ui
+                .ctx()
+                .layer_id_at(mt.center_pos)
+                .is_some_and(|l| l.order != egui::Order::Background);
+            let occluded = over_layer
                 || self
                     .mobile_occlusion
                     .iter()

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1879,14 +1879,24 @@ impl HookEchoApp {
         }
 
         let settings = Settings::load();
-        let tiles = TileManager::new(spawner.clone());
-        let vtiles = crate::vector_tiles::VectorTileManager::new(spawner.clone());
+        let mut tiles = TileManager::new(spawner.clone());
+        let mut vtiles = crate::vector_tiles::VectorTileManager::new(spawner.clone());
+        // Tile workers wake the UI the moment a tile is ready; without this a finished tile waits
+        // for the next repaint the app happens to want.
+        tiles.set_ctx(cc.egui_ctx.clone());
+        vtiles.set_ctx(cc.egui_ctx.clone());
         let (msg_tx, msg_rx) = std::sync::mpsc::channel();
         let (overlay_tx, overlay_rx) = std::sync::mpsc::channel();
         let (update_tx, update_rx) = std::sync::mpsc::channel();
         let (geocode_tx, geocode_rx) = std::sync::mpsc::channel();
         let (pf_icon_tx, pf_icon_rx) = std::sync::mpsc::channel();
-        let http = reqwest::Client::new();
+        // Every app-level fetch (alerts, overlays, placefiles, radar index) goes through this one.
+        // A hung request with no timeout leaves whatever it was loading stuck loading forever.
+        let http = reqwest::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .unwrap_or_default();
 
         // Open on the saved startup view if set (and its site still resolves), else where the app
         // was last looking, else the default site.

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -8213,6 +8213,31 @@ impl HookEchoApp {
         }
     }
 
+    /// Debug builds only: frame time and tile-queue depth in the top-left corner. `dumpsys
+    /// gfxinfo` and logcat cover most of what this shows, but neither says which frames were slow
+    /// while a gesture was in progress.
+    ///
+    /// ponytail: an unsmoothed millisecond readout, no history graph. Add one if a single number
+    /// stops being enough to tell a stutter from a stall.
+    #[cfg(debug_assertions)]
+    fn frame_time_overlay(&mut self, ctx: &egui::Context) {
+        let dt = ctx.input(|i| i.unstable_dt) * 1000.0;
+        let text = format!("{dt:.1} ms  ({:.0} fps)", 1000.0 / dt.max(0.001));
+        egui::Area::new(egui::Id::new("frame_time_overlay"))
+            .anchor(egui::Align2::LEFT_TOP, egui::vec2(6.0, 6.0))
+            .order(egui::Order::Tooltip)
+            .interactable(false)
+            .show(ctx, |ui| {
+                ui.label(
+                    egui::RichText::new(text)
+                        .monospace()
+                        .size(11.0)
+                        .color(egui::Color32::from_rgb(120, 255, 120))
+                        .background_color(egui::Color32::from_black_alpha(160)),
+                );
+            });
+    }
+
     /// Fetch the two frames after the playhead into the scan cache, so playback isn't a serial
     /// download-per-frame. At most two are in flight, and an entry that never comes back (its
     /// site changed under it) ages out after a minute.
@@ -11992,6 +12017,8 @@ impl eframe::App for HookEchoApp {
         // `platform::activity`). A frame that follows a gap means the app just came back, so
         // force one refresh rather than making the user wait out the poll interval.
         self.frame_nr = self.frame_nr.wrapping_add(1);
+        #[cfg(debug_assertions)]
+        self.frame_time_overlay(ctx);
         let focused = ctx.input(|i| i.viewport().focused.unwrap_or(true));
         if crate::platform::activity::mark_frame(focused) {
             self.overlay_last_fetch = None;

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -8741,12 +8741,17 @@ impl HookEchoApp {
         } else {
             1.0
         };
-        let raster_bias = ctx
-            .pixels_per_point()
-            .max(1.0)
-            .log2()
-            .round()
-            .clamp(0.0, bias_cap) as f64;
+        let raster_bias = if self.views[idx].basemap.tiles_are_512() {
+            // 512-px providers already carry the extra detail in the tile itself; biasing on top
+            // would fetch four of them per screen tile for nothing.
+            0.0
+        } else {
+            ctx.pixels_per_point()
+                .max(1.0)
+                .log2()
+                .round()
+                .clamp(0.0, bias_cap) as f64
+        };
         let visible = if is_raster {
             let vis = self.tiles.visible(&cam, vp, raster_bias);
             self.tiles.request_missing(&vis);

--- a/crates/hookecho/src/app/mobile/mod.rs
+++ b/crates/hookecho/src/app/mobile/mod.rs
@@ -286,23 +286,32 @@ impl super::HookEchoApp {
 
         // Owned alert rows (decoupled from `&self`) so the Alerts drawer can list + fly to them.
         let bounds = self.view_bounds();
-        let malerts: Vec<MAlert> = {
+        // Only the open Alerts sheet needs the owned rows; the dock badge just needs the count and
+        // the top escalation, which cost nothing to compute. Building the full list every frame
+        // meant several String clones per alert in view at 4-10 fps.
+        let want_rows = self.mobile_sheet == MobileSheet::Alerts;
+        let (malerts, alert_count, max_esc): (Vec<MAlert>, usize, u8) = {
             let feats = self.active_alert_features();
-            crate::ui::alert_panel::rows_in_view(feats, bounds)
-                .into_iter()
-                .map(|r| MAlert {
-                    id: r.info.id.clone(),
-                    title: r.info.event.clone(),
-                    sub: r.info.area.clone(),
-                    color: Color32::from_rgb(r.color[0], r.color[1], r.color[2]),
-                    lon: r.center.0,
-                    lat: r.center.1,
-                    esc: r.esc,
-                })
-                .collect()
+            let rows = crate::ui::alert_panel::rows_in_view(feats, bounds);
+            let count = rows.len();
+            let max_esc = rows.iter().map(|r| r.esc).max().unwrap_or(0);
+            let owned = if want_rows {
+                rows.into_iter()
+                    .map(|r| MAlert {
+                        id: r.info.id.clone(),
+                        title: r.info.event.clone(),
+                        sub: r.info.area.clone(),
+                        color: Color32::from_rgb(r.color[0], r.color[1], r.color[2]),
+                        lon: r.center.0,
+                        lat: r.center.1,
+                        esc: r.esc,
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            };
+            (owned, count, max_esc)
         };
-        let alert_count = malerts.len();
-        let max_esc = malerts.iter().map(|a| a.esc).max().unwrap_or(0);
 
         // Read-only copies used by closures that also write back (avoids borrow conflicts).
         let site = self.views[active]

--- a/crates/hookecho/src/headless.rs
+++ b/crates/hookecho/src/headless.rs
@@ -695,6 +695,7 @@ pub fn run_live(out_path: &str, site: &str, moment: Moment) -> anyhow::Result<()
             None => level2::download_latest_scan(site, day).await?,
         };
         println!("base volume: {} sweeps", base.sweeps().len());
+        let base = std::sync::Arc::new(base);
 
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         let site_owned = site.to_string();

--- a/crates/hookecho/src/headless.rs
+++ b/crates/hookecho/src/headless.rs
@@ -238,6 +238,7 @@ pub fn run(
         new_vector_tiles,
         visible_vector,
         clear_vector: false,
+        drop_vector_tiles: Vec::new(),
     };
     render_to_png(&rt, cb, out_path)
 }
@@ -285,6 +286,7 @@ pub fn run_multipane(site: &str, out_a: &str, out_b: &str) -> anyhow::Result<()>
             new_vector_tiles: Vec::new(),
             visible_vector: Vec::new(),
             clear_vector: false,
+            drop_vector_tiles: Vec::new(),
         }
     };
 
@@ -747,6 +749,7 @@ pub fn run_live(out_path: &str, site: &str, moment: Moment) -> anyhow::Result<()
         new_vector_tiles: Vec::new(),
         visible_vector: Vec::new(),
         clear_vector: false,
+        drop_vector_tiles: Vec::new(),
     };
     render_to_png(&rt, cb, out_path)
 }
@@ -826,6 +829,7 @@ pub fn run_placefile(path: &str, out_path: &str) -> anyhow::Result<()> {
         new_vector_tiles: Vec::new(),
         visible_vector: Vec::new(),
         clear_vector: false,
+        drop_vector_tiles: Vec::new(),
     };
     render_to_png(&rt, cb, out_path)
 }
@@ -881,6 +885,7 @@ pub fn run_overlay(out_path: &str) -> anyhow::Result<()> {
         new_vector_tiles,
         visible_vector,
         clear_vector: false,
+        drop_vector_tiles: Vec::new(),
     };
     render_to_png(&rt, cb, out_path)
 }
@@ -974,6 +979,7 @@ pub fn run_mrms(out_path: &str) -> anyhow::Result<()> {
         new_vector_tiles,
         visible_vector,
         clear_vector: false,
+        drop_vector_tiles: Vec::new(),
     };
     render_to_png(&rt, cb, out_path)
 }
@@ -1024,6 +1030,7 @@ pub fn run_lightning(out_path: &str) -> anyhow::Result<()> {
         new_vector_tiles,
         visible_vector,
         clear_vector: false,
+        drop_vector_tiles: Vec::new(),
     };
     render_to_png(&rt, cb, out_path)
 }
@@ -1090,6 +1097,7 @@ pub fn run_field(slug: &str, out_path: &str) -> anyhow::Result<()> {
         new_vector_tiles,
         visible_vector,
         clear_vector: false,
+        drop_vector_tiles: Vec::new(),
     };
     render_to_png(&rt, cb, out_path)
 }
@@ -1363,6 +1371,7 @@ pub fn run_l3grid(kind: &str, site: &str, out_path: &str) -> anyhow::Result<()> 
         new_vector_tiles,
         visible_vector,
         clear_vector: false,
+        drop_vector_tiles: Vec::new(),
     };
     render_to_png(&rt, cb, out_path)
 }
@@ -1431,6 +1440,7 @@ pub fn run_env(slug: &str, out_path: &str) -> anyhow::Result<()> {
         new_vector_tiles,
         visible_vector,
         clear_vector: false,
+        drop_vector_tiles: Vec::new(),
     };
     render_to_png(&rt, cb, out_path)
 }
@@ -1608,6 +1618,7 @@ pub fn run_hrrr_layer(
         new_vector_tiles,
         visible_vector,
         clear_vector: false,
+        drop_vector_tiles: Vec::new(),
     };
     render_to_png(&rt, cb, out_path)
 }
@@ -1639,6 +1650,7 @@ fn render_field_png(
         new_vector_tiles,
         visible_vector,
         clear_vector: false,
+        drop_vector_tiles: Vec::new(),
     };
     render_to_png(rt, cb, out_path)
 }

--- a/crates/hookecho/src/render/mercator.rs
+++ b/crates/hookecho/src/render/mercator.rs
@@ -62,7 +62,10 @@ impl Camera {
     /// Zoom toward a screen point (cursor) so that world point stays under the cursor.
     pub fn zoom_at(&mut self, delta: f64, cursor_px: (f32, f32), viewport_px: (f32, f32)) {
         let before = self.screen_to_world(cursor_px, viewport_px);
-        self.zoom = (self.zoom + delta).clamp(2.0, 18.0);
+        // 20 rather than the tile providers' 18: `tile_cover` clamps the tile z on its own, so the
+        // last two levels overzoom the resident tiles instead of turning a spread-pinch into a
+        // silent no-op — which is what it felt like at the old ceiling.
+        self.zoom = (self.zoom + delta).clamp(2.0, 20.0);
         let after = self.screen_to_world(cursor_px, viewport_px);
         self.center.0 += before.0 - after.0;
         self.center.1 += before.1 - after.1;

--- a/crates/hookecho/src/render/mod.rs
+++ b/crates/hookecho/src/render/mod.rs
@@ -209,6 +209,8 @@ pub struct MapCallback {
     pub visible_vector: Vec<TileId>,
     /// Drop all cached vector tiles before uploading (style or tess-zoom changed).
     pub clear_vector: bool,
+    /// Individual vector tiles the manager evicted; freed before this frame's uploads.
+    pub drop_vector_tiles: Vec<TileId>,
 }
 
 #[repr(C)]
@@ -267,7 +269,9 @@ struct PaneGpu {
     tile_vbuf: wgpu::Buffer,
     radar_vbuf: wgpu::Buffer,
     radar: Option<RadarGpu>,
-    frame_visible: Vec<VisibleTile>,
+    /// Ids of the tiles this frame's quads draw, in quad order. Not the same as the visible list:
+    /// a missing tile is stood in for by resident children or an ancestor.
+    frame_visible: Vec<TileId>,
     frame_visible_vector: Vec<TileId>,
     frame_draw_radar: bool,
     frame_draw_overlay: bool,
@@ -586,6 +590,51 @@ impl RenderResources {
         })
     }
 
+    /// Quads to draw for one visible tile: normally itself, but if its texture hasn't arrived,
+    /// whatever resident neighbours in the pyramid cover the same ground.
+    ///
+    /// Children first (pinch-out: the level we came from is still resident and sharper), each
+    /// covering its quarter with the full texture. Otherwise the nearest resident ancestor, up to
+    /// three levels up, drawn once with its UVs cropped to the part this tile occupies. Without
+    /// this the whole basemap blanks every time the integer zoom level changes, even though the
+    /// pixels to show are sitting on the GPU.
+    #[allow(clippy::type_complexity)] // one call site; a struct here would be ceremony
+    fn tile_quads(&self, v: &VisibleTile) -> Vec<(TileId, [f32; 2], [f32; 2], [f32; 2], [f32; 2])> {
+        const FULL: ([f32; 2], [f32; 2]) = ([0.0, 0.0], [1.0, 1.0]);
+        if self.tiles.contains_key(&v.id) {
+            return vec![(v.id, v.world_min, v.world_max, FULL.0, FULL.1)];
+        }
+        let (z, x, y) = v.id;
+        let [x0, y0] = v.world_min;
+        let [x1, y1] = v.world_max;
+        let (mx, my) = ((x0 + x1) / 2.0, (y0 + y1) / 2.0);
+        let kids: Vec<_> = [(0u32, 0u32), (1, 0), (0, 1), (1, 1)]
+            .into_iter()
+            .filter_map(|(dx, dy)| {
+                let id = (z + 1, x * 2 + dx, y * 2 + dy);
+                self.tiles.contains_key(&id).then(|| {
+                    let (qx0, qx1) = if dx == 0 { (x0, mx) } else { (mx, x1) };
+                    let (qy0, qy1) = if dy == 0 { (y0, my) } else { (my, y1) };
+                    (id, [qx0, qy0], [qx1, qy1], FULL.0, FULL.1)
+                })
+            })
+            .collect();
+        if !kids.is_empty() {
+            return kids;
+        }
+        for up in 1..=3u8 {
+            if up > z {
+                break;
+            }
+            let id = (z - up, x >> up, y >> up);
+            if self.tiles.contains_key(&id) {
+                let (uv_min, uv_max) = ancestor_uv(x, y, up);
+                return vec![(id, v.world_min, v.world_max, uv_min, uv_max)];
+            }
+        }
+        Vec::new()
+    }
+
     fn upload_tile(&mut self, device: &wgpu::Device, queue: &wgpu::Queue, t: &PendingTile) {
         let size = wgpu::Extent3d {
             width: t.width,
@@ -749,6 +798,9 @@ impl RenderResources {
         if cb.clear_vector {
             self.vector_tiles.clear();
         }
+        for id in &cb.drop_vector_tiles {
+            self.vector_tiles.remove(id);
+        }
         for t in &cb.new_vector_tiles {
             self.upload_vector_tile(device, t);
         }
@@ -787,45 +839,45 @@ impl RenderResources {
             .radar_upload
             .as_ref()
             .map(|r| self.build_radar(device, queue, r));
-        // Build the tile quad list against the shared tile cache before mutably borrowing the pane.
+        // Build the tile quad list against the shared tile cache before mutably borrowing the pane
+        // — a tile with no texture yet borrows one from the tiles around it (see `tile_quads`).
         let mut tverts: Vec<TileVertex> = Vec::new();
-        let mut visible: Vec<VisibleTile> = Vec::new();
+        let mut visible: Vec<TileId> = Vec::new();
         for v in &cb.visible {
-            if tverts.len() as u64 + 6 > MAX_TILE_VERTS {
-                break;
+            for (id, wmin, wmax, uvmin, uvmax) in self.tile_quads(v) {
+                if tverts.len() as u64 + 6 > MAX_TILE_VERTS {
+                    break;
+                }
+                let ([x0, y0], [x1, y1]) = (wmin, wmax);
+                let ([u0, t0], [u1, t1]) = (uvmin, uvmax);
+                tverts.extend_from_slice(&[
+                    TileVertex {
+                        world: [x0, y0],
+                        uv: [u0, t0],
+                    },
+                    TileVertex {
+                        world: [x1, y0],
+                        uv: [u1, t0],
+                    },
+                    TileVertex {
+                        world: [x1, y1],
+                        uv: [u1, t1],
+                    },
+                    TileVertex {
+                        world: [x0, y0],
+                        uv: [u0, t0],
+                    },
+                    TileVertex {
+                        world: [x1, y1],
+                        uv: [u1, t1],
+                    },
+                    TileVertex {
+                        world: [x0, y1],
+                        uv: [u0, t1],
+                    },
+                ]);
+                visible.push(id);
             }
-            if !self.tiles.contains_key(&v.id) {
-                continue;
-            }
-            let [x0, y0] = v.world_min;
-            let [x1, y1] = v.world_max;
-            tverts.extend_from_slice(&[
-                TileVertex {
-                    world: [x0, y0],
-                    uv: [0.0, 0.0],
-                },
-                TileVertex {
-                    world: [x1, y0],
-                    uv: [1.0, 0.0],
-                },
-                TileVertex {
-                    world: [x1, y1],
-                    uv: [1.0, 1.0],
-                },
-                TileVertex {
-                    world: [x0, y0],
-                    uv: [0.0, 0.0],
-                },
-                TileVertex {
-                    world: [x1, y1],
-                    uv: [1.0, 1.0],
-                },
-                TileVertex {
-                    world: [x0, y1],
-                    uv: [0.0, 1.0],
-                },
-            ]);
-            visible.push(*v);
         }
         let overlay_present = self.overlay.is_some();
 
@@ -1066,8 +1118,8 @@ impl RenderResources {
         pass.set_pipeline(&self.tile_pipeline);
         pass.set_bind_group(0, cam, &[]);
         pass.set_vertex_buffer(0, pane.tile_vbuf.slice(..));
-        for (i, v) in pane.frame_visible.iter().enumerate() {
-            if let Some(tile) = self.tiles.get(&v.id) {
+        for (i, id) in pane.frame_visible.iter().enumerate() {
+            if let Some(tile) = self.tiles.get(id) {
                 pass.set_bind_group(1, &tile.bind_group, &[]);
                 let base = (i * 6) as u32;
                 pass.draw(base..base + 6, 0..1);
@@ -1174,5 +1226,33 @@ impl egui_wgpu::CallbackTrait for MapCallback {
         crate::prof_scope!("render paint");
         let res: &RenderResources = resources.get().unwrap();
         res.record_pane(self.pane, pass);
+    }
+}
+
+/// Where tile `(x, y)` sits inside the ancestor `up` levels above it, in that ancestor's UV space.
+/// `up = 1` gives one of four quadrants, `up = 2` one of sixteen, and so on.
+fn ancestor_uv(x: u32, y: u32, up: u8) -> ([f32; 2], [f32; 2]) {
+    let n = (1u32 << up) as f32;
+    let fx = (x & ((1 << up) - 1)) as f32 / n;
+    let fy = (y & ((1 << up) - 1)) as f32 / n;
+    ([fx, fy], [fx + 1.0 / n, fy + 1.0 / n])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ancestor_uv;
+
+    #[test]
+    fn ancestor_uv_picks_the_right_quadrant() {
+        // Direct parent: (x, y) = (3, 2) is the odd column, even row -> right/top quadrant.
+        assert_eq!(ancestor_uv(3, 2, 1), ([0.5, 0.0], [1.0, 0.5]));
+        assert_eq!(ancestor_uv(2, 3, 1), ([0.0, 0.5], [0.5, 1.0]));
+        // Two levels up: sixteenths, and only the low bits matter.
+        assert_eq!(ancestor_uv(0, 0, 2), ([0.0, 0.0], [0.25, 0.25]));
+        assert_eq!(ancestor_uv(7, 5, 2), ([0.75, 0.25], [1.0, 0.5]));
+        // Three levels up: the whole ancestor is still covered exactly.
+        let (min, max) = ancestor_uv(7, 7, 3);
+        assert_eq!(min, [0.875, 0.875]);
+        assert_eq!(max, [1.0, 1.0]);
     }
 }

--- a/crates/hookecho/src/tiles.rs
+++ b/crates/hookecho/src/tiles.rs
@@ -312,6 +312,14 @@ impl BasemapStyle {
         }
     }
 
+    /// Whether this style's tiles are 512 px rather than 256. Mapbox and MapTiler both serve the
+    /// same tile grid at either size, so one 512 tile replaces the four 256 tiles a high-DPI
+    /// screen would otherwise fetch a level deeper — same pixels on screen, a quarter of the
+    /// requests. Callers use this to drop the retina zoom bias.
+    pub fn tiles_are_512(self) -> bool {
+        matches!(self.provider_kind(), Provider::Mapbox | Provider::MapTiler)
+    }
+
     /// Is this style selectable given which provider keys are set?
     pub fn available(self, mapbox_key: bool, maptiler_key: bool) -> bool {
         match self.provider_kind() {
@@ -334,8 +342,14 @@ impl BasemapStyle {
     }
 
     /// Per-style cache subdir so sources don't collide on disk. Keys never appear here.
-    fn provider(self) -> &'static str {
-        self.slug()
+    fn provider(self) -> String {
+        // 512-px tiles share the tile grid with the 256-px ones they replace, so a cache written
+        // before the switch would keep serving blurry 256s from the same paths. Separate dir.
+        if self.tiles_are_512() {
+            format!("{}-512", self.slug())
+        } else {
+            self.slug().to_string()
+        }
     }
 
     /// Mapbox style-id / MapTiler map-id used in the tile URL.
@@ -417,14 +431,14 @@ impl BasemapStyle {
             },
             Provider::Mapbox => (!mapbox_key.is_empty()).then(|| {
                 format!(
-                    "https://api.mapbox.com/styles/v1/mapbox/{}/tiles/256/{z}/{x}/{y}?access_token={mapbox_key}",
+                    "https://api.mapbox.com/styles/v1/mapbox/{}/tiles/512/{z}/{x}/{y}?access_token={mapbox_key}",
                     self.style_id()
                 )
             }),
             Provider::MapTiler => (!maptiler_key.is_empty()).then(|| {
                 let ext = if self == BasemapStyle::MapTilerSatellite { "jpg" } else { "png" };
                 format!(
-                    "https://api.maptiler.com/maps/{}/256/{z}/{x}/{y}.{ext}?key={maptiler_key}",
+                    "https://api.maptiler.com/maps/{}/{z}/{x}/{y}.{ext}?key={maptiler_key}",
                     self.style_id()
                 )
             }),

--- a/crates/hookecho/src/tiles.rs
+++ b/crates/hookecho/src/tiles.rs
@@ -566,11 +566,30 @@ struct FetchedTile {
     height: u32,
 }
 
+/// A finished fetch, or the id of one that failed (so it can leave `requested` and be retried).
+type TileResult = Result<FetchedTile, TileId>;
+
+/// How many tile fetches may be in flight at once. A screenful is ~28 tiles, and firing all of
+/// them at a CDN at once means 28 TLS handshakes competing for the same radio: the first tile
+/// lands later than it would have with a queue behind it.
+const MAX_INFLIGHT: usize = 6;
+
+/// How long a failed tile is left alone before the next visibility pass retries it.
+const RETRY_AFTER: std::time::Duration = std::time::Duration::from_secs(5);
+
 pub struct TileManager {
     spawner: crate::rt::Spawner,
     client: reqwest::Client,
-    tx: Sender<FetchedTile>,
-    rx: Receiver<FetchedTile>,
+    tx: Sender<TileResult>,
+    rx: Receiver<TileResult>,
+    /// Repaint handle. Tile fetches finish on a worker thread; without this the frame that would
+    /// show them waits for whatever wakes egui next — on Android an idle heartbeat up to 250 ms
+    /// away, per tile.
+    ctx: Option<egui::Context>,
+    /// Fetches currently in flight, shared with the tasks so they can decrement on the way out.
+    inflight: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    /// Tiles whose fetch failed, and when. Retried after [`RETRY_AFTER`].
+    failed: std::collections::HashMap<TileId, std::time::Instant>,
     requested: HashSet<TileId>,
     /// Tiles believed to be live on the GPU, newest-touched first. This mirrors the renderer's
     /// tile map exactly: the CPU side decides what gets evicted and tells the renderer, so the
@@ -591,6 +610,10 @@ impl TileManager {
         let (tx, rx) = std::sync::mpsc::channel();
         let client = reqwest::Client::builder()
             .user_agent(USER_AGENT)
+            // Without these a request that never answers holds its slot forever: the tile stays in
+            // `requested`, so that square of map is permanently blank.
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(30))
             .build()
             .expect("build reqwest client");
         let cache_root = crate::paths::cache_dir().map(|d| d.join("tiles"));
@@ -602,6 +625,9 @@ impl TileManager {
             client,
             tx,
             rx,
+            ctx: None,
+            inflight: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            failed: std::collections::HashMap::new(),
             requested: HashSet::new(),
             uploaded: LruCache::new(NonZeroUsize::new(RASTER_TILE_CACHE).unwrap()),
             evicted: Vec::new(),
@@ -661,9 +687,21 @@ impl TileManager {
 
     /// Kick off fetches for any visible tiles not yet requested.
     pub fn request_missing(&mut self, visible: &[VisibleTile]) {
+        use std::sync::atomic::Ordering;
         for v in visible {
             if self.requested.contains(&v.id) {
                 continue;
+            }
+            if self
+                .failed
+                .get(&v.id)
+                .is_some_and(|t| t.elapsed() < RETRY_AFTER)
+            {
+                continue;
+            }
+            // Queue the rest for a later pass rather than dumping a whole screenful on the radio.
+            if self.inflight.load(Ordering::Relaxed) >= MAX_INFLIGHT {
+                break;
             }
             let (z, x, y) = v.id;
             let Some(mut url) = self
@@ -693,19 +731,34 @@ impl TileManager {
             });
             let client = self.client.clone();
             let tx = self.tx.clone();
+            let ctx = self.ctx.clone();
+            let inflight = self.inflight.clone();
+            let blocking = self.spawner.clone();
+            self.inflight.fetch_add(1, Ordering::Relaxed);
             self.spawner.spawn(async move {
-                if let Ok(bytes) = load_tile_bytes(&client, &url, path.as_deref()).await {
-                    if let Ok(img) = image::load_from_memory(&bytes) {
-                        let rgba = img.to_rgba8();
-                        let (w, h) = rgba.dimensions();
-                        let _ = tx.send(FetchedTile {
-                            id: (z, x, y),
-                            rgba: rgba.into_raw(),
-                            width: w,
-                            height: h,
+                let bytes = load_tile_bytes(&client, &url, path.as_deref()).await;
+                // PNG/JPEG decode is pure CPU and would otherwise run on the async worker, where
+                // it stalls every other fetch sharing that thread.
+                blocking.spawn_blocking(move || {
+                    let decoded = bytes
+                        .ok()
+                        .and_then(|b| image::load_from_memory(&b).ok())
+                        .map(|img| {
+                            let rgba = img.to_rgba8();
+                            let (w, h) = rgba.dimensions();
+                            FetchedTile {
+                                id: (z, x, y),
+                                rgba: rgba.into_raw(),
+                                width: w,
+                                height: h,
+                            }
                         });
+                    let _ = tx.send(decoded.ok_or((z, x, y)));
+                    inflight.fetch_sub(1, Ordering::Relaxed);
+                    if let Some(ctx) = ctx {
+                        ctx.request_repaint();
                     }
-                }
+                });
             });
         }
     }
@@ -760,16 +813,39 @@ impl TileManager {
     pub fn drain_ready(&mut self) -> Vec<PendingTile> {
         let mut ready = Vec::new();
         while let Ok(t) = self.rx.try_recv() {
-            if self.uploaded.put(t.id, ()).is_none() {
-                ready.push(PendingTile {
-                    id: t.id,
-                    rgba: t.rgba,
-                    width: t.width,
-                    height: t.height,
-                });
+            let t = match t {
+                Ok(t) => t,
+                Err(id) => {
+                    // Out of `requested` so the next visibility pass is the retry, and into
+                    // `failed` so that pass isn't the very next frame.
+                    self.requested.remove(&id);
+                    self.failed.insert(id, std::time::Instant::now());
+                    continue;
+                }
+            };
+            self.failed.remove(&t.id);
+            // `push` (not `put`) hands back whatever it evicted, so the renderer can free the
+            // texture instead of leaking it.
+            let evicted = self.uploaded.push(t.id, ());
+            if let Some((id, _)) = evicted.filter(|(id, _)| *id != t.id) {
+                self.requested.remove(&id);
+                self.evicted.push(id);
+            } else if evicted.is_some() {
+                continue; // already resident
             }
+            ready.push(PendingTile {
+                id: t.id,
+                rgba: t.rgba,
+                width: t.width,
+                height: t.height,
+            });
         }
         ready
+    }
+
+    /// Repaint handle for the fetch tasks — set once at startup.
+    pub fn set_ctx(&mut self, ctx: egui::Context) {
+        self.ctx = Some(ctx);
     }
 
     /// Mark this frame's tiles as most-recently-used and return anything that fell out of the
@@ -779,11 +855,19 @@ impl TileManager {
     pub fn touch_visible(&mut self, visible: &[VisibleTile]) -> Vec<TileId> {
         // Grow to fit a wide view: the cap is a resting size, not a per-frame limit.
         let want = RASTER_TILE_CACHE.max(visible.len() + 16);
-        if self.uploaded.cap().get() != want {
-            self.uploaded.resize(NonZeroUsize::new(want).unwrap());
-        }
         for v in visible {
             self.uploaded.promote(&v.id);
+        }
+        // Pop down to size FIRST: shrinking an `LruCache` evicts silently, and a silently evicted
+        // tile is a texture the renderer never hears about again.
+        while self.uploaded.len() > want {
+            if let Some((id, _)) = self.uploaded.pop_lru() {
+                self.requested.remove(&id);
+                self.evicted.push(id);
+            }
+        }
+        if self.uploaded.cap().get() != want {
+            self.uploaded.resize(NonZeroUsize::new(want).unwrap());
         }
         while self.uploaded.len() > want {
             if let Some((id, _)) = self.uploaded.pop_lru() {

--- a/crates/hookecho/src/tiles.rs
+++ b/crates/hookecho/src/tiles.rs
@@ -977,7 +977,7 @@ const DISK_CACHE_BYTES: u64 = if cfg!(target_os = "android") {
 /// writing into it, and a tile deleted out from under a read just gets re-fetched anyway. Chase
 /// packs live under the same root and are deliberately not spared — they are re-downloadable, and
 /// a pack the user still cares about is a pack they have been looking at recently.
-fn sweep_tile_cache(root: &std::path::Path) {
+pub(crate) fn sweep_tile_cache(root: &std::path::Path) {
     fn walk(
         dir: &std::path::Path,
         out: &mut Vec<(std::time::SystemTime, u64, std::path::PathBuf)>,

--- a/crates/hookecho/src/ui/alert_panel.rs
+++ b/crates/hookecho/src/ui/alert_panel.rs
@@ -35,7 +35,8 @@ pub struct Row<'a> {
 /// deduped by alert id, sorted by severity then soonest expiry.
 pub fn rows_in_view(feats: &[GeoFeature], bounds: (f64, f64, f64, f64)) -> Vec<Row<'_>> {
     let (vx0, vy0, vx1, vy1) = bounds;
-    let mut seen = std::collections::HashSet::new();
+    // Borrowed ids: this runs every frame, and cloning each id was an allocation per alert.
+    let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
     let mut rows: Vec<Row> = Vec::new();
     for f in feats {
         let Some(a) = &f.alert else { continue };
@@ -45,7 +46,7 @@ pub fn rows_in_view(feats: &[GeoFeature], bounds: (f64, f64, f64, f64)) -> Vec<R
         if x1 < vx0 || x0 > vx1 || y1 < vy0 || y0 > vy1 {
             continue; // bbox disjoint from the view
         }
-        if !seen.insert(a.id.clone()) {
+        if !seen.insert(a.id.as_str()) {
             continue;
         }
         rows.push(Row {

--- a/crates/hookecho/src/vector_tiles.rs
+++ b/crates/hookecho/src/vector_tiles.rs
@@ -10,6 +10,7 @@ use crate::basemap_style;
 use crate::render::mercator::Camera;
 use crate::render::{OverlayVertex, PendingVectorTile, TileId, VisibleTile};
 use crate::tiles::{load_tile_bytes, tile_cover};
+use lru::LruCache;
 use lyon::path::Path;
 use lyon::tessellation::{
     BuffersBuilder, FillOptions, FillRule, FillTessellator, FillVertex, StrokeOptions,
@@ -18,11 +19,15 @@ use lyon::tessellation::{
 use mvt_reader::feature::Value;
 use mvt_reader::Reader;
 use std::collections::{HashMap, HashSet};
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::mpsc::{Receiver, Sender};
 
 const TILEJSON_URL: &str = "https://tiles.openfreemap.org/planet";
 const MAX_VECTOR_Z: u8 = 14;
+/// How many tessellated vector tiles to keep on the GPU. Vertex buffers are a few hundred KB
+/// each, so a phone gets a smaller resting set than a desktop.
+const VECTOR_TILE_CACHE: usize = if cfg!(target_os = "android") { 96 } else { 256 };
 const USER_AGENT: &str = "Mozilla/5.0 (compatible; hookecho/0.0; +github.com/d4vid87/hookecho)";
 
 // Fill layers in painter's-algorithm order (drawn after the background quad, before strokes).
@@ -445,10 +450,16 @@ pub struct VectorTileManager {
     /// Repaint handle, so a finished tile draws now instead of at the next idle heartbeat.
     ctx: Option<egui::Context>,
     requested: HashSet<TileId>,
-    uploaded: HashSet<TileId>,
+    /// Tessellated tiles live on the GPU; this mirrors them so the oldest can be dropped. A
+    /// HashSet here meant a long pan grew vertex buffers until the style changed.
+    uploaded: LruCache<TileId, ()>,
+    /// Ids the LRU pushed out, handed to the renderer to free.
+    vevicted: Vec<TileId>,
     labels: HashMap<TileId, Vec<PlaceLabel>>,
     dark: bool,
     tess_zoom: i32,
+    /// Candidate new tessellation zoom and when it was first seen — see [`Self::note_zoom`].
+    zoom_settled: Option<(i32, std::time::Instant)>,
     cache_root: Option<PathBuf>,
     template: Option<String>,
     template_tx: Sender<Option<String>>,
@@ -467,6 +478,10 @@ impl VectorTileManager {
             .build()
             .expect("build reqwest client");
         let cache_root = crate::paths::cache_dir().map(|d| d.join("vector"));
+        // The vector cache grew forever; the raster one has been swept at startup all along.
+        if let Some(root) = cache_root.clone() {
+            std::thread::spawn(move || crate::tiles::sweep_tile_cache(&root));
+        }
         Self {
             spawner,
             client,
@@ -474,10 +489,12 @@ impl VectorTileManager {
             rx,
             ctx: None,
             requested: HashSet::new(),
-            uploaded: HashSet::new(),
+            uploaded: LruCache::new(NonZeroUsize::new(VECTOR_TILE_CACHE).unwrap()),
+            vevicted: Vec::new(),
             labels: HashMap::new(),
             dark: true,
             tess_zoom: 7,
+            zoom_settled: None,
             cache_root,
             template: None,
             template_tx,
@@ -508,8 +525,23 @@ impl VectorTileManager {
     pub fn note_zoom(&mut self, cam_zoom: f64) -> bool {
         let tz = cam_zoom.round() as i32;
         if tz == self.tess_zoom {
+            self.zoom_settled = None;
             return false;
         }
+        // Mid-pinch this fires at every integer step, and each one throws away the whole vector
+        // basemap and re-tessellates it — the worst possible moment. Wait for the zoom to hold
+        // still before acting on it.
+        let settled = *self
+            .zoom_settled
+            .get_or_insert_with(|| (tz, std::time::Instant::now()));
+        if settled.0 != tz {
+            self.zoom_settled = Some((tz, std::time::Instant::now()));
+            return false;
+        }
+        if settled.1.elapsed() < std::time::Duration::from_millis(700) {
+            return false;
+        }
+        self.zoom_settled = None;
         let overzoom = self.tess_zoom > MAX_VECTOR_Z as i32 || tz > MAX_VECTOR_Z as i32;
         self.tess_zoom = tz;
         if overzoom {
@@ -627,16 +659,46 @@ impl VectorTileManager {
     pub fn drain_ready(&mut self) -> Vec<PendingVectorTile> {
         let mut ready = Vec::new();
         while let Ok(f) = self.rx.try_recv() {
-            if self.uploaded.insert(f.id) {
-                self.labels.insert(f.id, f.labels);
-                ready.push(PendingVectorTile {
-                    id: f.id,
-                    vertices: f.vertices,
-                    indices: f.indices,
-                });
+            match self.uploaded.push(f.id, ()) {
+                Some((id, _)) if id == f.id => continue, // already resident
+                Some((id, _)) => {
+                    self.requested.remove(&id);
+                    self.labels.remove(&id);
+                    self.vevicted.push(id);
+                }
+                None => {}
             }
+            self.labels.insert(f.id, f.labels);
+            ready.push(PendingVectorTile {
+                id: f.id,
+                vertices: f.vertices,
+                indices: f.indices,
+            });
         }
         ready
+    }
+
+    /// Vector tiles the LRU pushed out since the last call, for the renderer to free.
+    pub fn take_evicted(&mut self) -> Vec<TileId> {
+        std::mem::take(&mut self.vevicted)
+    }
+
+    /// Keep this frame's tiles at the front of the LRU so a wide view can't evict what it draws.
+    pub fn touch_visible(&mut self, visible: &[VisibleTile]) {
+        let want = VECTOR_TILE_CACHE.max(visible.len() + 8);
+        for v in visible {
+            self.uploaded.promote(&v.id);
+        }
+        while self.uploaded.len() > want {
+            if let Some((id, _)) = self.uploaded.pop_lru() {
+                self.requested.remove(&id);
+                self.labels.remove(&id);
+                self.vevicted.push(id);
+            }
+        }
+        if self.uploaded.cap().get() != want {
+            self.uploaded.resize(NonZeroUsize::new(want).unwrap());
+        }
     }
 
     /// Labels for the given visible tile ids (for the egui text pass).

--- a/crates/hookecho/src/vector_tiles.rs
+++ b/crates/hookecho/src/vector_tiles.rs
@@ -456,6 +456,8 @@ pub struct VectorTileManager {
     /// Ids the LRU pushed out, handed to the renderer to free.
     vevicted: Vec<TileId>,
     labels: HashMap<TileId, Vec<PlaceLabel>>,
+    /// Bumped on every change to `labels` (see [`Self::label_generation`]).
+    label_gen: u64,
     dark: bool,
     tess_zoom: i32,
     /// Candidate new tessellation zoom and when it was first seen — see [`Self::note_zoom`].
@@ -492,6 +494,7 @@ impl VectorTileManager {
             uploaded: LruCache::new(NonZeroUsize::new(VECTOR_TILE_CACHE).unwrap()),
             vevicted: Vec::new(),
             labels: HashMap::new(),
+            label_gen: 0,
             dark: true,
             tess_zoom: 7,
             zoom_settled: None,
@@ -517,6 +520,7 @@ impl VectorTileManager {
         self.requested.clear();
         self.uploaded.clear();
         self.labels.clear();
+        self.label_gen += 1;
         true
     }
 
@@ -548,6 +552,7 @@ impl VectorTileManager {
             self.requested.clear();
             self.uploaded.clear();
             self.labels.clear();
+            self.label_gen += 1;
             true
         } else {
             false
@@ -664,11 +669,13 @@ impl VectorTileManager {
                 Some((id, _)) => {
                     self.requested.remove(&id);
                     self.labels.remove(&id);
+                    self.label_gen += 1;
                     self.vevicted.push(id);
                 }
                 None => {}
             }
             self.labels.insert(f.id, f.labels);
+            self.label_gen += 1;
             ready.push(PendingVectorTile {
                 id: f.id,
                 vertices: f.vertices,
@@ -693,12 +700,18 @@ impl VectorTileManager {
             if let Some((id, _)) = self.uploaded.pop_lru() {
                 self.requested.remove(&id);
                 self.labels.remove(&id);
+                self.label_gen += 1;
                 self.vevicted.push(id);
             }
         }
         if self.uploaded.cap().get() != want {
             self.uploaded.resize(NonZeroUsize::new(want).unwrap());
         }
+    }
+
+    /// Bumped whenever the label set changes, so callers can cache derived views of it.
+    pub fn label_generation(&self) -> u64 {
+        self.label_gen
     }
 
     /// Labels for the given visible tile ids (for the egui text pass).

--- a/crates/hookecho/src/vector_tiles.rs
+++ b/crates/hookecho/src/vector_tiles.rs
@@ -442,6 +442,8 @@ pub struct VectorTileManager {
     client: reqwest::Client,
     tx: Sender<FetchedVector>,
     rx: Receiver<FetchedVector>,
+    /// Repaint handle, so a finished tile draws now instead of at the next idle heartbeat.
+    ctx: Option<egui::Context>,
     requested: HashSet<TileId>,
     uploaded: HashSet<TileId>,
     labels: HashMap<TileId, Vec<PlaceLabel>>,
@@ -460,6 +462,8 @@ impl VectorTileManager {
         let (template_tx, template_rx) = std::sync::mpsc::channel();
         let client = reqwest::Client::builder()
             .user_agent(USER_AGENT)
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(30))
             .build()
             .expect("build reqwest client");
         let cache_root = crate::paths::cache_dir().map(|d| d.join("vector"));
@@ -468,6 +472,7 @@ impl VectorTileManager {
             client,
             tx,
             rx,
+            ctx: None,
             requested: HashSet::new(),
             uploaded: HashSet::new(),
             labels: HashMap::new(),
@@ -479,6 +484,11 @@ impl VectorTileManager {
             template_rx,
             template_requested: false,
         }
+    }
+
+    /// Repaint handle for the fetch tasks — set once at startup.
+    pub fn set_ctx(&mut self, ctx: egui::Context) {
+        self.ctx = Some(ctx);
     }
 
     /// Switch dark/light. Returns true if changed (caller should clear the GPU vector cache).
@@ -551,14 +561,23 @@ impl VectorTileManager {
             let client = self.client.clone();
             let tx = self.tx.clone();
             let id = v.id;
+            let ctx = self.ctx.clone();
+            let blocking = self.spawner.clone();
             self.spawner.spawn(async move {
                 if let Ok(bytes) = load_tile_bytes(&client, &url, path.as_deref()).await {
-                    let (vertices, indices, labels) = build_tile(&bytes, id, dark, tess_zoom);
-                    let _ = tx.send(FetchedVector {
-                        id,
-                        vertices,
-                        indices,
-                        labels,
+                    // gunzip + lyon tessellation is the heaviest CPU in the app after the volume
+                    // decode; running it on the async worker starves every other fetch.
+                    blocking.spawn_blocking(move || {
+                        let (vertices, indices, labels) = build_tile(&bytes, id, dark, tess_zoom);
+                        let _ = tx.send(FetchedVector {
+                            id,
+                            vertices,
+                            indices,
+                            labels,
+                        });
+                        if let Some(ctx) = ctx {
+                            ctx.request_repaint();
+                        }
                     });
                 }
             });

--- a/crates/wxdata/Cargo.toml
+++ b/crates/wxdata/Cargo.toml
@@ -11,7 +11,7 @@ nexrad-level3 = { path = "../nexrad-level3" }
 hdf5lite = { path = "../hdf5lite" }
 # Vendored via [patch.crates-io] in the workspace Cargo.toml — see the note there. Its HTTP
 # client is patched to use webpki-roots TLS so AWS S3 fetches work on Android.
-nexrad-data = "1.0.0-rc.7"
+nexrad-data = { version = "1.0.0-rc.7", features = ["parallel"] }
 nexrad-model = "1.0.0-rc.2"
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/wxdata/src/level2.rs
+++ b/crates/wxdata/src/level2.rs
@@ -179,13 +179,19 @@ pub async fn download_scan(id: Identifier) -> anyhow::Result<Scan> {
     let file = archive::download_file(id)
         .await
         .map_err(|e| anyhow::anyhow!("download_file: {e}"))?;
-    let file = if file.compressed() {
-        file.decompress()
-            .map_err(|e| anyhow::anyhow!("decompress: {e}"))?
-    } else {
-        file
-    };
-    let scan = file.scan().map_err(|e| anyhow::anyhow!("scan: {e}"))?;
+    // bzip2 decompression plus the message decode is tens of MB of pure CPU. On the async worker
+    // it blocks every other fetch sharing that thread for as long as it runs; the `parallel`
+    // feature of nexrad-data then spreads the decode itself across rayon.
+    let scan = tokio::task::spawn_blocking(move || {
+        let file = if file.compressed() {
+            file.decompress()
+                .map_err(|e| anyhow::anyhow!("decompress: {e}"))?
+        } else {
+            file
+        };
+        file.scan().map_err(|e| anyhow::anyhow!("scan: {e}"))
+    })
+    .await??;
     // Legacy (pre-2008) volumes carry no volume data block, so the decoder can't name the radar.
     // The volume's own filename can: "KTLX19910605_162126".
     Ok(match scan.site() {

--- a/crates/wxdata/src/level2.rs
+++ b/crates/wxdata/src/level2.rs
@@ -137,15 +137,10 @@ pub async fn latest_identifier(site: &str) -> anyhow::Result<Identifier> {
 /// the radar writes it as it scans. A volume caught early enough can be missing the metadata
 /// record that carries its scan strategy, and the only cure is to fall back a volume.
 pub async fn latest_identifiers(site: &str, n: usize) -> anyhow::Result<Vec<Identifier>> {
-    use nexrad_data::aws::archive;
-
     let today = chrono::Utc::now().date_naive();
     let mut out: Vec<Identifier> = Vec::new();
     for day in [today, today.pred_opt().unwrap_or(today)] {
-        let mut ids = archive::list_files(site, &day)
-            .await
-            .map_err(|e| anyhow::anyhow!("list_files({site}, {day}): {e}"))?;
-        ids.sort_by_key(|id| id.date_time());
+        let mut ids = list_day(site, day).await?;
         while out.len() < n {
             match ids.pop() {
                 Some(id) => out.push(id),
@@ -164,11 +159,41 @@ pub async fn latest_identifiers(site: &str, n: usize) -> anyhow::Result<Vec<Iden
 
 /// List every volume for `site` on a specific UTC `date`, oldest first.
 pub async fn list_volumes(site: &str, date: chrono::NaiveDate) -> anyhow::Result<Vec<Identifier>> {
+    list_day(site, date).await
+}
+
+/// Recent day listings, so a site switch doesn't LIST the same S3 prefix two or three times over
+/// (the head poll and the timeline listing both want today's).
+///
+/// ponytail: a flat map with a short TTL and no eviction — a session touches a handful of
+/// site/day pairs. Bound it if that ever stops being true.
+type DayListCache =
+    std::collections::HashMap<(String, chrono::NaiveDate), (std::time::Instant, Vec<Identifier>)>;
+static DAY_LIST_CACHE: std::sync::OnceLock<std::sync::Mutex<DayListCache>> =
+    std::sync::OnceLock::new();
+
+/// Listing TTL. Volumes land every 4-6 minutes; 20 s is short enough that the head poll still
+/// sees a new one promptly and long enough to collapse the burst a site switch makes.
+const DAY_LIST_TTL: std::time::Duration = std::time::Duration::from_secs(20);
+
+async fn list_day(site: &str, date: chrono::NaiveDate) -> anyhow::Result<Vec<Identifier>> {
     use nexrad_data::aws::archive;
+    let key = (site.to_string(), date);
+    let cache = DAY_LIST_CACHE.get_or_init(Default::default);
+    if let Ok(map) = cache.lock() {
+        if let Some((at, ids)) = map.get(&key) {
+            if at.elapsed() < DAY_LIST_TTL {
+                return Ok(ids.clone());
+            }
+        }
+    }
     let mut ids = archive::list_files(site, &date)
         .await
         .map_err(|e| anyhow::anyhow!("list_files({site}, {date}): {e}"))?;
     ids.sort_by_key(|id| id.date_time());
+    if let Ok(mut map) = cache.lock() {
+        map.insert(key, (std::time::Instant::now(), ids.clone()));
+    }
     Ok(ids)
 }
 

--- a/crates/wxdata/src/level3.rs
+++ b/crates/wxdata/src/level3.rs
@@ -186,7 +186,16 @@ pub async fn fetch_cells(http: &reqwest::Client, site: &str) -> Vec<Cell> {
     let mut storms: Vec<Cell> = Vec::new();
     let mut by_id: HashMap<String, usize> = HashMap::new();
 
-    if let Some((p, _)) = fetch_latest(http, &s3, "NST").await {
+    // All four products are independent S3 round trips; serially they were the bulk of the wait
+    // after a site switch.
+    let (nst, ss_txt, hi_txt, nmd) = tokio::join!(
+        fetch_latest(http, &s3, "NST"),
+        fetch_tgftp(http, &s3, "p62ss"),
+        fetch_tgftp(http, &s3, "p59hi"),
+        fetch_latest(http, &s3, "NMD"),
+    );
+
+    if let Some((p, _)) = nst {
         let (lat0, lon0) = (p.lat as f64, p.lon as f64);
         let table = p.tabular.clone().unwrap_or_default();
         let graphic = p.graphic.clone().unwrap_or_default();
@@ -237,7 +246,7 @@ pub async fn fetch_cells(http: &reqwest::Client, site: &str) -> Vec<Cell> {
         }
     }
 
-    if let Some(p) = fetch_tgftp(http, &s3, "p62ss").await {
+    if let Some(p) = ss_txt {
         for (id, ss) in parse_storm_structure(&p.raw_text.unwrap_or_default()) {
             if let Some(&i) = by_id.get(&id) {
                 storms[i].base_kft = ss.base;
@@ -251,7 +260,7 @@ pub async fn fetch_cells(http: &reqwest::Client, site: &str) -> Vec<Cell> {
         }
     }
 
-    if let Some(p) = fetch_tgftp(http, &s3, "p59hi").await {
+    if let Some(p) = hi_txt {
         for (id, h) in parse_hail(&p.raw_text.unwrap_or_default()) {
             if let Some(&i) = by_id.get(&id) {
                 storms[i].poh = h.poh;
@@ -262,7 +271,7 @@ pub async fn fetch_cells(http: &reqwest::Client, site: &str) -> Vec<Cell> {
     }
 
     let mut meso = Vec::new();
-    if let Some((p, _)) = fetch_latest(http, &s3, "NMD").await {
+    if let Some((p, _)) = nmd {
         let (lat0, lon0) = (p.lat as f64, p.lon as f64);
         for m in &p.meso {
             let (lon, lat) = offset_lonlat(lon0, lat0, m.x_km, m.y_km);

--- a/crates/wxdata/src/live.rs
+++ b/crates/wxdata/src/live.rs
@@ -47,7 +47,7 @@ pub struct Update {
 #[cfg(not(target_arch = "wasm32"))]
 pub async fn stream<F>(
     site: String,
-    base: Scan,
+    base: Arc<Scan>,
     active: fn() -> bool,
     mut on_update: F,
 ) -> anyhow::Result<()>
@@ -68,25 +68,47 @@ where
     let latest_seq = joined.sequence();
     let volume = *joined.volume();
     let prefix = *joined.date_time_prefix();
-    // ponytail: sequential O(n) backfill downloads on start so the first frame is a full
-    // volume; gaps are tolerated (a missing chunk just omits its radials).
-    for seq in 2..latest_seq {
-        let id = ChunkIdentifier::new(
-            site.clone(),
-            volume,
-            prefix,
-            seq,
-            ChunkType::Intermediate,
-            None,
-        );
-        if let Ok((_, ch)) = download_chunk(&site, &id).await {
-            chunks.push(ch);
+    // Backfill the middle chunks so the first frame is a full volume. Up to ~53 of them, and
+    // serially that was the whole reason a live site took seconds to show anything; six at a time
+    // keeps the radio busy without opening a connection per chunk. Gaps are tolerated (a missing
+    // chunk just omits its radials), but order matters, so results are re-sorted by sequence.
+    let mut backfill: Vec<(usize, Chunk<'static>)> = Vec::new();
+    for window in (2..latest_seq).collect::<Vec<_>>().chunks(6) {
+        let mut set = tokio::task::JoinSet::new();
+        for &seq in window {
+            let site = site.clone();
+            set.spawn(async move {
+                let id = ChunkIdentifier::new(
+                    site.clone(),
+                    volume,
+                    prefix,
+                    seq,
+                    ChunkType::Intermediate,
+                    None,
+                );
+                download_chunk(&site, &id)
+                    .await
+                    .ok()
+                    .map(|(_, ch)| (seq, ch))
+            });
+        }
+        while let Some(res) = set.join_next().await {
+            if let Ok(Some(hit)) = res {
+                backfill.push(hit);
+            }
         }
     }
+    backfill.sort_by_key(|(seq, _)| *seq);
+    chunks.extend(backfill.into_iter().map(|(_, ch)| ch));
     chunks.push(init.latest_chunk.chunk);
 
-    let mut merged = Arc::new(base);
+    let mut merged = base;
+    // First emit assembles the whole backfilled volume; after that only the chunks since the last
+    // sweep boundary are re-assembled (plus the start chunk, which carries the VCP and site
+    // metadata assembly needs). Re-decoding every accumulated chunk at every boundary was O(n^2)
+    // over a volume, and the chunk count grows to ~55.
     emit(&it, &chunks, &mut merged, &mut on_update);
+    let mut window_start = chunks.len();
 
     loop {
         let wait = it
@@ -110,11 +132,20 @@ where
                 let ctype = dc.identifier.chunk_type();
                 if ctype == ChunkType::Start {
                     chunks.clear(); // volume rollover: start a fresh accumulator
+                    window_start = 0;
                 }
                 chunks.push(dc.chunk);
                 let sweep_done = it.chunk_metadata(seq).is_some_and(|m| m.is_last_in_sweep());
                 if sweep_done || ctype == ChunkType::End {
-                    emit(&it, &chunks, &mut merged, &mut on_update);
+                    let window: Vec<Chunk<'static>> = chunks
+                        .first()
+                        .filter(|_| window_start > 0)
+                        .into_iter()
+                        .chain(chunks[window_start..].iter())
+                        .cloned()
+                        .collect();
+                    emit(&it, &window, &mut merged, &mut on_update);
+                    window_start = chunks.len();
                 }
             }
             Ok(None) => { /* not available yet; loop and wait again */ }
@@ -131,7 +162,12 @@ fn emit<F: FnMut(Update)>(
     merged: &mut Arc<Scan>,
     on_update: &mut F,
 ) {
-    let partial = match assemble_volume(chunks.iter().cloned()) {
+    // Re-assembling every accumulated chunk at each sweep boundary is the heaviest CPU on this
+    // task; `block_in_place` moves it off the async worker so chunk polling and every other
+    // fetch on that thread keep running. (Requires the multi-threaded runtime, which is what the
+    // app and the headless harness both build.)
+    let assembled = tokio::task::block_in_place(|| assemble_volume(chunks.iter().cloned()));
+    let partial = match assembled {
         Ok(s) => s,
         Err(e) => {
             log::debug!("assemble skipped: {e}");

--- a/crates/wxdata/src/tdwr.rs
+++ b/crates/wxdata/src/tdwr.rs
@@ -227,28 +227,42 @@ pub async fn fetch_volume(
     let short = &meta.id[1..];
     let day = Utc::now().format("%Y_%m_%d").to_string();
 
+    // Six products, twelve round trips. Serially that was most of the wait for a TDWR site;
+    // they're independent, so fetch and decode them all at once.
+    let mut set = tokio::task::JoinSet::new();
+    for (n, (product, gate_len)) in PRODUCTS.iter().enumerate() {
+        let (http, prefix) = (http.clone(), format!("{short}_{product}_{day}"));
+        let (product, gate_len) = (*product, *gate_len);
+        set.spawn(async move {
+            let key = newest_key(&http, &prefix).await?;
+            let resp = http.get(format!("{BUCKET}/{key}")).send().await.ok()?;
+            let bytes = resp.bytes().await.ok()?;
+            let p = match nexrad_level3::decode(&bytes) {
+                Ok(p) => p,
+                Err(e) => {
+                    log::warn!("tdwr decode {key}: {e}");
+                    return None;
+                }
+            };
+            // Elevation numbers must be unique per sweep; reflectivity and velocity at one tilt
+            // stay separate sweeps, which the split-cut-aware binning already handles.
+            let sweep = sweep_from(&p, n as u8 + 1, gate_len, product.starts_with("TV"));
+            Some((n, sweep, key))
+        });
+    }
+    let mut found: Vec<(usize, Option<Sweep>, String)> = Vec::new();
+    while let Some(res) = set.join_next().await {
+        if let Ok(Some(hit)) = res {
+            found.push(hit);
+        }
+    }
+    // Keep the product order stable: sweeps are keyed by elevation number, and the caller's
+    // "did the volume change?" check compares the name of the newest key.
+    found.sort_by_key(|(n, _, _)| *n);
     let mut sweeps = Vec::new();
     let mut newest: Option<(String, DateTime<Utc>)> = None;
-    for (n, (product, gate_len)) in PRODUCTS.iter().enumerate() {
-        let Some(key) = newest_key(http, &format!("{short}_{product}_{day}")).await else {
-            continue;
-        };
-        let Ok(resp) = http.get(format!("{BUCKET}/{key}")).send().await else {
-            continue;
-        };
-        let Ok(bytes) = resp.bytes().await else {
-            continue;
-        };
-        let p = match nexrad_level3::decode(&bytes) {
-            Ok(p) => p,
-            Err(e) => {
-                log::warn!("tdwr decode {key}: {e}");
-                continue;
-            }
-        };
-        // Elevation numbers must be unique per sweep; reflectivity and velocity at one tilt stay
-        // separate sweeps, which the split-cut-aware binning already handles.
-        if let Some(s) = sweep_from(&p, n as u8 + 1, *gate_len, product.starts_with("TV")) {
+    for (_, sweep, key) in found {
+        if let Some(s) = sweep {
             sweeps.push(s);
         }
         if let Some(t) = key_time(&key) {

--- a/vendor/nexrad-data/src/aws/client.rs
+++ b/vendor/nexrad-data/src/aws/client.rs
@@ -20,6 +20,10 @@ pub fn client() -> &'static Client {
         #[cfg(not(target_arch = "wasm32"))]
         {
             builder = builder.pool_max_idle_per_host(4);
+            // hookecho patch: timeouts. Volume fetches are the app's slowest path, and a request
+            // that never answers wedges the pane's `loading` flag with no way back.
+            builder = builder.connect_timeout(std::time::Duration::from_secs(10));
+            builder = builder.timeout(std::time::Duration::from_secs(60));
             // hookecho patch: reqwest 0.13's `rustls` feature wires rustls-platform-verifier as
             // the cert verifier, which on Android needs a bundled Kotlin helper class (and panics
             // if uninitialized). Hand reqwest a fully-built rustls config using webpki roots


### PR DESCRIPTION
Pinch zoom on the phone was laggy, anchored on the wrong point, jumped, and was
intermittently dead; basemap tiles, radar after a site switch, and animation
frames all loaded slowly regardless of network. This is the fix, in nine
independently revertable slices.

**Input**
- Floating read-only surfaces (warning banners, chase HUD, follow notice, error
  chip, coach marks) no longer take input, so egui's `layer_id_at` stops
  reporting them as chrome over the map. The coach card sits dead center on a
  phone, which made pinch a no-op on every fresh install.
- 150 ms cooldown after a gesture kills the two-finger-tap popup and the jump
  when the second finger lifts.
- Zoom is applied before the pan (the translation was being scaled wrong), and
  the camera clamp goes 18 -> 20 so a spread-pinch at the old ceiling isn't a
  silent no-op.

**Tiles**
- Fetch workers repaint on arrival instead of waiting up to 250 ms for the idle
  heartbeat; HTTP/2; connect/request timeouts everywhere; at most 6 fetches in
  flight; failed tiles retried after 5 s instead of never.
- 512 px tiles for Mapbox and MapTiler (a quarter of the requests for the same
  pixels), verified against the live APIs.
- Missing tiles draw resident children or a UV-cropped ancestor, so the basemap
  never blanks at a zoom crossing.
- Decode and tessellation moved to `spawn_blocking`; GPU textures freed on LRU
  eviction instead of leaking; vector cache bounded and swept.

**Radar**
- Volume decode off the async workers and parallel (rayon).
- Site switch: storm-cell products, TDWR tilts and day listings parallelised or
  shared instead of a serial chain of round trips.
- Live stream: parallel backfill, incremental per-sweep assembly, and no more
  tens-of-MB deep copy on the UI thread.
- Loop: cache sized to the window it plays, two-frame prefetch, and a playhead
  that waits (briefly, bounded) for data instead of skipping past it.

**Verified on an S24 Ultra**: cold start with the tile cache cleared paints the
full basemap in ~2 s; a site switch to a fresh region paints map and radar in
under 2 s; playback loops; RSS is ~540 MB where an over-sized loop cache had it
near 1 GB. `cargo clippy -D warnings`, `cargo test --workspace` (345 passing),
`cargo ndk` build, `shoot.sh check`, and a desktop run all pass.

Not verified by the harness: the pinch gesture itself. Synthetic two-finger
input via `uinput` is cancelled by the platform on this device (the app sees
the first touch, then the sequence is cancelled), so pinch needs one manual
check on the phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)