### PR TITLE
First-run revamp: four setup cards and an optional spotlight tour

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,12 @@ Versioned `v*` releases are the stable channel. Every push to `main` also
 refreshes a [`latest`](../../releases/tag/latest) rolling prerelease carrying the
 same artifacts, if you want the newest work without waiting for a tag.
 
-First launch opens a setup wizard: pick your home radar site, a theme (13 built
+First launch opens a four-card setup: home radar site, map and theme (13 built
 in), and how warnings should reach you (chime and/or [ntfy.sh](https://ntfy.sh)
-push to your phone). After that, three one-time callouts point at the controls
-you'll actually use. Re-run the wizard anytime from the sidebar's **App → Setup wizard**.
+push to your phone). The last card offers a 60-second tour — four stops
+spotlighted on the live map, two of which you finish by doing the thing rather
+than reading about it. Neither is forced, and both re-run from the sidebar's
+**App** section, `Ctrl+K`, or **Settings → General**.
 
 ## The interface
 

--- a/android/README.md
+++ b/android/README.md
@@ -79,7 +79,9 @@ a Gradle `preBuild` hook deletes anything in that directory that is not `libhook
 
 ## First run
 
-The setup wizard opens (home radar, theme, alerting).
+A four-card setup opens (home radar, map and theme, alerting and saved places), ending with an
+optional 60-second tour of the sheet, the dock and the timeline. Both re-run from **Layers → App**
+and **Settings → General**.
 
 Background alerting is opt-in from Settings. When it is on, a foreground service polls
 `api.weather.gov` for your saved markers (60 s while something is warned, 5 min otherwise) and a

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1097,6 +1097,8 @@ pub(crate) enum AppWindow {
     Climatology,
     LayerManager,
     Wizard,
+    /// The spotlight tour of the live chrome.
+    Tour,
     About,
 }
 
@@ -1627,6 +1629,9 @@ pub struct HookEchoApp {
     couplet_cache: Option<((usize, String, usize), Vec<wxdata::rotation::CoupletHit>)>,
     site_dialog: Option<ui::site_dialog::SiteDialog>,
     wizard: ui::wizard::Wizard,
+    /// The optional spotlight tour, and where the chrome drew the things it points at this frame.
+    tour: ui::tour::Tour,
+    tour_anchors: ui::tour::TourAnchors,
     settings_window: ui::settings_window::SettingsWindow,
     /// Active color tables (one per moment); reloaded when the palette settings change.
     palettes: Palettes,
@@ -2380,6 +2385,8 @@ impl HookEchoApp {
                 }
                 w
             },
+            tour: Default::default(),
+            tour_anchors: Default::default(),
             settings_window: Default::default(),
             palettes: Palettes::default(),
             live_stream: None,
@@ -5438,7 +5445,9 @@ impl HookEchoApp {
         let mosaic = self.mosaic_status();
         let mut etop_dbz = self.settings.etop_dbz;
         let mut hide = false;
-        egui::Panel::left("sidebar")
+        // Tour spotlights, recorded from inside the panel (no `self` reachable in there).
+        let mut alerts_rect = None;
+        let sidebar_rect = egui::Panel::left("sidebar")
             .exact_size(264.0)
             .show(root, |ui| {
                 // Title on the same line as the tabs: the name is branding, not a section, and
@@ -5461,7 +5470,9 @@ impl HookEchoApp {
                     } else {
                         format!("Alerts ({alert_count})")
                     };
-                    if ui.selectable_label(alerts_tab, label).clicked() {
+                    let alerts_hit = ui.selectable_label(alerts_tab, label);
+                    alerts_rect = Some(alerts_hit.rect);
+                    if alerts_hit.clicked() {
                         alerts_tab = true;
                     }
                     // Collapse, on the row it collapses. The floating button that brings the
@@ -5576,7 +5587,11 @@ impl HookEchoApp {
                 egui::CollapsingHeader::new("App")
                     .default_open(false)
                     .show(ui, |ui| self.app_rows(ui));
-            });
+            })
+            .response
+            .rect;
+        self.tour_anchors.menu = Some(sidebar_rect);
+        self.tour_anchors.alerts = alerts_rect;
         self.show_alert_panel = alerts_tab;
         self.settings.mute_alerts = muted;
         if hide {
@@ -5656,6 +5671,8 @@ impl HookEchoApp {
         let dvr = self.dvr_depth();
         // Edited through a local so the pill closure keeps its single `&mut self.views` borrow.
         let mut loop_frames = self.settings.live_loop_frames;
+        // Where the scrubber lands, for the tour's spotlight (same reason: no `self` in there).
+        let mut scrub_rect = None;
         egui::Panel::bottom("timeline_bar")
             .exact_size(44.0)
             .show(root, |ui| {
@@ -5792,6 +5809,7 @@ impl HookEchoApp {
                         [slider_w, 20.0],
                         egui::Slider::new(&mut ph_idx, 0..=last).show_value(false),
                     );
+                    scrub_rect = Some(resp.rect);
                     if resp.changed() {
                         t.playhead = ph_idx;
                         t.playing = false;
@@ -5859,6 +5877,7 @@ impl HookEchoApp {
                 });
             });
         self.settings.live_loop_frames = loop_frames;
+        self.tour_anchors.timeline = scrub_rect;
         if go_head {
             self.views[self.active].timeline.go_head();
         }
@@ -5903,49 +5922,56 @@ impl HookEchoApp {
         let mut thr = self.views[self.active].thresholds[mi];
         let (vmin, vmax) = moment.value_range();
         let (unit_factor, unit_label) = display_units(moment, &self.settings);
-        ui.horizontal(|ui| {
-            if ui
-                .button(format!("{}  {site}", egui_phosphor::regular::BROADCAST))
-                .on_hover_text("Choose the radar site")
-                .clicked()
-            {
-                actions.open_site_dialog = true;
-            }
-            ui.label(
-                egui::RichText::new(crate::products::name(moment, srv))
-                    .size(style::FONT_BASE)
-                    .strong(),
-            );
-        });
+        let head_rect = ui
+            .horizontal(|ui| {
+                if ui
+                    .button(format!("{}  {site}", egui_phosphor::regular::BROADCAST))
+                    .on_hover_text("Choose the radar site")
+                    .clicked()
+                {
+                    actions.open_site_dialog = true;
+                }
+                ui.label(
+                    egui::RichText::new(crate::products::name(moment, srv))
+                        .size(style::FONT_BASE)
+                        .strong(),
+                );
+            })
+            .response
+            .rect;
         // Always one line, always present: a wrapping row reflowed between 9- and 14-tilt VCPs and
         // vanished entirely between volumes, which slid the whole layer tree below it up and down.
         // A fixed-height horizontal scroll keeps the sidebar still and scrolls the extra tilts.
-        ui.scope(|ui| {
-            ui.set_height(TILT_ROW_H);
-            egui::ScrollArea::horizontal()
-                .id_salt("tilt_row")
-                .show(ui, |ui| {
-                    ui.horizontal(|ui| {
-                        ui.label(
-                            egui::RichText::new("Tilt")
-                                .size(style::FONT_SM)
-                                .color(egui::Color32::from_gray(150)),
-                        )
-                        .on_hover_text("How high above the ground the beam is looking");
-                        if elevations.is_empty() {
-                            ui.weak("\u{2014}");
-                        }
-                        for (i, angle) in elevations.iter().enumerate() {
-                            if ui
-                                .selectable_label(i == tilt, format!("{angle:.1}\u{b0}"))
-                                .clicked()
-                            {
-                                pick_tilt = Some(i);
+        let tilt_rect = ui
+            .scope(|ui| {
+                ui.set_height(TILT_ROW_H);
+                egui::ScrollArea::horizontal()
+                    .id_salt("tilt_row")
+                    .show(ui, |ui| {
+                        ui.horizontal(|ui| {
+                            ui.label(
+                                egui::RichText::new("Tilt")
+                                    .size(style::FONT_SM)
+                                    .color(egui::Color32::from_gray(150)),
+                            )
+                            .on_hover_text("How high above the ground the beam is looking");
+                            if elevations.is_empty() {
+                                ui.weak("\u{2014}");
                             }
-                        }
+                            for (i, angle) in elevations.iter().enumerate() {
+                                if ui
+                                    .selectable_label(i == tilt, format!("{angle:.1}\u{b0}"))
+                                    .clicked()
+                                {
+                                    pick_tilt = Some(i);
+                                }
+                            }
+                        });
                     });
-                });
-        });
+            })
+            .response
+            .rect;
+        self.tour_anchors.product = Some(head_rect.union(tilt_rect));
         egui::CollapsingHeader::new("Product options")
             .default_open(false)
             .show(ui, |ui| {
@@ -6990,6 +7016,12 @@ impl HookEchoApp {
                 false,
             ),
             (W::Wizard, "Setup wizard…", "Re-run first-time setup", false),
+            (
+                W::Tour,
+                "Take the tour…",
+                "A 60-second walk through the app's controls",
+                false,
+            ),
         ] {
             // The raymarch samples a `texture_3d<u32>`, which WebGL2 does not guarantee; on wasm
             // the entry would open a black window.
@@ -7211,6 +7243,7 @@ impl HookEchoApp {
                 }
                 W::LayerManager => self.layer_window_open = true,
                 W::Wizard => self.wizard.start(),
+                W::Tour => self.tour.start(),
                 W::About => {
                     self.about_open = true;
                     self.check_for_update(ctx);
@@ -12279,6 +12312,9 @@ impl HookEchoApp {
             if ui.button("Setup wizard…").clicked() {
                 self.wizard.start();
             }
+            if ui.button("Take the tour…").clicked() {
+                self.tour.start();
+            }
             if ui.button("Exit").clicked() {
                 ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
             }
@@ -12566,97 +12602,6 @@ impl HookEchoApp {
                 }
                 ShotDest::Loop => self.record_loop_frame(&image),
             }
-        }
-    }
-
-    /// One-time callouts pointing at the three floating surfaces a newcomer has to find: the
-    /// search pill, the Layers button, and the timeline.
-    ///
-    /// Existing users see these once too — the chrome is new to them as well, which is the point.
-    /// ponytail: three hardcoded callouts, no tour framework; a real tour can come if the set grows.
-    fn coach_marks(&mut self, ctx: &egui::Context) {
-        use crate::ui::style;
-        if !self.settings.setup_done || self.settings.coach_done || self.wizard.open {
-            return;
-        }
-        let accent = crate::theme::accent(self.settings.theme);
-        // Any real interaction — a click, or a touch gesture — means the cards have been read.
-        let done = ctx.input(|i| i.pointer.any_click() || i.multi_touch().is_some());
-        // Mobile has its own chrome (dock + sheets) and its own gestures, so it gets its own
-        // three callouts rather than pointing at pills that aren't there.
-        let marks: &[(&str, egui::Align2, egui::Vec2, &str)] = if cfg!(target_os = "android") {
-            &[
-                (
-                    "coach_m_dock",
-                    egui::Align2::CENTER_BOTTOM,
-                    egui::vec2(0.0, -110.0),
-                    "Everything lives down here: play the loop, pick layers and products, change radar site.",
-                ),
-                (
-                    "coach_m_map",
-                    egui::Align2::CENTER_CENTER,
-                    egui::vec2(0.0, -60.0),
-                    "Pinch to zoom, drag to pan. Long-press anywhere on the map for what's there — alerts, storms, distance.",
-                ),
-                (
-                    "coach_m_time",
-                    egui::Align2::CENTER_BOTTOM,
-                    egui::vec2(0.0, -240.0),
-                    "This row is the timeline: tap the frame count to scrub back through the storm, or jump to live.",
-                ),
-            ]
-        } else {
-            &[
-            (
-                "coach_sidebar",
-                egui::Align2::LEFT_TOP,
-                egui::vec2(340.0, 60.0),
-                "Everything lives in this sidebar: every product, layer and tool, each with a plain-English description. Ctrl+K jumps to its search.",
-            ),
-            (
-                "coach_product",
-                egui::Align2::LEFT_BOTTOM,
-                egui::vec2(340.0, -60.0),
-                "The current product, its tilt, and its expert knobs live at the top of the sidebar.",
-            ),
-            (
-                "coach_timeline",
-                egui::Align2::CENTER_BOTTOM,
-                egui::vec2(0.0, -14.0),
-                "This is the timeline — play the loop, scrub back through the storm, jump to live.",
-            ),
-            ]
-        };
-        for (id, align, offset, text) in marks {
-            let (id, align, offset, text) = (*id, *align, *offset, *text);
-            egui::Area::new(egui::Id::new(id))
-                .constrain_to(self.chrome_rect)
-                .anchor(align, offset)
-                .order(egui::Order::Foreground)
-                // The map card sits dead center on a phone, and an interactable layer there makes
-                // every pinch a no-op until it's dismissed. The cards take no input at all; any
-                // tap or gesture anywhere dismisses the whole set (below).
-                .interactable(false)
-                .show(ctx, |ui| {
-                    style::glass(ui, 240)
-                        .stroke(egui::Stroke::new(1.5, accent))
-                        .show(ui, |ui| {
-                            ui.set_max_width(300.0);
-                            ui.label(
-                                egui::RichText::new(text)
-                                    .size(style::FONT_BASE)
-                                    .color(egui::Color32::from_gray(238)),
-                            );
-                            ui.label(
-                                egui::RichText::new("Tap anywhere to dismiss")
-                                    .size(style::FONT_SM)
-                                    .color(accent),
-                            );
-                        });
-                });
-        }
-        if done {
-            self.settings.coach_done = true;
         }
     }
 
@@ -13991,6 +13936,9 @@ impl eframe::App for HookEchoApp {
                 .show(root, |_| {});
         }
 
+        // The tour highlights real chrome, so the rects have to come from this frame's draw.
+        self.tour_anchors = Default::default();
+
         // Docked desktop chrome. Declared before every floating Area so those constrain to what's
         // left of the viewport (`self.chrome_rect`) instead of covering the bars.
         if !cfg!(target_os = "android") && !self.obs_mode {
@@ -14012,7 +13960,6 @@ impl eframe::App for HookEchoApp {
         let mut actions = ui::layer_options::UiActions::default();
         if cfg!(target_os = "android") && !self.obs_mode {
             actions = self.mobile_chrome(root, ctx);
-            self.coach_marks(ctx);
         }
         self.apply_ui_actions(actions, ctx);
 
@@ -14022,7 +13969,22 @@ impl eframe::App for HookEchoApp {
             self.sidebar_button(ctx);
             self.info_chip(ctx);
             self.error_chip(ctx);
-            self.coach_marks(ctx);
+        }
+
+        // The spotlight tour, over the chrome it points at. Paused under the wizard and the
+        // cheat sheet — all three draw on `Order::Foreground` and would fight for it.
+        if self.tour.open && !self.wizard.open && !self.show_cheatsheet {
+            let v = &self.views[self.active];
+            let sig = ui::tour::Signals {
+                moment: v.moment,
+                srv: v.srv,
+                playhead: v.timeline.playhead,
+                following: v.timeline.following,
+            };
+            let accent = crate::theme::accent(self.settings.theme);
+            self.tour.advance_if_done(sig);
+            let anchors = self.tour_anchors;
+            self.tour.show(ctx, &anchors, sig, accent);
         }
 
         // One quiet check per session, once the app has settled — so a stale build tells you so
@@ -14104,6 +14066,12 @@ impl eframe::App for HookEchoApp {
             self.settings_window
                 .show(ctx, &mut self.settings, &self.palettes, sync_view, &entries);
         self.capture_key = self.settings_window.capturing;
+        if std::mem::take(&mut self.settings_window.run_wizard) {
+            self.wizard.start();
+        }
+        if std::mem::take(&mut self.settings_window.run_tour) {
+            self.tour.start();
+        }
         match sync_action {
             Some(ui::settings_window::SyncAction::SignIn) => self.sync_sign_in(),
             Some(ui::settings_window::SyncAction::SignOut) => self.sync_sign_out(),

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -14018,7 +14018,7 @@ impl eframe::App for HookEchoApp {
 
         // First-run setup wizard.
         let active = self.active;
-        if let Some(site) = ui::wizard::show(
+        if let Some(fin) = ui::wizard::show(
             ctx,
             &mut self.wizard,
             &mut self.settings,
@@ -14028,11 +14028,15 @@ impl eframe::App for HookEchoApp {
             self.settings.setup_done = true;
             self.settings.save();
             let v = &mut self.views[self.active];
-            v.site = Some(site.clone());
-            ui::site_dialog::center_on_site(&mut v.camera, &site);
+            v.site = Some(fin.site.clone());
+            ui::site_dialog::center_on_site(&mut v.camera, &fin.site);
+            if fin.take_tour {
+                self.tour.start();
+            }
         }
         if !self.wizard.open && !self.settings.setup_done {
-            // Dismissed without finishing: don't nag every frame, but keep for next launch.
+            // Dismissed without finishing. Setup is optional and re-runnable from three places,
+            // so take the ✕ at its word rather than reopening this on every launch.
             self.settings.setup_done = true;
             self.settings.save();
         }

--- a/crates/hookecho/src/app/mobile/mod.rs
+++ b/crates/hookecho/src/app/mobile/mod.rs
@@ -177,6 +177,7 @@ impl super::HookEchoApp {
             || self.show_cheatsheet
             || self.about_open
             || self.wizard.open
+            || self.tour.open
             || self.cells_window.open
             || self.forecast_open
             || self.settings_window.open
@@ -226,6 +227,7 @@ impl super::HookEchoApp {
             self.show_cheatsheet,
             self.about_open,
             self.wizard.open,
+            self.tour.open,
             self.cells_window.open,
             self.forecast_open,
             self.settings_window.open,

--- a/crates/hookecho/src/app/mobile/sheet.rs
+++ b/crates/hookecho/src/app/mobile/sheet.rs
@@ -101,6 +101,11 @@ impl crate::app::HookEchoApp {
                 ),
             )
         } else {
+            // The tour's first two stops point at the scrubber and the product chips, which only
+            // exist once the sheet is off Peek. Open it for them rather than spotlighting nothing.
+            if self.tour.wants_sheet() && self.mobile_snap == SheetSnap::Peek {
+                self.mobile_snap = SheetSnap::Half;
+            }
             let target = self.mobile_snap.height(content);
             // While a drag is live the finger owns the height; otherwise it eases to the snap.
             let h = match self.mobile_sheet_drag {
@@ -281,10 +286,9 @@ impl crate::app::HookEchoApp {
             let slider = egui::Slider::new(&mut idx, 0.0..=(info.nframes - 1) as f32)
                 .show_value(false)
                 .handle_shape(egui::style::HandleShape::Circle);
-            if ui
-                .add_sized([ui.available_width(), m3::MIN_TARGET], slider)
-                .changed()
-            {
+            let scrub = ui.add_sized([ui.available_width(), m3::MIN_TARGET], slider);
+            self.tour_anchors.timeline = Some(scrub.rect);
+            if scrub.changed() {
                 let t = &mut self.views[active].timeline;
                 t.playhead = idx.round() as usize;
                 t.following = false;
@@ -323,7 +327,7 @@ impl crate::app::HookEchoApp {
             (Moment::DifferentialReflectivity, false, "ZDR"),
             (Moment::DifferentialPhase, false, "KDP"),
         ];
-        ui.horizontal_wrapped(|ui| {
+        let chips = ui.horizontal_wrapped(|ui| {
             for (m, want_srv, label) in rows {
                 let selected = info.moment == m && (m != Moment::Velocity || info.srv == want_srv);
                 if m3::chip(ui, label, selected).clicked() {
@@ -334,6 +338,7 @@ impl crate::app::HookEchoApp {
                 }
             }
         });
+        self.tour_anchors.product = Some(chips.response.rect);
         // ---- Tilt ----
         if info.n_tilt > 1 {
             ui.add_space(m3::SP_2);

--- a/crates/hookecho/src/app/mobile/toolbar.rs
+++ b/crates/hookecho/src/app/mobile/toolbar.rs
@@ -113,6 +113,12 @@ impl crate::app::HookEchoApp {
                 });
             }
         });
+        // Tour spotlights: the dock is five even slots, Layers first and Alerts last.
+        let slot = rect.width() / 5.0;
+        let slot_rect =
+            |i: f32| Rect::from_min_size(rect.min + vec2(slot * i, 0.0), vec2(slot, rect.height()));
+        self.tour_anchors.menu = Some(slot_rect(0.0));
+        self.tour_anchors.alerts = Some(slot_rect(4.0));
     }
 
     /// The slim chip row along the top edge: site + VCP on the left, the armed-tool status in the

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -291,9 +291,6 @@ pub struct Settings {
     /// First-run setup wizard completed (or dismissed). `false` shows it at startup.
     #[serde(default)]
     pub setup_done: bool,
-    /// The one-time callouts pointing at the floating chrome have been dismissed.
-    #[serde(default)]
-    pub coach_done: bool,
     /// Sound played when a new NWS warning appears (gated by `alert_sound`).
     #[serde(default)]
     pub warn_sound: AlertSound,
@@ -665,7 +662,6 @@ impl Default for Settings {
             rain_alerts: false,
             rain_sound: AlertSound::default(),
             setup_done: false,
-            coach_done: false,
             warn_sound: AlertSound::default(),
             tds_sound: AlertSound::default(),
             rotation_sound: default_rotation_sound(),
@@ -866,6 +862,14 @@ mod tests {
     }
 
     #[test]
+    fn a_settings_file_from_the_coach_mark_era_still_loads() {
+        // `coach_done` went away with the coach marks; every installed settings.json still has it.
+        let s: Settings =
+            serde_json::from_str(r#"{"coach_done": true, "setup_done": true}"#).unwrap();
+        assert!(s.setup_done);
+    }
+
+    #[test]
     fn roundtrips() {
         let s = Settings {
             workspaces: Vec::new(),
@@ -951,7 +955,6 @@ mod tests {
             rain_alerts: true,
             rain_sound: AlertSound::Ding,
             setup_done: true,
-            coach_done: true,
             warn_sound: AlertSound::Siren,
             tds_sound: AlertSound::Custom("/tmp/tds.wav".to_string()),
             rotation_sound: AlertSound::Siren,

--- a/crates/hookecho/src/ui/mod.rs
+++ b/crates/hookecho/src/ui/mod.rs
@@ -99,6 +99,8 @@ pub mod sounding_window;
 /// Live station telemetry cards.
 pub mod station_card;
 pub mod style;
+/// The optional spotlight tour of the live chrome.
+pub mod tour;
 pub mod verify_window;
 pub mod video_window;
 pub mod volume3d_window;

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -57,6 +57,9 @@ pub struct SettingsWindow {
     storage: Option<std::sync::mpsc::Receiver<Vec<crate::storage::Entry>>>,
     #[cfg(not(target_arch = "wasm32"))]
     storage_rows: Option<Vec<crate::storage::Entry>>,
+    /// Set by the General tab's two buttons; the app drains them after `show`.
+    pub run_wizard: bool,
+    pub run_tour: bool,
     /// True while a keypress is being captured — the app stands its global hotkey table down so
     /// binding `A` doesn't also toggle the alert panel.
     pub capturing: bool,
@@ -117,7 +120,9 @@ impl SettingsWindow {
                 });
                 ui.separator();
                 match self.tab {
-                    Tab::General => general_tab(ui, settings),
+                    Tab::General => {
+                        general_tab(ui, settings, &mut self.run_wizard, &mut self.run_tour)
+                    }
                     Tab::Palettes => self.palettes_tab(ui, settings, palettes),
                     Tab::Units => units_tab(ui, settings),
                     Tab::Basemaps => basemaps_tab(ui, settings),
@@ -612,7 +617,12 @@ fn sync_tab(ui: &mut egui::Ui, settings: &mut Settings, sync: &SyncView) -> Opti
     action
 }
 
-fn general_tab(ui: &mut egui::Ui, settings: &mut Settings) {
+fn general_tab(
+    ui: &mut egui::Ui,
+    settings: &mut Settings,
+    run_wizard: &mut bool,
+    run_tour: &mut bool,
+) {
     egui::Grid::new("general_grid")
         .num_columns(2)
         .spacing([12.0, 8.0])
@@ -662,6 +672,26 @@ fn general_tab(ui: &mut egui::Ui, settings: &mut Settings) {
     if !valid && !settings.default_site.is_empty() {
         ui.colored_label(egui::Color32::YELLOW, "⚠ unknown site id");
     }
+
+    ui.add_space(8.0);
+    ui.separator();
+    ui.strong("Getting started");
+    ui.horizontal(|ui| {
+        if ui
+            .button("Setup wizard\u{2026}")
+            .on_hover_text("Re-run first-time setup")
+            .clicked()
+        {
+            *run_wizard = true;
+        }
+        if ui
+            .button("Take the tour\u{2026}")
+            .on_hover_text("A 60-second walk through the app's controls")
+            .clicked()
+        {
+            *run_tour = true;
+        }
+    });
 
     ui.add_space(8.0);
     ui.separator();

--- a/crates/hookecho/src/ui/tour.rs
+++ b/crates/hookecho/src/ui/tour.rs
@@ -1,0 +1,387 @@
+//! The optional 60-second tour: a spotlight on the app's own chrome, four stops long.
+//!
+//! It replaces three hardcoded coach-mark cards that pointed at pixel offsets and died on the
+//! first stray click. Here the highlighted rects are the real `Response` rects the chrome
+//! registered this frame (see [`TourAnchors`]), so the tour cannot drift out of sync with the
+//! layout, and the dimming is painted by a `layer_painter` — a painter takes no input, so the
+//! control under the spotlight stays clickable. That is what lets two of the four stops be
+//! "do the thing" rather than "read the card".
+//!
+//! Nothing here auto-starts. The wizard offers it on its last card, and it is re-runnable from
+//! the command palette, the sidebar's App section, and Settings → General.
+
+use wxdata::level2::Moment;
+
+use crate::ui::style;
+
+/// Where the chrome actually drew the four things the tour points at, this frame.
+///
+/// Cleared before chrome runs and re-registered by the draw sites, desktop and mobile alike; a
+/// stop whose anchor is `None` (hidden chrome, obs mode, a collapsed sheet) still shows its card,
+/// centered and without a hole.
+#[derive(Default, Clone, Copy)]
+pub struct TourAnchors {
+    pub timeline: Option<egui::Rect>,
+    pub product: Option<egui::Rect>,
+    pub menu: Option<egui::Rect>,
+    pub alerts: Option<egui::Rect>,
+}
+
+/// The bits of app state the two hands-on stops watch. Compared against a snapshot taken when
+/// the step opened: any difference means the user did the thing.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub struct Signals {
+    pub moment: Moment,
+    pub srv: bool,
+    pub playhead: usize,
+    pub following: bool,
+}
+
+/// Stop titles, and the one source of truth for how many stops there are.
+const TITLES: [&str; 4] = [
+    "Time travel",
+    "The products",
+    "Everything else",
+    "What's out there",
+]; // len = the "(n/4)" denominator
+
+pub struct Tour {
+    pub open: bool,
+    step: usize,
+    /// Signals as they were when the current step opened.
+    base: Option<Signals>,
+}
+
+impl Default for Tour {
+    fn default() -> Self {
+        Self {
+            open: false,
+            step: 0,
+            base: None,
+        }
+    }
+}
+
+impl Tour {
+    /// Start (or restart) at the first stop.
+    pub fn start(&mut self) {
+        self.open = true;
+        self.step = 0;
+        self.base = None;
+    }
+
+    fn next(&mut self) {
+        self.step += 1;
+        self.base = None;
+        if self.step >= TITLES.len() {
+            self.open = false;
+        }
+    }
+
+    /// Advance the two hands-on stops when the user does the thing. Pure — the tests drive it
+    /// without an egui context.
+    pub fn advance_if_done(&mut self, sig: Signals) {
+        if !self.open {
+            return;
+        }
+        let base = *self.base.get_or_insert(sig);
+        let done = match self.step {
+            // Scrubbed, or jumped back to live.
+            0 => sig.playhead != base.playhead || sig.following != base.following,
+            // Switched product (storm-relative velocity counts — it's a different picture).
+            1 => sig.moment != base.moment || sig.srv != base.srv,
+            // The rest are read-and-Next.
+            _ => false,
+        };
+        if done {
+            self.next();
+        }
+    }
+
+    /// The first two stops need the phone's sheet open — that is where the scrubber and the
+    /// product chips live.
+    pub fn wants_sheet(&self) -> bool {
+        self.open && self.step < 2
+    }
+
+    fn body(&self, sig: Signals) -> String {
+        let android = cfg!(target_os = "android");
+        match self.step {
+            0 => if android {
+                "Drag the scrubber to walk back through the storm, or tap Live to snap to the \
+                 newest scan. Every overlay — warnings, reports, lightning — follows you back in \
+                 time."
+            } else {
+                "Drag the timeline to walk back through the storm, or click LIVE to snap to the \
+                 newest scan. Every overlay — warnings, reports, lightning — follows you back in \
+                 time."
+            }
+            .to_string(),
+            1 => {
+                let p = crate::products::info(sig.moment);
+                let how = if android {
+                    "Tap another product chip"
+                } else {
+                    "Pick another product, or press its number key"
+                };
+                format!(
+                    "You're looking at {}: {}.\n\n{} — the tilt row beside them is how high above \
+                     the ground the beam is aimed.",
+                    p.name, p.blurb, how
+                )
+            }
+            2 => if android {
+                "Layers opens everything else: overlays, tools, windows, the radar site. It has a \
+                 search box — type what you want in plain English (\"hail\", \"sounding\", a town \
+                 name) and it's one tap away."
+            } else {
+                "The sidebar holds everything else: products, overlays, tools, windows, settings. \
+                 Ctrl+K jumps straight to its search — type what you want in plain English \
+                 (\"hail\", \"sounding\", a town name) and Enter runs the top match."
+            }
+            .to_string(),
+            _ => {
+                let tap = if android { "Tap" } else { "Click" };
+                format!(
+                    "{tap} a storm on the map to interrogate it — what the beam sees there, which \
+                     warnings cover it, how far away it is.\n\nThe bell counts warnings in view; \
+                     open it for the list, worst first. Alerts on your saved places work with the \
+                     app closed.\n\nPress ? any time for the keyboard map."
+                )
+            }
+        }
+    }
+
+    fn anchor(&self, a: &TourAnchors) -> Option<egui::Rect> {
+        match self.step {
+            0 => a.timeline,
+            1 => a.product,
+            2 => a.menu,
+            _ => a.alerts,
+        }
+    }
+
+    /// Draw the current stop. Call after the chrome has registered its anchors.
+    pub fn show(
+        &mut self,
+        ctx: &egui::Context,
+        anchors: &TourAnchors,
+        sig: Signals,
+        accent: egui::Color32,
+    ) {
+        if !self.open {
+            return;
+        }
+        let step = self.step.min(TITLES.len() - 1);
+        let screen = ctx.content_rect();
+        let hole = self
+            .anchor(anchors)
+            .map(|r| r.expand(6.0).intersect(screen));
+        // Dim everything but the hole. Four rects rather than a mask because a painter has no
+        // clip stack worth fighting, and four rects is four lines.
+        let p = ctx.layer_painter(egui::LayerId::new(
+            egui::Order::Foreground,
+            egui::Id::new("tour_dim"),
+        ));
+        let dim = egui::Color32::from_black_alpha(140);
+        match hole {
+            Some(h) => {
+                let (l, r, t, b) = (h.left(), h.right(), h.top(), h.bottom());
+                for rect in [
+                    egui::Rect::from_min_max(screen.min, egui::pos2(screen.right(), t)),
+                    egui::Rect::from_min_max(
+                        egui::pos2(screen.left(), b),
+                        egui::pos2(screen.right(), screen.bottom()),
+                    ),
+                    egui::Rect::from_min_max(egui::pos2(screen.left(), t), egui::pos2(l, b)),
+                    egui::Rect::from_min_max(egui::pos2(r, t), egui::pos2(screen.right(), b)),
+                ] {
+                    p.rect_filled(rect, 0.0, dim);
+                }
+                p.rect_stroke(
+                    h,
+                    6.0,
+                    egui::Stroke::new(2.0, accent),
+                    egui::StrokeKind::Middle,
+                );
+            }
+            None => {
+                p.rect_filled(screen, 0.0, dim);
+            }
+        }
+
+        let card_w = 320.0_f32.min(screen.width() - 32.0);
+        // Below the spotlight if it fits, above otherwise; centered when there is no spotlight.
+        let (pivot, pos) = match hole {
+            Some(h) if screen.bottom() - h.bottom() > 220.0 => (
+                egui::Align2::CENTER_TOP,
+                egui::pos2(h.center().x, h.bottom() + 12.0),
+            ),
+            Some(h) => (
+                egui::Align2::CENTER_BOTTOM,
+                egui::pos2(h.center().x, h.top() - 12.0),
+            ),
+            None => (egui::Align2::CENTER_CENTER, screen.center()),
+        };
+        let body = self.body(sig);
+        let mut act = None;
+        egui::Area::new(egui::Id::new("tour_card"))
+            .order(egui::Order::Foreground)
+            .constrain_to(screen)
+            .pivot(pivot)
+            .fixed_pos(pos)
+            .show(ctx, |ui| {
+                style::glass(ui, 245)
+                    .stroke(egui::Stroke::new(1.5, accent))
+                    .show(ui, |ui| {
+                        ui.set_width(card_w);
+                        ui.horizontal(|ui| {
+                            ui.label(
+                                egui::RichText::new(TITLES[step])
+                                    .size(style::FONT_BASE)
+                                    .strong()
+                                    .color(accent),
+                            );
+                            ui.with_layout(
+                                egui::Layout::right_to_left(egui::Align::Center),
+                                |ui| {
+                                    ui.label(
+                                        egui::RichText::new(format!(
+                                            "{}/{}",
+                                            step + 1,
+                                            TITLES.len()
+                                        ))
+                                        .size(style::FONT_SM)
+                                        .color(egui::Color32::from_gray(150)),
+                                    );
+                                },
+                            );
+                        });
+                        ui.add_space(4.0);
+                        ui.label(
+                            egui::RichText::new(body)
+                                .size(style::FONT_BASE)
+                                .color(egui::Color32::from_gray(238)),
+                        );
+                        ui.add_space(8.0);
+                        ui.horizontal(|ui| {
+                            if ui.small_button("Skip tour").clicked() {
+                                act = Some(false);
+                            }
+                            ui.with_layout(
+                                egui::Layout::right_to_left(egui::Align::Center),
+                                |ui| {
+                                    let last = step + 1 == TITLES.len();
+                                    if ui.button(if last { "Done" } else { "Next" }).clicked() {
+                                        act = Some(true);
+                                    }
+                                },
+                            );
+                        });
+                    });
+            });
+        match act {
+            Some(true) => self.next(),
+            Some(false) => self.open = false,
+            None => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sig() -> Signals {
+        Signals {
+            moment: Moment::Reflectivity,
+            srv: false,
+            playhead: 3,
+            following: true,
+        }
+    }
+
+    #[test]
+    fn scrubbing_finishes_the_timeline_stop() {
+        let mut t = Tour::default();
+        t.start();
+        t.advance_if_done(sig()); // snapshots
+        t.advance_if_done(sig());
+        assert_eq!(t.step, 0, "nothing happened, so nothing advances");
+        t.advance_if_done(Signals {
+            playhead: 4,
+            following: false,
+            ..sig()
+        });
+        assert_eq!(t.step, 1);
+    }
+
+    #[test]
+    fn switching_product_finishes_the_product_stop() {
+        let mut t = Tour::default();
+        t.start();
+        t.step = 1;
+        t.advance_if_done(sig());
+        t.advance_if_done(Signals {
+            moment: Moment::Velocity,
+            ..sig()
+        });
+        assert_eq!(t.step, 2);
+        // Storm-relative counts as a switch too.
+        let mut t = Tour::default();
+        t.start();
+        t.step = 1;
+        t.advance_if_done(sig());
+        t.advance_if_done(Signals { srv: true, ..sig() });
+        assert_eq!(t.step, 2);
+    }
+
+    #[test]
+    fn the_passive_stops_only_move_on_next() {
+        let mut t = Tour::default();
+        t.start();
+        t.step = 2;
+        t.advance_if_done(sig());
+        t.advance_if_done(Signals {
+            moment: Moment::Velocity,
+            playhead: 99,
+            ..sig()
+        });
+        assert_eq!(t.step, 2);
+        t.next();
+        assert_eq!(t.step, 3);
+    }
+
+    #[test]
+    fn the_last_next_closes_the_tour() {
+        let mut t = Tour::default();
+        t.start();
+        for _ in 0..TITLES.len() {
+            assert!(t.open);
+            t.next();
+        }
+        assert!(!t.open);
+    }
+
+    #[test]
+    fn start_resets_a_finished_tour() {
+        let mut t = Tour::default();
+        t.start();
+        t.step = 3;
+        t.advance_if_done(sig());
+        t.start();
+        assert!(t.open && t.step == 0 && t.base.is_none());
+    }
+
+    #[test]
+    fn a_closed_tour_ignores_signals() {
+        let mut t = Tour::default();
+        t.advance_if_done(sig());
+        t.advance_if_done(Signals {
+            playhead: 9,
+            ..sig()
+        });
+        assert_eq!(t.step, 0);
+        assert!(!t.open);
+    }
+}

--- a/crates/hookecho/src/ui/tour.rs
+++ b/crates/hookecho/src/ui/tour.rs
@@ -45,21 +45,12 @@ const TITLES: [&str; 4] = [
     "What's out there",
 ]; // len = the "(n/4)" denominator
 
+#[derive(Default)]
 pub struct Tour {
     pub open: bool,
     step: usize,
     /// Signals as they were when the current step opened.
     base: Option<Signals>,
-}
-
-impl Default for Tour {
-    fn default() -> Self {
-        Self {
-            open: false,
-            step: 0,
-            base: None,
-        }
-    }
 }
 
 impl Tour {

--- a/crates/hookecho/src/ui/tour.rs
+++ b/crates/hookecho/src/ui/tour.rs
@@ -172,11 +172,14 @@ impl Tour {
             .map(|r| r.expand(6.0).intersect(screen));
         // Dim everything but the hole. Four rects rather than a mask because a painter has no
         // clip stack worth fighting, and four rects is four lines.
-        let p = ctx.layer_painter(egui::LayerId::new(
+        let mut p = ctx.layer_painter(egui::LayerId::new(
             egui::Order::Foreground,
             egui::Id::new("tour_dim"),
         ));
-        let dim = egui::Color32::from_black_alpha(140);
+        // A layer painter is clipped to `available_rect` — what's left after the docked panels —
+        // so without this the sidebar and the legend never dim.
+        p.set_clip_rect(screen);
+        let dim = egui::Color32::from_black_alpha(160);
         match hole {
             Some(h) => {
                 let (l, r, t, b) = (h.left(), h.right(), h.top(), h.bottom());

--- a/crates/hookecho/src/ui/tour.rs
+++ b/crates/hookecho/src/ui/tour.rs
@@ -164,7 +164,9 @@ impl Tour {
             return;
         }
         let step = self.step.min(TITLES.len() - 1);
-        let screen = ctx.content_rect();
+        // Dim the whole window: `content_rect` stops at the docked panels, which left the sidebar
+        // and the legend at full brightness and the spotlight looking like a stray shadow.
+        let screen = ctx.viewport_rect();
         let hole = self
             .anchor(anchors)
             .map(|r| r.expand(6.0).intersect(screen));
@@ -212,13 +214,13 @@ impl Tour {
                 egui::Align2::CENTER_BOTTOM,
                 egui::pos2(h.center().x, h.top() - 12.0),
             ),
-            None => (egui::Align2::CENTER_CENTER, screen.center()),
+            None => (egui::Align2::CENTER_CENTER, ctx.content_rect().center()),
         };
         let body = self.body(sig);
         let mut act = None;
         egui::Area::new(egui::Id::new("tour_card"))
             .order(egui::Order::Foreground)
-            .constrain_to(screen)
+            .constrain_to(ctx.content_rect())
             .pivot(pivot)
             .fixed_pos(pos)
             .show(ctx, |ui| {

--- a/crates/hookecho/src/ui/wizard.rs
+++ b/crates/hookecho/src/ui/wizard.rs
@@ -1,11 +1,24 @@
-//! First-run setup wizard: walks through radar site, map/API keys, theme, sounds, saved
-//! locations, and alerts. Shown once (gated on `Settings::setup_done`), re-runnable from Help.
+//! First-run setup: four cards — home radar site, map and look, alerts and places, and the
+//! hand-off. Shown once (gated on `Settings::setup_done`), re-runnable from the sidebar's App
+//! section, the command palette, and Settings → General.
+//!
+//! It used to be ten pages, two of which were walls of text describing controls the app no longer
+//! has. Teaching the chrome is the tour's job now ([`crate::ui::tour`]); this is only the
+//! configuration you cannot guess for someone, and the last card offers the tour.
 
 use crate::settings::{Settings, Theme};
 use crate::tiles::BasemapStyle;
 use crate::ui::marker_window::IconTextures;
 
-const LAST_STEP: usize = 9;
+/// Card titles, and the one source of truth for how many cards there are.
+const TITLES: [&str; 4] = ["Welcome", "Map & look", "Alerts & places", "Ready"];
+
+/// What the last card hands back.
+pub struct Finish {
+    /// The chosen home site, to load and fly to.
+    pub site: String,
+    pub take_tour: bool,
+}
 
 #[derive(Default)]
 pub struct Wizard {
@@ -22,16 +35,21 @@ impl Wizard {
     }
 }
 
-/// Show the wizard. Returns `Some(site)` when finished (the chosen home site to load); the caller
-/// marks `setup_done`, saves settings, and jumps the view there. `basemap` is the active pane's
-/// style (updated live as the user picks); `icon_tex` renders marker-icon thumbnails.
+fn heading(ui: &mut egui::Ui, step: usize) {
+    ui.strong(format!("{} ({}/{})", TITLES[step], step + 1, TITLES.len()));
+    ui.add_space(6.0);
+}
+
+/// Show the wizard. Returns `Some` when finished; the caller marks `setup_done`, saves settings,
+/// jumps the view to the site, and starts the tour if it was asked for. `basemap` is the active
+/// pane's style (updated live as the user picks); `icon_tex` renders marker-icon thumbnails.
 pub fn show(
     ctx: &egui::Context,
     wiz: &mut Wizard,
     settings: &mut Settings,
     basemap: &mut BasemapStyle,
     icon_tex: &IconTextures,
-) -> Option<String> {
+) -> Option<Finish> {
     if !wiz.open {
         return None;
     }
@@ -46,53 +64,17 @@ pub fn show(
             // Full width on desktop; on a phone, whatever fits (phone_surface caps the window).
             ui.set_width(420.0_f32.min(ctx.content_rect().width() - 40.0));
             match wiz.step {
-                0 => page_welcome(ui),
-                1 => page_site(ui, wiz, settings),
-                2 => page_map(ui, settings, basemap),
-                3 => page_theme(ui, settings),
-                4 => page_alerts(ui, settings),
-                5 => {
-                    ui.strong("Sounds (6/10)");
-                    ui.small(
-                        "Pick a sound per alert kind, set the volume, and preview with \u{25b6}.",
-                    );
-                    ui.add_space(6.0);
-                    crate::ui::settings_window::sound_picker(ui, settings);
-                }
-                6 => {
-                    ui.strong("Saved locations (7/10)");
-                    ui.small(
-                        "Add places you care about \u{2014} warning alerts, lightning and \
-                         rain-arrival alerts all watch them. Later you can search a place and \
-                         save it, or drop one with the Drop marker tool. Tap any marker on the \
-                         map to rename or remove it.",
-                    );
-                    ui.add_space(6.0);
-                    egui::ScrollArea::vertical()
-                        .max_height(220.0)
-                        .show(ui, |ui| {
-                            let _ = crate::ui::marker_window::marker_grid(
-                                ui,
-                                &mut settings.markers,
-                                icon_tex,
-                            );
-                        });
-                    if ui.button("\u{2795} Add location").clicked() {
-                        let n = settings.markers.len() + 1;
-                        settings.markers.push(crate::settings::Marker {
-                            name: format!("Location {n}"),
-                            lat: 0.0,
-                            lon: 0.0,
-                            icon: None,
-                            alert_radius_mi: crate::settings::default_alert_radius_mi(),
-                            video_url: String::new(),
-                            home: false,
+                0 => card_site(ui, wiz, settings),
+                1 => card_map(ui, settings, basemap),
+                2 => card_alerts(ui, settings, icon_tex),
+                _ => {
+                    if let Some(take_tour) = card_done(ui, settings, *basemap) {
+                        finished = Some(Finish {
+                            site: settings.default_site.clone(),
+                            take_tour,
                         });
                     }
                 }
-                7 => page_products(ui),
-                8 => page_tools(ui),
-                _ => page_done(ui, settings, *basemap),
             }
             ui.add_space(8.0);
             ui.separator();
@@ -101,12 +83,9 @@ pub fn show(
                     wiz.step -= 1;
                 }
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                    if wiz.step < LAST_STEP {
-                        if ui.button("Next").clicked() {
-                            wiz.step += 1;
-                        }
-                    } else if ui.button("Finish").clicked() {
-                        finished = Some(settings.default_site.clone());
+                    // The last card's own two buttons are the finish; there is no Next past it.
+                    if wiz.step + 1 < TITLES.len() && ui.button("Next").clicked() {
+                        wiz.step += 1;
                     }
                 });
             });
@@ -117,125 +96,12 @@ pub fn show(
     finished
 }
 
-/// What each product shows, in the words the app uses everywhere else.
-fn page_products(ui: &mut egui::Ui) {
-    ui.strong("The radar products (8/10)");
-    ui.add_space(6.0);
-    ui.small(
-        "Switch with the pill at the bottom-left, or the number keys. Tilt is on the same pill \
-         \u{2014} how high above the ground the beam is looking.",
+fn card_site(ui: &mut egui::Ui, wiz: &mut Wizard, settings: &mut Settings) {
+    heading(ui, 0);
+    ui.label(
+        "Under a minute of setup, and everything here can be changed later in Settings.\n\nStart \
+         with your home radar \u{2014} the one you'll open to.",
     );
-    ui.add_space(6.0);
-    for p in &crate::products::PRODUCTS {
-        ui.horizontal(|ui| {
-            ui.add_sized(
-                [22.0, 16.0],
-                egui::Label::new(
-                    egui::RichText::new(p.hotkey.to_string())
-                        .small()
-                        .color(egui::Color32::from_gray(140)),
-                )
-                .selectable(false),
-            );
-            ui.vertical(|ui| {
-                ui.label(egui::RichText::new(p.name).strong());
-                ui.small(p.blurb);
-            });
-        });
-        ui.add_space(3.0);
-    }
-    ui.add_space(2.0);
-    ui.small(
-        "\u{201c}Compare 4 tilts\u{201d} (Ctrl+K) opens the same product at four heights at once.",
-    );
-}
-
-/// The rest of the toolbox, one line each — the point is to know these exist.
-fn page_tools(ui: &mut egui::Ui) {
-    ui.strong("What else is in here (9/10)");
-    ui.add_space(6.0);
-    ui.small(
-        "Everything below is one search away: open the menu (top-left) and type, or press Ctrl+K.",
-    );
-    ui.add_space(6.0);
-    let group = |ui: &mut egui::Ui, title: &str, rows: &[(&str, &str)]| {
-        ui.label(
-            egui::RichText::new(title)
-                .strong()
-                .color(egui::Color32::from_rgb(110, 170, 240)),
-        );
-        for (name, what) in rows {
-            ui.horizontal_wrapped(|ui| {
-                ui.label(egui::RichText::new(*name).strong());
-                ui.small(format!("\u{2014} {what}"));
-            });
-        }
-        ui.add_space(5.0);
-    };
-    group(
-        ui,
-        "Looking ahead",
-        &[
-            (
-                "Future radar",
-                "the forecast radar picture, on the timeline's tail",
-            ),
-            (
-                "Future rotation tracks",
-                "where storms are forecast to rotate",
-            ),
-            (
-                "Point forecast",
-                "tap anywhere for that spot's 7-day and hourly",
-            ),
-            ("Surface fronts", "the national weather map, fronts and H/L"),
-        ],
-    );
-    group(
-        ui,
-        "When storms are up",
-        &[
-            (
-                "Storm attributes",
-                "every tracked storm in one sortable table",
-            ),
-            ("Alerts panel", "warnings in view, worst first"),
-            ("Cross-sections", "slice a storm vertically, in any product"),
-            (
-                "Rain arrival",
-                "how many minutes until rain reaches your places",
-            ),
-        ],
-    );
-    group(
-        ui,
-        "Looking back",
-        &[
-            ("Timeline", "scrub back through any date since June 1991"),
-            ("Event library", "jump straight to a famous storm"),
-            ("Instant replay", "re-play the scans already in memory (R)"),
-        ],
-    );
-}
-
-fn page_welcome(ui: &mut egui::Ui) {
-    ui.strong("Welcome (1/10)");
-    ui.add_space(6.0);
-    ui.label("This quick setup configures your radar, map, theme, sounds, and saved locations. It takes under a minute — everything here can be changed later in Settings.");
-    ui.add_space(6.0);
-    ui.label("Afterwards the whole app is one map with a few floating controls:");
-    ui.add_space(2.0);
-    ui.small("• The bar along the bottom is the timeline — play, scrub, and jump back to live.");
-    ui.small("• Bottom-left names the product you're looking at; tap it to switch.");
-    ui.small("• The menu button (top-left) opens everything: layers, tools, radar site, settings.");
-    ui.small("• The bell (top-right) shows active alerts; its number is how many.");
-    ui.small("• Search the menu for a place or any action — on desktop, Ctrl+K opens it straight.");
-    ui.add_space(4.0);
-    ui.small("Press Next to begin.");
-}
-
-fn page_site(ui: &mut egui::Ui, wiz: &mut Wizard, settings: &mut Settings) {
-    ui.strong("Home radar site (2/10)");
     ui.add_space(6.0);
     ui.add(egui::TextEdit::singleline(&mut wiz.filter).hint_text("Search by ID, city, or state…"));
     let needle = wiz.filter.to_ascii_uppercase();
@@ -250,7 +116,7 @@ fn page_site(ui: &mut egui::Ui, wiz: &mut Wizard, settings: &mut Settings) {
                 {
                     continue;
                 }
-                let label = format!("{}  —  {}, {}", s.id, s.city, s.state);
+                let label = format!("{}  \u{2014}  {}, {}", s.id, s.city, s.state);
                 if ui
                     .selectable_label(settings.default_site == s.id, label)
                     .clicked()
@@ -261,9 +127,12 @@ fn page_site(ui: &mut egui::Ui, wiz: &mut Wizard, settings: &mut Settings) {
         });
 }
 
-fn page_map(ui: &mut egui::Ui, settings: &mut Settings, basemap: &mut BasemapStyle) {
-    ui.strong("Map & API keys (3/10)");
-    ui.small("Optional keys unlock premium basemaps. Free keys: mapbox.com and maptiler.com. Plenty of basemaps work with no key at all.");
+fn card_map(ui: &mut egui::Ui, settings: &mut Settings, basemap: &mut BasemapStyle) {
+    heading(ui, 1);
+    ui.small(
+        "Plenty of basemaps work with no key at all. Free keys from mapbox.com and maptiler.com \
+         unlock the premium ones; they stay on this machine.",
+    );
     ui.add_space(6.0);
     // Same widget as the Settings > Basemaps tab: responsive width plus the Android Paste button
     // (a soft keyboard cannot reach the system clipboard on a NativeActivity).
@@ -289,13 +158,10 @@ fn page_map(ui: &mut egui::Ui, settings: &mut Settings, basemap: &mut BasemapSty
                 }
             });
     });
-}
-
-fn page_theme(ui: &mut egui::Ui, settings: &mut Settings) {
-    ui.strong("Look and feel (4/10)");
-    ui.add_space(6.0);
+    ui.add_space(8.0);
+    ui.label("Theme");
     egui::ScrollArea::vertical()
-        .max_height(220.0)
+        .max_height(180.0)
         .show(ui, |ui| {
             for t in Theme::ALL {
                 ui.horizontal(|ui| {
@@ -310,9 +176,8 @@ fn page_theme(ui: &mut egui::Ui, settings: &mut Settings) {
         });
 }
 
-fn page_alerts(ui: &mut egui::Ui, settings: &mut Settings) {
-    ui.strong("Alerts (5/10)");
-    ui.add_space(6.0);
+fn card_alerts(ui: &mut egui::Ui, settings: &mut Settings, icon_tex: &IconTextures) {
+    heading(ui, 2);
     ui.checkbox(
         &mut settings.alert_sound,
         "Play a sound when a new warning appears",
@@ -325,12 +190,51 @@ fn page_alerts(ui: &mut egui::Ui, settings: &mut Settings) {
         ui.label("ntfy.sh topic:");
         ui.text_edit_singleline(&mut settings.ntfy_topic);
     });
-    ui.small("Optional: push notifications to your phone when a warning covers a saved location. Leave empty to skip.");
+    ui.small("Optional: push to your phone when a warning covers a saved location.");
+    // Collapsed: a sound per alert kind is a preference, not a decision anyone has to make in
+    // their first minute.
+    egui::CollapsingHeader::new("Alert sounds")
+        .default_open(false)
+        .show(ui, |ui| {
+            crate::ui::settings_window::sound_picker(ui, settings);
+        });
+
+    ui.add_space(8.0);
+    ui.separator();
+    ui.strong("Saved locations");
+    ui.small(
+        "Places the alerts watch \u{2014} warnings, lightning and rain arrival. Later you can \
+         search a place and save it, or drop one with the Drop marker tool.",
+    );
+    ui.add_space(6.0);
+    egui::ScrollArea::vertical()
+        .max_height(180.0)
+        .show(ui, |ui| {
+            crate::ui::marker_window::marker_grid(ui, &mut settings.markers, icon_tex);
+        });
+    if ui.button("\u{2795} Add location").clicked() {
+        let n = settings.markers.len() + 1;
+        // Seed at the home radar rather than at (0, 0) in the Gulf of Guinea, staggered so a
+        // second one is visibly its own marker. Drag or edit from there.
+        let (lat, lon) = wxdata::sites::site_by_id(&settings.default_site)
+            .map(|s| (s.latitude as f64, s.longitude as f64))
+            .unwrap_or((0.0, 0.0));
+        let offset = 0.05 * n as f64;
+        settings.markers.push(crate::settings::Marker {
+            name: format!("Location {n}"),
+            lat: lat + offset,
+            lon: lon + offset,
+            icon: None,
+            alert_radius_mi: crate::settings::default_alert_radius_mi(),
+            video_url: String::new(),
+            home: false,
+        });
+    }
 }
 
-fn page_done(ui: &mut egui::Ui, settings: &Settings, basemap: BasemapStyle) {
-    ui.strong("All set (10/10)");
-    ui.add_space(6.0);
+/// The hand-off. `Some(take_tour)` once the user picks one of the two ways out.
+fn card_done(ui: &mut egui::Ui, settings: &Settings, basemap: BasemapStyle) -> Option<bool> {
+    heading(ui, 3);
     ui.label(format!("Home radar: {}", settings.default_site));
     ui.label(format!("Theme: {}", settings.theme.label()));
     ui.label(format!("Basemap: {}", basemap.label()));
@@ -339,9 +243,51 @@ fn page_done(ui: &mut egui::Ui, settings: &Settings, basemap: BasemapStyle) {
         "Alert sound: {}",
         if settings.alert_sound { "on" } else { "off" }
     ));
-    ui.add_space(4.0);
+    ui.add_space(8.0);
     ui.small(
-        "Press Finish to jump to your home radar. Re-run this anytime from the sidebar's App \
-         section, and press Ctrl+K whenever you're looking for something.",
+        "The tour is four stops on the live map \u{2014} the timeline, the products, where \
+         everything else lives, and how to read a storm.",
     );
+    ui.add_space(6.0);
+    let mut out = None;
+    ui.horizontal(|ui| {
+        if ui.button("Take the 60-second tour").clicked() {
+            out = Some(true);
+        }
+        if ui.button("Explore on my own").clicked() {
+            out = Some(false);
+        }
+    });
+    ui.add_space(4.0);
+    ui.small(if cfg!(target_os = "android") {
+        "Both are re-runnable later from Layers \u{2192} App, and from Settings \u{2192} General."
+    } else {
+        "Both are re-runnable later from the sidebar's App section, Ctrl+K, and Settings \
+         \u{2192} General."
+    });
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_last_card_is_the_finish() {
+        // `show` offers Next while `step + 1 < len`, so the last index has to be the summary —
+        // otherwise the wizard has no way out but its ✕.
+        assert_eq!(TITLES.len(), 4);
+        assert_eq!(TITLES[TITLES.len() - 1], "Ready");
+    }
+
+    #[test]
+    fn start_resets_to_the_first_card() {
+        let mut w = Wizard {
+            open: false,
+            step: 3,
+            filter: "KTLX".into(),
+        };
+        w.start();
+        assert!(w.open && w.step == 0 && w.filter.is_empty());
+    }
 }

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -7,8 +7,10 @@ parts that need a filesystem or GPS.
 
 ## Getting oriented
 
-First launch runs the setup wizard: home radar site, theme, how warnings reach
-you. After that the whole app is four regions — **left sidebar** (site, product,
+First launch runs a four-card setup: home radar site, map and theme, how
+warnings reach you. Its last card offers a 60-second tour of the live map; take
+it or skip it, and re-run either from the sidebar's **App** section, `Ctrl+K`,
+or **Settings → General**. After that the whole app is four regions — **left sidebar** (site, product,
 tilt, every layer, window, tool and setting), **bottom bar** (the timeline),
 **right edge** (the color scale for what you're looking at), and the map.
 

--- a/scripts/shots/settings.template.json
+++ b/scripts/shots/settings.template.json
@@ -5,7 +5,6 @@
   "mapbox_key": "",
   "ui_scale": 1.0,
   "setup_done": true,
-  "coach_done": true,
   "dealias_velocity": true,
   "alert_sound": false,
   "lightning_alarm": false,

--- a/scripts/shots/shoot.sh
+++ b/scripts/shots/shoot.sh
@@ -37,6 +37,7 @@ L_XSECTION="Tool: Cross-section"
 L_FORECAST="Tool: Point forecast"
 L_STORMTABLE="Storm attributes…"
 L_VERIFY="Warning verification…"
+L_TOUR="Take the tour…"
 L_FRONTS="Surface fronts (H/L)"
 L_GLM="Satellite lightning (GLM)"
 L_VILD="VIL density (derived)"
@@ -65,7 +66,7 @@ preflight() {
   # "4 panes" is built by format!("{n} pane{}"), so it never appears literally in the source.
   grep -qF '{n} pane' "$REPO/crates/hookecho/src/app.rs" \
     || die "palette label '$L_PANES' is not in app.rs any more — update shoot.sh"
-  for l in "$L_ALLTILTS" "$L_LINKCAM" "$L_WIND" "$L_SITES" "$L_XSECTION" "$L_FORECAST" "$L_STORMTABLE" "$L_FRONTS" "$L_GLM" \
+  for l in "$L_TOUR" "$L_ALLTILTS" "$L_LINKCAM" "$L_WIND" "$L_SITES" "$L_XSECTION" "$L_FORECAST" "$L_STORMTABLE" "$L_FRONTS" "$L_GLM" \
            "$L_MRMS" "$L_MOSAIC" "$L_QPE" "$L_HRRR" "$L_VERIFY" \
            "$L_VILD" "$L_MEHS" "$L_SNOW" "$L_RECON"; do
     grep -qF "$l" "$REPO/crates/hookecho/src/app.rs" \
@@ -284,6 +285,24 @@ scene_alerts() {
   launch "$TUSCALOOSA"; wait_settle 16; key 1; sleep 1
   key a; sleep 2
   snap alerts
+}
+
+# --- onboarding -------------------------------------------------------------------------------
+
+scene_wizard() {
+  # A profile with setup_done cleared is the whole trick: the app opens the wizard itself.
+  launch "$TUSCALOOSA" '{"setup_done": false}'
+  wait_settle 12
+  snap wizard
+}
+
+scene_tour() {
+  # The tour spotlights live chrome, so it needs a loaded map under it — stop 1 points at the
+  # timeline, which does not exist until there are frames.
+  launch "$TUSCALOOSA"; wait_settle 16; key 1; sleep 1
+  palette "$L_TOUR"
+  sleep 1.5
+  snap tour
 }
 
 scene_products() {


### PR DESCRIPTION
The first-run experience was a ten-page modal wizard with no skip, followed by
three coach-mark cards pinned to hardcoded pixel offsets that dismissed
themselves on the first click anywhere and could never be shown again. Two of
the three described chrome the desktop build stopped having when the sidebar
became a docked panel.

**Setup is four cards now** — home radar, map and look, alerts and places, and
a summary. Nothing was dropped: every setting the ten pages configured is still
here, condensed. What's gone is the two pages of prose listing every product
and every tool, which is the tour's job and the searchable registry's job.

**The tour is four stops on the live map**, offered by the last setup card and
never forced. It spotlights the real `Response` rects the chrome registered
that frame, so it cannot drift out of sync with the layout, and the dimming is
painted through `layer_painter`, which takes no input — the highlighted control
stays clickable. That's what lets the timeline and product stops advance when
you scrub or switch product rather than when you finish reading.

Nothing auto-reopens. Both re-run from the command palette, the sidebar's App
section, and a new **Settings → General** pair.

Also fixed along the way:
- "Add location" seeded markers at (0, 0), in the Gulf of Guinea. Now the home
  radar, staggered per marker.
- The old inspect copy said "long-press"; the gesture is a plain tap/click.
- The dismissal path's comment claimed it kept the wizard for next launch when
  it does the opposite. Behavior is right, comment wasn't.
- `coach_done` is gone from `Settings`; installed settings files that still
  carry it load fine (test added).

### Verification
- `cargo clippy --workspace --all-targets` clean, `cargo test --workspace`
  (212 in the app crate, 6 of them the tour's state machine)
- wasm: `cargo check --target wasm32-unknown-unknown -p hookecho --lib` clean
- `./scripts/shots/shoot.sh check` passes; two new opt-in scenes (`wizard`,
  `tour`) drove both flows under Xvfb and were eyeballed
- Android not built here (no NDK) and needs no Kotlin change; a device pass
  should confirm the sheet auto-raise on stops 1-2 and back-button dismissal

🤖 Generated with [Claude Code](https://claude.com/claude-code)