### PR TITLE
R13 batch A — visual comfort

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ clearing a cache costs the next fetch and nothing else.
   newest still instead, refreshed on the poll clock (a phone can't spawn ffmpeg,
   and a video decoder per open card is not what its battery is for).
 - Multi-pane layouts, placefiles with icon sheets and a layer manager, a sensor
-  dashboard, range rings, 13 themes, and tray-based background alerting.
+  dashboard, range rings, 15 themes, and tray-based background alerting.
 
 ### On your phone
 
@@ -675,7 +675,11 @@ ones worth knowing before you look:
 The whole interface is reachable from the keyboard, and the widget tree is
 published to screen readers (AT-SPI on Linux, UI Automation on Windows). There
 is a **High contrast** theme in Settings → General for low vision and for
-reading the screen in direct sun.
+reading the screen in direct sun, an **OLED black** theme for night use, and
+colorblind-safe reflectivity and velocity color tables in Settings → Palettes
+(a viridis ramp whose brightness rises with dBZ, and a blue/orange diverging
+velocity table — red/green diverging tables do not survive protan or deutan
+vision).
 
 ## Repository layout
 

--- a/crates/hookecho/data/colortables/REF-CVD.pal
+++ b/crates/hookecho/data/colortables/REF-CVD.pal
@@ -1,0 +1,18 @@
+; Hook Echo built-in — colorblind-safe reflectivity (viridis)
+;
+; Perceptually uniform and readable under protan/deutan/tritan vision: brightness rises
+; monotonically with dBZ, so the ramp still reads as "stronger" even with no hue channel at
+; all. Colors are the standard viridis control points, sampled evenly over 10..75 dBZ.
+product: BR
+units: dBZ
+step: 10
+
+color: 10 68 1 84
+color: 18 71 45 123
+color: 26 59 82 139
+color: 34 44 114 142
+color: 42 33 145 140
+color: 50 94 201 98
+color: 58 181 222 43
+color: 66 253 231 37
+color: 75 255 255 255

--- a/crates/hookecho/data/colortables/VEL-CVD.pal
+++ b/crates/hookecho/data/colortables/VEL-CVD.pal
@@ -1,0 +1,19 @@
+; Hook Echo built-in — colorblind-safe velocity (blue/orange diverging)
+;
+; Inbound blue, outbound orange: the one diverging pair that survives every common form of
+; color vision deficiency (red/green diverging tables do not). Zero is a neutral gray so the
+; couplet still reads as a sign flip. Authored in knots like the default table.
+product: BV
+units: KTS
+step: 20
+scale: 1.9426
+
+color: -120 8 48 107
+color: -80 33 113 181
+color: -40 107 174 214
+color: -10 200 214 224
+color: 0 150 150 150
+color: 10 254 224 182
+color: 40 241 105 19
+color: 80 166 54 3
+color: 120 127 39 4

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -3280,6 +3280,20 @@ impl HookEchoApp {
         }
     }
 
+    /// Height of pane `idx`'s beam centre above the radar, in feet, over the point `ll`
+    /// (`[lon, lat]`). `None` when the pane has no site or no loaded tilt.
+    ///
+    /// Ground range is close enough to slant range for the shallow tilts this is read at, and the
+    /// 4/3-earth model is the same one the cross-section draws with
+    /// ([`wxdata::xsection::beam_height_km`]), so the two agree.
+    fn beam_height_ft(&self, idx: usize, ll: [f64; 2]) -> Option<f64> {
+        let v = &self.views[idx];
+        let site = wxdata::sites::site_by_id(v.site.as_deref()?)?;
+        let elev = *v.volume.as_ref()?.elevations.get(v.tilt)? as f64;
+        let (km, _) = crate::geo::great_circle([site.longitude as f64, site.latitude as f64], ll);
+        Some(wxdata::xsection::beam_height_km(km, elev) * 3280.84)
+    }
+
     /// Chime when a new volume lands on the live pane you are watching — the "look up" cue for
     /// someone doing something else while a storm is on.
     ///
