### PR TITLE
R13 batch B — smarter alerts

### DIFF
--- a/android/app/src/main/kotlin/zip/batman/hookecho/AlertService.kt
+++ b/android/app/src/main/kotlin/zip/batman/hookecho/AlertService.kt
@@ -125,12 +125,19 @@ class AlertService : Service() {
         fun pollOnce(context: Context, seen: LinkedHashSet<String>): Boolean {
             var hot = false
             val before = seen.size
+            // Quiet hours silences everything below the emergency tier. The alert is still
+            // recorded as seen, so it does not re-fire the moment the window ends.
+            val quiet = Nws.inQuietHours(
+                context.filesDir,
+                java.util.Calendar.getInstance().get(java.util.Calendar.HOUR_OF_DAY),
+            )
             runCatching {
                 for (m in Nws.watched(context.filesDir)) {
                     for (p in m.samples) {
                         for (a in Nws.alertsAt(p[0], p[1])) {
                             if (a.tier >= Nws.TIER_WARNING) hot = true
-                            if (seen.add(a.id)) notify(context, m, a)
+                            val loud = !quiet || a.tier >= Nws.TIER_EMERGENCY
+                            if (seen.add(a.id) && loud) notify(context, m, a)
                         }
                     }
                 }

--- a/android/app/src/main/kotlin/zip/batman/hookecho/Nws.kt
+++ b/android/app/src/main/kotlin/zip/batman/hookecho/Nws.kt
@@ -34,6 +34,29 @@ object Nws {
 
     data class Alert(val id: String, val event: String, val headline: String, val tier: Int)
 
+    /**
+     * Is the phone inside the user's quiet-hours window? Same `settings.json` fields, and the
+     * same reading as the desktop: start == end is no window rather than all day, and a window
+     * whose end is before its start wraps midnight.
+     *
+     * The escalated tier is not filtered here — callers let it through regardless, which is the
+     * point of the tier.
+     */
+    fun inQuietHours(filesDir: File, hour: Int): Boolean {
+        val f = File(filesDir, "config/settings.json")
+        if (!f.exists()) return false
+        val root = runCatching { JSONObject(f.readText()) }.getOrNull() ?: return false
+        if (!root.optBoolean("quiet_hours", false)) return false
+        val s = Math.floorMod(root.optInt("quiet_start_hour", 22), 24)
+        val e = Math.floorMod(root.optInt("quiet_end_hour", 7), 24)
+        val h = Math.floorMod(hour, 24)
+        return when {
+            s == e -> false
+            s < e -> h in s until e
+            else -> h >= s || h < e
+        }
+    }
+
     /** Rim points around a marker, so `?point=` sees a warning that only reaches the radius. */
     private const val RIM_POINTS = 6
 

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1283,6 +1283,8 @@ enum ShotDest {
     File(std::path::PathBuf),
     Clipboard,
     Loop,
+    /// Pushed to the user's ntfy topic as an attachment, captioned with this title.
+    Push(String),
 }
 
 /// In-progress loop export (GIF or MP4): steps the active timeline, grabbing one screenshot per
@@ -1838,6 +1840,8 @@ pub struct HookEchoApp {
     goes_times_style: Option<crate::tiles::BasemapStyle>,
     goes_time_idx: Option<usize>,
     goes_times_rx: Option<std::sync::mpsc::Receiver<Vec<chrono::DateTime<chrono::Utc>>>>,
+    /// A warning that wants a radar picture pushed after it (see `settings.ntfy_snapshot`).
+    snapshot_push: Option<String>,
     /// Per-location cooldown for the rotation-near-a-watched-place alert.
     rotation_alerted: std::collections::HashMap<String, Instant>,
     /// Volume start time of the last new-scan chime (see `scan_chime`).
@@ -2520,6 +2524,7 @@ impl HookEchoApp {
             goes_times_style: None,
             goes_time_idx: None,
             goes_times_rx: None,
+            snapshot_push: None,
             rotation_alerted: std::collections::HashMap::new(),
             last_chime: None,
             screenshot_pending: None,
@@ -3617,6 +3622,10 @@ impl HookEchoApp {
                     if !self.settings.mute_alerts {
                         crate::speech::speak(&format!("{} for {}{}", a.event, area, until));
                     }
+                }
+                if notify_ok && self.settings.ntfy_snapshot {
+                    // Newest wins: one picture per pass, of whatever last warned.
+                    self.snapshot_push = Some(format!("{label} — {area}"));
                 }
                 self.banner(label, area);
                 alerted |= notify_ok;
@@ -12724,6 +12733,65 @@ impl HookEchoApp {
         }
     }
 
+    /// A warning asked for a radar picture: take one, as long as nothing else is mid-capture.
+    ///
+    /// Deliberately the live view rather than a headless render — it is the picture the user is
+    /// looking at, product, overlays, zoom and all, and it costs one frame instead of a second
+    /// render path. Skipped on Android, where the alert path runs in a service with no surface.
+    fn drive_snapshot_push(&mut self, ctx: &egui::Context) {
+        if self.snapshot_push.is_none()
+            || self.screenshot_pending.is_some()
+            || self.share_card.is_some()
+            || cfg!(target_os = "android")
+        {
+            return;
+        }
+        let title = self.snapshot_push.take().expect("checked above");
+        self.request_capture(ctx, ShotDest::Push(title));
+    }
+
+    /// PUT a captured frame to the user's ntfy topic as an attachment.
+    fn push_snapshot(&self, title: String, image: &egui::ColorImage) {
+        let topic = self.settings.ntfy_topic.trim().to_string();
+        if topic.is_empty() {
+            return;
+        }
+        let (w, h) = (image.size[0] as u32, image.size[1] as u32);
+        let mut rgba = Vec::with_capacity((w * h * 4) as usize);
+        for px in &image.pixels {
+            rgba.extend_from_slice(&[px.r(), px.g(), px.b(), px.a()]);
+        }
+        let mut png = std::io::Cursor::new(Vec::new());
+        if let Err(e) = image::write_buffer_with_format(
+            &mut png,
+            &rgba,
+            w,
+            h,
+            image::ColorType::Rgba8,
+            image::ImageFormat::Png,
+        ) {
+            log::warn!("alert snapshot encode failed: {e}");
+            return;
+        }
+        let body = png.into_inner();
+        // ntfy caps attachments (a few MB on the public server); a screen-sized PNG is well under,
+        // but say so in the log rather than wondering why nothing arrived.
+        log::debug!("pushing alert snapshot: {} KiB", body.len() / 1024);
+        let http = self.http.clone();
+        self.spawner.spawn(async move {
+            let res = http
+                .put(format!("https://ntfy.sh/{topic}"))
+                .header("Title", title)
+                .header("Filename", "radar.png")
+                .body(body)
+                .send()
+                .await;
+            if let Err(e) = res {
+                log::warn!("ntfy snapshot push failed: {e}");
+            }
+        });
+    }
+
     /// Ask the viewport for an image, `dest` decides where it lands.
     ///
     /// With the share card on, the request waits two frames while [`share_card_footer`] draws the
@@ -12843,6 +12911,7 @@ impl HookEchoApp {
                     self.toast(ToastKind::Success, "View copied to clipboard");
                 }
                 ShotDest::Loop => self.record_loop_frame(&image),
+                ShotDest::Push(title) => self.push_snapshot(title, &image),
             }
         }
     }
@@ -13670,6 +13739,7 @@ impl eframe::App for HookEchoApp {
             self.ui_scale_applied = z;
         }
 
+        self.drive_snapshot_push(ctx);
         self.save_pending_screenshot(ctx);
         self.load_marker_icons(ctx);
         self.drive_loop_export(ctx);

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1838,6 +1838,8 @@ pub struct HookEchoApp {
     goes_times_style: Option<crate::tiles::BasemapStyle>,
     goes_time_idx: Option<usize>,
     goes_times_rx: Option<std::sync::mpsc::Receiver<Vec<chrono::DateTime<chrono::Utc>>>>,
+    /// Per-location cooldown for the rotation-near-a-watched-place alert.
+    rotation_alerted: std::collections::HashMap<String, Instant>,
     /// Volume start time of the last new-scan chime (see `scan_chime`).
     last_chime: Option<chrono::DateTime<Utc>>,
     /// Where a requested screenshot should go once the image event arrives.
@@ -2518,6 +2520,7 @@ impl HookEchoApp {
             goes_times_style: None,
             goes_time_idx: None,
             goes_times_rx: None,
+            rotation_alerted: std::collections::HashMap::new(),
             last_chime: None,
             screenshot_pending: None,
             share_card: None,
@@ -3335,6 +3338,31 @@ impl HookEchoApp {
         crate::audio::play(sound, self.settings.alert_volume);
     }
 
+    /// Everywhere the proximity alerts watch: the saved markers, plus your own live position when
+    /// "alert where I am" is on and there is a fix. Returns `(name, lon, lat, radius_mi)`.
+    ///
+    /// The GPS entry is deliberately not a real marker — a marker that moves would drag its way
+    /// through the saved list, and it must vanish the moment the fix or the setting does.
+    fn watched_points(&self) -> Vec<(String, f64, f64, f64)> {
+        let mut out: Vec<(String, f64, f64, f64)> = self
+            .settings
+            .markers
+            .iter()
+            .map(|m| (m.name.clone(), m.lon, m.lat, m.alert_radius_mi))
+            .collect();
+        if self.settings.alert_follow_gps {
+            if let Some((lon, lat)) = self.chase_pos {
+                out.push((
+                    "my location".to_string(),
+                    lon,
+                    lat,
+                    crate::settings::default_alert_radius_mi(),
+                ));
+            }
+        }
+        out
+    }
+
     /// Is the local clock inside the user's quiet-hours window?
     fn in_quiet_hours(&self) -> bool {
         use chrono::Timelike;
@@ -3624,11 +3652,10 @@ impl HookEchoApp {
         let mut fired = false;
         // Names first: the alert calls below need `&mut self`.
         let near: Vec<String> = self
-            .settings
-            .markers
-            .iter()
-            .filter(|m| field.max_within_km(m.lon, m.lat, RADIUS_KM) >= DENSITY_MIN)
-            .map(|m| m.name.clone())
+            .watched_points()
+            .into_iter()
+            .filter(|(_, lon, lat, _)| field.max_within_km(*lon, *lat, RADIUS_KM) >= DENSITY_MIN)
+            .map(|(name, ..)| name)
             .collect();
         for name in near {
             let recent = self
@@ -4878,7 +4905,63 @@ impl HookEchoApp {
             }
         }
         self.rot_active = now_active;
+        self.rotation_near_you(&hits);
         hits
+    }
+
+    /// "There is rotation near a place you care about" — the detection above fires once for the
+    /// whole radar, which tells you a couplet exists somewhere in a 150 km circle. This one names
+    /// the place and the distance, and it re-fires as a storm works down a line, so it is the
+    /// alert worth pushing to a phone.
+    ///
+    /// Same shape as the lightning alarm: a per-location cooldown, so a couplet that persists over
+    /// six volumes is one alert, not six.
+    fn rotation_near_you(&mut self, hits: &[wxdata::rotation::CoupletHit]) {
+        const COOLDOWN: std::time::Duration = std::time::Duration::from_secs(600);
+        if hits.is_empty() {
+            return;
+        }
+        // Strongest couplet within each watched radius, if any.
+        let near: Vec<(String, f64, f32)> = self
+            .watched_points()
+            .into_iter()
+            .filter_map(|(name, lon, lat, radius_mi)| {
+                let radius_km = radius_mi * crate::geo::KM_PER_MILE;
+                hits.iter()
+                    .filter_map(|h| {
+                        let (km, _) = crate::geo::great_circle([lon, lat], [h.lon, h.lat]);
+                        (km <= radius_km).then_some((km, h.vrot_ms))
+                    })
+                    .min_by(|a, b| a.0.total_cmp(&b.0))
+                    .map(|(km, vrot)| (name, km, vrot))
+            })
+            .collect();
+        let mut fired = false;
+        for (name, km, vrot_ms) in near {
+            if self
+                .rotation_alerted
+                .get(&name)
+                .is_some_and(|t| t.elapsed() < COOLDOWN)
+            {
+                continue;
+            }
+            self.rotation_alerted.insert(name.clone(), Instant::now());
+            let kt = vrot_ms as f64 * 1.943_844;
+            let mi = km / crate::geo::KM_PER_MILE;
+            self.banner(
+                format!("\u{21bb} Rotation near {name}"),
+                format!("{kt:.0} kt couplet, {mi:.0} mi away"),
+            );
+            self.notify_alert(
+                &format!("\u{21bb} Rotation near {name}"),
+                &format!("{kt:.0} kt rotational velocity, {mi:.0} mi from {name}"),
+                true,
+            );
+            fired = true;
+        }
+        if fired && self.settings.alert_sound {
+            self.play_alert_urgent(&self.settings.rotation_sound.clone());
+        }
     }
 
     /// DVR instant replay: jump the active timeline to the earliest frame still buffered in the

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -3319,10 +3319,26 @@ impl HookEchoApp {
     /// Every alert sound goes through here, so one mute switch covers all of them (and any that
     /// get added later) instead of a guard per call site.
     fn play_alert(&self, sound: &crate::settings::AlertSound) {
+        if self.settings.mute_alerts || self.in_quiet_hours() {
+            return;
+        }
+        crate::audio::play(sound, self.settings.alert_volume);
+    }
+
+    /// A sound quiet hours does not silence: the escalated warning tiers and the two detections
+    /// that mean a tornado may be on the ground. `mute_alerts` still wins — that switch is the
+    /// user saying so about right now, where quiet hours is a standing preference.
+    fn play_alert_urgent(&self, sound: &crate::settings::AlertSound) {
         if self.settings.mute_alerts {
             return;
         }
         crate::audio::play(sound, self.settings.alert_volume);
+    }
+
+    /// Is the local clock inside the user's quiet-hours window?
+    fn in_quiet_hours(&self) -> bool {
+        use chrono::Timelike;
+        self.settings.in_quiet_hours(chrono::Local::now().hour())
     }
 
     /// Surface auxiliary-feed failures queued by [`note_feed_error`], once per feed per session.
@@ -3477,6 +3493,9 @@ impl HookEchoApp {
             if self.known_warning_ids.insert(a.id.clone()) && self.warnings_seeded {
                 let esc = wxdata::alerts::escalation(a);
                 let urgent = esc >= 2;
+                // Severity floor: below the tier the user set, the warning still banners and
+                // still joins the alert list — it just doesn't push, speak or make noise.
+                let notify_ok = esc >= self.settings.alert_min_escalation;
                 // A watched location always alerts + pushes: inside the polygon, or within that
                 // marker's radius of it. Home first, then the closest — a warning that clips two
                 // saved places should name the one you sleep in.
@@ -3500,7 +3519,7 @@ impl HookEchoApp {
                         .first()
                         .is_some_and(|outer| wxdata::overlay::rings_intersect(outer, &z.ring))
                 });
-                if let Some(z) = zone {
+                if let (Some(z), true) = (zone, notify_ok) {
                     self.notify_alert(
                         &format!("⚠ {} — {}", a.event, z.name),
                         if a.headline.is_empty() {
@@ -3515,15 +3534,17 @@ impl HookEchoApp {
                 let (label, area) = match hit {
                     Some((m, km)) => {
                         // Watched location covered → push to the phone (opt-in ntfy topic).
-                        self.notify_alert(
-                            &format!("⚠ {} — {}", a.event, m.name),
-                            if a.headline.is_empty() {
-                                &a.area
-                            } else {
-                                &a.headline
-                            },
-                            urgent,
-                        );
+                        if notify_ok {
+                            self.notify_alert(
+                                &format!("⚠ {} — {}", a.event, m.name),
+                                if a.headline.is_empty() {
+                                    &a.area
+                                } else {
+                                    &a.headline
+                                },
+                                urgent,
+                            );
+                        }
                         let where_ = if km <= 0.05 {
                             format!("covers {}", m.name)
                         } else {
@@ -3545,10 +3566,12 @@ impl HookEchoApp {
                         (a.event.clone(), a.area.clone())
                     }
                 };
-                max_esc = max_esc.max(esc);
+                if notify_ok {
+                    max_esc = max_esc.max(esc);
+                }
                 // Read it out before the banner text is moved into the queue: chasing is an
                 // eyes-on-the-road activity, and a warning you have to read is one you read late.
-                if self.settings.speak_warnings {
+                if self.settings.speak_warnings && notify_ok {
                     let until = a
                         .expires
                         .map(|t| {
@@ -3568,7 +3591,7 @@ impl HookEchoApp {
                     }
                 }
                 self.banner(label, area);
-                alerted = true;
+                alerted |= notify_ok;
             }
         }
         self.warnings_seeded = true;
@@ -3578,12 +3601,12 @@ impl HookEchoApp {
             let _ = std::io::stdout().flush();
             if self.settings.alert_sound {
                 // Escalated (Tornado Emergency / PDS / destructive) warnings use the emergency sound.
-                let sound = if max_esc >= 2 {
-                    &self.settings.emergency_sound
+                if max_esc >= 2 {
+                    // Escalated (Tornado Emergency / PDS / destructive): past quiet hours too.
+                    self.play_alert_urgent(&self.settings.emergency_sound.clone());
                 } else {
-                    &self.settings.warn_sound
-                };
-                self.play_alert(sound);
+                    self.play_alert(&self.settings.warn_sound.clone());
+                }
             }
         }
     }
@@ -4014,6 +4037,13 @@ impl HookEchoApp {
     /// Best-effort on the shared tokio runtime; failures are logged, never fatal.
     // ponytail: fire-and-forget, no retry; add a bounded retry queue if users report drops.
     fn notify_alert(&self, title: &str, body: &str, urgent: bool) {
+        // Quiet hours hold everything back except the escalated tier, which is the one worth
+        // waking up for. Banners and the alert list are untouched — this gates what leaves the
+        // machine and what makes noise, not what the app knows.
+        if !urgent && self.in_quiet_hours() {
+            log::debug!("quiet hours: holding push {title:?}");
+            return;
+        }
         let http = self.http.clone();
         let (title, body) = (title.to_string(), body.to_string());
 
@@ -4789,7 +4819,7 @@ impl HookEchoApp {
                 true,
             );
             if self.settings.alert_sound {
-                self.play_alert(&self.settings.tds_sound.clone());
+                self.play_alert_urgent(&self.settings.tds_sound.clone());
             }
         }
         self.tds_active = now_active;
@@ -4844,7 +4874,7 @@ impl HookEchoApp {
                 true,
             );
             if self.settings.alert_sound {
-                self.play_alert(&self.settings.rotation_sound.clone());
+                self.play_alert_urgent(&self.settings.rotation_sound.clone());
             }
         }
         self.rot_active = now_active;

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -294,6 +294,11 @@ pub struct Settings {
     /// First-run setup wizard completed (or dismissed). `false` shows it at startup.
     #[serde(default)]
     pub setup_done: bool,
+    /// Watch wherever you are, not only the places you saved: while a GPS fix is coming in it
+    /// joins the marker list for the proximity alerts (lightning, rotation), under the name
+    /// "my location". Nothing is written to the saved markers and nothing is shared.
+    #[serde(default)]
+    pub alert_follow_gps: bool,
     /// Quiet hours: between `quiet_start_hour` and `quiet_end_hour` (local, 24h), alert sounds
     /// and pushes are held back. Escalated warnings — Tornado Emergency, PDS, destructive — go
     /// through anyway: the whole point of the tier is that it is worth waking up for.
@@ -703,6 +708,7 @@ impl Default for Settings {
             rain_alerts: false,
             rain_sound: AlertSound::default(),
             setup_done: false,
+            alert_follow_gps: false,
             quiet_hours: false,
             quiet_start_hour: default_quiet_start(),
             quiet_end_hour: default_quiet_end(),
@@ -1027,6 +1033,7 @@ mod tests {
             rain_alerts: true,
             rain_sound: AlertSound::Ding,
             setup_done: true,
+            alert_follow_gps: false,
             quiet_hours: false,
             quiet_start_hour: 22,
             quiet_end_hour: 7,

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -294,6 +294,19 @@ pub struct Settings {
     /// First-run setup wizard completed (or dismissed). `false` shows it at startup.
     #[serde(default)]
     pub setup_done: bool,
+    /// Quiet hours: between `quiet_start_hour` and `quiet_end_hour` (local, 24h), alert sounds
+    /// and pushes are held back. Escalated warnings — Tornado Emergency, PDS, destructive — go
+    /// through anyway: the whole point of the tier is that it is worth waking up for.
+    #[serde(default)]
+    pub quiet_hours: bool,
+    #[serde(default = "default_quiet_start")]
+    pub quiet_start_hour: u32,
+    #[serde(default = "default_quiet_end")]
+    pub quiet_end_hour: u32,
+    /// Lowest NWS escalation tier (see `wxdata::alerts::escalation`) allowed to push and sound.
+    /// 0 lets everything through, which is the default.
+    #[serde(default)]
+    pub alert_min_escalation: u8,
     /// Chime when a new radar volume lands on the live pane in view.
     #[serde(default)]
     pub scan_chime: bool,
@@ -404,6 +417,14 @@ pub struct Bookmark {
     /// UTC time to seek to (Unix seconds); `None` = live/head.
     #[serde(default)]
     pub time_secs: Option<i64>,
+}
+
+fn default_quiet_start() -> u32 {
+    22
+}
+
+fn default_quiet_end() -> u32 {
+    7
 }
 
 fn default_scan_sound() -> AlertSound {
@@ -682,6 +703,10 @@ impl Default for Settings {
             rain_alerts: false,
             rain_sound: AlertSound::default(),
             setup_done: false,
+            quiet_hours: false,
+            quiet_start_hour: default_quiet_start(),
+            quiet_end_hour: default_quiet_end(),
+            alert_min_escalation: 0,
             scan_chime: false,
             scan_sound: default_scan_sound(),
             warn_sound: AlertSound::default(),
@@ -735,6 +760,26 @@ impl Settings {
             }
             p.map(PathBuf::from)
         })
+    }
+
+    /// Is local `hour` inside the quiet-hours window? Handles the ordinary case of a window that
+    /// crosses midnight (22 → 7). Start == end means "no window", not "all day" — a 24-hour mute
+    /// is what `mute_alerts` is for, and reading it the other way would silence someone by
+    /// accident.
+    pub fn in_quiet_hours(&self, hour: u32) -> bool {
+        if !self.quiet_hours {
+            return false;
+        }
+        let (s, e, h) = (
+            self.quiet_start_hour % 24,
+            self.quiet_end_hour % 24,
+            hour % 24,
+        );
+        match s.cmp(&e) {
+            std::cmp::Ordering::Equal => false,
+            std::cmp::Ordering::Less => (s..e).contains(&h),
+            std::cmp::Ordering::Greater => h >= s || h < e,
+        }
     }
 
     /// The saved settings JSON, or `None` if there is none to read.
@@ -982,6 +1027,10 @@ mod tests {
             rain_alerts: true,
             rain_sound: AlertSound::Ding,
             setup_done: true,
+            quiet_hours: false,
+            quiet_start_hour: 22,
+            quiet_end_hour: 7,
+            alert_min_escalation: 0,
             scan_chime: false,
             scan_sound: AlertSound::Ding,
             warn_sound: AlertSound::Siren,
@@ -1014,6 +1063,31 @@ mod tests {
         let json = serde_json::to_string(&s).unwrap();
         let back: Settings = serde_json::from_str(&json).unwrap();
         assert_eq!(s, back);
+    }
+
+    #[test]
+    fn quiet_hours_window_wraps_midnight() {
+        let mut s = Settings {
+            quiet_hours: true,
+            quiet_start_hour: 22,
+            quiet_end_hour: 7,
+            ..Settings::default()
+        };
+        assert!(s.in_quiet_hours(23) && s.in_quiet_hours(0) && s.in_quiet_hours(6));
+        assert!(!s.in_quiet_hours(7), "the end hour is already awake");
+        assert!(!s.in_quiet_hours(21) && !s.in_quiet_hours(12));
+        // A window inside one day.
+        s.quiet_start_hour = 9;
+        s.quiet_end_hour = 17;
+        assert!(s.in_quiet_hours(9) && s.in_quiet_hours(16) && !s.in_quiet_hours(17));
+        // Equal bounds is no window, not all day.
+        s.quiet_end_hour = 9;
+        assert!(!s.in_quiet_hours(9) && !s.in_quiet_hours(3));
+        // And off is off.
+        s.quiet_hours = false;
+        s.quiet_start_hour = 0;
+        s.quiet_end_hour = 23;
+        assert!(!s.in_quiet_hours(5));
     }
 
     #[test]

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -294,6 +294,10 @@ pub struct Settings {
     /// First-run setup wizard completed (or dismissed). `false` shows it at startup.
     #[serde(default)]
     pub setup_done: bool,
+    /// Attach a picture of the radar to the ntfy push when a warning fires. Desktop only: the
+    /// Android background service has no GPU surface to render from, and says so in the UI.
+    #[serde(default)]
+    pub ntfy_snapshot: bool,
     /// Watch wherever you are, not only the places you saved: while a GPS fix is coming in it
     /// joins the marker list for the proximity alerts (lightning, rotation), under the name
     /// "my location". Nothing is written to the saved markers and nothing is shared.
@@ -708,6 +712,7 @@ impl Default for Settings {
             rain_alerts: false,
             rain_sound: AlertSound::default(),
             setup_done: false,
+            ntfy_snapshot: false,
             alert_follow_gps: false,
             quiet_hours: false,
             quiet_start_hour: default_quiet_start(),
@@ -1033,6 +1038,7 @@ mod tests {
             rain_alerts: true,
             rain_sound: AlertSound::Ding,
             setup_done: true,
+            ntfy_snapshot: false,
             alert_follow_gps: false,
             quiet_hours: false,
             quiet_start_hour: 22,

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -835,6 +835,34 @@ fn alerts_tab(ui: &mut egui::Ui, settings: &mut Settings) {
 
     ui.add_space(8.0);
     ui.separator();
+    ui.strong("When to interrupt");
+    ui.horizontal(|ui| {
+        ui.checkbox(&mut settings.quiet_hours, "Quiet hours");
+        ui.add_enabled_ui(settings.quiet_hours, |ui| {
+            ui.add(egui::DragValue::new(&mut settings.quiet_start_hour).range(0..=23));
+            ui.label("to");
+            ui.add(egui::DragValue::new(&mut settings.quiet_end_hour).range(0..=23));
+            ui.weak("local");
+        });
+    });
+    ui.weak(
+        "Holds sounds and pushes between those hours. Tornado Emergency, PDS and destructive \
+         warnings still come through — that tier is what quiet hours is for.",
+    );
+    ui.horizontal(|ui| {
+        ui.label("Push and sound only for:");
+        for (tier, label) in [
+            (0u8, "Every warning"),
+            (1, "Considerable and up"),
+            (2, "Escalated only"),
+        ] {
+            ui.selectable_value(&mut settings.alert_min_escalation, tier, label);
+        }
+    });
+    ui.weak("Quieter warnings still banner and still show in the alert list.");
+
+    ui.add_space(8.0);
+    ui.separator();
     ui.strong("Push notifications (ntfy.sh)");
     ui.horizontal(|ui| {
         ui.label("Topic:");

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -836,6 +836,11 @@ fn alerts_tab(ui: &mut egui::Ui, settings: &mut Settings) {
     ui.add_space(8.0);
     ui.separator();
     ui.strong("When to interrupt");
+    ui.checkbox(&mut settings.alert_follow_gps, "Alert where I am, too")
+        .on_hover_text(
+            "While a GPS fix is coming in, your own position joins the saved locations the \
+             lightning and rotation alerts watch. Nothing is saved or shared.",
+        );
     ui.horizontal(|ui| {
         ui.checkbox(&mut settings.quiet_hours, "Quiet hours");
         ui.add_enabled_ui(settings.quiet_hours, |ui| {

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -875,6 +875,13 @@ fn alerts_tab(ui: &mut egui::Ui, settings: &mut Settings) {
     });
     ui.weak("When a warning covers a saved location marker, a push is sent to ntfy.sh/<topic>.");
     ui.weak("Subscribe to the same topic in the ntfy app on your phone. Leave blank to disable.");
+    ui.add_enabled_ui(!cfg!(target_os = "android"), |ui| {
+        ui.checkbox(&mut settings.ntfy_snapshot, "Attach a picture of the radar")
+            .on_hover_text(
+                "Pushes the view you're looking at alongside the warning. Desktop only — the \
+                 phone's background alert service has nothing to render from.",
+            );
+    });
 
     ui.add_space(8.0);
     ui.separator();


### PR DESCRIPTION
Second batch of the R13 feature expansion: making the alerting selective enough
to leave on.

- **Quiet hours** (local start/end, wraps midnight) hold sounds and pushes.
  Tornado Emergency / PDS / destructive warnings still come through — that tier
  is the reason the window exists. `mute_alerts` still wins over both.
- **Severity floor**: the lowest NWS escalation tier allowed to push, speak or
  sound. Below it a warning still banners and still joins the alert list.
- Android reads the same `settings.json` fields in its background poll, so the
  phone behaves the same with the app closed. A silenced alert is still marked
  seen, so it does not re-fire the moment the window ends.
- **Rotation near a watched place** — the existing detector fires once for the
  whole radar; this names the place and the distance and re-fires as a storm
  works down a line. Per-location cooldown, same shape as the lightning alarm.
- **Alert where I am, too** folds the live GPS fix into the watched list as
  "my location" for the lightning and rotation alarms. Not a real marker: it
  has to vanish with the fix, and nothing is saved or shared.
- **Radar picture in the warning push** — ntfy takes an attachment as the PUT
  body, so the push can carry the view instead of only its text. Reuses the
  capture path, one frame. Off by default; disabled on Android, where the alert
  service has no surface to render from.

Verified: `cargo clippy --workspace --all-targets`, `cargo test --workspace`
(417 passed), wasm `cargo check`, `./scripts/shots/shoot.sh check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)