### PR TITLE
R16 Batch A: installable, shareable, and readable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,23 @@ jobs:
             /DExeDir=${{ github.workspace }}\target\release `
             /Odist packaging\windows\hookecho.iss
 
+      # The store manifests name a version and hash the artifacts we just built. Stamping them
+      # here means the winget PR, the Homebrew tap push and the AUR push all start from files that
+      # already match the release, instead of from hand-copied checksums. They are submission
+      # inputs, so they ride out as an artifact rather than being committed back to main.
+      - name: Stamp the store manifests
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        run: |
+          scripts/release/stamp-manifests.sh "${GITHUB_REF_NAME#v}" dist/Hook_Echo-WX-setup-x86_64.exe
+
+      - name: Upload the store manifests
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@v4
+        with:
+          name: store-manifests
+          path: packaging/
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -251,6 +268,20 @@ jobs:
           ./dist/HookEcho.app/Contents/MacOS/hookecho --version
           ./dist/HookEcho.app/Contents/MacOS/hookecho --headless-icon /tmp/icon.png 64
           test -s /tmp/icon.png
+
+      # The icon smoke proves the binary starts; this proves it renders — wgpu comes up on Metal,
+      # a live volume is fetched and drawn off-screen, and the PNG reads back. It is the closest
+      # thing to running the app that exists without Apple hardware to run it on.
+      # `--basemap none` keeps the test off the tile servers; the size floor catches a valid PNG
+      # of nothing. continue-on-error until it has been seen green: a red step nobody can debug
+      # locally would block every release instead of reporting on one.
+      - name: Render smoke
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          ./dist/HookEcho.app/Contents/MacOS/hookecho --snapshot /tmp/smoke.png KTLX \
+            --basemap none --size 256
+          test "$(stat -f%z /tmp/smoke.png)" -ge 5000
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,83 @@
+# Architecture
+
+How Hook Echo-WX is put together, for someone about to change it.
+[CONTRIBUTING.md](CONTRIBUTING.md) covers the workflow — the gate, the tests,
+the commit style. This file covers the shape of the code.
+
+The one-sentence version: **a frame of UI mutates state, one sync step turns that
+state into GPU uploads and background fetches, and results come back over
+channels and repaint.** Everything below is a detail of that loop.
+
+## The crates
+
+| Crate | What it is |
+| --- | --- |
+| `crates/hookecho` | The app. egui UI, wgpu pipelines, settings, desktop binary, Android `cdylib`, wasm entry. |
+| `crates/wxdata` | Fetch and decode. One module per feed (see [docs/DATA.md](docs/DATA.md)). Draws nothing, holds no UI state. |
+| `crates/nexrad-level3` | From-scratch NEXRAD Level 3 (RPG) product decoder. |
+| `crates/hdf5lite` | Minimal read-only HDF5, enough for NOAA's netCDF-4 granules. |
+| `crates/hookecho-ffi` | C ABI over the decoders, for embedding elsewhere. |
+| `vendor/gribberish` | Vendored GRIB2 decoder with local fixes; grep `hookecho patch:`. |
+
+The `wxdata`/`hookecho` split is the load-bearing boundary. A new feed is a
+module in `wxdata` that returns plain data, plus a layer in `hookecho` that
+draws it. If a decoder needs to know about the camera, the split is being
+violated.
+
+## Entry points
+
+All four platforms build the same `HookEchoApp`; only the launch differs
+(`crates/hookecho/src/lib.rs`):
+
+- **Desktop** — `main.rs` dispatches any `--headless-*` verifier or `--serve`, then `run_desktop()`.
+- **Android** — `android_main()` takes the `AndroidApp` handle, points `paths` at the app-private dir, stashes the handle in `platform` for insets.
+- **Web** — `start(canvas_id)` from `web/index.html`. No filesystem, no live chunk stream, only feeds that allow cross-origin.
+- **Headless** — `headless.rs` drives the real pipelines to a PNG with no window. These are the smoke tests.
+
+## The frame loop
+
+`app.rs` is the shell (it is large; the mobile chrome is split into
+`app/mobile/`, per-pane state into `view.rs`):
+
+1. **UI runs.** Buttons, hotkeys, the command palette and the mobile sheet all mutate the *active* `MapView` and nothing else. One action, one path — this is why a hotkey and a button never drift apart.
+2. **Sync step.** Once per frame, the app diffs that state against what the GPU and the fetchers already have: uploads a changed sweep, requests a missing tilt, kicks off a feed refresh.
+3. **Results arrive.** Every fetch returns over an `std::sync::mpsc` channel and asks egui to repaint. `rt.rs` is the whole platform difference: a tokio runtime natively, `spawn_local` on the web.
+
+`platform.rs` gates background work on foreground state — eframe stops calling
+`update()` when Android tears down the surface, so workers check that stamp
+instead of burning battery behind a dark screen.
+
+## State
+
+- `view.rs` — one map pane: camera, product, tilt, loaded `Volume`, LRU of recent scans.
+- `workspace.rs` — a saved arrangement of panes, restored in one command.
+- `settings.rs` — JSON at the platform config dir, `#[serde(default)]` so old files stay loadable. Writes are coalesced into a one-second dirty-diff save, because the Android alert service reads the same file while the app runs.
+- `paths.rs` — every persistent path in the app. The desktop config/data/cache split and Android's single private dir differ here and nowhere else.
+
+## Rendering
+
+`render/` draws through `egui_wgpu::CallbackTrait`, inside egui's own render
+pass:
+
+- `render/mercator.rs` — projection and camera. World coordinates are normalized mercator in `[0,1]`, matching the XYZ tile scheme.
+- `render/mod.rs` — the slippy-map raster tile layer and the polar radar layer. Radar is drawn in polar space on the GPU; it is never resampled to a grid first.
+- `render/field_ramps.rs` — one table mapping every gridded field's values to colors *and* to its legend. Single source, so a scale cannot drift from its own key.
+- `render3d.rs` + `shaders/raymarch.wgsl` — maximum-intensity raymarch of the volume. Cost is the step count in `dims.w`; `ui/volume3d_window.rs` exposes it as the quality preset.
+- `colormap.rs` — color tables, including GRLevelX `.pal` import/export.
+- `tiles.rs`, `vector_tiles.rs` — basemap fetch, LRU cache, visible-tile computation.
+- `wind_gpu.rs`, `stationlayer.rs`, `fronts_draw.rs`, … — the individual overlay layers.
+
+## Extension points, in order of how much they cost you
+
+1. **A `.pal` color table** — no code.
+2. **A placefile** — no code; the GRLevelX text format, rendered natively.
+3. **A plugin** (`plugins.rs`) — any command that prints a placefile on stdout. Language independent, OS-isolated, no new dependencies. It runs with your privileges: the caps are hygiene, not a sandbox.
+4. **A feed** — a `wxdata` module plus a layer, plus a `--headless-*` verifier for it.
+
+## Where the sharp edges are
+
+- **`app.rs` is a god file.** Splitting it is welcome, but state that is genuinely per-pane belongs in `view.rs`, not a new module beside `app.rs`.
+- **The Android field-name contract.** `AlertService.kt` parses `settings.json` by hand in another language. The test `kotlin_alert_service_field_names_survive` is the only compiler that sees both sides.
+- **`cfg` fences are load-bearing.** Web has no filesystem or process spawning; Android has neither `serve` nor ffmpeg. Check `lib.rs` — the module list documents which is which.
+- **`// ponytail:` comments** are the ledger of deliberate ceilings. `grep -rn "ponytail:" crates/` is where [ROADMAP.md](ROADMAP.md) gets restocked.
+- **No telemetry, no accounts, no server of ours.** The app talks to NOAA and the NWS directly. A change that adds a hosted dependency is a change to the product, not just the code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,17 @@ clear before it lands.
 Rule of thumb: if it fetches or decodes, it belongs in `wxdata`; if it draws or
 holds UI state, it belongs in `hookecho`.
 
