### PR TITLE
fix(web): keep the wasm build compiling

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1928,9 +1928,7 @@ impl HookEchoApp {
         let (pf_icon_tx, pf_icon_rx) = std::sync::mpsc::channel();
         // Every app-level fetch (alerts, overlays, placefiles, radar index) goes through this one.
         // A hung request with no timeout leaves whatever it was loading stuck loading forever.
-        let http = reqwest::Client::builder()
-            .connect_timeout(std::time::Duration::from_secs(10))
-            .timeout(std::time::Duration::from_secs(30))
+        let http = crate::platform::http_timeouts(reqwest::Client::builder())
             .build()
             .unwrap_or_default();
 

--- a/crates/hookecho/src/platform.rs
+++ b/crates/hookecho/src/platform.rs
@@ -960,3 +960,16 @@ pub use android_ime::{clipboard_text, pump_ime, show_soft_input};
 pub use android_location::start_location;
 #[cfg(target_os = "android")]
 pub use android_tts::speak;
+
+/// Timeouts for an HTTP client, where the platform has them.
+///
+/// A hung request with no timeout holds its slot forever: whatever it was loading stays loading,
+/// and a tile that never answers leaves that square of map permanently blank. reqwest's web
+/// backend exposes neither knob — fetch owns the request there — so on wasm this is a no-op.
+pub fn http_timeouts(b: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
+    #[cfg(not(target_arch = "wasm32"))]
+    let b = b
+        .timeout(std::time::Duration::from_secs(30))
+        .connect_timeout(std::time::Duration::from_secs(10));
+    b
+}

--- a/crates/hookecho/src/tiles.rs
+++ b/crates/hookecho/src/tiles.rs
@@ -622,13 +622,10 @@ pub struct TileManager {
 impl TileManager {
     pub fn new(spawner: crate::rt::Spawner) -> Self {
         let (tx, rx) = std::sync::mpsc::channel();
-        let client = reqwest::Client::builder()
-            .user_agent(USER_AGENT)
-            // Without these a request that never answers holds its slot forever: the tile stays in
-            // `requested`, so that square of map is permanently blank.
-            .connect_timeout(std::time::Duration::from_secs(10))
-            .timeout(std::time::Duration::from_secs(30))
-            .build()
+        let client = crate::platform::http_timeouts(
+            reqwest::Client::builder().user_agent(USER_AGENT),
+        )
+        .build()
             .expect("build reqwest client");
         let cache_root = crate::paths::cache_dir().map(|d| d.join("tiles"));
         if let Some(root) = cache_root.clone() {

--- a/crates/hookecho/src/vector_tiles.rs
+++ b/crates/hookecho/src/vector_tiles.rs
@@ -473,11 +473,10 @@ impl VectorTileManager {
     pub fn new(spawner: crate::rt::Spawner) -> Self {
         let (tx, rx) = std::sync::mpsc::channel();
         let (template_tx, template_rx) = std::sync::mpsc::channel();
-        let client = reqwest::Client::builder()
-            .user_agent(USER_AGENT)
-            .connect_timeout(std::time::Duration::from_secs(10))
-            .timeout(std::time::Duration::from_secs(30))
-            .build()
+        let client = crate::platform::http_timeouts(
+            reqwest::Client::builder().user_agent(USER_AGENT),
+        )
+        .build()
             .expect("build reqwest client");
         let cache_root = crate::paths::cache_dir().map(|d| d.join("vector"));
         // The vector cache grew forever; the raster one has been swept at startup all along.

--- a/crates/wxdata/src/level2.rs
+++ b/crates/wxdata/src/level2.rs
@@ -207,7 +207,7 @@ pub async fn download_scan(id: Identifier) -> anyhow::Result<Scan> {
     // bzip2 decompression plus the message decode is tens of MB of pure CPU. On the async worker
     // it blocks every other fetch sharing that thread for as long as it runs; the `parallel`
     // feature of nexrad-data then spreads the decode itself across rayon.
-    let scan = tokio::task::spawn_blocking(move || {
+    let scan = crate::task::blocking(move || {
         let file = if file.compressed() {
             file.decompress()
                 .map_err(|e| anyhow::anyhow!("decompress: {e}"))?

--- a/crates/wxdata/src/level3.rs
+++ b/crates/wxdata/src/level3.rs
@@ -188,7 +188,7 @@ pub async fn fetch_cells(http: &reqwest::Client, site: &str) -> Vec<Cell> {
 
     // All four products are independent S3 round trips; serially they were the bulk of the wait
     // after a site switch.
-    let (nst, ss_txt, hi_txt, nmd) = tokio::join!(
+    let (nst, ss_txt, hi_txt, nmd) = futures_util::join!(
         fetch_latest(http, &s3, "NST"),
         fetch_tgftp(http, &s3, "p62ss"),
         fetch_tgftp(http, &s3, "p59hi"),

--- a/crates/wxdata/src/lib.rs
+++ b/crates/wxdata/src/lib.rs
@@ -41,6 +41,7 @@ pub mod sounding;
 pub mod spc;
 pub mod spotters;
 pub mod stations;
+pub mod task;
 pub mod tds;
 pub mod tdwr;
 pub mod torclimo;

--- a/crates/wxdata/src/live.rs
+++ b/crates/wxdata/src/live.rs
@@ -9,11 +9,15 @@
 //! All merged state lives on this task; the UI thread only ever receives a finished `Scan`.
 
 use crate::level2::{elevation_angles, Scan};
+// The streaming half of the API is native-only: `stream` is what drives it, and there is no
+// tokio (nor a second thread to run it on) in the web build.
+#[cfg(not(target_arch = "wasm32"))]
 use nexrad_data::aws::realtime::{
     assemble_volume, download_chunk, Chunk, ChunkIdentifier, ChunkIterator, ChunkType,
 };
 use nexrad_model::data::Sweep;
 use std::sync::Arc;
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Duration;
 
 /// A merged live volume ready to display.
@@ -156,6 +160,7 @@ where
 
 /// Assemble `chunks`, merge into `merged`, and emit if anything changed. Assembly failure
 /// (e.g. a still-incomplete volume) is skipped; the next sweep boundary self-heals.
+#[cfg(not(target_arch = "wasm32"))]
 fn emit<F: FnMut(Update)>(
     it: &ChunkIterator,
     chunks: &[Chunk<'static>],
@@ -166,7 +171,7 @@ fn emit<F: FnMut(Update)>(
     // task; `block_in_place` moves it off the async worker so chunk polling and every other
     // fetch on that thread keep running. (Requires the multi-threaded runtime, which is what the
     // app and the headless harness both build.)
-    let assembled = tokio::task::block_in_place(|| assemble_volume(chunks.iter().cloned()));
+    let assembled = crate::task::in_place(|| assemble_volume(chunks.iter().cloned()));
     let partial = match assembled {
         Ok(s) => s,
         Err(e) => {

--- a/crates/wxdata/src/task.rs
+++ b/crates/wxdata/src/task.rs
@@ -1,0 +1,34 @@
+//! Where CPU work runs, per target.
+//!
+//! Decoding a volume or assembling live chunks is tens of MB of pure CPU. On native that has to
+//! come off the async worker or it stalls every other fetch sharing that thread. On wasm there is
+//! no tokio and no thread to move to, so it runs where it stands — the web build is single
+//! threaded either way.
+
+/// Run `f` off the async runtime and await its result.
+#[cfg(not(target_arch = "wasm32"))]
+pub async fn blocking<T: Send + 'static>(
+    f: impl FnOnce() -> T + Send + 'static,
+) -> anyhow::Result<T> {
+    Ok(tokio::task::spawn_blocking(f).await?)
+}
+
+/// wasm: no threads, so this is a plain call. Never fails, but keeps the native signature.
+#[cfg(target_arch = "wasm32")]
+pub async fn blocking<T>(f: impl FnOnce() -> T) -> anyhow::Result<T> {
+    Ok(f())
+}
+
+/// Run `f` on the current thread, telling the runtime it is about to block.
+///
+/// Requires the multi-threaded runtime, which is what the app and the headless harness both build.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn in_place<T>(f: impl FnOnce() -> T) -> T {
+    tokio::task::block_in_place(f)
+}
+
+/// wasm: nothing to tell.
+#[cfg(target_arch = "wasm32")]
+pub fn in_place<T>(f: impl FnOnce() -> T) -> T {
+    f()
+}

--- a/crates/wxdata/src/tdwr.rs
+++ b/crates/wxdata/src/tdwr.rs
@@ -229,11 +229,11 @@ pub async fn fetch_volume(
 
     // Six products, twelve round trips. Serially that was most of the wait for a TDWR site;
     // they're independent, so fetch and decode them all at once.
-    let mut set = tokio::task::JoinSet::new();
+    let mut jobs = Vec::new();
     for (n, (product, gate_len)) in PRODUCTS.iter().enumerate() {
         let (http, prefix) = (http.clone(), format!("{short}_{product}_{day}"));
         let (product, gate_len) = (*product, *gate_len);
-        set.spawn(async move {
+        jobs.push(async move {
             let key = newest_key(&http, &prefix).await?;
             let resp = http.get(format!("{BUCKET}/{key}")).send().await.ok()?;
             let bytes = resp.bytes().await.ok()?;
@@ -250,12 +250,13 @@ pub async fn fetch_volume(
             Some((n, sweep, key))
         });
     }
-    let mut found: Vec<(usize, Option<Sweep>, String)> = Vec::new();
-    while let Some(res) = set.join_next().await {
-        if let Ok(Some(hit)) = res {
-            found.push(hit);
-        }
-    }
+    // `join_all` and not a JoinSet: these are twelve round trips with a small decode each, so the
+    // concurrency that matters is the IO, and this way the web build compiles the same code.
+    let mut found: Vec<(usize, Option<Sweep>, String)> = futures_util::future::join_all(jobs)
+        .await
+        .into_iter()
+        .flatten()
+        .collect();
     // Keep the product order stable: sweeps are keyed by elevation number, and the caller's
     // "did the volume change?" check compares the name of the newest key.
     found.sort_by_key(|(n, _, _)| *n);


### PR DESCRIPTION
The `Web (wasm32)` CI job has been failing since the Android perf work — that is the mail you have been getting. tokio is a native-only dependency of `wxdata`, and four of the new hot paths called it directly; reqwest's web backend also has neither `timeout` nor `connect_timeout`.

- `wxdata::task` holds the two "where does CPU work run" helpers: `blocking` (`spawn_blocking` natively, a plain call on wasm, which has no thread to move to) and `in_place`. Used by `level2::download_scan` and `live::emit`.
- `level3::fetch_cells` joins with `futures_util::join!` (already a dependency on every target).
- `tdwr::fetch_volume` uses `futures_util::future::join_all` instead of a `JoinSet`: twelve round trips with a small decode each, so the concurrency that matters is the IO.
- `live`'s streaming imports move under the same cfg as `stream` itself.
- `platform::http_timeouts` applies the client timeouts on native and nothing on wasm, replacing three hand-rolled builder chains.

No behaviour change on native.

Gates: `cargo check --target wasm32-unknown-unknown -p hookecho --lib` (the exact CI command) clean, `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo test --workspace` 345 passed, `cargo ndk -t arm64-v8a build --lib -p hookecho --release` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)