### PR TITLE
R17: correctness batch — background alert parity, stream cancellation, and the small lies

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,23 +17,38 @@ upgrade path out of it (`grep -rn "ponytail:" crates/`).
 
 ## Next
 
-- A packed-RGBA fallback for GPU wind on devices that cannot render to float
-  textures — the CPU path already covers them, so this is only worth doing if
-  one shows up that needs the speed.
+- **GOES satellite imagery** — ABI Level 2 CMIP from the `noaa-goes19`/`-18`
+  buckets, CONUS to start, three bands (visible, clean IR, mid-level water
+  vapor), animated on the timeline the radar already uses. The GIBS basemap
+  layer shows the latest image; this is the archive and the loop.
 - Blending surface observations into the effective-layer analysis, which is the
   remaining difference from SPC's mesoanalysis now that the vertical resolution
   is there.
-
-## Later
-
 - Per-pane thresholds and field layers, saved with the workspace. The difference
   layer would rather be two panes than one subtraction, but field layers are
   app-global, so that waits on this.
+
+## Later
+
+Restocked from `grep -rn "ponytail:" crates/` — 88 of them at the moment, each
+naming its own upgrade path.
+
 - A valid-time alignment for the difference layer: it labels the two cycles
   today rather than interpolating either onto the other's instant.
-- A hover readout and a diverging legend for the difference layer.
 - Colormaps and stroke widths that respond to the high-contrast theme, not just
-  the chrome.
+  the chrome (`theme.rs`).
+- Web persistence: caches live in memory in the browser, so a reload refetches
+  everything. IndexedDB or OPFS is the upgrade (`paths.rs`).
+- A tablet layout for Android — the phone chrome is what a tablet gets today
+  (`ui/m3.rs`).
+- Background alerts that test real polygon intersection instead of sampling
+  points around a marker's radius (`Nws.kt`).
+- Placefile `Image:`, which needs a georeferenced textured quad — and a real
+  file in the wild to pin the corner syntax.
+- Snap positions for the mobile sheets; they dismiss on a drag today but have no
+  half-open state.
+- Temperature units for the gridded contour labels, which still do their own
+  K → °F while the station plots follow the Units setting.
 
 ## Not planned
 
@@ -54,7 +69,8 @@ Already shipped, and sometimes mistaken for gaps:
   updates sweep by sweep during a scan.
 - **GPU wind particles** — advected in a fragment shader, ping-ponging two
   textures, with the CPU mesh still there as the fallback
-  (`HOOKECHO_CPU_WIND=1`).
+  (`HOOKECHO_CPU_WIND=1`). Positions are packed into RGBA already, so a device
+  without float render targets is not the blocker it is sometimes taken for.
 - **Saved workspaces**, three of them shipped, remembering panes, overlays and
   field layers.
 - **Disk caches** for volumes, zones, soundings and snapshots, all capped and
@@ -69,7 +85,7 @@ Already shipped, and sometimes mistaken for gaps:
   wallpaper scripts, with size and zoom on `/snapshot.png` too.
 - **True lunar ephemeris** (Meeus), in place of the mean synodic month.
 - **A model difference layer** — GFS against ECMWF, HRRR against RAP — drawing
-  nothing where the two agree.
+  nothing where the two agree, with a hover readout and a diverging legend.
 - **Effective-layer parameters on the full pressure ladder**, up to 100 hPa, so
   the depth-dependent ones exist on the days they describe.
 - **A headless-browser smoke test in CI**, which is the check `cargo check`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,9 +9,10 @@ upgrade path out of it (`grep -rn "ponytail:" crates/`).
 
 - **macOS**, as an experiment. CI builds and smoke-tests an app bundle, but
   nobody has run it on real hardware, and it is ad-hoc signed.
-- **Store submissions.** The Flatpak, Snap, Homebrew and winget manifests are in
-  the repo and build; none of them is published, which is an account and a
-  review queue away rather than a code change.
+- **Store submissions.** The Flatpak, Snap, Homebrew, AUR and winget manifests
+  are in the repo and build; none of them is published, which is an account and
+  a review queue away rather than a code change. The order and the per-store
+  steps are in [packaging/SUBMITTING.md](packaging/SUBMITTING.md).
 - **Placefile `Image:` support**: parsed and skipped today, waiting on a real
   file in the wild to use as a fixture.
 