@@ -11816,7 +11830,13 @@ impl HookEchoApp {
                 painter.line_segment([a, b], egui::Stroke::new(2.0, col));
                 let (km, brg) = crate::geo::great_circle(self.measure[0], self.measure[1]);
                 let mi = km * 0.621_371; // statute miles
-                let txt = format!("{mi:.1} mi  @ {brg:.0}°");
+                let mut txt = format!("{mi:.1} mi  @ {brg:.0}°");
+                // How high the beam is over the far end of the line. The number that decides
+                // whether "there's nothing on radar there" means the storm is weak or means the
+                // scan is looking over its head, and until now it lived only in the cross-section.
+                if let Some(h) = self.beam_height_ft(idx, self.measure[1]) {
+                    txt.push_str(&format!("  ·  beam {h:.0} ft"));
+                }
                 let mid = a + (b - a) * 0.5;
                 painter.text(
                     mid + egui::vec2(0.0, -10.0),

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1838,6 +1838,8 @@ pub struct HookEchoApp {
     goes_times_style: Option<crate::tiles::BasemapStyle>,
     goes_time_idx: Option<usize>,
     goes_times_rx: Option<std::sync::mpsc::Receiver<Vec<chrono::DateTime<chrono::Utc>>>>,
+    /// Volume start time of the last new-scan chime (see `scan_chime`).
+    last_chime: Option<chrono::DateTime<Utc>>,
     /// Where a requested screenshot should go once the image event arrives.
     screenshot_pending: Option<ShotDest>,
     /// A capture waiting on the share-card footer to be on screen: the destination, and how many
@@ -2516,6 +2518,7 @@ impl HookEchoApp {
             goes_times_style: None,
             goes_time_idx: None,
             goes_times_rx: None,
+            last_chime: None,
             screenshot_pending: None,
             share_card: None,
             loop_export: None,
@@ -3274,6 +3277,28 @@ impl HookEchoApp {
             b.2 = Instant::now();
         } else {
             self.warning_banners.push((event, area, Instant::now()));
+        }
+    }
+
+    /// Chime when a new volume lands on the live pane you are watching — the "look up" cue for
+    /// someone doing something else while a storm is on.
+    ///
+    /// Only the active pane, only while following the head, and only for a volume newer than the
+    /// last one chimed for: a scrub, a backfilled frame, or the same volume growing another chunk
+    /// is not a new scan. The first volume after a site switch or a cold start is swallowed, since
+    /// that one is the user's own doing.
+    fn scan_chime(&mut self, view: usize, time: chrono::DateTime<Utc>) {
+        if !self.settings.scan_chime || view != self.active || !self.views[view].timeline.following
+        {
+            return;
+        }
+        let first = self.last_chime.is_none();
+        if self.last_chime.is_some_and(|t| t >= time) {
+            return;
+        }
+        self.last_chime = Some(time);
+        if !first {
+            self.play_alert(&self.settings.scan_sound.clone());
         }
     }
 
@@ -8723,6 +8748,7 @@ impl HookEchoApp {
                     v.clamp_tilt();
                     v.clamp_moment();
                     self.pane_shown.remove(&view);
+                    self.scan_chime(view, time);
                 }
                 DataMsg::Frames {
                     view,
@@ -8758,6 +8784,7 @@ impl HookEchoApp {
                     // fallback: if the stream dies, interval polling resumes on schedule.
                     v.last_poll = Some(Instant::now());
                     self.pane_shown.remove(&view);
+                    self.scan_chime(view, time);
                 }
                 DataMsg::UpToDate { view, .. } => self.views[view].loading = false,
                 DataMsg::Prefetched { name, scan, .. } => {
@@ -12441,6 +12468,7 @@ impl HookEchoApp {
                 let file = import.path.to_string_lossy().into_owned();
                 let sound = crate::settings::AlertSound::Custom(file);
                 match import.tag.as_str() {
+                    "New scan" => self.settings.scan_sound = sound,
                     "Warning" => self.settings.warn_sound = sound,
                     "Emergency" => self.settings.emergency_sound = sound,
                     "TDS" => self.settings.tds_sound = sound,

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1840,6 +1840,9 @@ pub struct HookEchoApp {
     goes_times_rx: Option<std::sync::mpsc::Receiver<Vec<chrono::DateTime<chrono::Utc>>>>,
     /// Where a requested screenshot should go once the image event arrives.
     screenshot_pending: Option<ShotDest>,
+    /// A capture waiting on the share-card footer to be on screen: the destination, and how many
+    /// more frames to draw the footer before asking for the image (see `share_card_footer`).
+    share_card: Option<(ShotDest, u8)>,
     loop_export: Option<LoopExport>,
     /// When true, all panes share the active pane's camera.
     link_cameras: bool,
@@ -2514,6 +2517,7 @@ impl HookEchoApp {
             goes_time_idx: None,
             goes_times_rx: None,
             screenshot_pending: None,
+            share_card: None,
             loop_export: None,
             link_cameras: false,
             cells_site: None,
@@ -12248,20 +12252,17 @@ impl HookEchoApp {
             ui.label(egui::RichText::new("Capture").strong());
             if ui.button("Save screenshot…").clicked() {
                 if let Some(path) = crate::dialog::save_path("hookecho.png", "png") {
-                    self.screenshot_pending = Some(ShotDest::File(path));
-                    ui.ctx()
-                        .send_viewport_cmd(egui::ViewportCommand::Screenshot(
-                            egui::UserData::default(),
-                        ));
+                    self.request_capture(ui.ctx(), ShotDest::File(path));
                 }
             }
             if ui.button("Copy view to clipboard").clicked() {
-                self.screenshot_pending = Some(ShotDest::Clipboard);
-                ui.ctx()
-                    .send_viewport_cmd(
-                        egui::ViewportCommand::Screenshot(egui::UserData::default()),
-                    );
+                self.request_capture(ui.ctx(), ShotDest::Clipboard);
             }
+            ui.checkbox(&mut self.settings.share_card, "Caption shared images")
+                .on_hover_text(
+                    "Stamp the site, product, valid time and source onto saved and copied \
+                     images, so a screenshot still says what it is once it leaves here",
+                );
             if ui
                 .add_enabled(
                     self.loop_export.is_none(),
@@ -12560,6 +12561,86 @@ impl HookEchoApp {
                 }
             }
         }
+    }
+
+    /// Ask the viewport for an image, `dest` decides where it lands.
+    ///
+    /// With the share card on, the request waits two frames while [`share_card_footer`] draws the
+    /// caption band, so the capture contains it.
+    ///
+    /// ponytail: the caption is drawn by egui into the frame rather than composited into the
+    /// pixels afterwards — text layout, fonts and the theme are already solved here, and
+    /// compositing them onto a raw RGBA buffer is a rasterizer we would have to grow.
+    fn request_capture(&mut self, ctx: &egui::Context, dest: ShotDest) {
+        if self.settings.share_card {
+            // Two frames: one to lay the band out, one to be sure it is on screen when the
+            // viewport grabs the image.
+            self.share_card = Some((dest, 2));
+            ctx.request_repaint();
+        } else {
+            self.screenshot_pending = Some(dest);
+            ctx.send_viewport_cmd(egui::ViewportCommand::Screenshot(egui::UserData::default()));
+        }
+    }
+
+    /// The share card: a caption band across the bottom of the map naming what the picture shows,
+    /// drawn only on the frames a capture is waiting for. A radar screenshot with no site, product
+    /// or time on it is a pretty picture; this is the difference between that and a report.
+    fn share_card_footer(&mut self, ctx: &egui::Context) {
+        let Some((_, frames)) = &mut self.share_card else {
+            return;
+        };
+        *frames -= 1;
+        let fire = *frames == 0;
+
+        let v = &self.views[self.active];
+        let site = v.site.clone().unwrap_or_else(|| "no site".to_string());
+        let product = crate::products::info(v.moment).name.to_string();
+        let time = v
+            .volume
+            .as_ref()
+            .map(|vol| crate::timefmt::fmt_date_clock(vol.time, self.active_tz()))
+            .unwrap_or_default();
+        let accent = crate::theme::accent(self.settings.theme);
+        egui::Area::new(egui::Id::new("share_card"))
+            .order(egui::Order::Foreground)
+            .constrain_to(self.chrome_rect)
+            .anchor(egui::Align2::CENTER_BOTTOM, egui::vec2(0.0, -10.0))
+            .show(ctx, |ui| {
+                crate::ui::style::glass(ui, 245).show(ui, |ui| {
+                    ui.horizontal(|ui| {
+                        ui.label(
+                            egui::RichText::new(&site)
+                                .size(crate::ui::style::FONT_BASE)
+                                .strong()
+                                .color(accent),
+                        );
+                        let mut line = product;
+                        if !time.is_empty() {
+                            line.push_str(" · ");
+                            line.push_str(&time);
+                        }
+                        ui.label(
+                            egui::RichText::new(line)
+                                .size(crate::ui::style::FONT_BASE)
+                                .color(egui::Color32::from_gray(238)),
+                        );
+                        ui.label(
+                            egui::RichText::new("Hook Echo-WX · data: NOAA/NWS")
+                                .size(crate::ui::style::FONT_SM)
+                                .color(egui::Color32::from_gray(160)),
+                        );
+                    });
+                });
+            });
+
+        if fire {
+            // The band is on screen: take the picture, and keep the caption for this one frame.
+            let (dest, _) = self.share_card.take().expect("checked above");
+            self.screenshot_pending = Some(dest);
+            ctx.send_viewport_cmd(egui::ViewportCommand::Screenshot(egui::UserData::default()));
+        }
+        ctx.request_repaint();
     }
 
     /// If a screenshot was requested, save the delivered image event to the pending path.
@@ -13970,6 +14051,9 @@ impl eframe::App for HookEchoApp {
             self.info_chip(ctx);
             self.error_chip(ctx);
         }
+
+        // Over everything, and only while a capture is pending.
+        self.share_card_footer(ctx);
 
         // The spotlight tour, over the chrome it points at. Paused under the wizard and the
         // cheat sheet — all three draw on `Order::Foreground` and would fight for it.

--- a/crates/hookecho/src/colormap.rs
+++ b/crates/hookecho/src/colormap.rs
@@ -282,6 +282,41 @@ static BUILTINS: LazyLock<[ColorTable; 6]> = LazyLock::new(|| {
         .map(|(name, src)| parse_pal(src).unwrap_or_else(|e| panic!("built-in {name}.pal: {e}")))
 });
 
+/// Extra built-in tables a moment can be switched to without a file on disk, keyed by the name
+/// that appears after `builtin:` in `settings.palettes` (see [`resolve_builtin`]).
+///
+/// ponytail: the alternates are `.pal` text like every other table, so they cost one array entry
+/// and no new code path — no `enum PaletteSource`, no migration.
+const ALT_SRC: [(&str, usize, &str); 2] = [
+    (
+        "Colorblind-safe (viridis)",
+        0, // Moment::Reflectivity
+        include_str!("../data/colortables/REF-CVD.pal"),
+    ),
+    (
+        "Colorblind-safe (blue/orange)",
+        1, // Moment::Velocity
+        include_str!("../data/colortables/VEL-CVD.pal"),
+    ),
+];
+
+/// The `settings.palettes` value that selects built-in alternate `name`.
+pub const BUILTIN_PREFIX: &str = "builtin:";
+
+/// Names of the built-in alternates offered for `moment`, in menu order.
+pub fn alt_names(moment: Moment) -> impl Iterator<Item = &'static str> {
+    ALT_SRC
+        .iter()
+        .filter(move |(_, idx, _)| *idx == moment.index())
+        .map(|(name, _, _)| *name)
+}
+
+/// Parse the built-in alternate `name`, or `None` if there is no such alternate.
+fn resolve_builtin(name: &str) -> Option<ColorTable> {
+    let (_, _, src) = ALT_SRC.iter().find(|(n, _, _)| *n == name)?;
+    parse_pal(src).ok()
+}
+
 /// The built-in default table for `moment`.
 pub fn default_table(moment: Moment) -> &'static ColorTable {
     &BUILTINS[moment.index()]
@@ -321,6 +356,18 @@ impl Palettes {
                 // `.pal3` goes through the same parser: v3 is v2 plus directives this one
                 // already ignores, so a v3 table loads as its common subset rather than not at
                 // all. A file that shares nothing with v2 falls out as "no color stops".
+                // A `builtin:` token names a compiled-in alternate rather than a file. An
+                // unknown name falls through to the default with an error, same as a bad file.
+                Some(path) if path.to_string_lossy().starts_with(BUILTIN_PREFIX) => {
+                    let name = path.to_string_lossy()[BUILTIN_PREFIX.len()..].to_string();
+                    match resolve_builtin(&name) {
+                        Some(t) => (t, None),
+                        None => (
+                            default_table(moment).clone(),
+                            Some(format!("unknown built-in palette {name:?}")),
+                        ),
+                    }
+                }
                 Some(path) => match std::fs::read_to_string(path)
                     .map_err(|e| e.to_string())
                     .and_then(|s| parse_pal(&s).map_err(|e| e.to_string()))
@@ -348,6 +395,36 @@ mod tests {
         }
         // And the LazyLock array builds without panicking.
         assert_eq!(default_table(Moment::Reflectivity).stops.len(), 9);
+    }
+
+    #[test]
+    fn builtin_alternates_parse_and_load() {
+        // The hardcoded moment indices in ALT_SRC have to match Moment::index().
+        assert_eq!(Moment::Reflectivity.index(), 0);
+        assert_eq!(Moment::Velocity.index(), 1);
+        assert_eq!(alt_names(Moment::Reflectivity).count(), 1);
+        assert_eq!(alt_names(Moment::SpectrumWidth).count(), 0);
+
+        let mut p = Palettes::default();
+        let mut paths: [Option<std::path::PathBuf>; 6] = Default::default();
+        let name = alt_names(Moment::Reflectivity).next().unwrap();
+        paths[0] = Some(format!("{BUILTIN_PREFIX}{name}").into());
+        paths[1] = Some(format!("{BUILTIN_PREFIX}nope").into());
+        p.reload(&paths);
+        assert_eq!(p.errors[0], None);
+        assert_ne!(
+            p.table(Moment::Reflectivity),
+            default_table(Moment::Reflectivity)
+        );
+        // Viridis is monotone in brightness — that is the whole point of the table.
+        let lum = |v: f32| {
+            let c = p.table(Moment::Reflectivity).sample(v).unwrap();
+            c[0] as u32 + c[1] as u32 + c[2] as u32
+        };
+        assert!(lum(20.0) < lum(40.0) && lum(40.0) < lum(60.0));
+        // An unknown name keeps the default and says so rather than blanking the moment.
+        assert!(p.errors[1].is_some());
+        assert_eq!(p.table(Moment::Velocity), default_table(Moment::Velocity));
     }
 
     /// A v3-flavoured table: v3-only directives the parser does not know, around ordinary

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -26,11 +26,12 @@ pub enum Theme {
     Redline,
     Glacier,
     HighContrast,
+    Oled,
 }
 
 impl Theme {
     /// All themes in menu order.
-    pub const ALL: [Theme; 14] = [
+    pub const ALL: [Theme; 15] = [
         Theme::Dark,
         Theme::Light,
         Theme::System,
@@ -45,6 +46,7 @@ impl Theme {
         Theme::Redline,
         Theme::Glacier,
         Theme::HighContrast,
+        Theme::Oled,
     ];
 
     pub fn label(self) -> &'static str {
@@ -63,6 +65,7 @@ impl Theme {
             Theme::Redline => "Redline",
             Theme::Glacier => "Glacier",
             Theme::HighContrast => "High contrast",
+            Theme::Oled => "OLED black",
         }
     }
 }

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -751,6 +751,10 @@ impl Settings {
     pub fn export_bundle(&self) -> Result<String, String> {
         let mut palette_files = BTreeMap::new();
         for (moment, path) in &self.palettes {
+            // A built-in alternate is compiled in on the other machine too — nothing to inline.
+            if path.starts_with(crate::colormap::BUILTIN_PREFIX) {
+                continue;
+            }
             match std::fs::read_to_string(path) {
                 Ok(text) => {
                     palette_files.insert(moment.clone(), text);

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -294,6 +294,13 @@ pub struct Settings {
     /// First-run setup wizard completed (or dismissed). `false` shows it at startup.
     #[serde(default)]
     pub setup_done: bool,
+    /// Chime when a new radar volume lands on the live pane in view.
+    #[serde(default)]
+    pub scan_chime: bool,
+    /// Sound for the new-scan chime. Ding by default — a scan every four minutes should be a tap
+    /// on the shoulder, not a warning tone.
+    #[serde(default = "default_scan_sound")]
+    pub scan_sound: AlertSound,
     /// Sound played when a new NWS warning appears (gated by `alert_sound`).
     #[serde(default)]
     pub warn_sound: AlertSound,
@@ -397,6 +404,10 @@ pub struct Bookmark {
     /// UTC time to seek to (Unix seconds); `None` = live/head.
     #[serde(default)]
     pub time_secs: Option<i64>,
+}
+
+fn default_scan_sound() -> AlertSound {
+    AlertSound::Ding
 }
 
 fn default_true() -> bool {
@@ -671,6 +682,8 @@ impl Default for Settings {
             rain_alerts: false,
             rain_sound: AlertSound::default(),
             setup_done: false,
+            scan_chime: false,
+            scan_sound: default_scan_sound(),
             warn_sound: AlertSound::default(),
             tds_sound: AlertSound::default(),
             rotation_sound: default_rotation_sound(),
@@ -969,6 +982,8 @@ mod tests {
             rain_alerts: true,
             rain_sound: AlertSound::Ding,
             setup_done: true,
+            scan_chime: false,
+            scan_sound: AlertSound::Ding,
             warn_sound: AlertSound::Siren,
             tds_sound: AlertSound::Custom("/tmp/tds.wav".to_string()),
             rotation_sound: AlertSound::Siren,

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -354,6 +354,11 @@ pub struct Settings {
     /// Enhanced Echo Tops product; raise it to track the core rather than the anvil.
     #[serde(default = "default_etop_dbz")]
     pub etop_dbz: f32,
+    /// Caption saved and copied images with site, product, valid time and source. On by default:
+    /// a radar picture that leaves the app without those four things cannot be checked by whoever
+    /// receives it.
+    #[serde(default = "default_true")]
+    pub share_card: bool,
     /// Hide the docked sidebar on the left (desktop). A floating button on the map's top-left
     /// brings it back, as does the drawer hotkey.
     #[serde(default)]
@@ -606,6 +611,7 @@ impl Default for Settings {
     fn default() -> Self {
         Self {
             default_site: "KTLX".to_string(),
+            share_card: true,
             hide_sidebar: false,
             hide_toolbar: false,
             layer_order: Vec::new(),
@@ -882,6 +888,7 @@ mod tests {
             workspaces: Vec::new(),
             seeded_workspaces: false,
             smooth_radar: false,
+            share_card: true,
             hide_sidebar: false,
             hide_toolbar: false,
             layer_order: Vec::new(),

--- a/crates/hookecho/src/theme.rs
+++ b/crates/hookecho/src/theme.rs
@@ -210,6 +210,21 @@ fn palette(theme: Theme, system_dark: bool) -> Palette {
             text: c(0xffffff),
             accent: c(0xffe600),
         },
+        // OLED black — Dark's chrome over a true-black background. On an OLED panel a #000000
+        // pixel is an off pixel: less battery on a phone at 3am, and no backlight glow around
+        // the map at night. Unlike High contrast this keeps the normal accent and stroke, so it
+        // is the everyday dark theme rather than an accessibility mode.
+        Theme::Oled => Palette {
+            is_dark: true,
+            bg: c(0x000000),
+            extreme: c(0x000000),
+            faint: c(0x0b0d10),
+            stroke: c(0x23272f),
+            widget: c(0x121418),
+            widget_hover: c(0x1c1f25),
+            text: c(0xc8d0da),
+            accent: ACCENT,
+        },
     }
 }
 

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -384,12 +384,20 @@ impl SettingsWindow {
                     ui.label(key);
 
                     let current = settings.palettes.get(key).cloned();
+                    // A `builtin:` value names a compiled-in alternate, not a file, so it has no
+                    // stem — show the alternate's own name.
+                    let builtin = current
+                        .as_deref()
+                        .and_then(|v| v.strip_prefix(crate::colormap::BUILTIN_PREFIX))
+                        .map(str::to_string);
                     let current_stem = current
                         .as_deref()
+                        .filter(|_| builtin.is_none())
                         .and_then(|p| std::path::Path::new(p).file_name().and_then(|s| s.to_str()))
                         .map(str::to_string);
-                    let selected_text = current_stem
+                    let selected_text = builtin
                         .clone()
+                        .or_else(|| current_stem.clone())
                         .unwrap_or_else(|| "Default".to_string());
 
                     egui::ComboBox::from_id_salt(("pal_combo", key))
@@ -397,6 +405,15 @@ impl SettingsWindow {
                         .show_ui(ui, |ui| {
                             if ui.selectable_label(current.is_none(), "Default").clicked() {
                                 settings.palettes.remove(key);
+                            }
+                            for name in crate::colormap::alt_names(moment) {
+                                let is_sel = builtin.as_deref() == Some(name);
+                                if ui.selectable_label(is_sel, name).clicked() {
+                                    settings.palettes.insert(
+                                        key.to_string(),
+                                        format!("{}{name}", crate::colormap::BUILTIN_PREFIX),
+                                    );
+                                }
                             }
                             for stem in &self.pal_stems {
                                 let is_sel = current_stem.as_deref() == Some(stem.as_str());

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -771,6 +771,10 @@ pub fn sound_picker(ui: &mut egui::Ui, settings: &mut Settings) {
         .on_hover_text("Silences chimes and spoken warnings without changing the choices below");
     ui.checkbox(&mut settings.alert_sound, "Play a sound on alerts")
         .on_hover_text("Master switch for the warning / TDS / lightning alert sounds");
+    ui.checkbox(&mut settings.scan_chime, "Chime on every new scan")
+        .on_hover_text(
+            "A tap on the shoulder when a new volume lands on the live pane you're watching",
+        );
     ui.horizontal(|ui| {
         ui.label("Volume");
         ui.add(egui::Slider::new(&mut settings.alert_volume, 0.0..=1.0).step_by(0.05));
@@ -779,7 +783,8 @@ pub fn sound_picker(ui: &mut egui::Ui, settings: &mut Settings) {
 
     // One row per alert kind: sound combo (+ Custom… file picker) and a ▶ preview.
     type SoundRow = (&'static str, fn(&mut Settings) -> &mut AlertSound);
-    let rows: [SoundRow; 5] = [
+    let rows: [SoundRow; 6] = [
+        ("New scan", |s| &mut s.scan_sound),
         ("Warning", |s| &mut s.warn_sound),
         ("Emergency", |s| &mut s.emergency_sound),
         ("TDS", |s| &mut s.tds_sound),


### PR DESCRIPTION
First batch of the R13 feature expansion: the small, self-contained comfort
items, each one commit.

- **Colorblind-safe color tables** — a viridis reflectivity ramp (brightness
  rises monotonically with dBZ, so it reads with no hue channel at all) and a
  blue/orange diverging velocity table. Both are ordinary `.pal` text through
  the existing parser; `settings.palettes` holds a `builtin:<name>` token
  instead of a path, so there is no new palette-source type and no migration.
- **OLED black theme** — Dark's chrome over `#000000`; an off pixel on an OLED
  panel. Distinct from High contrast, which stays the accessibility mode.
- **Share card** — saved and copied images carry a caption band with site,
  product, valid time and source, so a screenshot still says what it is once it
  leaves the app. Drawn by egui for the two frames a capture waits on rather
  than composited onto raw RGBA afterwards. On by default, toggle in Capture.
- **New-scan chime** — optional tap on the shoulder when a volume lands on the
  live pane in view. Active pane, following the head, newer volume only; first
  volume after a site switch swallowed. Goes through `play_alert`, so Mute all
  covers it.
- **Beam height on Measure** — height of the beam centre over the far end of
  the line, from the same 4/3-earth model the cross-section uses.

Verified: `cargo clippy --workspace --all-targets`, `cargo test --workspace`
(416 passed), wasm `cargo check`, `./scripts/shots/shoot.sh check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)