+[ARCHITECTURE.md](ARCHITECTURE.md) goes a level deeper: the frame loop, where
+state lives, the render layers, and the sharp edges worth knowing before you
+change one.
+
+## Issues
+
+Bug reports and feature requests get a first reply within about a week. There is
+one maintainer and no company behind this, so an issue that sits is unread, not
+rejected — a nudge on the thread is welcome. Issues tagged `good first issue`
+are ones with a known shape and no hidden context; take one without asking.
+
 ## The gate
 
 Every commit is expected to pass:

--- a/README.md
+++ b/README.md
@@ -43,12 +43,15 @@ built from NOAA's free GRIB grids, so it needs no API key.</sub>
   never been run on real Apple hardware, and it is ad-hoc signed, so Gatekeeper
   will ask before it opens. Homebrew users can build it instead:
   `brew install --HEAD d4vid87/hookecho/hookecho` (formula in
-  [`packaging/homebrew`](packaging/homebrew)).
+  [`packaging/homebrew`](packaging/homebrew)). **macOS testers wanted** — there
+  is no Apple hardware behind this project, so an
+  [issue](../../issues) saying what did or did not work is the only way this
+  build stops being experimental.
 - **Package managers**: manifests for
   [Flatpak](packaging/flatpak), [Snap](snap/snapcraft.yaml),
-  [Homebrew](packaging/homebrew) and [winget](packaging/winget) live in the
-  repo. None are published to their stores yet — building from these files
-  works today; a `flatpak install hookecho` does not.
+  [Homebrew](packaging/homebrew), [winget](packaging/winget) and the
+  [AUR](packaging/aur) live in the repo. None are published to their stores
+  yet — building from these files works today; a `flatpak install hookecho` does not.
 - **From source**: `cargo run --release` (needs a Rust toolchain; on Linux also
   ALSA/Wayland/GTK dev headers — see `.github/workflows/ci.yml`). Android builds
   via `android/build.sh` (NDK + `cargo-ndk`).
@@ -628,10 +631,24 @@ hookecho://goto/KTLX                                   # a radar site
 hookecho://goto/KTLX,-97.28,35.33,9                    # site, lon, lat, zoom
 hookecho://goto/,-97.28,35.33,9                        # no site: just the view
 hookecho://goto/KTLX,-97.28,35.33,9,2013-05-20T20:00:00Z   # and an instant
+hookecho://goto/KTLX,-97.28,35.33,9,VEL,1              # and a product and tilt
 ```
 
 The timestamp is RFC 3339 and puts the timeline where it was, so a link can
-point at a moment in the archive rather than at "now".
+point at a moment in the archive rather than at "now". The trailing fields are
+recognized by shape, not position: a timestamp, a product code (`VEL`, `ZDR`,
+`CC`, …) and a tilt index can appear in any order, and any you leave out keep
+whatever the person opening the link already had.
+
+The browser build takes the same thing in the URL fragment, which never leaves
+the client — no server sees where you are looking:
+
+```
+https://hookecho.pages.dev/#goto=KTLX,-97.28,35.33,9,VEL
+```
+
+"Copy link to this view" in the command palette writes the right form for
+whichever build you are running.
 
 ## Keyboard
 

--- a/README.md
+++ b/README.md
@@ -678,9 +678,12 @@ reading the screen in direct sun.
   local-parameter fixes; grep `hookecho patch:`).
 - `scripts/shots` — the screenshot harness that produced everything above.
 
-Also worth reading: [docs/DATA.md](docs/DATA.md) — every feed the app decodes,
-with its cadence, latency and whether it needs a key; [ROADMAP.md](ROADMAP.md) —
-what's next and what isn't planned; [CONTRIBUTING.md](CONTRIBUTING.md) — how the
+Also worth reading: [docs/GUIDE.md](docs/GUIDE.md) — the task-by-task user
+guide, "how do I actually do this"; [docs/DATA.md](docs/DATA.md) — every feed the
+app decodes, with its cadence, latency and whether it needs a key;
+[ROADMAP.md](ROADMAP.md) — what's next and what isn't planned;
+[ARCHITECTURE.md](ARCHITECTURE.md) — how the code is shaped;
+[CONTRIBUTING.md](CONTRIBUTING.md) — how the
 workspace fits together and what a patch has to clear;
 [CHANGELOG.md](CHANGELOG.md) — what changed per release;
 [docs/promotion.md](docs/promotion.md) — how a release is cut and announced.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -52,8 +52,13 @@
         android:label="@string/app_name"
         android:theme="@style/Theme.HookEcho"
         android:enableOnBackInvokedCallback="true">
+        <!-- singleTask, not the default: `android_main` runs once per process, so a second activity
+             instance (a deep link, or relaunching after back) leaves the Rust event loop attached to
+             the activity that is gone — the app freezes on its last frame or sits on the splash
+             screen forever. One instance means every later launch arrives through onNewIntent. -->
         <activity
             android:name=".MainActivity"
+            android:launchMode="singleTask"
             android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|keyboard|keyboardHidden|navigation|uiMode|density"
             android:screenOrientation="sensor"
             android:windowSoftInputMode="adjustResize"

--- a/android/app/src/main/kotlin/zip/batman/hookecho/MainActivity.kt
+++ b/android/app/src/main/kotlin/zip/batman/hookecho/MainActivity.kt
@@ -88,6 +88,24 @@ class MainActivity : GameActivity() {
 
     private external fun nativeOnBack()
 
+    /**
+     * Back out of the app and the process has to go with it.
+     *
+     * `android_main` is a one-shot: the Rust event loop starts when the native thread does, and it
+     * does not stop when the Java activity is destroyed — it keeps ticking frames against a window
+     * that no longer exists, which measured at 100% of a core indefinitely, and the next launch
+     * finds a process that already ran its entry point, so it sits on the splash screen forever.
+     * Ending the process is the only exit that leaves the next launch a clean one.
+     *
+     * Only when the user is actually leaving: a destroy for a configuration change must not take
+     * the process with it. [AlertService] is `START_STICKY`, so background alerting comes back on
+     * its own for anyone who has it switched on.
+     */
+    override fun onDestroy() {
+        super.onDestroy()
+        if (isFinishing) android.os.Process.killProcess(android.os.Process.myPid())
+    }
+
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)

--- a/crates/hookecho/Cargo.toml
+++ b/crates/hookecho/Cargo.toml
@@ -94,7 +94,7 @@ getrandom = { version = "0.3", features = ["wasm_js"] }
 # app's own logs in the devtools console, which is the only debugger a wasm build has.
 console_error_panic_hook = "0.1"
 console_log = "1"
-web-sys = { version = "0.3", features = ["Document", "Window", "HtmlCanvasElement", "Storage", "HtmlAudioElement", "SpeechSynthesis", "SpeechSynthesisUtterance"] }
+web-sys = { version = "0.3", features = ["Document", "Window", "HtmlCanvasElement", "Location", "Storage", "HtmlAudioElement", "SpeechSynthesis", "SpeechSynthesisUtterance"] }
 
 # Native file dialogs — desktop only. rfd has no Android backend, and Android replaces it with a
 # fixed exports dir + Storage-Access-Framework (deferred); see `dialog.rs`.

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1606,6 +1606,9 @@ pub struct HookEchoApp {
     /// the pair rarely shares a cycle, and a difference between two instants has to say so.
     diff_field: crate::fielddiff::DiffField,
     diff_valid: Option<(String, String)>,
+    /// When `goto.txt` was last looked for. Android only — see the poll in `update`.
+    #[cfg(target_os = "android")]
+    goto_poll: Option<Instant>,
     /// The field the difference layer was last fetched for, so a change refetches at once.
     diff_key: Option<(crate::fielddiff::DiffField, u16)>,
     /// Where the open sounding was taken, so a forecast-hour change can refetch the same point.
@@ -2324,6 +2327,8 @@ impl HookEchoApp {
             global_layer_key: std::collections::HashMap::new(),
             diff_field: crate::fielddiff::DiffField::default(),
             diff_valid: None,
+            #[cfg(target_os = "android")]
+            goto_poll: None,
             diff_key: None,
             sounding_at: None,
             zone_pts: Vec::new(),
@@ -13124,6 +13129,18 @@ impl eframe::App for HookEchoApp {
             }
             // A resume is also how a notification tap arrives: the activity wrote the target
             // before handing us back the surface.
+            self.drain_goto_file();
+        }
+        // A deep link that arrives while the app is already on screen never produces a resume, so
+        // the drain above would never see it — the activity is reused (`launchMode="singleTask"`)
+        // and only `onNewIntent` fires. ponytail: a one-second stat of a path that usually does
+        // not exist, rather than a JNI callback into the event loop.
+        #[cfg(target_os = "android")]
+        if self
+            .goto_poll
+            .is_none_or(|t| t.elapsed() >= std::time::Duration::from_secs(1))
+        {
+            self.goto_poll = Some(Instant::now());
             self.drain_goto_file();
         }
         // A file the user picked, from any of the import buttons. Routed here rather than at the

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -6948,8 +6948,8 @@ impl HookEchoApp {
                     !self.settings.mapbox_key.is_empty(),
                     !self.settings.maptiler_key.is_empty(),
                 );
-                let v = &mut self.views[self.active];
-                v.basemap = v.basemap.next(mb, mt);
+                let next = self.views[self.active].basemap.next(mb, mt);
+                self.set_basemap(next);
             }
             PaletteAction::ToggleMute => self.apply_action(BindableAction::ToggleMute, ctx),
             PaletteAction::ToggleToolbar => {
@@ -12074,6 +12074,19 @@ impl HookEchoApp {
             if ui.button("Exit").clicked() {
                 ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
             }
+        }
+    }
+
+    /// Put `style` under the active pane and remember it.
+    ///
+    /// Remembering is the point: the basemap used to live only on the view, so a style picked
+    /// during a chase was gone at the next launch, which read `settings.basemap` and found
+    /// whatever the setup wizard wrote months earlier.
+    pub(crate) fn set_basemap(&mut self, style: crate::tiles::BasemapStyle) {
+        self.views[self.active].basemap = style;
+        if self.settings.basemap != style.slug() {
+            self.settings.basemap = style.slug().to_string();
+            self.settings.save();
         }
     }
 

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -22,10 +22,10 @@ use lru::LruCache;
 use std::num::NonZeroUsize;
 use std::sync::mpsc::{Receiver, Sender};
 use std::sync::Arc;
-use wxdata::clock::Instant;
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::runtime::Runtime;
 use wxdata::alerts::{self};
+use wxdata::clock::Instant;
 use wxdata::level2::{self, BinnedSweep, Identifier, Moment, Scan};
 use wxdata::level3::{self, Cell, CellKind};
 use wxdata::live;
@@ -391,7 +391,7 @@ impl OverlaySource {
             }
             OverlaySource::ModelDiff(field, fh) => {
                 use crate::fielddiff::DiffField;
-                use wxdata::global::{GlobalModel, GlobalField};
+                use wxdata::global::{GlobalField, GlobalModel};
                 let (a, b, valid) = match field {
                     DiffField::Global(kind) => {
                         let g: GlobalField = kind.into();
@@ -415,10 +415,20 @@ impl OverlaySource {
                         };
                         let (hrrr, rap) = futures_util::future::try_join(
                             wxdata::hrrr::fetch_field(
-                                http, wxdata::hrrr::Model::Hrrr, var, level, 0, min_valid,
+                                http,
+                                wxdata::hrrr::Model::Hrrr,
+                                var,
+                                level,
+                                0,
+                                min_valid,
                             ),
                             wxdata::hrrr::fetch_field(
-                                http, wxdata::hrrr::Model::Rap, var, level, 0, min_valid,
+                                http,
+                                wxdata::hrrr::Model::Rap,
+                                var,
+                                level,
+                                0,
+                                min_valid,
                             ),
                         )
                         .await?;
@@ -1401,34 +1411,106 @@ fn windy_url(overlay: &str, lon: f64, lat: f64, zoom: f64) -> String {
 /// site-less `,lon,lat,zoom` form), and a tapped `hookecho://goto/…` link.
 const GOTO_SCHEME: &str = "hookecho://goto/";
 