--- a/android/app/src/main/kotlin/zip/batman/hookecho/AlertService.kt
+++ b/android/app/src/main/kotlin/zip/batman/hookecho/AlertService.kt
@@ -127,9 +127,11 @@ class AlertService : Service() {
             val before = seen.size
             runCatching {
                 for (m in Nws.watched(context.filesDir)) {
-                    for (a in Nws.alertsAt(m.lat, m.lon)) {
-                        if (a.tier >= Nws.TIER_WARNING) hot = true
-                        if (seen.add(a.id)) notify(context, m, a)
+                    for (p in m.samples) {
+                        for (a in Nws.alertsAt(p[0], p[1])) {
+                            if (a.tier >= Nws.TIER_WARNING) hot = true
+                            if (seen.add(a.id)) notify(context, m, a)
+                        }
                     }
                 }
             }.onFailure { /* offline or NWS hiccup: try again next pass */ }

--- a/android/app/src/main/kotlin/zip/batman/hookecho/Nws.kt
+++ b/android/app/src/main/kotlin/zip/batman/hookecho/Nws.kt
@@ -19,19 +19,100 @@ object Nws {
     const val TIER_EMERGENCY = 3
     private const val USER_AGENT = "hookecho (github.com/d4vid87/hookecho)"
 
-    data class Watch(val name: String, val lat: Double, val lon: Double)
+    /**
+     * A watched place: [lat]/[lon] is where a notification flies the camera, [samples] is every
+     * point asked about. A marker with a watch radius contributes its rim as well as its centre,
+     * and a drawn zone contributes its vertices, so a warning that stops down the road is still
+     * a warning here.
+     */
+    data class Watch(
+        val name: String,
+        val lat: Double,
+        val lon: Double,
+        val samples: List<DoubleArray>,
+    )
 
     data class Alert(val id: String, val event: String, val headline: String, val tier: Int)
 
-    /** Saved markers from settings.json — the same file the Rust app reads and writes. */
+    /** Rim points around a marker, so `?point=` sees a warning that only reaches the radius. */
+    private const val RIM_POINTS = 6
+
+    /** Vertices sampled per drawn zone, evenly spaced around its ring. */
+    private const val ZONE_POINTS = 8
+
+    /** Ceiling on `?point=` requests per pass; api.weather.gov is not ours to hammer. */
+    private const val SAMPLE_CAP = 40
+
+    /**
+     * Saved markers and drawn zones from settings.json — the same file the Rust app reads and
+     * writes (`markers[].name/lat/lon/alert_radius_mi`, `alert_polygons[].name/ring`).
+     *
+     * ponytail: sampled points, not geometry. `?point=` resolves zone-only alerts (geometry null)
+     * server-side, which polygon math in Kotlin would have to re-implement; the ceiling is a small
+     * warning threading between two samples. Real polygon intersection is the upgrade path.
+     */
     fun watched(filesDir: File): List<Watch> {
         val f = File(filesDir, "config/settings.json")
         if (!f.exists()) return emptyList()
-        val markers = JSONObject(f.readText()).optJSONArray("markers") ?: return emptyList()
-        return (0 until markers.length()).mapNotNull { i ->
-            val m = markers.optJSONObject(i) ?: return@mapNotNull null
-            Watch(m.optString("name", "Saved location"), m.optDouble("lat"), m.optDouble("lon"))
-        }.filter { it.lat.isFinite() && it.lon.isFinite() }
+        val root = JSONObject(f.readText())
+        val out = ArrayList<Watch>()
+
+        val markers = root.optJSONArray("markers")
+        for (i in 0 until (markers?.length() ?: 0)) {
+            val m = markers?.optJSONObject(i) ?: continue
+            val lat = m.optDouble("lat")
+            val lon = m.optDouble("lon")
+            if (!lat.isFinite() || !lon.isFinite()) continue
+            val radiusMi = m.optDouble("alert_radius_mi", 0.0).let { if (it.isFinite()) it else 0.0 }
+            val samples = ArrayList<DoubleArray>()
+            samples.add(doubleArrayOf(lat, lon))
+            if (radiusMi > 0.0) {
+                for (k in 0 until RIM_POINTS) samples.add(offset(lat, lon, radiusMi, k * 360.0 / RIM_POINTS))
+            }
+            out.add(Watch(m.optString("name", "Saved location"), lat, lon, samples))
+        }
+
+        val zones = root.optJSONArray("alert_polygons")
+        for (i in 0 until (zones?.length() ?: 0)) {
+            val z = zones?.optJSONObject(i) ?: continue
+            val ring = z.optJSONArray("ring") ?: continue
+            val pts = (0 until ring.length()).mapNotNull { k ->
+                val p = ring.optJSONArray(k) ?: return@mapNotNull null
+                val lon = p.optDouble(0)
+                val lat = p.optDouble(1)
+                if (lat.isFinite() && lon.isFinite()) doubleArrayOf(lat, lon) else null
+            }
+            if (pts.isEmpty()) continue
+            val lat = pts.sumOf { it[0] } / pts.size
+            val lon = pts.sumOf { it[1] } / pts.size
+            val step = maxOf(1, pts.size / ZONE_POINTS)
+            val samples = ArrayList<DoubleArray>()
+            samples.add(doubleArrayOf(lat, lon))
+            for (k in pts.indices step step) samples.add(pts[k])
+            out.add(Watch(z.optString("name", "Watch zone"), lat, lon, samples))
+        }
+
+        // Trim from the back so early markers keep their rim rather than every place losing it.
+        var budget = SAMPLE_CAP
+        return out.map { w ->
+            val take = w.samples.take(maxOf(1, minOf(w.samples.size, budget)))
+            budget -= take.size
+            w.copy(samples = take)
+        }
+    }
+
+    /** Destination point `distMi` from (`lat`,`lon`) on `bearingDeg`, spherical earth. */
+    private fun offset(lat: Double, lon: Double, distMi: Double, bearingDeg: Double): DoubleArray {
+        val ang = distMi / 3958.8
+        val br = Math.toRadians(bearingDeg)
+        val la = Math.toRadians(lat)
+        val lo = Math.toRadians(lon)
+        val la2 = Math.asin(Math.sin(la) * Math.cos(ang) + Math.cos(la) * Math.sin(ang) * Math.cos(br))
+        val lo2 = lo + Math.atan2(
+            Math.sin(br) * Math.sin(ang) * Math.cos(la),
+            Math.cos(ang) - Math.sin(la) * Math.sin(la2),
+        )
+        return doubleArrayOf(Math.toDegrees(la2), Math.toDegrees(lo2))
     }
 
     fun alertsAt(lat: Double, lon: Double): List<Alert> {

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -14143,10 +14143,19 @@ impl eframe::App for HookEchoApp {
                 Err(e) => self.marker_window.status = Some(e),
             }
         }
-        if let Some(query) = self
+        let query = self
             .marker_window
-            .show(ctx, &mut self.settings, &self.marker_icon_tex)
-        {
+            .show(ctx, &mut self.settings, &self.marker_icon_tex);
+        // The map popup indexes into the same list: a delete above it leaves it describing the
+        // wrong marker, which is the one way this UI can lie about which place you are editing.
+        if let (Some(gone), Some(open)) = (self.marker_window.removed, self.marker_popup) {
+            self.marker_popup = match gone.cmp(&open) {
+                std::cmp::Ordering::Less => Some(open - 1),
+                std::cmp::Ordering::Equal => None,
+                std::cmp::Ordering::Greater => Some(open),
+            };
+        }
+        if let Some(query) = query {
             self.marker_window.searching = true;
             self.marker_window.status = Some("Searching…".into());
             let http = self.http.clone();

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1714,8 +1714,7 @@ pub struct HookEchoApp {
     /// the pair rarely shares a cycle, and a difference between two instants has to say so.
     diff_field: crate::fielddiff::DiffField,
     diff_valid: Option<(String, String)>,
-    /// When `goto.txt` was last looked for. Android only — see the poll in `update`.
-    #[cfg(target_os = "android")]
+    /// When `goto.txt` was last looked for — see the poll in `update`.
     goto_poll: Option<Instant>,
     /// The last difference grid, kept on the CPU after upload so the cursor can read a number off
     /// it. A diverging color says "the models disagree here"; only a value says by how much.
@@ -2441,7 +2440,6 @@ impl HookEchoApp {
             diff_field: crate::fielddiff::DiffField::default(),
             diff_valid: None,
             diff_grid: None,
-            #[cfg(target_os = "android")]
             goto_poll: None,
             diff_key: None,
             sounding_at: None,
@@ -13354,10 +13352,10 @@ impl eframe::App for HookEchoApp {
             self.drain_goto_file();
         }
         // A deep link that arrives while the app is already on screen never produces a resume, so
-        // the drain above would never see it — the activity is reused (`launchMode="singleTask"`)
-        // and only `onNewIntent` fires. ponytail: a one-second stat of a path that usually does
-        // not exist, rather than a JNI callback into the event loop.
-        #[cfg(target_os = "android")]
+        // the drain above would never see it — on Android the activity is reused
+        // (`launchMode="singleTask"`) and only `onNewIntent` fires; on desktop the second process
+        // hands its link over and exits. ponytail: a one-second stat of a path that usually does
+        // not exist, rather than a callback into the event loop.
         if self
             .goto_poll
             .is_none_or(|t| t.elapsed() >= std::time::Duration::from_secs(1))

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -10726,6 +10726,7 @@ impl HookEchoApp {
         // boundary reads off the map before any card is open. Clicking one opens its card.
         if self.show_stations {
             let show_labels = cam.zoom >= 8.0;
+            let temp_unit = self.settings.temp_unit;
             for ob in &self.stations.obs {
                 let w = crate::render::mercator::lonlat_to_world(ob.lon, ob.lat);
                 let (sx, sy) = cam.world_to_screen(w, vp);
@@ -10756,7 +10757,7 @@ impl HookEchoApp {
                 }
                 if show_labels {
                     let label = match ob.temp_c {
-                        Some(t) => format!("{:.0}F", t * 9.0 / 5.0 + 32.0),
+                        Some(t) => format!("{:.0}{}", temp_unit.from_c(t), temp_unit.label()),
                         None => ob.id.clone(),
                     };
                     let (off, align) = if metar {
@@ -11119,6 +11120,7 @@ impl HookEchoApp {
                     .partial_cmp(&a.wspd_kt)
                     .unwrap_or(std::cmp::Ordering::Equal)
             });
+            let temp_unit = self.settings.temp_unit;
             let mut placed: Vec<egui::Rect> = Vec::new();
             for ob in obs {
                 let w = crate::render::mercator::lonlat_to_world(ob.lon, ob.lat);
@@ -11156,7 +11158,7 @@ impl HookEchoApp {
                         painter.text(
                             p + egui::vec2(-6.0, -6.0),
                             egui::Align2::RIGHT_BOTTOM,
-                            format!("{:.0}", t * 9.0 / 5.0 + 32.0),
+                            format!("{:.0}", temp_unit.from_c(t)),
                             f.clone(),
                             egui::Color32::from_rgb(240, 90, 90),
                         );
@@ -11165,7 +11167,7 @@ impl HookEchoApp {
                         painter.text(
                             p + egui::vec2(-6.0, 6.0),
                             egui::Align2::RIGHT_TOP,
-                            format!("{:.0}", d * 9.0 / 5.0 + 32.0),
+                            format!("{:.0}", temp_unit.from_c(d)),
                             f,
                             egui::Color32::from_rgb(90, 220, 120),
                         );
@@ -11192,7 +11194,8 @@ impl HookEchoApp {
                 }
             }
         }
-        // ponytail: °F hardcoded (US station-plot convention); wire to the Units setting if asked.
+        // ponytail: the station plots follow the Units setting; the gridded contour labels
+        // (K → °F, `field_ramps`) still do not, and want the same treatment when asked.
 
         // River flood gauges (NWPS): category-colored inverted-triangle droplet + stage tooltip.
         // ponytail: hover tooltip carries name/stage/forecast; skipped a click→Detail popup — the

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -2286,6 +2286,7 @@ impl HookEchoApp {
                     ("zones", "zone cache"),
                     ("raob", "RAOB cache"),
                     ("snapshots", "snapshot cache"),
+                    ("pficons", "placefile icon cache"),
                 ] {
                     crate::tiles::sweep_cache_dir(
                         &dir.join(sub),
@@ -13182,18 +13183,54 @@ fn draw_sprite(
     painter.add(egui::Shape::mesh(mesh));
 }
 
+/// Where a placefile's icon sheet is kept between runs, if this platform has a disk.
+///
+/// Named by a hash of the URL: sheets come from arbitrary hosts and their paths are not safe to
+/// use as filenames.
+fn icon_sheet_cache_path(url: &str) -> Option<std::path::PathBuf> {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    url.hash(&mut h);
+    Some(
+        crate::paths::cache_dir()?
+            .join("pficons")
+            .join(format!("{:016x}", h.finish())),
+    )
+}
+
 /// Download and decode a placefile icon sheet (PNG/GIF) into an egui image.
 async fn fetch_icon_sheet(http: &reqwest::Client, url: &str) -> anyhow::Result<egui::ColorImage> {
-    // Generic web hosts, so use the browser-ish UA the tile fetches already send.
-    let bytes = http
-        .get(url)
-        .header("User-Agent", crate::tiles::USER_AGENT)
-        .send()
-        .await?
-        .error_for_status()?
-        .bytes()
-        .await?;
-    let img = image::load_from_memory(&bytes)?.to_rgba8();
+    // Read-through disk cache, same shape as the basemap tiles: an icon sheet is a few KB of PNG
+    // that never changes, and re-fetching every placefile's sheet at every startup is the kind of
+    // traffic somebody else's web host notices. A corrupt file simply fails to decode and is
+    // refetched. Nothing on the web, where `cache_dir()` is None.
+    let cached = icon_sheet_cache_path(url);
+    let hit = cached
+        .as_ref()
+        .and_then(|p| std::fs::read(p).ok())
+        .and_then(|b| image::load_from_memory(&b).ok());
+    let img = match hit {
+        Some(img) => img.to_rgba8(),
+        None => {
+            // Generic web hosts, so use the browser-ish UA the tile fetches already send.
+            let bytes = http
+                .get(url)
+                .header("User-Agent", crate::tiles::USER_AGENT)
+                .send()
+                .await?
+                .error_for_status()?
+                .bytes()
+                .await?;
+            let img = image::load_from_memory(&bytes)?.to_rgba8();
+            if let Some(path) = &cached {
+                if let Some(dir) = path.parent() {
+                    let _ = std::fs::create_dir_all(dir);
+                }
+                let _ = std::fs::write(path, &bytes);
+            }
+            img
+        }
+    };
     let (w, h) = img.dimensions();
     Ok(egui::ColorImage::from_rgba_unmultiplied(
         [w as usize, h as usize],
@@ -14963,6 +15000,20 @@ mod field_lut_tests {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn icon_sheet_cache_paths_are_per_url_and_filename_safe() {
+        let Some(a) = super::icon_sheet_cache_path("https://example.com/a/icons.png") else {
+            return; // no disk on this platform: nothing to name
+        };
+        let b = super::icon_sheet_cache_path("https://example.com/b/icons.png").unwrap();
+        assert_ne!(a, b, "two sheets must not share a file");
+        let name = a.file_name().unwrap().to_str().unwrap();
+        assert!(
+            name.chars().all(|c| c.is_ascii_hexdigit()),
+            "a URL is not a filename: got {name}"
+        );
+    }
     use super::*;
 
     #[test]

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -606,7 +606,7 @@ impl OverlaySource {
                 // METARs down with it.
                 match wxdata::ndbc::fetch_bbox(http, lat0, lon0, lat1, lon1).await {
                     Ok(buoys) => obs.extend(buoys),
-                    Err(e) => log::warn!("ndbc buoys: {e}"),
+                    Err(e) => note_feed_error("Buoy observations", e),
                 }
                 OverlayMsg::Metar(obs)
             }
@@ -616,7 +616,10 @@ impl OverlaySource {
                 let mut sites =
                     wxdata::webcams::fetch_bbox(http, min_lon, min_lat, max_lon, max_lat)
                         .await
-                        .unwrap_or_default();
+                        .unwrap_or_else(|e| {
+                            note_feed_error("FAA webcams", e);
+                            Vec::new()
+                        });
                 if !windy_key.is_empty() {
                     // A bad or throttled key must not take the FAA cameras down with it.
                     match wxdata::webcams::fetch_windy_bbox(
@@ -625,7 +628,7 @@ impl OverlaySource {
                     .await
                     {
                         Ok(w) => sites.extend(w),
-                        Err(e) => log::warn!("windy webcams: {e}"),
+                        Err(e) => note_feed_error("Windy webcams", e),
                     }
                 }
                 OverlayMsg::Webcams(sites)
@@ -1162,6 +1165,29 @@ pub(crate) enum ToastKind {
     Info,
     Success,
     Error,
+}
+
+/// Auxiliary-feed failures waiting to be told to the user.
+///
+/// A global rather than a channel: these happen in half a dozen spawned tasks across three
+/// different message enums, and none of them owns a sender. The app drains it once a frame.
+///
+/// ponytail: unbounded and process-wide, which is fine for something drained every frame and
+/// gated to one toast per feed. A sender per task is the upgrade if it ever needs ordering
+/// against the other messages.
+static FEED_ERRORS: std::sync::Mutex<Vec<(&'static str, String)>> =
+    std::sync::Mutex::new(Vec::new());
+
+/// Log an auxiliary feed's failure and queue it for the user.
+///
+/// "Auxiliary" means a feed whose failure leaves the rest of its layer standing — buoys inside
+/// the station plot, Windy inside the webcams. Those used to fail into the log alone, which is
+/// indistinguishable from the feed simply having nothing to show.
+pub(crate) fn note_feed_error(feed: &'static str, err: impl std::fmt::Display) {
+    log::warn!("{feed}: {err}");
+    if let Ok(mut q) = FEED_ERRORS.lock() {
+        q.push((feed, err.to_string()));
+    }
 }
 
 /// A short-lived note about something the user just did.
@@ -2100,6 +2126,8 @@ pub struct HookEchoApp {
     /// Transient results of things the user just did (export saved, encode failed). The third
     /// lane, distinct from the warning banners (weather) and the error chip (radar feed).
     toasts: Vec<Toast>,
+    /// Auxiliary feeds already reported to the user; see [`HookEchoApp::drain_feed_errors`].
+    feed_errors_told: std::collections::HashSet<&'static str>,
     /// Right-dock active-alerts panel toggle.
     show_alert_panel: bool,
     /// Cross-section tool: clicked endpoints `[lon,lat]` (max 2), the built section + its texture.
@@ -2647,6 +2675,7 @@ impl HookEchoApp {
             rot_active: false,
             warning_banners: Vec::new(),
             toasts: Vec::new(),
+            feed_errors_told: std::collections::HashSet::new(),
             show_alert_panel: false,
             xsection_pts: Vec::new(),
             xsection: None,
@@ -2982,7 +3011,7 @@ impl HookEchoApp {
                     let _ = tx.send(msg);
                     ctx.request_repaint();
                 }
-                Err(e) => log::warn!("overlay fetch failed: {e}"),
+                Err(e) => note_feed_error("Overlay", e),
             }
         });
     }
@@ -3245,6 +3274,22 @@ impl HookEchoApp {
             return;
         }
         crate::audio::play(sound, self.settings.alert_volume);
+    }
+
+    /// Surface auxiliary-feed failures queued by [`note_feed_error`], once per feed per session.
+    ///
+    /// Once, deliberately: a feed that is down stays down, and a toast every refresh would be the
+    /// nag this app does not do. The log keeps every occurrence.
+    fn drain_feed_errors(&mut self) {
+        let queued: Vec<(&'static str, String)> = match FEED_ERRORS.lock() {
+            Ok(mut q) => std::mem::take(&mut *q),
+            Err(_) => return,
+        };
+        for (feed, err) in queued {
+            if self.feed_errors_told.insert(feed) {
+                self.toast(ToastKind::Error, format!("{feed} unavailable — {err}"));
+            }
+        }
     }
 
     /// Say something happened. Operation results used to reach the user only through the log.
@@ -8444,7 +8489,7 @@ impl HookEchoApp {
                         let _ = tx.send((url, image));
                         ctx2.request_repaint();
                     }
-                    Err(e) => log::warn!("icon sheet {url} failed: {e}"),
+                    Err(e) => note_feed_error("Placefile icons", format!("{url}: {e}")),
                 }
             });
         }
@@ -8581,6 +8626,7 @@ impl HookEchoApp {
     }
 
     fn poll_messages(&mut self) {
+        self.drain_feed_errors();
         while let Ok(msg) = self.msg_rx.try_recv() {
             let idx = msg.view();
             // LiveEnded must be handled even after a site change (to drop the stream handle).
@@ -9214,7 +9260,7 @@ impl HookEchoApp {
                     });
                     ctx.request_repaint();
                 }
-                Err(e) => log::warn!("list frames {site} {date}: {e}"),
+                Err(e) => note_feed_error("Archive frame list", format!("{site} {date}: {e}")),
             }
         });
     }
@@ -12748,15 +12794,16 @@ impl HookEchoApp {
             return;
         }
         ctx.request_repaint_after(std::time::Duration::from_millis(500));
-        egui::Area::new(egui::Id::new("error_chip"))
+        let chip = egui::Area::new(egui::Id::new("error_chip"))
             .constrain_to(self.chrome_rect)
             .anchor(
                 egui::Align2::CENTER_BOTTOM,
                 egui::vec2(0.0, crate::ui::style::LANE_BOTTOM_CHASE),
             )
-            // Self-expires after HOLD_SECS, so it needs no dismiss click — and an interactable
-            // layer over the map blanks pinch wherever it sits.
-            .interactable(false)
+            // Interactable so the message can be read and copied: six seconds is not long enough
+            // to transcribe a URL out of a failure. The chip is small and sits in the bottom lane,
+            // so what it costs the map underneath is that strip.
+            .interactable(true)
             .show(ctx, |ui| {
                 crate::ui::style::glass(ui, 246)
                     .stroke(egui::Stroke::new(
@@ -12764,13 +12811,27 @@ impl HookEchoApp {
                         egui::Color32::from_rgb(230, 100, 100).gamma_multiply(0.8),
                     ))
                     .show(ui, |ui| {
-                        ui.label(
-                            egui::RichText::new(&msg)
-                                .size(crate::ui::style::FONT_BASE)
-                                .color(egui::Color32::from_rgb(240, 150, 150)),
-                        );
-                    });
+                        ui.add(
+                            egui::Label::new(
+                                egui::RichText::new(&msg)
+                                    .size(crate::ui::style::FONT_BASE)
+                                    .color(egui::Color32::from_rgb(240, 150, 150)),
+                            )
+                            .sense(egui::Sense::click()),
+                        )
+                        .on_hover_text("Click to copy")
+                    })
             });
+        let resp = &chip.inner.inner;
+        if resp.hovered() {
+            // Hold while it is being read.
+            self.error_chip = Some((msg.clone(), now));
+        }
+        if resp.clicked() {
+            ctx.copy_text(msg);
+            self.toast(ToastKind::Success, "Error copied");
+            self.error_chip = None;
+        }
     }
 }
 

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -8744,10 +8744,9 @@ impl HookEchoApp {
             let due = self
                 .last_stream_attempt
                 .is_none_or(|t| t.elapsed().as_secs() >= 60);
-            if due {
+            // `want` already implies both, but the two are computed a screen away from here.
+            if let (true, Some(site), Some(base)) = (due, site, base) {
                 self.last_stream_attempt = Some(Instant::now());
-                let site = site.unwrap();
-                let base = base.unwrap();
                 let gen = self.live_gen.load(std::sync::atomic::Ordering::Relaxed);
                 self.spawn_stream(idx, site.clone(), base, ctx.clone(), gen);
                 self.live_stream = Some((idx, site, gen));
@@ -9245,7 +9244,11 @@ impl HookEchoApp {
         // The pane's product list is the union over every volume from this site, so a single frame
         // in a loop can lack the selected moment (a legacy volume, a split cut that hasn't arrived).
         // Draw what this volume does have rather than blanking the radar for that frame.
-        let have = self.views[data].volume.as_ref().unwrap().moments;
+        // Caller resolved `data` to a view that has a volume; a "wait" is the honest answer if
+        // that stops being true rather than taking the frame down.
+        let Some(have) = self.views[data].volume.as_ref().map(|v| v.moments) else {
+            return (None, true);
+        };
         let moment = if have[moment.index()] {
             moment
         } else {
@@ -9259,7 +9262,9 @@ impl HookEchoApp {
         } else {
             None
         };
-        let name = self.views[data].volume.as_ref().unwrap().name.clone();
+        let Some(name) = self.views[data].volume.as_ref().map(|v| v.name.clone()) else {
+            return (None, true);
+        };
         let uv_key = storm_uv.map(|(e, n)| (e.to_bits(), n.to_bits()));
         // Dealiasing only applies to Doppler velocity, and only where it is actually folded:
         // a TDWR's Level 3 velocity is already unfolded before it leaves the radar.
@@ -9284,7 +9289,9 @@ impl HookEchoApp {
         }
         let table = self.palettes.table(moment);
         let upload = {
-            let vol = self.views[data].volume.as_mut().unwrap();
+            let Some(vol) = self.views[data].volume.as_mut() else {
+                return (None, true);
+            };
             // No tilts yet (a volume that has only just started arriving) is a "wait", not a
             // failure: erroring here put "tilt 0 out of range" on the map once per volume.
             if vol.elevations.is_empty() {

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -8731,10 +8731,9 @@ impl HookEchoApp {
         // Abort an existing stream if it no longer matches the active view/site or isn't wanted.
         if let Some((sv, ss, _)) = &self.live_stream {
             if !want || *sv != idx || Some(ss.as_str()) != site.as_deref() {
-                // ponytail: the cancelled stream notices at its next wake, so on a fast site
-                // switch two streams overlap for up to the 15 s wait clamp. Both merge into
-                // their own volumes and only the live one is displayed, so the cost is one
-                // wasted chunk fetch. An abort channel if that ever shows up on a phone bill.
+                // ponytail: the cancelled stream notices within a second (its wait is sliced),
+                // so a fast site switch overlaps two streams for about that long and at most
+                // one in-flight chunk fetch. An abort channel if even that shows up.
                 self.live_gen
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 self.live_stream = None;

--- a/crates/hookecho/src/app/mobile/sheet.rs
+++ b/crates/hookecho/src/app/mobile/sheet.rs
@@ -434,9 +434,11 @@ pub(crate) const LIVE_TINT: Color32 = OMEGA_ORANGE;
 ///
 /// Returns the rect it covers, for gesture occlusion.
 ///
-/// ponytail: fixed at the "expanded" height rather than draggable. These sheets are lists you
-/// came to read, not a summary you peek at — give them a snap ladder when one of them grows a
-/// map-adjacent preview worth half-opening.
+/// Drag the handle down to dismiss: past a quarter of the sheet's height it closes, otherwise it
+/// springs back. The body keeps its own scroll drag, so only the handle and title strip move it.
+///
+/// ponytail: dismiss only, no snap ladder — these sheets are lists you came to read, not a
+/// summary you peek at. Half-open states when one of them grows a map-adjacent preview.
 pub(crate) fn modal_sheet<R>(
     ctx: &egui::Context,
     content: Rect,
@@ -446,7 +448,14 @@ pub(crate) fn modal_sheet<R>(
     add: impl FnOnce(&mut egui::Ui) -> R,
 ) -> Rect {
     let h = content.height() * 0.88;
-    let rect = Rect::from_min_max(pos2(content.left(), content.bottom() - h), content.max);
+    // Drag offset lives in egui's temp memory: it is per-sheet transient UI state with no
+    // business in the app struct, and it dying with the sheet is the wanted behavior.
+    let drag_id = Id::new((id, "drag_y"));
+    let drag_y: f32 = ctx.memory(|m| m.data.get_temp(drag_id).unwrap_or(0.0));
+    let rect = Rect::from_min_max(
+        pos2(content.left(), content.bottom() - h + drag_y),
+        pos2(content.right(), content.bottom() + drag_y),
+    );
 
     // Scrim first, in its own layer under the sheet.
     egui::Area::new(Id::new(format!("{id}_scrim")))
@@ -489,8 +498,20 @@ pub(crate) fn modal_sheet<R>(
                 egui::UiBuilder::new().max_rect(rect.shrink2(vec2(m3::SP_4, 0.0))),
                 |ui| {
                     ui.set_width(rect.width() - m3::SP_4 * 2.0);
-                    if m3::drag_handle(ui).clicked() {
+                    let handle = m3::drag_handle(ui);
+                    if handle.clicked() {
                         *close = true;
+                    }
+                    if handle.dragged() {
+                        let dy = (drag_y + handle.drag_delta().y).max(0.0);
+                        ctx.memory_mut(|m| m.data.insert_temp(drag_id, dy));
+                    }
+                    if handle.drag_stopped() {
+                        // A quarter of the way down is a dismiss; anything less springs back.
+                        if drag_y > h * 0.25 {
+                            *close = true;
+                        }
+                        ctx.memory_mut(|m| m.data.insert_temp(drag_id, 0.0f32));
                     }
                     ui.horizontal(|ui| {
                         ui.set_height(m3::MIN_TARGET);

--- a/crates/hookecho/src/colormap.rs
+++ b/crates/hookecho/src/colormap.rs
@@ -243,7 +243,9 @@ pub fn parse_pal(text: &str) -> anyhow::Result<ColorTable> {
     }
 
     if stops.is_empty() {
-        anyhow::bail!("no color stops in .pal");
+        anyhow::bail!(
+            "no color stops: this file has no Color/SolidColor lines the .pal parser recognizes"
+        );
     }
     // Apply Scale/Offset, then sort ascending (files are often authored high-to-low).
     if scale == 0.0 {
@@ -316,18 +318,13 @@ impl Palettes {
         for (i, moment) in Moment::ALL.into_iter().enumerate() {
             let (table, err) = match &paths[i] {
                 None => (default_table(moment).clone(), None),
+                // `.pal3` goes through the same parser: v3 is v2 plus directives this one
+                // already ignores, so a v3 table loads as its common subset rather than not at
+                // all. A file that shares nothing with v2 falls out as "no color stops".
                 Some(path) => match std::fs::read_to_string(path)
                     .map_err(|e| e.to_string())
-                    .and_then(|s| {
-                        if path
-                            .extension()
-                            .is_some_and(|e| e.eq_ignore_ascii_case("pal3"))
-                        {
-                            Err(".pal3 (GRLevelX v3) not supported".to_string())
-                        } else {
-                            parse_pal(&s).map_err(|e| e.to_string())
-                        }
-                    }) {
+                    .and_then(|s| parse_pal(&s).map_err(|e| e.to_string()))
+                {
                     Ok(t) => (t, None),
                     Err(e) => (default_table(moment).clone(), Some(e)),
                 },
@@ -351,6 +348,41 @@ mod tests {
         }
         // And the LazyLock array builds without panicking.
         assert_eq!(default_table(Moment::Reflectivity).stops.len(), 9);
+    }
+
+    /// A v3-flavoured table: v3-only directives the parser does not know, around ordinary
+    /// `Color:` stops. Loading it as its common subset is the whole feature.
+    #[test]
+    fn a_pal3_table_loads_as_its_common_subset() {
+        let src = "\
+Product: BR
+Units: dBZ
+ColorTableVersion: 3
+Scale: 1.0
+Offset: 0.0
+Step: 5
+Blend: true
+Color: 5 100 100 100
+Color: 40 255 255 0
+SolidColorRange: 60 70 255 0 0
+";
+        let dir = std::env::temp_dir().join("hookecho-pal3-test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("v3.pal3");
+        std::fs::write(&path, src).unwrap();
+
+        let mut p = Palettes::default();
+        let mut paths: [Option<std::path::PathBuf>; 6] = Default::default();
+        paths[Moment::Reflectivity.index()] = Some(path.clone());
+        p.reload(&paths);
+
+        assert_eq!(
+            p.errors[Moment::Reflectivity.index()],
+            None,
+            ".pal3 must load, not be rejected on its extension"
+        );
+        assert_eq!(p.table(Moment::Reflectivity).stops.len(), 2);
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]

--- a/crates/hookecho/src/dialog.rs
+++ b/crates/hookecho/src/dialog.rs
@@ -54,7 +54,7 @@ impl ImportKind {
     fn extensions(self) -> &'static [&'static str] {
         match self {
             ImportKind::SettingsBundle => &["json"],
-            ImportKind::Palette => &["pal"],
+            ImportKind::Palette => &["pal", "pal3"],
             ImportKind::MarkerIcon => &["png"],
             ImportKind::AlertSound => &["wav", "mp3", "ogg", "flac"],
         }

--- a/crates/hookecho/src/main.rs
+++ b/crates/hookecho/src/main.rs
@@ -896,15 +896,103 @@ fn main() -> eframe::Result<()> {
     // URL Protocol registry key on Windows) arrives as an argument. The app already knows how to
     // read one out of the environment — Android's notification tap uses the same path — so this
     // is a handover, not a second parser.
-    //
-    // ponytail: a link opens a second instance. A single-instance socket is the fix if that
-    // becomes annoying rather than theoretical.
     if let Some(link) = args.iter().find(|a| a.starts_with("hookecho://")) {
+        // An already-running instance is what the user means by "open this link": a second
+        // window with its own caches, streams and GPU context is not. Hand it over and leave.
+        if hand_link_to_running_instance(link) {
+            log::info!("handed {link} to the running instance");
+            return Ok(());
+        }
         log::info!("opening link {link}");
         std::env::set_var("HOOKECHO_GOTO", link);
     }
+    single_instance::listen();
 
     hookecho::run_desktop()
+}
+
+/// Write `link` into the drop box the running instance polls, if there is one.
+///
+/// Returns whether it was handed over; false means this process is the instance.
+#[cfg(not(target_os = "android"))]
+fn hand_link_to_running_instance(link: &str) -> bool {
+    if !single_instance::another_is_running() {
+        return false;
+    }
+    let Some(path) = hookecho::paths::goto_file() else {
+        return false;
+    };
+    if let Some(dir) = path.parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    std::fs::write(&path, link).is_ok()
+}
+
+/// Whether another Hook Echo owns this machine's session, over a bound loopback port.
+///
+/// A bound socket is its own liveness proof — no stale pid file to reason about — and the
+/// greeting keeps an unrelated listener on the port from swallowing links.
+///
+/// ponytail: a fixed port and a plain greeting, no payload over the wire (the link goes through
+/// the same `goto.txt` drop box Android already uses). If the port is taken by something else,
+/// the link opens a second instance, which is exactly today's behavior.
+#[cfg(not(target_os = "android"))]
+mod single_instance {
+    use std::io::{Read, Write};
+    use std::net::{Ipv4Addr, TcpListener, TcpStream, SocketAddrV4};
+    use std::time::Duration;
+
+    /// Registered-user range, and nothing else known claims it.
+    const PORT: u16 = 47_913;
+    const GREETING: &[u8] = b"hookecho\n";
+
+    pub fn another_is_running() -> bool {
+        probe(PORT)
+    }
+
+    fn probe(port: u16) -> bool {
+        let addr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, port);
+        let Ok(mut sock) = TcpStream::connect_timeout(&addr.into(), Duration::from_millis(300))
+        else {
+            return false;
+        };
+        let _ = sock.set_read_timeout(Some(Duration::from_millis(300)));
+        let mut buf = [0u8; GREETING.len()];
+        sock.read_exact(&mut buf).is_ok() && buf == GREETING
+    }
+
+    /// Answer future launches. Silently does nothing if the port is unavailable — the app runs
+    /// fine without this, it just stops being the one instance.
+    pub fn listen() {
+        listen_on(PORT);
+    }
+
+    /// Returns the port actually bound, so a test can use an ephemeral one.
+    fn listen_on(port: u16) -> Option<u16> {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, port)).ok()?;
+        let bound = listener.local_addr().ok()?.port();
+        std::thread::spawn(move || {
+            for stream in listener.incoming().flatten() {
+                let mut stream = stream;
+                let _ = stream.write_all(GREETING);
+            }
+        });
+        Some(bound)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn the_greeting_is_what_identifies_us() {
+            // Nothing listening: not us, and not a hang either.
+            assert!(!probe(1));
+
+            let port = listen_on(0).expect("bind an ephemeral port");
+            assert!(probe(port), "a listening instance answers");
+        }
+    }
 }
 
 /// Write a multi-resolution Windows `.ico` of the app logo (16/32/48/256 px, the sizes Explorer,

--- a/crates/hookecho/src/paths.rs
+++ b/crates/hookecho/src/paths.rs
@@ -53,10 +53,14 @@ pub fn data_dir() -> Option<PathBuf> {
 }
 
 /// Deep-link drop box: the Android alert service's notification tap writes `SITE,lon,lat,zoom`
-/// here (see `MainActivity.kt`) and the app consumes it at startup and on resume. `None` on
-/// desktop, where the env var does the same job.
+/// here (see `MainActivity.kt`) and the app consumes it at startup and on resume. On desktop a
+/// second launch carrying a `hookecho://` link writes the same file for the running instance
+/// (see `main.rs`), so the handover shape is one thing on both platforms.
 pub fn goto_file() -> Option<PathBuf> {
-    BASE.get().map(|b| b.join("goto.txt"))
+    match BASE.get() {
+        Some(b) => Some(b.join("goto.txt")),
+        None => cache_dir().map(|c| c.join("goto.txt")),
+    }
 }
 
 /// Where the activity drops a file the user picked through the Storage Access Framework, in the

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -258,8 +258,9 @@ pub struct Settings {
     pub plugins: Vec<PluginConfig>,
     /// Android only: run a foreground service that watches `markers` for NWS alerts and posts a
     /// notification, so warnings arrive with the app closed. Opt-in — it costs a permanent
-    /// notification and some battery. The Kotlin service reads `markers` and this flag straight
-    /// out of settings.json, so both names are load-bearing across the language boundary.
+    /// notification and some battery. The switch itself reaches Kotlin over JNI
+    /// (`platform::set_background_alerts`), not through this file; what the service reads here is
+    /// `markers` and `alert_polygons`, so those names are load-bearing across the boundary.
     #[serde(default)]
     pub background_alerts: bool,
     /// Keep running in the background (hide to tray) instead of quitting when the window closes.
@@ -1001,6 +1002,10 @@ mod tests {
                 video_url: String::new(),
                 home: false,
             }],
+            alert_polygons: vec![AlertPolygon {
+                name: "Farm".to_string(),
+                ring: vec![[-97.0, 35.0], [-96.9, 35.0], [-96.9, 35.1]],
+            }],
             background_alerts: true,
             ..Settings::default()
         })
@@ -1008,11 +1013,23 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(v["background_alerts"], serde_json::json!(true));
         let m = &v["markers"][0];
-        for key in ["name", "lat", "lon"] {
+        for key in ["name", "lat", "lon", "alert_radius_mi"] {
             assert!(
                 m.get(key).is_some(),
                 "AlertService.kt reads markers[].{key}"
             );
         }
+        let z = &v["alert_polygons"][0];
+        for key in ["name", "ring"] {
+            assert!(
+                z.get(key).is_some(),
+                "AlertService.kt reads alert_polygons[].{key}"
+            );
+        }
+        assert_eq!(
+            z["ring"][0][0],
+            serde_json::json!(-97.0),
+            "Nws.kt reads ring vertices as [lon, lat]"
+        );
     }
 }

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -131,6 +131,9 @@ pub struct Settings {
     pub palettes: BTreeMap<String, String>,
     /// Velocity/spectrum-width display unit (internal data stays m/s).
     pub velocity_unit: VelocityUnit,
+    /// Temperature display unit for the surface station plots (internal data stays Celsius).
+    #[serde(default)]
+    pub temp_unit: TempUnit,
     /// Whether radar timestamps read in the site's local time or in UTC.
     #[serde(default)]
     pub time_display: TimeDisplay,
@@ -537,6 +540,34 @@ impl TimeDisplay {
     }
 }
 
+/// Display unit for temperature. Observations arrive in Celsius; US surface plots read in
+/// Fahrenheit, which is why that is the default here and not the one on the wire.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum TempUnit {
+    #[default]
+    Fahrenheit,
+    Celsius,
+}
+
+impl TempUnit {
+    pub const ALL: [TempUnit; 2] = [TempUnit::Fahrenheit, TempUnit::Celsius];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            TempUnit::Fahrenheit => "°F",
+            TempUnit::Celsius => "°C",
+        }
+    }
+
+    /// Convert an observation's Celsius into this unit.
+    pub fn from_c(self, c: f32) -> f32 {
+        match self {
+            TempUnit::Fahrenheit => c * 9.0 / 5.0 + 32.0,
+            TempUnit::Celsius => c,
+        }
+    }
+}
+
 /// Display unit for velocity products. GRLevelX defaults to knots; internal math is m/s.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum VelocityUnit {
@@ -585,6 +616,7 @@ impl Default for Settings {
             presets: Vec::new(),
             palettes: BTreeMap::new(),
             velocity_unit: VelocityUnit::default(),
+            temp_unit: TempUnit::default(),
             time_display: TimeDisplay::default(),
             // 1.0 everywhere: this multiplies the native scale factor, and Android's display
             // density already sizes widgets for touch — an extra 1.3 shrank the S24's logical
@@ -850,6 +882,7 @@ mod tests {
             presets: vec!["KTLX".to_string(), "KOUN".to_string()],
             palettes: BTreeMap::from([("REF".to_string(), "/tmp/foo.pal".to_string())]),
             velocity_unit: VelocityUnit::Mph,
+            temp_unit: TempUnit::Celsius,
             time_display: TimeDisplay::Utc,
             ui_scale: 1.2,
             sync_client_id: String::new(),
@@ -975,6 +1008,13 @@ mod tests {
         let s: Settings = serde_json::from_str(json).unwrap();
         assert_eq!(s.default_site, "KDMX");
         assert_eq!(s.overlays_on, vec!["Alerts", "Teleportation"]);
+    }
+
+    #[test]
+    fn temp_unit_converts_from_celsius() {
+        assert_eq!(TempUnit::Celsius.from_c(21.0), 21.0);
+        assert!((TempUnit::Fahrenheit.from_c(0.0) - 32.0).abs() < 1e-4);
+        assert!((TempUnit::Fahrenheit.from_c(-40.0) + 40.0).abs() < 1e-4);
     }
 
     #[test]

--- a/crates/hookecho/src/tiles.rs
+++ b/crates/hookecho/src/tiles.rs
@@ -449,13 +449,11 @@ impl BasemapStyle {
                     "https://a.tile-cyclosm.openstreetmap.fr/cyclosm/{z}/{x}/{y}.png"
                 )),
                 // NASA GIBS WMTS (web mercator), latest GOES imagery. GIBS uses `{z}/{y}/{x}`.
-                _ if self.goes_layer().is_some() => {
-                    let (layer, level) = self.goes_layer().unwrap();
-                    Some(format!(
+                _ => self.goes_layer().map(|(layer, level)| {
+                    format!(
                         "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/{layer}/default/default/GoogleMapsCompatible_Level{level}/{z}/{y}/{x}.png"
-                    ))
-                }
-                _ => None,
+                    )
+                }),
             },
             Provider::Mapbox => (!mapbox_key.is_empty()).then(|| {
                 format!(

--- a/crates/hookecho/src/ui/marker_window.rs
+++ b/crates/hookecho/src/ui/marker_window.rs
@@ -21,6 +21,9 @@ pub struct MarkerWindow {
     pub searching: bool,
     /// Last search outcome, shown under the box ("Added …" or an error).
     pub status: Option<String>,
+    /// Marker index removed this frame. The app's map popup indexes into the same list, so a
+    /// delete above it leaves it describing somebody else's marker.
+    pub removed: Option<usize>,
 }
 
 impl MarkerWindow {
@@ -35,6 +38,7 @@ impl MarkerWindow {
     ) -> Option<String> {
         let mut open = self.open;
         let mut go: Option<String> = None;
+        self.removed = None;
         crate::ui::phone_surface(ctx, egui::Window::new("Location Markers"))
             .open(&mut open)
             .default_size([520.0, 360.0])
@@ -69,7 +73,7 @@ impl MarkerWindow {
                      Ctrl+K ▸ \"Tool: Drop marker\". Tap a marker on the map to rename or remove it.",
                 );
                 ui.add_space(4.0);
-                marker_grid(ui, &mut settings.markers, icon_tex);
+                self.removed = marker_grid(ui, &mut settings.markers, icon_tex).or(self.removed);
                 ui.add_space(6.0);
                 if ui.button("➕ Add blank marker").clicked() {
                     let n = settings.markers.len() + 1;
@@ -91,7 +95,13 @@ impl MarkerWindow {
 
 /// Editable marker table (home/name/lat/lon/watch radius/icon). Shared by the manager window and
 /// the wizard.
-pub fn marker_grid(ui: &mut egui::Ui, markers: &mut Vec<Marker>, icon_tex: &IconTextures) {
+/// Returns the index that was removed this frame, if any: a popup open on a later marker is
+/// pointing at the wrong one afterwards, and the caller is the only place that knows.
+pub fn marker_grid(
+    ui: &mut egui::Ui,
+    markers: &mut Vec<Marker>,
+    icon_tex: &IconTextures,
+) -> Option<usize> {
     let mut remove: Option<usize> = None;
     let mut make_home: Option<usize> = None;
     egui::Grid::new("markers_grid")
@@ -180,6 +190,7 @@ pub fn marker_grid(ui: &mut egui::Ui, markers: &mut Vec<Marker>, icon_tex: &Icon
             m.home = j == i;
         }
     }
+    remove
 }
 
 /// Copy a picked PNG into the marker-icons dir and return the stored filename.

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -431,6 +431,16 @@ fn units_tab(ui: &mut egui::Ui, settings: &mut Settings) {
         });
         ui.end_row();
 
+        ui.label("Temperature");
+        ui.horizontal(|ui| {
+            for u in crate::settings::TempUnit::ALL {
+                ui.selectable_value(&mut settings.temp_unit, u, u.label());
+            }
+        })
+        .response
+        .on_hover_text("Surface station plots (observations arrive in Celsius)");
+        ui.end_row();
+
         ui.label("Time display");
         ui.horizontal(|ui| {
             for d in TimeDisplay::ALL {

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -338,9 +338,13 @@ impl SettingsWindow {
             if let Ok(entries) = std::fs::read_dir(&dir) {
                 for e in entries.flatten() {
                     let p = e.path();
-                    if p.extension().is_some_and(|x| x.eq_ignore_ascii_case("pal")) {
-                        if let Some(stem) = p.file_stem().and_then(|s| s.to_str()) {
-                            self.pal_stems.push(stem.to_string());
+                    // File names, not stems: `.pal` and `.pal3` both load, and two tables can
+                    // share a stem.
+                    if p.extension()
+                        .is_some_and(|x| x.eq_ignore_ascii_case("pal") || x.eq_ignore_ascii_case("pal3"))
+                    {
+                        if let Some(name) = p.file_name().and_then(|s| s.to_str()) {
+                            self.pal_stems.push(name.to_string());
                         }
                     }
                 }
@@ -377,7 +381,7 @@ impl SettingsWindow {
                     let current = settings.palettes.get(key).cloned();
                     let current_stem = current
                         .as_deref()
-                        .and_then(|p| std::path::Path::new(p).file_stem().and_then(|s| s.to_str()))
+                        .and_then(|p| std::path::Path::new(p).file_name().and_then(|s| s.to_str()))
                         .map(str::to_string);
                     let selected_text = current_stem
                         .clone()
@@ -393,7 +397,7 @@ impl SettingsWindow {
                                 let is_sel = current_stem.as_deref() == Some(stem.as_str());
                                 if ui.selectable_label(is_sel, stem).clicked() {
                                     if let Some(d) = &dir {
-                                        let path = d.join(format!("{stem}.pal"));
+                                        let path = d.join(stem);
                                         settings.palettes.insert(
                                             key.to_string(),
                                             path.to_string_lossy().into_owned(),

--- a/crates/hookecho/src/ui/wizard.rs
+++ b/crates/hookecho/src/ui/wizard.rs
@@ -71,7 +71,7 @@ pub fn show(
                     egui::ScrollArea::vertical()
                         .max_height(220.0)
                         .show(ui, |ui| {
-                            crate::ui::marker_window::marker_grid(
+                            let _ = crate::ui::marker_window::marker_grid(
                                 ui,
                                 &mut settings.markers,
                                 icon_tex,

--- a/crates/hookecho/tests/flatpak_sources.rs
+++ b/crates/hookecho/tests/flatpak_sources.rs
@@ -1,0 +1,78 @@
+//! `packaging/flatpak/cargo-sources.json` is generated from `Cargo.lock` and then committed, so
+//! it goes stale the moment a dependency moves and nobody notices until a Flathub build fails.
+//!
+//! This is the notice: every registry crate in the lockfile must have a source entry. Regenerate
+//! with `flatpak-cargo-generator.py Cargo.lock -o packaging/flatpak/cargo-sources.json`.
+
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR is crates/hookecho.
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("repo root")
+}
+
+/// `name` + `version` of every crate in the lockfile that comes from a registry.
+///
+/// Line-wise rather than a TOML dependency: the lock format is `[[package]]` blocks of plain
+/// `key = "value"`, and a package without a `source` is one of ours (a workspace member or a
+/// vendored patch), which has no crates.io tarball to fetch.
+fn locked_registry_crates(lock: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for block in lock.split("[[package]]").skip(1) {
+        let field = |key: &str| {
+            block
+                .lines()
+                .find_map(|l| l.strip_prefix(key)?.split('"').nth(1))
+                .map(str::to_string)
+        };
+        if let (Some(name), Some(version), Some(_)) = (
+            field("name = "),
+            field("version = "),
+            field("source = "),
+        ) {
+            out.push(format!("{name}-{version}"));
+        }
+    }
+    out
+}
+
+#[test]
+fn cargo_sources_covers_the_lockfile() {
+    let root = repo_root();
+    let lock = std::fs::read_to_string(root.join("Cargo.lock")).expect("Cargo.lock");
+    let sources =
+        std::fs::read_to_string(root.join("packaging/flatpak/cargo-sources.json")).expect("sources");
+
+    let missing: Vec<String> = locked_registry_crates(&lock)
+        .into_iter()
+        .filter(|c| !sources.contains(&format!("/{c}.crate")))
+        .collect();
+
+    assert!(
+        missing.is_empty(),
+        "packaging/flatpak/cargo-sources.json is stale — missing {} crate(s): {}\n\
+         Regenerate: flatpak-cargo-generator.py Cargo.lock -o packaging/flatpak/cargo-sources.json",
+        missing.len(),
+        missing.join(", ")
+    );
+}
+
+#[test]
+fn the_lockfile_parser_finds_registry_crates_and_skips_ours() {
+    let lock = r#"
+[[package]]
+name = "hookecho"
+version = "0.8.0"
+dependencies = ["wxdata"]
+
+[[package]]
+name = "serde"
+version = "1.0.200"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deadbeef"
+"#;
+    assert_eq!(locked_registry_crates(lock), vec!["serde-1.0.200"]);
+}

--- a/crates/hookecho/tests/flatpak_sources.rs
+++ b/crates/hookecho/tests/flatpak_sources.rs
@@ -1,8 +1,12 @@
-//! `packaging/flatpak/cargo-sources.json` is generated from `Cargo.lock` and then committed, so
+//! `packaging/flatpak/cargo-sources.json` is generated from a `Cargo.lock` and then committed, so
 //! it goes stale the moment a dependency moves and nobody notices until a Flathub build fails.
 //!
 //! This is the notice: every registry crate in the lockfile must have a source entry. Regenerate
 //! with `flatpak-cargo-generator.py Cargo.lock -o packaging/flatpak/cargo-sources.json`.
+//!
+//! It only means something once `Cargo.lock` is committed. It is gitignored today, so a fresh
+//! checkout resolves whatever is newest and the generated file is behind by construction — the
+//! check is inert until that changes, and says so when it skips.
 
 use std::path::PathBuf;
 
@@ -39,9 +43,26 @@ fn locked_registry_crates(lock: &str) -> Vec<String> {
     out
 }
 
+/// Whether `Cargo.lock` is committed. Without that there is no fixed set of crates to compare
+/// against, and every checkout would fail this test for a different reason.
+fn lockfile_is_tracked(root: &std::path::Path) -> bool {
+    std::process::Command::new("git")
+        .args(["ls-files", "--error-unmatch", "Cargo.lock"])
+        .current_dir(root)
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
 #[test]
 fn cargo_sources_covers_the_lockfile() {
     let root = repo_root();
+    if !lockfile_is_tracked(&root) {
+        eprintln!(
+            "skipped: Cargo.lock is not committed, so cargo-sources.json cannot be checked \
+             against a fixed dependency set"
+        );
+        return;
+    }
     let lock = std::fs::read_to_string(root.join("Cargo.lock")).expect("Cargo.lock");
     let sources =
         std::fs::read_to_string(root.join("packaging/flatpak/cargo-sources.json")).expect("sources");

--- a/crates/wxdata/Cargo.toml
+++ b/crates/wxdata/Cargo.toml
@@ -53,3 +53,7 @@ web-sys = { version = "0.3", features = ["Window", "Location"] }
 gloo-timers = { version = "0.3", features = ["futures"] }
 # Already in the lockfile under eframe. Backs `clock::Instant`: the standard library's panics here.
 web-time = "1"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+# `start_paused` only, so a test of a fifteen-second wait takes no wall clock.
+tokio = { version = "1", features = ["test-util"] }

--- a/crates/wxdata/src/contour.rs
+++ b/crates/wxdata/src/contour.rs
@@ -153,11 +153,15 @@ fn stitch(segs: Vec<[(f64, f64); 2]>) -> Vec<Vec<(f64, f64)>> {
         used[start] = true;
         let mut line = vec![segs[start][0], segs[start][1]];
         // Grow the tail, then the head.
-        while let Some((si, next)) = next_at(key(*line.last().unwrap()), &used, &adj) {
+        while let Some((si, next)) =
+            line.last().and_then(|&p| next_at(key(p), &used, &adj))
+        {
             used[si] = true;
             line.push(next);
         }
-        while let Some((si, prev)) = next_at(key(*line.first().unwrap()), &used, &adj) {
+        while let Some((si, prev)) =
+            line.first().and_then(|&p| next_at(key(p), &used, &adj))
+        {
             used[si] = true;
             line.insert(0, prev);
         }
@@ -169,6 +173,11 @@ fn stitch(segs: Vec<[(f64, f64); 2]>) -> Vec<Vec<(f64, f64)>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn stitching_nothing_yields_nothing() {
+        assert!(stitch(Vec::new()).is_empty());
+    }
 
     fn field(nx: usize, ny: usize, vals: Vec<f32>) -> MrmsField {
         MrmsField {

--- a/crates/wxdata/src/dealias.rs
+++ b/crates/wxdata/src/dealias.rs
@@ -73,7 +73,9 @@ pub fn dealias(
             labels[i] = region;
             stack.push((az, g));
             while let Some((caz, cg)) = stack.pop() {
-                let cv = vel[idx(caz, cg)].unwrap();
+                // A labelled cell always has a velocity (that is what labelling means); skip
+                // rather than assert it, so a future labelling change degrades instead of panics.
+                let Some(cv) = vel[idx(caz, cg)] else { continue };
                 for (naz, ng) in neighbors(caz, cg) {
                     let ni = idx(naz, ng);
                     let Some(nv) = vel[ni] else { continue };
@@ -100,8 +102,8 @@ pub fn dealias(
             if ra == NONE {
                 continue;
             }
+            let Some(va) = vel[i] else { continue };
             sizes[ra] += 1;
-            let va = vel[i].unwrap();
             // Only scan the +az and +gate neighbors to record each boundary once.
             for (naz, ng) in [((az + 1) % az_bins, g), (az, g + 1)] {
                 if ng >= gate_count {
@@ -112,7 +114,7 @@ pub fn dealias(
                 if rb == NONE || rb == ra {
                     continue;
                 }
-                let vb = vel[ni].unwrap();
+                let Some(vb) = vel[ni] else { continue };
                 edges[ra].push((rb, va, vb));
                 edges[rb].push((ra, vb, va));
             }
@@ -122,7 +124,9 @@ pub fn dealias(
     // --- 3. Greedy BFS unfold from the largest region (anchor = 0 folds). ---
     let mut unfold = vec![0i32; region_count];
     let mut solved = vec![false; region_count];
-    let anchor = (0..region_count).max_by_key(|&r| sizes[r]).unwrap();
+    let Some(anchor) = (0..region_count).max_by_key(|&r| sizes[r]) else {
+        return vel.to_vec();
+    };
     solved[anchor] = true;
     let mut queue = std::collections::VecDeque::new();
     for &(nb, _, _) in &edges[anchor] {
@@ -202,6 +206,18 @@ mod tests {
             let err = err.min(2.0 * nyq - err);
             assert!(err < 0.5, "gate expected ~{t}, got {got}");
         }
+    }
+
+    // The region walk assumes a labelled gate has a velocity. These are the two fields where
+    // that assumption is nearest the edge — no data at all, and exactly one gate of it.
+    #[test]
+    fn degenerate_fields_come_back_unchanged() {
+        let empty: Vec<Option<f32>> = vec![None; 12];
+        assert_eq!(dealias(&empty, 3, 4, 25.0), empty);
+
+        let mut one = vec![None; 12];
+        one[5] = Some(7.0);
+        assert_eq!(dealias(&one, 3, 4, 25.0), one);
     }
 
     #[test]

--- a/crates/wxdata/src/live.rs
+++ b/crates/wxdata/src/live.rs
@@ -117,9 +117,9 @@ where
             .and_then(|d| d.to_std().ok())
             .unwrap_or(Duration::from_secs(2))
             .clamp(Duration::from_secs(1), Duration::from_secs(15));
-        crate::task::sleep(wait).await;
-
-        if !active() {
+        // Sliced, not one long sleep: a cancelled stream that only notices at the end of a
+        // fifteen-second wait keeps pulling chunks for a site the user already left.
+        if !crate::task::sleep_while(wait, &active).await {
             // Backgrounded: end the stream rather than idle in it. Idling would keep a timer
             // (and this task) alive across the whole background period; the caller restarts the
             // stream when the app comes back, which is what it already does after any other
@@ -137,7 +137,9 @@ where
                 }
                 chunks.push(dc.chunk);
                 let sweep_done = it.chunk_metadata(seq).is_some_and(|m| m.is_last_in_sweep());
-                if sweep_done || ctype == ChunkType::End {
+                // The fetch itself can outlast the cancellation: a sweep assembled for a site the
+                // caller has already left is a stale frame handed to a live view.
+                if (sweep_done || ctype == ChunkType::End) && active() {
                     let window: Vec<Chunk<'static>> = chunks
                         .first()
                         .filter(|_| window_start > 0)

--- a/crates/wxdata/src/placefile.rs
+++ b/crates/wxdata/src/placefile.rs
@@ -248,13 +248,13 @@ pub fn parse(text: &str) -> Placefile {
                         break;
                     }
                     if l.is_empty() {
-                        if !rings.last().unwrap().is_empty() {
+                        if rings.last().is_none_or(|r| !r.is_empty()) {
                             rings.push(Vec::new());
                         }
                         continue;
                     }
-                    if let Some(c) = parse_coord(l) {
-                        rings.last_mut().unwrap().push(c);
+                    if let (Some(c), Some(ring)) = (parse_coord(l), rings.last_mut()) {
+                        ring.push(c);
                     }
                 }
                 rings.retain(|r| r.len() >= 3);
@@ -425,6 +425,16 @@ pub fn parse(text: &str) -> Placefile {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A blank line before any coordinate, and a ring too short to be a polygon: the parser has
+    /// to survive both without producing an item.
+    #[test]
+    fn a_polygon_with_no_usable_ring_is_dropped() {
+        let pf = parse(
+            "Color: 255 0 0\nPolygon:\n\n 35.0, -97.0\n 35.1, -97.0\nEnd:\n",
+        );
+        assert!(pf.items.is_empty(), "two points is not a polygon");
+    }
 
     #[test]
     fn parses_common_statements() {

--- a/crates/wxdata/src/task.rs
+++ b/crates/wxdata/src/task.rs
@@ -44,3 +44,48 @@ pub async fn sleep(d: std::time::Duration) {
 pub async fn sleep(d: std::time::Duration) {
     gloo_timers::future::TimeoutFuture::new(d.as_millis() as u32).await;
 }
+
+/// Yield for `d`, but give up early once `active` goes false.
+///
+/// Returns whether the wait ran to completion. Sleeping the whole interval in one go left a
+/// cancelled live stream alive for up to its poll interval; slicing it costs one predicate call a
+/// second and is the same on both targets, since neither has a cancellable timer worth the
+/// plumbing.
+pub async fn sleep_while(d: std::time::Duration, active: impl Fn() -> bool) -> bool {
+    let slice = std::time::Duration::from_secs(1);
+    let mut left = d;
+    while !left.is_zero() {
+        if !active() {
+            return false;
+        }
+        let step = left.min(slice);
+        sleep(step).await;
+        left -= step;
+    }
+    active()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    #[tokio::test(start_paused = true)]
+    async fn sleep_while_gives_up_within_a_slice() {
+        let calls = AtomicUsize::new(0);
+        // False from the second check on: a long wait must end after roughly one slice, not
+        // after the whole interval.
+        let done = sleep_while(Duration::from_secs(15), || {
+            calls.fetch_add(1, Ordering::Relaxed) == 0
+        })
+        .await;
+        assert!(!done, "an inactive wait reports that it did not finish");
+        assert_eq!(calls.load(Ordering::Relaxed), 2, "one slice, then give up");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn sleep_while_runs_the_whole_wait_when_active() {
+        assert!(sleep_while(Duration::from_secs(3), || true).await);
+    }
+}

--- a/docs/DATA.md
+++ b/docs/DATA.md
@@ -19,6 +19,7 @@ ours, and both move around during busy weather.
 | N0B mosaic (multi-radar stitch) | Unidata S3, six nearest sites | per volume, per site | ~1–2 min; sites disagree by a scan | no |
 | TDWR (44 airport radars) | Unidata S3 Level 3 tilts (TZ0–2, TV0–2) | ~1 min | ~1–2 min | no |
 | MRMS national mosaic and fields | NOAA MRMS on AWS | ~2 min | ~2–4 min | no |
+| ODIM_H5 (European radars) | decode only — open a file; no open live source | — | — | no |
 
 Archive coverage runs back to **June 1991** for Level 2, and every WSR-88D plus
 the 44 TDWRs are addressable.
@@ -69,8 +70,17 @@ the 44 TDWRs are addressable.
 | Point forecast outside the US | Open-Meteo (ECMWF/GFS/ICON) | hourly | minutes | no |
 | Area forecast discussions | `api.weather.gov` products | per issue (~2×/day + updates) | minutes | no |
 | Surface fronts | WPC `CODSUS` bulletin | ~4×/day | ~1 h | no |
+| Global models (GFS, ECMWF open IFS) | `noaa-gfs-bdp-pds` on AWS; `data.ecmwf.int` | 6-hourly runs | ~3–5 h behind the run hour | no |
 | Tropical cyclones (positions, cones, tracks) | NHC `CurrentStorms.json` + MapServer | per advisory (6 h, plus intermediates) | minutes | no |
 | Storm surge | NHC map service | per advisory | minutes | no |
+
+## Analysis and verification
+
+| Feed | Source | Cadence | Latency | Key |
+| --- | --- | --- | --- | --- |
+| Warning verification (POD, FAR, CSI, lead time) | IEM "Cow" (`mesonet.agron.iastate.edu`) | on demand, per office and day | the report database's own lag (days) | no |
+| Ionospheric electric field (PPEF) | NOAA/NCEI PPEF model | 5 min | ~1 h ahead (a forecast) | no |
+| Ground electric field | a field mill you run and point the app at | yours | yours | no |
 
 ## Imagery, maps and cameras
 
@@ -93,8 +103,16 @@ the 44 TDWRs are addressable.
   density layer cover the gap from public sources.
 - **A vendor "premium" radar API.** Everything above is a government or
   volunteer feed; there's no tier of this app that unlocks better data.
-- **Any telemetry.** The app makes no request that isn't a data feed you can see
-  in this table.
+- **Any telemetry.** Nothing reports on you, your machine or your usage — there
+  is no analytics endpoint and no server of ours to send one to.
+
+  For completeness, the requests the app makes that are not feeds in this table,
+  all of them optional or user-initiated: a GitHub Releases check for a newer
+  version; the opt-in Anthropic digest, which sends the discussion text you
+  asked to be summarized and needs your own API key; Google OAuth and Drive,
+  when you turn on settings sync, into your own account's app folder; and the
+  ntfy/Discord/Slack/Matrix push you configured, to the address you gave. Each
+  is off unless you turn it on.
 
 ## Keys
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -87,8 +87,10 @@ warned for.
 
 ## Make it yours
 
-- **Color tables**: Settings → Palettes imports GRLevelX `.pal` files, per
-  product, and exports what you've built.
+- **Color tables**: Settings → Palettes imports GRLevelX `.pal` and `.pal3`
+  files, per product, and exports what you've built. A v3 table loads as the
+  part v2 shares — its colors and stops — so anything v3-only is ignored rather
+  than refused.
 - **Themes**: 13 built in.
 - **Keyboard**: every binding is remappable in Settings.
 - **Workspaces**: save a pane arrangement (sites, products, tilts, overlays) and

--- a/packaging/SUBMITTING.md
+++ b/packaging/SUBMITTING.md
@@ -21,7 +21,13 @@ Longest review, so start here.
   `packaging/flatpak/cargo-sources.json`.
 - Regenerate the sources file after any `Cargo.lock` change:
   `python3 flatpak-cargo-generator.py Cargo.lock -o packaging/flatpak/cargo-sources.json`.
-  The `flatpak_sources` test in `crates/hookecho/tests/` fails when it is stale.
+- **Known gap:** `Cargo.lock` is gitignored, so the committed sources file is
+  generated from whatever a machine resolved that day and a fresh checkout
+  resolves something newer. As of this writing it is ~79 crates behind, which is
+  a Flathub build failure waiting to happen. Committing the lockfile — normal
+  for an application, and what makes a build reproducible — is the fix; the
+  `flatpak_sources` test in `crates/hookecho/tests/` starts enforcing freshness
+  the moment it lands, and skips until then.
 - Build it locally first — `flatpak-builder --force-clean build
   packaging/flatpak/zip.batman.hookecho.yml` — because a build failure in their
   CI costs another round trip through the queue.

--- a/packaging/SUBMITTING.md
+++ b/packaging/SUBMITTING.md
@@ -1,0 +1,76 @@
+# Submitting to the stores
+
+The manifests in this directory all build. None of them is published, and
+publishing is the part that cannot be automated from here: every store wants an
+account, a pull request against somebody else's repository, or both, and most
+want a human to look at it.
+
+Do these in the order below. The first has the longest queue, so it goes first
+even though it is the most work.
+
+Everything here assumes the release artifacts exist and
+`scripts/release/stamp-manifests.sh <version>` has been run — that is what fills
+in the versions and hashes the manifests carry as placeholders. Nothing it
+stamps is committed back to this repo; the stamped copies are submission inputs.
+
+## 1. Flathub — weeks
+
+Longest review, so start here.
+
+- Input: `packaging/flatpak/zip.batman.hookecho.yml` and
+  `packaging/flatpak/cargo-sources.json`.
+- Regenerate the sources file after any `Cargo.lock` change:
+  `python3 flatpak-cargo-generator.py Cargo.lock -o packaging/flatpak/cargo-sources.json`.
+  The `flatpak_sources` test in `crates/hookecho/tests/` fails when it is stale.
+- Build it locally first — `flatpak-builder --force-clean build
+  packaging/flatpak/zip.batman.hookecho.yml` — because a build failure in their
+  CI costs another round trip through the queue.
+- Submit: a pull request to
+  [flathub/flathub](https://github.com/flathub/flathub) on the `new-pr` branch,
+  one app per PR. Expect review comments about the `finish-args` sandbox holes
+  specifically; each one needs a justification in the thread.
+
+## 2. AUR — same day
+
+- Input: `packaging/aur/PKGBUILD`, stamped.
+- Needs an AUR account with an SSH key registered.
+- `makepkg --printsrcinfo > .SRCINFO` in the package checkout — the AUR rejects
+  a push whose `.SRCINFO` does not match the `PKGBUILD`, and this is the step
+  everyone forgets.
+- `git push` to `ssh://aur@aur.archlinux.org/hookecho.git`. No review.
+
+## 3. Homebrew tap — same day
+
+- Input: `packaging/homebrew/hookecho.rb`, stamped.
+- A tap is its own GitHub repository named `homebrew-hookecho`; the formula goes
+  in `Formula/`. Users then run `brew tap d4vid87/hookecho && brew install
+  hookecho`.
+- Not homebrew-core: that wants a notable user base and no `HEAD` builds, and
+  the tap is the honest place for this until the former is true.
+
+## 4. winget — days
+
+- Inputs: the three files in `packaging/winget/`, stamped — the installer
+  manifest carries the SHA256 of the built setup `.exe`.
+- Validate first: `winget validate --manifest packaging/winget` and, on a
+  Windows machine, `winget install --manifest packaging/winget`.
+- Submit: a pull request to
+  [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) under
+  `manifests/z/zip.batman/hookecho/<version>/`. Their bot does most of the
+  review; the usual failure is a hash that does not match the URL's contents.
+
+## 5. Snap — needs a name registration first
+
+- Input: `snap/snapcraft.yaml` (repo root, not this directory).
+- Register the name at [snapcraft.io/register-snap](https://snapcraft.io/register-snap)
+  first: it can be taken, and finding that out after a build is the expensive
+  order.
+- `snapcraft` to build, `snapcraft upload --release=edge hookecho_*.snap` to
+  push. Promote to `stable` once it has been installed from `edge` on a machine
+  that is not the build machine.
+
+## After any of them lands
+
+Update the install section of the README with the real command, and say in the
+release notes which channel it went to. A store entry nobody is told about is
+the same as no store entry.


### PR DESCRIPTION
Thirteen commits, fixes before features. Each passes `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace`.

## The real bug

**Android background alerts ignored the marker watch radius and drawn zones.** In-app alerting has honored `markers[].alert_radius_mi` and `alert_polygons` for a while; the background service asked `?point=` about the pin alone, so a 20-mile watch radius fired only when a polygon covered the pin exactly — the one case the radius exists to widen.

Fixed by sampling: centre plus six rim points per marker, centroid plus up to eight vertices per zone, capped at forty requests a pass. Sampling rather than geometry because `?point=` resolves zone-only alerts (`geometry: null`) server-side, which Kotlin point-in-polygon cannot see at all. The field-name contract test now pins `alert_radius_mi` and `alert_polygons[].name/ring`, vertex order included.

## Correctness

- **A cancelled live stream** noticed at the end of a wait clamped to fifteen seconds, and could hand a sweep to the UI after cancellation. `task::sleep_while` slices the wait; the emit re-checks.
- **Unwraps on decoded and user-supplied data** (dealias, placefile, contour, plus four in the app) become let-else. None could fire today — all are guarded from a distance, which is the problem. The tests covering those shapes are the deliverable.
- **The marker popup** kept editing whatever marker slid into its index when a row above it was deleted.

## What you can see

- **Errors you can read**: the error chip holds while hovered and copies on click. Auxiliary feeds that failed into the log alone — buoys, Windy, the FAA cameras (which did not even log), placefile icons, the archive frame list — now toast once per feed per session.
- **Temperature units** in Settings ▸ Units, honored by the station plots. °F stays the default.
- **`.pal3` palettes** load as their common subset instead of being refused on the extension. The parser already ignored unknown directives.
- **`hookecho://` links reach the running instance** on desktop, over a loopback greeting, instead of opening a second window with its own caches and GPU context.
- **Mobile sheets drag down to dismiss.**
- **Placefile icon sheets cache on disk**, capped and swept like every other cache.

## Housekeeping

- ROADMAP claimed two shipped things were pending. Issue #11 closed as already done; #13 rewritten into the question that is actually open (does any real device still hit the CPU wind path?).
- DATA.md gains four missing modules and stops claiming the app "makes no request that isn't a data feed" — the release check, opt-in digest, Drive sync and push webhooks are requests. None is telemetry, so it now says that precisely.
- A test that fails when `packaging/flatpak/cargo-sources.json` goes stale, and `packaging/SUBMITTING.md` for the store queues.

## Not verified by hand

No Java on this machine, so the Kotlin is reviewed but uncompiled — it wants an `adb logcat` pass against a live warning before release. The sheet drag gesture is likewise untested by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)