### PR TITLE
feat(input): trackpad pinch zooms, horizontal scroll pans

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -9380,16 +9380,33 @@ impl HookEchoApp {
             self.views[idx].camera.pan_pixels(d.x, d.y);
             self.follow_cell = None; // a manual pan takes over the camera
         }
-        let scroll = ui.input(|i| i.smooth_scroll_delta.y);
-        if scroll.abs() > 0.0 {
-            if let Some(pos) = response.hover_pos() {
-                if prect.contains(pos) {
-                    self.active = idx;
-                    let cursor = (pos.x - prect.left(), pos.y - prect.top());
-                    self.views[idx]
-                        .camera
-                        .zoom_at(scroll as f64 * 0.005, cursor, vp);
-                }
+        // Wheel, trackpad, and pinch all land here. `zoom_delta` is a scale factor carrying the
+        // macOS/precision-touchpad pinch gesture (and ctrl+wheel, which egui folds into the same
+        // signal and subtracts from the scroll delta, so the two never double-apply). Horizontal
+        // scroll pans: on a trackpad a two-finger swipe is the obvious way to move the map, and on
+        // a mouse it is a tilt wheel nobody was using.
+        let (zoom, scroll) = ui.input(|i| (i.zoom_delta(), i.smooth_scroll_delta));
+        if let Some(pos) = response.hover_pos().filter(|p| prect.contains(*p)) {
+            let cursor = (pos.x - prect.left(), pos.y - prect.top());
+            // `zoom_delta()` reports a live touchscreen pinch too, which the gesture block below
+            // already owns (and it is the one that knows about the mobile chrome) — skip it here
+            // or a phone pinch zooms twice.
+            if gesture.is_none() && (zoom - 1.0).abs() > f32::EPSILON {
+                self.active = idx;
+                self.views[idx]
+                    .camera
+                    .zoom_at((zoom as f64).log2(), cursor, vp);
+            }
+            if scroll.y.abs() > 0.0 {
+                self.active = idx;
+                self.views[idx]
+                    .camera
+                    .zoom_at(scroll.y as f64 * 0.005, cursor, vp);
+            }
+            if scroll.x.abs() > 0.0 {
+                self.active = idx;
+                self.views[idx].camera.pan_pixels(scroll.x, 0.0);
+                self.follow_cell = None; // a manual pan takes over the camera
             }
         }
         // Two-finger gesture (touchscreens): pan by the gesture's translation, and zoom by the

--- a/crates/hookecho/src/ui/volume3d_window.rs
+++ b/crates/hookecho/src/ui/volume3d_window.rs
@@ -118,9 +118,16 @@ pub fn show(
                 st.az -= d.x * 0.4;
                 st.el = (st.el + d.y * 0.3).clamp(2.0, 88.0);
             }
-            let scroll = ctx.input(|i| i.smooth_scroll_delta.y);
-            if scroll != 0.0 && resp.hovered() {
-                st.dist = (st.dist - scroll * 0.003).clamp(1.3, 6.0);
+            // Wheel dollies the orbit camera; a trackpad pinch arrives as `zoom_delta` instead
+            // (scale factor, >1 is fingers apart = closer) and has to move `dist` the other way.
+            let (scroll, zoom) = ctx.input(|i| (i.smooth_scroll_delta.y, i.zoom_delta()));
+            if resp.hovered() {
+                if scroll != 0.0 {
+                    st.dist = (st.dist - scroll * 0.003).clamp(1.3, 6.0);
+                }
+                if (zoom - 1.0).abs() > f32::EPSILON {
+                    st.dist = (st.dist / zoom).clamp(1.3, 6.0);
+                }
             }
             let aspect = rect.width() / rect.height().max(1.0);
             // The threshold is a uniform, not a re-upload: dragging the slider never rebuilds the

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -28,6 +28,9 @@ place name. You do not need to learn where anything lives.
 5. The **LIVE** badge on the bottom bar means you're on the newest scan. Anything
    that moves you off it turns it off; click it to snap back.
 
+Moving the map: drag to pan, scroll to zoom. On a trackpad, pinch to zoom and
+swipe sideways to pan; on a touchscreen, two fingers do both.
+
 **Is it rotating?** Velocity, 0.5°, look for tight inbound (green) next to
 outbound (red) over a few gates. Then turn on **storm-relative velocity** in
 Layer options — it subtracts the storm's own motion, so rotation stops hiding
@@ -51,7 +54,8 @@ one action in `Ctrl+K` ("four products" / "four tilts").
 **Cross-section**: click two points on the map and get the storm in profile —
 core, overhang, and how high the echo goes. Any product.
 
-**3D**: the volume as an orbitable raymarch. Drag to orbit, scroll to zoom, set
+**3D**: the volume as an orbitable raymarch. Drag to orbit, scroll or pinch to
+zoom, set
 a dBZ floor ("Only above" → *Hail core*) so cores stand alone. Drop **Quality**
 to Low on a phone or an integrated GPU; it only changes sampling, not the data.
 


### PR DESCRIPTION
From the macOS tester report on #9:

> it took me a little bit to figure out how to zoom in/out (mouse scrolling!), i attempted to use trackpad gestures.

The map read only `smooth_scroll_delta.y`, so a mouse wheel was the only way to zoom. winit turns a macOS pinch into `egui::Event::Zoom` and nothing here was reading it.

- Map panes: `zoom_delta()` zooms at the cursor (pinch, and ctrl+wheel — egui folds both into that signal and removes them from the scroll delta, so no double-apply); horizontal scroll pans, which is what a two-finger sideways swipe gives.
- 3D window: pinch moves the orbit distance the same way the wheel does.
- Touchscreens unchanged: `zoom_delta()` falls back to the live multi-touch pinch, which the existing gesture block already owns (it is the one that knows which pinches land on the mobile chrome), so the new branch skips any frame with a touch gesture in flight.
- `docs/GUIDE.md` says how to move the map, which it previously never did.

**Unverified on Apple hardware** — there is none behind this project, which is what #9 exists for. Checked by `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, and mouse wheel on Linux.

Refs #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)