### PR TITLE
fix(mobile): stop the bottom sheet from eating pinch over the map

### DIFF
--- a/crates/hookecho/src/app/mobile/sheet.rs
+++ b/crates/hookecho/src/app/mobile/sheet.rs
@@ -115,6 +115,12 @@ impl crate::app::HookEchoApp {
         egui::Area::new(Id::new("m_sheet"))
             .order(egui::Order::Middle)
             .fixed_pos(rect.min)
+            // The body always lays out at full height and is clipped to the current snap, so the
+            // Area's own bounds are taller than the sheet you can see. egui constrains an Area to
+            // the screen by shifting it UP, which parked an invisible input-eating layer over the
+            // middle of the map: `layer_id_at` saw the sheet where the map was, so pinch (and taps)
+            // there went nowhere. Constrain to the sheet instead: bounds now match the visible rect.
+            .constrain_to(rect)
             .show(ctx, |ui| {
                 // Claim the whole sheet rect up front. An Area's interactive region is its
                 // content's bounding box, so a sheet that painted itself and then laid out a


### PR DESCRIPTION
Pinch zoom was still dead on the S24 Ultra after the perf overhaul (#4). ADB debugging found the cause, and it was not the gesture math or the touch pipeline.

Two fingers reached the app with correct `zoom_delta` the whole time. Every frame the log read:

```
mt=Some((2, 1.28, [172.7 337.3])) layer=("m_sheet", Middle, [[0.0 332.0] - [360.0 732.0]])
```

The sheet was drawing at `[[0 578] - [360 732]]`. Its Area bounds were ~400pt tall because the sheet body always lays out at full height and is only clipped to the current snap. egui constrains an oversized Area to the screen by shifting it **up**, which parked an invisible input-eating layer across the middle band of the map. The pane's occlusion guard asked `layer_id_at(gesture center)`, got `m_sheet`, and dropped the pinch. Taps in the same band were swallowed too.

Fix: `.constrain_to(rect)` on the sheet Area so its bounds match the visible sheet.

Gates: `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo test --workspace` 345 passed, `cargo ndk` build, and pinch confirmed working on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)