-/// Parse `[hookecho://goto/]SITE,lon,lat,zoom[,RFC3339]`. The site may be empty.
-#[allow(clippy::type_complexity)]
-fn parse_goto(v: &str) -> Option<(String, f64, f64, f64, Option<DateTime<Utc>>)> {
-    let v = v.trim().strip_prefix(GOTO_SCHEME).unwrap_or(v.trim());
-    let p: Vec<&str> = v.split(',').map(str::trim).collect();
-    let (Some(site), Some(Ok(lon)), Some(Ok(lat)), Some(Ok(zoom))) = (
-        p.first(),
-        p.get(1).map(|s| s.parse()),
-        p.get(2).map(|s| s.parse()),
-        p.get(3).map(|s| s.parse()),
-    ) else {
-        return None;
-    };
-    let time = p.get(4).filter(|s| !s.is_empty()).and_then(|s| {
-        chrono::DateTime::parse_from_rfc3339(s)
-            .map(|t| t.with_timezone(&Utc))
-            .map_err(|e| log::warn!("goto: bad time {s:?}: {e}"))
-            .ok()
-    });
-    Some((site.to_string(), lon, lat, zoom, time))
+/// A parsed deep link. `moment`/`tilt` stay `None` unless the link named them, so a link that
+/// only says where to look leaves the product the viewer already had.
+struct Goto {
+    site: String,
+    lon: f64,
+    lat: f64,
+    zoom: f64,
+    time: Option<DateTime<Utc>>,
+    moment: Option<Moment>,
+    tilt: Option<usize>,
 }
 
-/// The shareable link for a view.
-fn goto_link(site: &str, lon: f64, lat: f64, zoom: f64, time: Option<DateTime<Utc>>) -> String {
+/// Parse `[hookecho://goto/]SITE[,lon,lat,zoom][,extra…]`, where each extra is an RFC3339 time, a
+/// moment code (`VEL`) or a tilt index — sniffed by shape, so their order does not matter. A bare
+/// `SITE` flies to the site itself; the site may be empty when lon/lat are given.
+fn parse_goto(v: &str) -> Option<Goto> {
+    let v = v.trim().strip_prefix(GOTO_SCHEME).unwrap_or(v.trim());
+    let p: Vec<&str> = v.split(',').map(str::trim).collect();
+    let mut g = if p.len() == 1 {
+        let s = wxdata::sites::site_by_id(p[0])?;
+        // Same zoom a cold start picks for the default site.
+        Goto {
+            site: p[0].to_ascii_uppercase(),
+            lon: s.longitude as f64,
+            lat: s.latitude as f64,
+            zoom: 8.0,
+            time: None,
+            moment: None,
+            tilt: None,
+        }
+    } else {
+        let (Some(site), Some(Ok(lon)), Some(Ok(lat)), Some(Ok(zoom))) = (
+            p.first(),
+            p.get(1).map(|s| s.parse()),
+            p.get(2).map(|s| s.parse()),
+            p.get(3).map(|s| s.parse()),
+        ) else {
+            return None;
+        };
+        Goto {
+            site: site.to_string(),
+            lon,
+            lat,
+            zoom,
+            time: None,
+            moment: None,
+            tilt: None,
+        }
+    };
+    for s in p.iter().skip(4).filter(|s| !s.is_empty()) {
+        if let Ok(t) = chrono::DateTime::parse_from_rfc3339(s) {
+            g.time = Some(t.with_timezone(&Utc));
+        } else if let Some(m) = Moment::from_code(s) {
+            g.moment = Some(m);
+        } else if let Ok(i) = s.parse::<usize>() {
+            g.tilt = Some(i);
+        } else {
+            log::warn!("goto: ignoring unrecognized field {s:?}");
+        }
+    }
+    Some(g)
+}
+
+/// The shareable link for a view. Native gets the `hookecho://` scheme the OS has registered; the
+/// browser build gets its own origin with the state in the fragment, which never leaves the client
+/// — no server, cache or worker ever sees where someone is looking.
+fn goto_link(
+    site: &str,
+    lon: f64,
+    lat: f64,
+    zoom: f64,
+    time: Option<DateTime<Utc>>,
+    moment: Moment,
+    tilt: usize,
+) -> String {
     let t = time
         .map(|t| format!(",{}", t.to_rfc3339()))
         .unwrap_or_default();
-    format!("{GOTO_SCHEME}{site},{lon:.4},{lat:.4},{zoom:.1}{t}")
+    let m = if moment != Moment::Reflectivity {
+        format!(",{}", moment.short_name())
+    } else {
+        String::new()
+    };
+    let z = if tilt != 0 {
+        format!(",{tilt}")
+    } else {
+        String::new()
+    };
+    let body = format!("{site},{lon:.4},{lat:.4},{zoom:.1}{t}{m}{z}");
+    #[cfg(target_arch = "wasm32")]
+    {
+        let origin = web_sys::window()
+            .and_then(|w| w.location().origin().ok())
+            .unwrap_or_default();
+        format!("{origin}/#goto={body}")
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        format!("{GOTO_SCHEME}{body}")
+    }
 }
 
 /// How a lightning flash looks at `age_secs`: bright white-hot when it just happened, fading to a
@@ -1609,6 +1691,9 @@ pub struct HookEchoApp {
     /// When `goto.txt` was last looked for. Android only — see the poll in `update`.
     #[cfg(target_os = "android")]
     goto_poll: Option<Instant>,
+    /// The last difference grid, kept on the CPU after upload so the cursor can read a number off
+    /// it. A diverging color says "the models disagree here"; only a value says by how much.
+    diff_grid: Option<wxdata::mrms::MrmsField>,
     /// The field the difference layer was last fetched for, so a change refetches at once.
     diff_key: Option<(crate::fielddiff::DiffField, u16)>,
     /// Where the open sounding was taken, so a forecast-hour change can refetch the same point.
@@ -2327,6 +2412,7 @@ impl HookEchoApp {
             global_layer_key: std::collections::HashMap::new(),
             diff_field: crate::fielddiff::DiffField::default(),
             diff_valid: None,
+            diff_grid: None,
             #[cfg(target_os = "android")]
             goto_poll: None,
             diff_key: None,
@@ -2598,6 +2684,8 @@ impl HookEchoApp {
         app.palettes.reload(&app.settings.palette_paths());
         app.apply_goto_env();
         app.drain_goto_file();
+        #[cfg(target_arch = "wasm32")]
+        app.apply_goto_hash();
         crate::platform::set_background_alerts(app.settings.background_alerts);
         app.fetch_overlays(&cc.egui_ctx.clone());
         app
@@ -2630,13 +2718,33 @@ impl HookEchoApp {
         self.apply_goto(v.trim());
     }
 
-    /// `SITE,lon,lat,zoom[,RFC3339]`, with or without the `hookecho://goto/` prefix.
+    /// `SITE[,lon,lat,zoom][,extra…]`, with or without the `hookecho://goto/` prefix.
     fn apply_goto(&mut self, v: &str) {
-        let Some((site, lon, lat, zoom, time)) = parse_goto(v) else {
-            log::warn!("HOOKECHO_GOTO: want SITE,lon,lat,zoom[,RFC3339], got {v:?}");
+        let Some(g) = parse_goto(v) else {
+            log::warn!("HOOKECHO_GOTO: want SITE[,lon,lat,zoom[,RFC3339|product|tilt]], got {v:?}");
             return;
         };
-        self.goto_view(&site, lon, lat, zoom, time);
+        self.goto_view(&g.site, g.lon, g.lat, g.zoom, g.time);
+        let view = &mut self.views[self.active];
+        if let Some(m) = g.moment {
+            view.moment = m;
+        }
+        if let Some(t) = g.tilt {
+            view.tilt = t;
+        }
+    }
+
+    /// The browser's own deep link: `https://…/#goto=KTLX,-97.3,35.3,9`. Read once at boot — a
+    /// fragment change afterwards is someone editing the URL bar, not a share being opened.
+    /// ponytail: no percent-decoding; fragments carry `,` and `:` verbatim.
+    #[cfg(target_arch = "wasm32")]
+    fn apply_goto_hash(&mut self) {
+        let Some(h) = web_sys::window().and_then(|w| w.location().hash().ok()) else {
+            return;
+        };
+        if let Some(v) = h.strip_prefix("#goto=") {
+            self.apply_goto(v);
+        }
     }
 
     /// Volume poll cadence, doubled on a metered link. A phone on mobile data pulls a multi-MB
@@ -4706,28 +4814,26 @@ impl HookEchoApp {
                 } else {
                     ui.horizontal(|ui| {
                         ui.strong(format!("{} tornadoes on record", self.climo_hits.len()));
-                        ui.with_layout(
-                            egui::Layout::right_to_left(egui::Align::Center),
-                            |ui| {
-                                let hits = &self.climo_hits;
-                                crate::ui::csv_buttons(
-                                    ui,
-                                    "tornadoes.csv",
-                                    "Every tornado on record here, not just the first 50",
-                                    || {
-                                        let mut s =
-                                            String::from("year,mag,start_lat,start_lon,end_lat,end_lon\n");
-                                        for t in hits {
-                                            s.push_str(&format!(
-                                                "{},{},{:.4},{:.4},{:.4},{:.4}\n",
-                                                t.year, t.mag, t.slat, t.slon, t.elat, t.elon
-                                            ));
-                                        }
-                                        s
-                                    },
-                                );
-                            },
-                        );
+                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                            let hits = &self.climo_hits;
+                            crate::ui::csv_buttons(
+                                ui,
+                                "tornadoes.csv",
+                                "Every tornado on record here, not just the first 50",
+                                || {
+                                    let mut s = String::from(
+                                        "year,mag,start_lat,start_lon,end_lat,end_lon\n",
+                                    );
+                                    for t in hits {
+                                        s.push_str(&format!(
+                                            "{},{},{:.4},{:.4},{:.4},{:.4}\n",
+                                            t.year, t.mag, t.slat, t.slon, t.elat, t.elon
+                                        ));
+                                    }
+                                    s
+                                },
+                            );
+                        });
                     });
                     let hist = wxdata::torclimo::mag_histogram(&self.climo_hits);
                     ui.horizontal_wrapped(|ui| {
@@ -6625,7 +6731,7 @@ impl HookEchoApp {
         push(
             "Copy link to this view",
             "Reference",
-            "A hookecho:// link to this site, place, zoom and time \u{2014} opens the app here",
+            "A link to this site, place, zoom, time and product \u{2014} opens Hook Echo here",
             true,
             PaletteAction::CopyViewLink,
             None,
@@ -6978,6 +7084,8 @@ impl HookEchoApp {
                     lat,
                     v.camera.zoom,
                     time,
+                    v.moment,
+                    v.tilt,
                 );
                 ctx.copy_text(link.clone());
                 self.banner("Link copied".to_string(), link);
@@ -7188,6 +7296,7 @@ impl HookEchoApp {
                         s.pending = Some(upload);
                     }
                     self.diff_valid = Some(valid);
+                    self.diff_grid = Some(field);
                 }
                 OverlayMsg::StormReports(bucket, reports) => match bucket {
                     None => self.storm_reports = reports,
@@ -8626,7 +8735,8 @@ impl HookEchoApp {
                 // switch two streams overlap for up to the 15 s wait clamp. Both merge into
                 // their own volumes and only the live one is displayed, so the cost is one
                 // wasted chunk fetch. An abort channel if that ever shows up on a phone bill.
-                self.live_gen.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                self.live_gen
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 self.live_stream = None;
             }
         }
@@ -11246,6 +11356,29 @@ impl HookEchoApp {
             }
         }
 
+        // The difference layer reads as "they disagree here" and nothing more without a number,
+        // so the cursor samples the grid it was drawn from.
+        if self
+            .fields
+            .get(&crate::render::FieldLayer::ModelDiff)
+            .is_some_and(|s| s.show)
+        {
+            if let (Some(grid), Some(hp)) = (self.diff_grid.as_ref(), response.hover_pos()) {
+                let w = cam.screen_to_world((hp.x - prect.left(), hp.y - prect.top()), vp);
+                let (lon, lat) = crate::render::mercator::world_to_lonlat(w.0, w.1);
+                if let Some(v) = grid.sample_bilinear(lon, lat) {
+                    let f = self.diff_field;
+                    let v = v * f.input_scale();
+                    let (a, b) = f.pair();
+                    response.clone().show_tooltip_text(format!(
+                        "{}: {v:+.1} {} ({a} \u{2212} {b})",
+                        f.label(),
+                        f.units()
+                    ));
+                }
+            }
+        }
+
         // Beam-vs-terrain blockage shading, under the reference annotations. The raster covers a
         // world-space rect, which maps linearly to screen, so it is one stretched image — and while
         // a rebuild is in flight the previous rect keeps it registered to the ground.
@@ -11640,7 +11773,11 @@ impl HookEchoApp {
                 .rev()
                 .find(|l| self.fields.get(l).is_some_and(|s| s.show))
             {
-                y += ui::legend::draw_field(&painter, prect, *top, y);
+                y += if *top == crate::render::FieldLayer::ModelDiff {
+                    ui::legend::draw_diff(&painter, prect, self.diff_field, y)
+                } else {
+                    ui::legend::draw_field(&painter, prect, *top, y)
+                };
             }
             // Wind particles carry their own scale — it isn't a FieldLayer, so it needs its own
             // call rather than a slot in DRAW_ORDER.
@@ -12178,14 +12315,16 @@ impl HookEchoApp {
             }
             K::Palette => {
                 // Setting the override triggers the next-frame dirty-diff palette reload.
-                self.settings.palettes.insert(
-                    import.tag,
-                    import.path.to_string_lossy().into_owned(),
-                );
+                self.settings
+                    .palettes
+                    .insert(import.tag, import.path.to_string_lossy().into_owned());
             }
             K::MarkerIcon => {
                 let idx = import.tag.parse::<usize>().ok();
-                match (idx.and_then(|i| self.settings.markers.get_mut(i)), crate::ui::marker_window::store_icon(&import.path)) {
+                match (
+                    idx.and_then(|i| self.settings.markers.get_mut(i)),
+                    crate::ui::marker_window::store_icon(&import.path),
+                ) {
                     (Some(m), Some(name)) => m.icon = Some(name),
                     _ => log::warn!("marker icon import went nowhere (marker {})", import.tag),
                 }
@@ -14764,32 +14903,58 @@ mod tests {
 
     #[test]
     fn goto_parses_every_form_it_arrives_in() {
-        let (site, lon, lat, zoom, time) = parse_goto("KTLX,-97.3,35.3,9").unwrap();
-        assert_eq!((site.as_str(), lon, lat, zoom), ("KTLX", -97.3, 35.3, 9.0));
-        assert!(time.is_none());
+        let g = parse_goto("KTLX,-97.3,35.3,9").unwrap();
+        assert_eq!(
+            (g.site.as_str(), g.lon, g.lat, g.zoom),
+            ("KTLX", -97.3, 35.3, 9.0)
+        );
+        assert!(g.time.is_none() && g.moment.is_none() && g.tilt.is_none());
         // The URL form is the same string behind a scheme.
         assert_eq!(
-            parse_goto("hookecho://goto/KTLX,-97.3,35.3,9").unwrap().0,
+            parse_goto("hookecho://goto/KTLX,-97.3,35.3,9")
+                .unwrap()
+                .site,
             "KTLX"
         );
         // AlertService writes a site-less notification link; that must keep working.
-        let (site, ..) = parse_goto(",-97.3,35.3,9").unwrap();
-        assert_eq!(site, "");
+        assert_eq!(parse_goto(",-97.3,35.3,9").unwrap().site, "");
         // Archive links carry a time.
-        let (.., time) = parse_goto("KTLX,-97.3,35.3,9,2013-05-20T20:00:00Z").unwrap();
-        assert_eq!(time.unwrap().to_rfc3339(), "2013-05-20T20:00:00+00:00");
+        let g = parse_goto("KTLX,-97.3,35.3,9,2013-05-20T20:00:00Z").unwrap();
+        assert_eq!(g.time.unwrap().to_rfc3339(), "2013-05-20T20:00:00+00:00");
+        // A bare site resolves from the registry.
+        let g = parse_goto("ktlx").unwrap();
+        assert_eq!(g.site, "KTLX");
+        assert!(g.lon < -97.0 && g.lat > 35.0 && g.zoom == 8.0);
+        // Product and tilt are sniffed by shape, in either order.
+        for v in ["KTLX,-97.3,35.3,9,VEL,2", "KTLX,-97.3,35.3,9,2,VEL"] {
+            let g = parse_goto(v).unwrap();
+            assert_eq!((g.moment, g.tilt), (Some(Moment::Velocity), Some(2)), "{v}");
+        }
         assert!(parse_goto("").is_none());
         assert!(parse_goto("garbage").is_none());
     }
 
     #[test]
     fn goto_link_round_trips() {
-        let link = goto_link("KFWS", -97.3031, 32.5731, 8.5, None);
+        let link = goto_link(
+            "KFWS",
+            -97.3031,
+            32.5731,
+            8.5,
+            None,
+            Moment::Reflectivity,
+            0,
+        );
         assert!(link.starts_with("hookecho://goto/KFWS,"), "{link}");
-        let (site, lon, lat, zoom, _) = parse_goto(&link).unwrap();
-        assert_eq!(site, "KFWS");
-        assert!((lon - -97.3031).abs() < 1e-4 && (lat - 32.5731).abs() < 1e-4);
-        assert_eq!(zoom, 8.5);
+        let g = parse_goto(&link).unwrap();
+        assert_eq!(g.site, "KFWS");
+        assert!((g.lon - -97.3031).abs() < 1e-4 && (g.lat - 32.5731).abs() < 1e-4);
+        assert_eq!(g.zoom, 8.5);
+        // Reflectivity at the base tilt is the default, so it stays out of the link.
+        assert!(!link.contains("dBZ"), "{link}");
+        let link = goto_link("KFWS", -97.3, 32.5, 8.5, None, Moment::Velocity, 3);
+        let g = parse_goto(&link).unwrap();
+        assert_eq!((g.moment, g.tilt), (Some(Moment::Velocity), Some(3)));
     }
 
     /// The draw tool must append into the stroke in flight and start a new one per drag, and Undo

--- a/crates/hookecho/src/app/mobile/mod.rs
+++ b/crates/hookecho/src/app/mobile/mod.rs
@@ -427,6 +427,52 @@ impl super::HookEchoApp {
         actions
     }
 
+    /// The basemap picker, as chips.
+    ///
+    /// The only way to change the map underneath the radar used to be the palette's "Cycle
+    /// basemap" row, which advances one step through forty styles and closes the sheet as it goes
+    /// — reaching satellite imagery from dark vector was nine round trips through the menu. These
+    /// set the style directly and leave the sheet open, so trying two is two taps.
+    fn basemap_chips(&mut self, ui: &mut egui::Ui) {
+        use crate::tiles::BasemapStyle;
+        let (mb, mt) = (
+            !self.settings.mapbox_key.is_empty(),
+            !self.settings.maptiler_key.is_empty(),
+        );
+        let cur = self.views[self.active].basemap;
+        let mut pick = None;
+        ui.label(egui::RichText::new("Basemap").size(crate::ui::m3::T_LABEL_LG));
+        ui.horizontal_wrapped(|ui| {
+            for s in BasemapStyle::COMMON {
+                if s.available(mb, mt)
+                    && crate::ui::m3::chip(ui, s.short_label(), s == cur).clicked()
+                {
+                    pick = Some(s);
+                }
+            }
+        });
+        // Everything COMMON leaves out — the other GOES products, the provider styles a key
+        // unlocks — behind one disclosure rather than in the chip row.
+        egui::CollapsingHeader::new("All basemaps")
+            .id_salt("m_basemap_all")
+            .default_open(!BasemapStyle::COMMON.contains(&cur))
+            .show(ui, |ui| {
+                ui.horizontal_wrapped(|ui| {
+                    for s in BasemapStyle::ALL {
+                        if BasemapStyle::COMMON.contains(&s) || !s.available(mb, mt) {
+                            continue;
+                        }
+                        if crate::ui::m3::chip(ui, s.label(), s == cur).clicked() {
+                            pick = Some(s);
+                        }
+                    }
+                });
+            });
+        if let Some(s) = pick {
+            self.set_basemap(s);
+        }
+    }
+
     /// The main menu, as a modal bottom sheet: the shared layer registry up top, the expert
     /// controls behind "Advanced", app rows below. Same content the desktop drawer shows — one
     /// list, not a phone copy of it that drifts.
@@ -449,6 +495,8 @@ impl super::HookEchoApp {
                     }
                 }
             });
+            ui.add_space(crate::ui::m3::SP_2);
+            self.basemap_chips(ui);
             ui.add_space(crate::ui::m3::SP_2);
             let entries = self.palette_entries();
             let mut query = std::mem::take(&mut self.mobile_drawer_query);

--- a/crates/hookecho/src/tiles.rs
+++ b/crates/hookecho/src/tiles.rs
@@ -129,6 +129,34 @@ impl BasemapStyle {
         BasemapStyle::MapTilerDatavizDark,
     ];
 
+    /// The handful worth a one-tap chip on a phone: two vector styles, three ways of seeing the
+    /// ground, roads, terrain, live satellite, and nothing at all. Everything else in [`Self::ALL`]
+    /// is a variation on one of these and lives behind the picker's "All basemaps".
+    pub const COMMON: [BasemapStyle; 8] = [
+        BasemapStyle::Dark,
+        BasemapStyle::Light,
+        BasemapStyle::Satellite,
+        BasemapStyle::EsriImagery,
+        BasemapStyle::OsmStandard,
+        BasemapStyle::OpenTopoMap,
+        BasemapStyle::GoesEast,
+        BasemapStyle::None,
+    ];
+
+    /// A chip-sized name. [`Self::label`] is the full one — "GOES-East (GeoColor)" wraps a phone
+    /// chip onto two lines and pushes the row off the sheet.
+    pub fn short_label(self) -> &'static str {
+        match self {
+            BasemapStyle::Satellite => "USGS",
+            BasemapStyle::EsriImagery => "Satellite",
+            BasemapStyle::OsmStandard => "Streets",
+            BasemapStyle::OpenTopoMap => "Topo",
+            BasemapStyle::GoesEast => "GOES-East",
+            BasemapStyle::GoesWest => "GOES-West",
+            _ => self.label(),
+        }
+    }
+
     pub fn label(self) -> &'static str {
         match self {
             BasemapStyle::Dark => "Dark",

--- a/crates/hookecho/src/ui/legend.rs
+++ b/crates/hookecho/src/ui/legend.rs
@@ -212,6 +212,68 @@ pub fn draw_field(
     }
 }
 
+/// The difference layer's key: the same diverging LUT the grid was colored with, drawn across
+/// ±range so the reader can tell a cool cell from a warm one and read the size of the split. The
+/// transparent middle is the deadband — where the two models agree and the layer draws nothing —
+/// so the card shows through there exactly as the map does.
+pub fn draw_diff(
+    painter: &egui::Painter,
+    map_rect: Rect,
+    field: crate::fielddiff::DiffField,
+    y_offset: f32,
+) -> f32 {
+    let font = FontId::proportional(10.0);
+    let origin = map_rect.left_top() + Vec2::new(INSET, INSET + y_offset);
+    let panel = Rect::from_min_size(origin, Vec2::new(BAR_W + PAD_X * 2.0, BAR_H + 16.0 + 14.0));
+    let bar = Rect::from_min_size(panel.min + Vec2::new(PAD_X, 16.0), Vec2::new(BAR_W, BAR_H));
+    card(painter, panel);
+
+    let (range, deadband) = field.range();
+    let lut = crate::fielddiff::diverging_lut(range, deadband);
+    // One column per pixel of bar, sampled through the same value→index→color path as the grid.
+    let cols = bar.width().round().max(1.0) as usize;
+    for i in 0..cols {
+        let v = ((i as f32 / (cols - 1).max(1) as f32) * 2.0 - 1.0) * range;
+        let k = crate::fielddiff::diff_index(v, range) as usize * 4;
+        let c = Color32::from_rgba_unmultiplied(lut[k], lut[k + 1], lut[k + 2], lut[k + 3]);
+        let x = bar.left() + i as f32;
+        painter.rect_filled(
+            Rect::from_min_max(egui::pos2(x, bar.top()), egui::pos2(x + 1.0, bar.bottom())),
+            0.0,
+            c,
+        );
+    }
+    painter.rect_stroke(
+        bar,
+        0.0,
+        Stroke::new(1.0, Color32::from_gray(90)),
+        egui::StrokeKind::Inside,
+    );
+
+    let (a, b) = field.pair();
+    for (text, align, x) in [
+        (format!("-{range:.0}"), Align2::LEFT_TOP, bar.left()),
+        ("0 (\u{2248})".to_string(), Align2::CENTER_TOP, bar.center().x),
+        (format!("+{range:.0}"), Align2::RIGHT_TOP, bar.right()),
+    ] {
+        painter.text(
+            egui::pos2(x, bar.bottom() + 2.0),
+            align,
+            text,
+            font.clone(),
+            Color32::from_gray(225),
+        );
+    }
+    painter.text(
+        panel.left_top() + Vec2::new(PAD_X, 3.0),
+        Align2::LEFT_TOP,
+        format!("{} {a}\u{2212}{b} ({})", field.label(), field.units()),
+        font,
+        Color32::WHITE,
+    );
+    panel.height() + 6.0
+}
+
 /// The same key, for a ramp that isn't a [`crate::render::FieldLayer`] — the wind particles carry
 /// their scale rather than uploading a grid, but they still owe the reader a legend.
 pub fn draw_ramp(

--- a/crates/hookecho/src/ui/volume3d_window.rs
+++ b/crates/hookecho/src/ui/volume3d_window.rs
@@ -14,7 +14,13 @@ pub struct Volume3dState {
     pub threshold_dbz: f32,
     /// Slab bounds as fractions of the box, `[x0, x1, y0, y1, z0, z1]`.
     pub clip: [f32; 6],
+    /// Raymarch samples per pixel. The cost of the window is almost entirely this number, so it
+    /// is the one knob worth exposing on a phone or an integrated GPU.
+    pub steps: u32,
 }
+
+/// The three quality rungs, coarsest first. 256 is what the window shipped with.
+const STEP_PRESETS: [(&str, u32); 3] = [("Low", 96), ("Medium", 160), ("High", 256)];
 
 impl Default for Volume3dState {
     fn default() -> Self {
@@ -25,6 +31,9 @@ impl Default for Volume3dState {
             // The volume's own floor: nothing hidden until the user asks.
             threshold_dbz: f32::NEG_INFINITY,
             clip: [0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+            // ponytail: a phone is the one place the full march reliably misses frame budget, so
+            // pick by platform rather than benchmarking the GPU.
+            steps: if cfg!(target_os = "android") { 96 } else { 256 },
         }
     }
 }
@@ -85,6 +94,13 @@ pub fn show(
                     }
                 }
             });
+            ui.horizontal(|ui| {
+                ui.label("Quality");
+                for (label, steps) in STEP_PRESETS {
+                    ui.selectable_value(&mut st.steps, steps, label)
+                        .on_hover_text(format!("{steps} samples per pixel"));
+                }
+            });
             egui::CollapsingHeader::new("Slice")
                 .default_open(false)
                 .show(ui, |ui| {
@@ -117,7 +133,7 @@ pub fn show(
                 },
                 clip: st.clip,
             };
-            let uniform = orbit_uniform(st.az, st.el, st.dist, aspect, n, nz, 256, view);
+            let uniform = orbit_uniform(st.az, st.el, st.dist, aspect, n, nz, st.steps, view);
             // On the window's first frame egui may hand us a zero-area rect (auto-size pass);
             // the paint callback would be culled and the one-shot upload lost, leaving the view
             // black until reopened. Hold the upload until the rect is real.
@@ -134,6 +150,13 @@ pub fn show(
 #[cfg(test)]
 mod tests {
     use crate::render3d::threshold_index;
+
+    #[test]
+    fn the_default_quality_is_one_of_the_presets() {
+        // Otherwise no button reads as selected and the row looks broken on first open.
+        let d = super::Volume3dState::default();
+        assert!(super::STEP_PRESETS.iter().any(|&(_, s)| s == d.steps));
+    }
 
     #[test]
     fn dbz_maps_into_the_volume_index_range() {

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -1,0 +1,132 @@
+# User guide
+
+Task by task: how to actually do the thing you opened the app for. The
+[README](../README.md) is the tour and the feature list; this is the "how do I…"
+The [browser demo](https://hookecho.pages.dev/) runs everything below except the
+parts that need a filesystem or GPS.
+
+## Getting oriented
+
+First launch runs the setup wizard: home radar site, theme, how warnings reach
+you. After that the whole app is four regions — **left sidebar** (site, product,
+tilt, every layer, window, tool and setting), **bottom bar** (the timeline),
+**right edge** (the color scale for what you're looking at), and the map.
+
+**If you remember one thing, remember `Ctrl+K`.** It searches the sidebar, and
+Enter runs the top match. Every action in the app is in there, described in
+plain English — products, layers, windows, workspaces, and "Fly to" for any
+place name. You do not need to learn where anything lives.
+
+## Watch a storm right now
+
+1. Sidebar → site → pick the radar nearest the storm (or `Ctrl+K`, type the ID).
+2. Product **Reflectivity (Z)** shows structure — where the rain and hail are.
+3. Product **Velocity (V)** shows motion. Dealiasing is on by default, so a
+   couplet reads as red against green rather than folding into nonsense.
+4. Tilt: the sidebar's tilt row walks the VCP's elevation angles. 0.5° is what's
+   near the ground; climb the tilts to see whether a storm leans.
+5. The **LIVE** badge on the bottom bar means you're on the newest scan. Anything
+   that moves you off it turns it off; click it to snap back.
+
+**Is it rotating?** Velocity, 0.5°, look for tight inbound (green) next to
+outbound (red) over a few gates. Then turn on **storm-relative velocity** in
+Layer options — it subtracts the storm's own motion, so rotation stops hiding
+inside the storm's translation.
+
+**Is it hail?** Reflectivity over ~50 dBZ is a candidate; confirm with
+correlation coefficient (CC) — hail is non-uniform, so CC drops. The **storm
+attributes** table (`Ctrl+K` → "cells") lists every tracked cell with hail size,
+tops and VIL, sorted; click a row to fly there.
+
+**Is it a tornado?** The tornado-debris signature is the three together at low
+tilt: a velocity couplet, high reflectivity, and a *hole* in CC where debris is
+lofted. The app flags candidates, but the three panels are the reason.
+
+## Look at four things at once
+
+Split into panes and give each its own product with cameras linked — Z, V, CC
+and ZDR on the same storm at the same second, or one product at four tilts. It's
+one action in `Ctrl+K` ("four products" / "four tilts").
+
+**Cross-section**: click two points on the map and get the storm in profile —
+core, overhang, and how high the echo goes. Any product.
+
+**3D**: the volume as an orbitable raymarch. Drag to orbit, scroll to zoom, set
+a dBZ floor ("Only above" → *Hail core*) so cores stand alone. Drop **Quality**
+to Low on a phone or an integrated GPU; it only changes sampling, not the data.
+
+## Replay something that already happened
+
+The timeline reaches back to **June 1991**.
+
+1. Right-click the **LIVE** badge → pick the archive day.
+2. Scrub. Warning polygons and local storm reports come along — what was
+   actually in force at the instant you're parked on, not today's.
+3. `R` replays the in-RAM decode buffer instantly.
+4. Export what you're watching: screenshot, GIF, or MP4 loop.
+
+Pre-dual-pol volumes (before ~2012 at your site) simply have no ZDR/CC. That's
+the data, not a bug.
+
+The **event library** has curated historic events; your own bookmarks sit beside
+them. And the **verification lab** scores an office's warnings for a day against
+the reports that came in — POD, FAR, CSI, lead times, and the reports nobody
+warned for.
+
+## Get told without watching
+
+- **Markers** are what alerts watch. Search a place in the sidebar → **Save marker**.
+- Settings → Alerts: chime, desktop notification, [ntfy.sh](https://ntfy.sh)
+  push, Discord/Slack/Matrix webhook. Triggers include warnings, lightning
+  distance, rain arrival, debris signature and rotation.
+- **Android**: opt into the background service and your phone notifies you with
+  the app closed, tiered watch / warning / emergency, tapping through to the storm.
+  The home-screen widget shows what's warned at your saved locations.
+- **Desktop**: tray-based background alerting, and `--serve` if you want the map
+  as an HTTP endpoint.
+
+## Make it yours
+
+- **Color tables**: Settings → Palettes imports GRLevelX `.pal` files, per
+  product, and exports what you've built.
+- **Themes**: 13 built in.
+- **Keyboard**: every binding is remappable in Settings.
+- **Workspaces**: save a pane arrangement (sites, products, tilts, overlays) and
+  restore it in one command. Three ship — Chase, National overview, Analysis.
+- **Placefiles**: the GRLevelX format, rendered natively, with per-layer opacity.
+- **Plugins**: any command that prints a placefile on stdout. See
+  [plugins.md](plugins.md).
+- **Sync** (optional): sign in with Google and settings, locations, placefiles,
+  palettes and keys follow you to your other machines, in your own Drive.
+  Setup: [sync.md](sync.md).
+
+## Out in the field
+
+- **Chase mode**: live GPS as a blue dot, a storm-relative HUD with closest
+  approach and escape bearing.
+- **Offline chase packs**: pre-download basemap tiles for the area you're
+  driving into, before you lose signal. Radar still needs data; the map won't.
+- **Position sharing**: opt in and every Hook Echo on the same network sees
+  everyone's dot. Off-network, point it at a relay URL you host.
+- **Streamer mode**: `F8` hides the chrome, `F9` auto-tours active warnings.
+
+## When something looks wrong
+
+- **Nothing loads.** The app talks to NOAA/NWS directly — check the network
+  first. `--status` prints a per-feed report from the terminal.
+- **A layer is empty and says it needs a key.** That's by design; it stays empty
+  rather than nagging. Keys go in Settings, and stay on your machine.
+- **The map is slow.** Lower the 3D quality preset, turn off animated wind
+  (particles), and reduce the number of panes. On Android, close station cards
+  you aren't reading.
+- **Times look wrong.** Radar times read in *the selected radar's* local time,
+  not yours and not Zulu. Settings → Units switches to UTC.
+- **A forecast layer looks too good.** Check for the model banner — HRRR future
+  radar, rotation tracks and smoke are model output, and the app labels them for
+  as long as they're on.
+- **Disk filling up.** Settings → Storage lists every cache against its cap,
+  with clear and open buttons. Nothing cached is irreplaceable.
+
+Still stuck, or something's wrong that isn't here — open an
+[issue](../../../issues). Include the site, the product and the time you were
+looking at; that's usually enough to replay it.

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,0 +1,48 @@
+# Maintainer: David May <davidmay87@gmail.com>
+#
+# AUR source package. Built from the tag rather than repackaging the AppImage: an -bin package
+# would ship a second copy of every bundled library, and the AUR prefers the real thing when the
+# source builds in a few minutes.
+#
+# Publishing: bump pkgver + sha256sums (scripts/release/stamp-manifests.sh does both), then
+# `makepkg --printsrcinfo > .SRCINFO` and push both files to ssh://aur@aur.archlinux.org/hookecho.git
+pkgname=hookecho
+pkgver=0.8.0
+pkgrel=1
+pkgdesc="Advanced NEXRAD weather radar viewer"
+arch=('x86_64')
+url="https://github.com/d4vid87/hookecho"
+license=('MIT')
+# Mirrors the build deps the release workflow installs; the binary dlopens the X11/Wayland client
+# libs and talks to portals over D-Bus, so these are the whole list.
+depends=('alsa-lib' 'systemd-libs' 'libxkbcommon' 'wayland' 'libxcb' 'gtk3')
+makedepends=('cargo')
+source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('a77106b1869671f6c697cc41c62117518dc9b590eccb932917f258c6509845e6')
+
+prepare() {
+  cd "$pkgname-$pkgver"
+  export RUSTUP_TOOLCHAIN=stable
+  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+}
+
+build() {
+  cd "$pkgname-$pkgver"
+  export RUSTUP_TOOLCHAIN=stable CARGO_TARGET_DIR=target
+  cargo build --frozen --release -p hookecho
+}
+
+package() {
+  cd "$pkgname-$pkgver"
+  install -Dm755 "target/release/$pkgname" "$pkgdir/usr/bin/$pkgname"
+  install -Dm644 packaging/hookecho.desktop "$pkgdir/usr/share/applications/hookecho.desktop"
+  install -Dm644 packaging/zip.batman.hookecho.metainfo.xml \
+    "$pkgdir/usr/share/metainfo/zip.batman.hookecho.metainfo.xml"
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  # Same procedural icon the AppImage renders, at every hicolor size.
+  for px in 48 64 128 256 512; do
+    "target/release/$pkgname" --headless-icon "$srcdir/icon-$px.png" "$px"
+    install -Dm644 "$srcdir/icon-$px.png" \
+      "$pkgdir/usr/share/icons/hicolor/${px}x${px}/apps/$pkgname.png"
+  done
+}

--- a/packaging/homebrew/hookecho.rb
+++ b/packaging/homebrew/hookecho.rb
@@ -8,7 +8,7 @@ class Hookecho < Formula
   homepage "https://github.com/d4vid87/hookecho"
   url "https://github.com/d4vid87/hookecho/archive/refs/tags/v0.8.0.tar.gz"
   # Filled in at tag time: `brew fetch --build-from-source hookecho` prints the checksum.
-  sha256 :no_check
+  sha256 "a77106b1869671f6c697cc41c62117518dc9b590eccb932917f258c6509845e6"
   license "MIT"
   head "https://github.com/d4vid87/hookecho.git", branch: "main"
 

--- a/packaging/winget/zip.batman.hookecho.installer.yaml
+++ b/packaging/winget/zip.batman.hookecho.installer.yaml
@@ -13,6 +13,6 @@ Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/d4vid87/hookecho/releases/download/v0.8.0/Hook_Echo-WX-setup-x86_64.exe
     # Filled in at tag time from `sha256sum` of the uploaded Hook_Echo-WX-setup-x86_64.exe.
-    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
+    InstallerSha256: D33D15376F444D071A3E278088B7A0C3BCFF9CF6CC2AC56C2E65BD42195226C5
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/packaging/zip.batman.hookecho.metainfo.xml
+++ b/packaging/zip.batman.hookecho.metainfo.xml
@@ -26,6 +26,34 @@
     </p>
   </description>
 
+  <developer id="zip.batman">
+    <name>David May</name>
+  </developer>
+
+  <!--
+    Flathub requires at least one screenshot, fetched over https at build time — so these point at
+    the same images the README uses, served raw from the tag rather than from `main`, which would
+    let a later commit change what a published listing shows.
+  -->
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/d4vid87/hookecho/v0.8.0/docs/shots/alltilts.jpg</image>
+      <caption>Level 2 reflectivity at every tilt, over an interactive basemap</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/d4vid87/hookecho/v0.8.0/docs/shots/mosaic.jpg</image>
+      <caption>The national MRMS mosaic</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/d4vid87/hookecho/v0.8.0/docs/shots/alerts.jpg</image>
+      <caption>Warnings, storm reports and spotters</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/d4vid87/hookecho/v0.8.0/docs/shots/hrrr.jpg</image>
+      <caption>HRRR model fields and severe composite parameters</caption>
+    </screenshot>
+  </screenshots>
+
   <launchable type="desktop-id">hookecho.desktop</launchable>
   <url type="homepage">https://github.com/d4vid87/hookecho</url>
   <url type="bugtracker">https://github.com/d4vid87/hookecho/issues</url>

--- a/scripts/release/stamp-manifests.sh
+++ b/scripts/release/stamp-manifests.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Fill the per-release checksums into the store manifests.
+#
+# The winget, Homebrew and AUR manifests all name a version and a hash of something that only
+# exists once the release artifacts are built — so they sit in the repo with placeholders and get
+# stamped here, from the artifacts themselves. The stamped copies are submission inputs (a PR to
+# winget-pkgs, a push to the tap and to the AUR); nothing commits them back to this repo.
+#
+# Usage: scripts/release/stamp-manifests.sh <version> [setup-exe]
+#   e.g. scripts/release/stamp-manifests.sh 0.8.0 dist/Hook_Echo-WX-setup-x86_64.exe
+set -euo pipefail
+
+VER="${1:?usage: stamp-manifests.sh <version> [setup-exe]}"
+EXE="${2:-dist/Hook_Echo-WX-setup-x86_64.exe}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+sha() { sha256sum "$1" | cut -d' ' -f1; }
+
+# winget: the hash is of the installer we just built, not of anything downloadable yet.
+EXE_SHA="$(sha "$EXE")"
+W=packaging/winget
+sed -i \
+  -e "s|^PackageVersion: .*|PackageVersion: $VER|" \
+  -e "s|releases/download/v[^/]*/|releases/download/v$VER/|" \
+  -e "s|^\( *InstallerSha256: \).*|\1${EXE_SHA^^}|" \
+  "$W/zip.batman.hookecho.installer.yaml"
+sed -i "s|^PackageVersion: .*|PackageVersion: $VER|" \
+  "$W/zip.batman.hookecho.yaml" "$W/zip.batman.hookecho.locale.en-US.yaml"
+
+# Homebrew and the AUR both build from the GitHub tag tarball, so both want its hash. GitHub
+# generates that tarball on demand but it is byte-stable for a given tag.
+TARBALL="$(mktemp -t hookecho-src-XXXX.tar.gz)"
+trap 'rm -f "$TARBALL"' EXIT
+curl -fsSL -o "$TARBALL" "https://github.com/d4vid87/hookecho/archive/refs/tags/v$VER.tar.gz"
+SRC_SHA="$(sha "$TARBALL")"
+
+sed -i \
+  -e "s|archive/refs/tags/v[^\"]*\.tar\.gz|archive/refs/tags/v$VER.tar.gz|" \
+  -e "s|^  sha256 .*|  sha256 \"$SRC_SHA\"|" \
+  packaging/homebrew/hookecho.rb
+
+sed -i \
+  -e "s|^pkgver=.*|pkgver=$VER|" \
+  -e "s|^pkgrel=.*|pkgrel=1|" \
+  -e "s|^sha256sums=.*|sha256sums=('$SRC_SHA')|" \
+  packaging/aur/PKGBUILD
+
+echo "stamped $VER: installer $EXE_SHA, source $SRC_SHA"


### PR DESCRIPTION
Four commits, all aimed at the same thing: someone hearing about the app should be able to install it, land on the exact view you meant to share, and read enough to be useful — before anyone writes another feature.

## What is in it

**`fix(android)`** — a second launch of the activity used to hit a dead process (`android_main` runs once per process), so the manifest goes `singleTask` and `onDestroy` kills the process. Deep links arriving while the app is already running are now drained on a 1 s poll instead of only at startup.

**`feat(mobile)`** — the basemap was a cycle action through forty styles, which is not a picker. Eight common styles as chips in the Layers sheet, and the choice persists.

**`docs`** — `docs/GUIDE.md` (task by task: is it rotating, is it hail, how do I replay 2013, what do I do when a layer is empty) and `ARCHITECTURE.md` (the frame loop, where state lives, the render layers, the sharp edges — the god file, the Kotlin field-name contract, the cfg fences). CONTRIBUTING now says what an issue can expect. The 3D raymarch step count was hardcoded to 256 at its only call site despite already being a uniform; it becomes a Quality row, defaulting to 96 on Android where the full march misses frame budget.

**`feat(share)`** — deep links carry the product and tilt, read by shape rather than position, each field optional. The site-only form the README documented is finally accepted. The browser build takes the same body in the URL fragment, so a shared link never tells the server where anyone is looking. Plus the packaging work the store submissions are blocked on: an AUR PKGBUILD, a manifest-stamping script that replaces the winget zeros placeholder and the Homebrew `:no_check`, the two metainfo elements Flathub requires, and a macOS render smoke test (the bundle currently proves only that `--version` runs).

## Checks

- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace` — 395 passed, 27 ignored (network)
- Android changes verified on a physical S24 Ultra over ADB: relaunch, deep link while running, basemap chips

## Not in it

Store submissions themselves (accounts and review queues, not code), and placefile `Image:`, which is waiting on a real file in the wild as a fixture — see #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)