### PR TITLE
R13 batch D — Android surfaces

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -59,8 +59,9 @@
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTask"
-            android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|keyboard|keyboardHidden|navigation|uiMode|density"
+            android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|keyboard|keyboardHidden|navigation|uiMode|density|smallestScreenSize"
             android:screenOrientation="sensor"
+            android:supportsPictureInPicture="true"
             android:windowSoftInputMode="adjustResize"
             android:exported="true"
             android:label="@string/app_name">
@@ -92,6 +93,31 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/widget_alerts_info" />
         </receiver>
+
+        <!-- Home-screen widget: the last radar view the app drew, with its age. No network of
+             its own — the app writes the picture, this shows it. -->
+        <receiver
+            android:name=".RadarWidget"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/widget_radar_info" />
+        </receiver>
+
+        <!-- Quick-settings tile: two swipes to the map. -->
+        <service
+            android:name=".RadarTile"
+            android:exported="true"
+            android:icon="@mipmap/ic_launcher_monochrome"
+            android:label="@string/app_name"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+        </service>
 
         <!-- Boot: enqueue the worker only. Android 15 refuses a dataSync FGS from here. -->
         <receiver

--- a/android/app/src/main/kotlin/zip/batman/hookecho/MainActivity.kt
+++ b/android/app/src/main/kotlin/zip/batman/hookecho/MainActivity.kt
@@ -80,6 +80,35 @@ class MainActivity : GameActivity() {
         File(filesDir, "import.txt").writeText("$pendingImport\t${dest.absolutePath}")
     }
 
+    /**
+     * Called from Rust: shrink the app into a picture-in-picture window so the loop keeps playing
+     * over whatever the user does next. No-op on a device that does not support PiP.
+     */
+    @Suppress("unused")
+    fun enterPip() {
+        runOnUiThread {
+            if (!packageManager.hasSystemFeature(android.content.pm.PackageManager.FEATURE_PICTURE_IN_PICTURE)) {
+                return@runOnUiThread
+            }
+            runCatching {
+                enterPictureInPictureMode(
+                    android.app.PictureInPictureParams.Builder()
+                        .setAspectRatio(android.util.Rational(4, 3))
+                        .build()
+                )
+            }
+        }
+    }
+
+    /**
+     * The Rust side hides its chrome in PiP — at that size a sidebar and a timeline leave no map
+     * at all, and none of it is touchable through a PiP window anyway.
+     */
+    override fun onPictureInPictureModeChanged(inPip: Boolean, config: android.content.res.Configuration) {
+        super.onPictureInPictureModeChanged(inPip, config)
+        nativeOnPipChanged(inPip)
+    }
+
     /** Called from Rust when what back would do changes. */
     @Suppress("unused")
     fun setBackConsumed(consumed: Boolean) {
@@ -87,6 +116,8 @@ class MainActivity : GameActivity() {
     }
 
     private external fun nativeOnBack()
+
+    private external fun nativeOnPipChanged(inPip: Boolean)
 
     /**
      * Back out of the app and the process has to go with it.

--- a/android/app/src/main/kotlin/zip/batman/hookecho/RadarTile.kt
+++ b/android/app/src/main/kotlin/zip/batman/hookecho/RadarTile.kt
@@ -1,0 +1,35 @@
+package zip.batman.hookecho
+
+import android.content.Intent
+import android.service.quicksettings.TileService
+
+/**
+ * Quick-settings tile: open the radar from the pull-down shade.
+ *
+ * Deliberately nothing more. A tile that showed live warning state would need its own polling, and
+ * that already exists as the alert service and the widget; this is the two-swipe path to the map
+ * when the sky goes green.
+ */
+class RadarTile : TileService() {
+    override fun onClick() {
+        super.onClick()
+        val intent = Intent(this, MainActivity::class.java)
+            .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+        // startActivityAndCollapse wants a PendingIntent from Android 14 on, and refuses an
+        // Intent there; below that it only takes the Intent.
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            startActivityAndCollapse(
+                android.app.PendingIntent.getActivity(
+                    this,
+                    0,
+                    intent,
+                    android.app.PendingIntent.FLAG_UPDATE_CURRENT or
+                        android.app.PendingIntent.FLAG_IMMUTABLE,
+                )
+            )
+        } else {
+            @Suppress("DEPRECATION")
+            startActivityAndCollapse(intent)
+        }
+    }
+}

--- a/android/app/src/main/kotlin/zip/batman/hookecho/RadarWidget.kt
+++ b/android/app/src/main/kotlin/zip/batman/hookecho/RadarWidget.kt
@@ -1,0 +1,77 @@
+package zip.batman.hookecho
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.graphics.BitmapFactory
+import android.widget.RemoteViews
+import java.io.File
+
+/**
+ * Home-screen widget showing the last radar view the app drew.
+ *
+ * The widget does no network and no rendering: it cannot host the Rust renderer, and a widget that
+ * fetched and decoded a volume on the home screen would be a second radar client running on
+ * someone's battery. Instead the app writes a small PNG whenever a scan lands
+ * ([SNAPSHOT] in its files dir) and this reads whatever is there, captioned with the age — a
+ * picture with no timestamp is worse than no picture, because it looks current.
+ */
+class RadarWidget : AppWidgetProvider() {
+    override fun onUpdate(context: Context, manager: AppWidgetManager, ids: IntArray) {
+        render(context, manager, ids)
+    }
+
+    private fun render(context: Context, manager: AppWidgetManager, ids: IntArray) {
+        val png = File(context.filesDir, SNAPSHOT)
+        val views = RemoteViews(context.packageName, R.layout.widget_radar)
+        if (png.exists()) {
+            runCatching { BitmapFactory.decodeFile(png.absolutePath) }.getOrNull()?.let {
+                views.setImageViewBitmap(R.id.widget_radar_image, it)
+            }
+            views.setTextViewText(R.id.widget_radar_text, age(png.lastModified()))
+        } else {
+            views.setTextViewText(R.id.widget_radar_text, "Open Hook Echo-WX to fill this in")
+        }
+        val tap = PendingIntent.getActivity(
+            context,
+            0,
+            Intent(context, MainActivity::class.java)
+                .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        views.setOnClickPendingIntent(R.id.widget_radar_root, tap)
+        for (id in ids) manager.updateAppWidget(id, views)
+    }
+
+    /** "4 min ago", and blunt about it once the picture is old enough to mislead. */
+    private fun age(modified: Long): String {
+        val mins = (System.currentTimeMillis() - modified) / 60_000
+        return when {
+            mins < 1 -> "just now"
+            mins < 60 -> "$mins min ago"
+            mins < 60 * 24 -> "${mins / 60} h ago — stale"
+            else -> "old — open the app"
+        }
+    }
+
+    companion object {
+        /** Where the Rust side writes the picture, relative to `filesDir`. */
+        const val SNAPSHOT = "widget-radar.png"
+
+        /** Re-render every placed widget now. Called from Rust after it writes a new snapshot. */
+        @JvmStatic
+        fun refresh(context: Context) {
+            val manager = AppWidgetManager.getInstance(context)
+            val ids = manager.getAppWidgetIds(ComponentName(context, RadarWidget::class.java))
+            if (ids.isEmpty()) return
+            context.sendBroadcast(
+                Intent(context, RadarWidget::class.java)
+                    .setAction(AppWidgetManager.ACTION_APPWIDGET_UPDATE)
+                    .putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, ids)
+            )
+        }
+    }
+}

--- a/android/app/src/main/res/layout/widget_radar.xml
+++ b/android/app/src/main/res/layout/widget_radar.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- The radar widget is one picture and one line of text: the last view the app drew, and how
+     old it is. RemoteViews cannot host the renderer, so freshness has to be stated rather than
+     assumed. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_radar_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="#CC101418">
+
+    <ImageView
+        android:id="@+id/widget_radar_image"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:scaleType="centerCrop"
+        android:contentDescription="@string/widget_radar_image_desc" />
+
+    <TextView
+        android:id="@+id/widget_radar_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="6dp"
+        android:textColor="#FFFFFF"
+        android:textSize="12sp" />
+</LinearLayout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Hook Echo-WX</string>
+    <string name="widget_radar_image_desc">Last radar view drawn by the app</string>
 </resources>

--- a/android/app/src/main/res/xml/widget_radar_info.xml
+++ b/android/app/src/main/res/xml/widget_radar_info.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 30 minutes is the floor Android allows a widget's own clock. The picture only changes while
+     the app is running anyway, and the app pushes a refresh whenever it writes a new one. -->
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="180dp"
+    android:minHeight="180dp"
+    android:updatePeriodMillis="1800000"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen"
+    android:initialLayout="@layout/widget_radar" />

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1285,6 +1285,8 @@ enum ShotDest {
     Loop,
     /// Pushed to the user's ntfy topic as an attachment, captioned with this title.
     Push(String),
+    /// Written silently for the Android home-screen widget to pick up.
+    Widget(std::path::PathBuf),
 }
 
 /// In-progress loop export (GIF or MP4): steps the active timeline, grabbing one screenshot per
@@ -1842,6 +1844,8 @@ pub struct HookEchoApp {
     /// Keep the GOES frame on the active pane's radar clock rather than on a hand-picked frame.
     goes_follow_radar: bool,
     goes_times_rx: Option<std::sync::mpsc::Receiver<Vec<chrono::DateTime<chrono::Utc>>>>,
+    /// When the Android widget snapshot was last written.
+    widget_shot_at: Option<Instant>,
     /// A warning that wants a radar picture pushed after it (see `settings.ntfy_snapshot`).
     snapshot_push: Option<String>,
     /// Per-location cooldown for the rotation-near-a-watched-place alert.
@@ -2527,6 +2531,7 @@ impl HookEchoApp {
             goes_time_idx: None,
             goes_follow_radar: true,
             goes_times_rx: None,
+            widget_shot_at: None,
             snapshot_push: None,
             rotation_alerted: std::collections::HashMap::new(),
             last_chime: None,
@@ -12324,6 +12329,14 @@ impl HookEchoApp {
                 ui.checkbox(&mut v.show_radar, "Radar");
                 ui.checkbox(&mut v.show_legend, "Legend");
             }
+            if cfg!(target_os = "android")
+                && ui
+                    .button("\u{1f5d6} Picture-in-picture")
+                    .on_hover_text("Shrink to a floating window with the loop still playing")
+                    .clicked()
+            {
+                crate::platform::enter_pip();
+            }
             if ui
                 .checkbox(&mut self.obs_mode, "Streamer / OBS mode (F8)")
                 .on_hover_text(
@@ -12768,6 +12781,62 @@ impl HookEchoApp {
         }
     }
 
+    /// Write the widget's picture, downscaled, and tell the widget about it.
+    ///
+    /// Downscaled because `RemoteViews.setImageViewBitmap` sends the bitmap over a Binder
+    /// transaction, and a phone-screen-sized bitmap is comfortably past the ~1 MB limit — the
+    /// widget would throw rather than draw. A home-screen tile is a few hundred pixels wide.
+    fn save_widget_snapshot(&self, path: &std::path::Path, image: &egui::ColorImage) {
+        const MAX_W: u32 = 640;
+        let (w, h) = (image.size[0] as u32, image.size[1] as u32);
+        if w == 0 || h == 0 {
+            return;
+        }
+        let mut rgba = Vec::with_capacity((w * h * 4) as usize);
+        for px in &image.pixels {
+            rgba.extend_from_slice(&[px.r(), px.g(), px.b(), px.a()]);
+        }
+        let Some(buf) = image::RgbaImage::from_raw(w, h, rgba) else {
+            return;
+        };
+        let small = if w > MAX_W {
+            let nh = (h as f32 * MAX_W as f32 / w as f32).round().max(1.0) as u32;
+            image::imageops::resize(&buf, MAX_W, nh, image::imageops::FilterType::Triangle)
+        } else {
+            buf
+        };
+        // Silent: nobody asked for this one, so a toast would be the app talking to itself. A
+        // failed write costs the widget one stale caption.
+        match small.save(path) {
+            Ok(()) => crate::platform::refresh_radar_widget(),
+            Err(e) => log::warn!("widget snapshot failed: {e}"),
+        }
+    }
+
+    /// Keep the Android home-screen widget's picture fresh while the app is on screen.
+    ///
+    /// Every few minutes, not every scan: the widget's own clock cannot beat 30 minutes anyway,
+    /// and a full-resolution PNG per volume is a write nobody asked for. Nothing runs off Android.
+    fn drive_widget_snapshot(&mut self, ctx: &egui::Context) {
+        const EVERY: std::time::Duration = std::time::Duration::from_secs(300);
+        if !cfg!(target_os = "android")
+            || self.screenshot_pending.is_some()
+            || self.share_card.is_some()
+            || self.views[self.active].volume.is_none()
+        {
+            return;
+        }
+        if self.widget_shot_at.is_some_and(|t| t.elapsed() < EVERY) {
+            return;
+        }
+        let Some(path) = crate::paths::widget_snapshot() else {
+            return;
+        };
+        self.widget_shot_at = Some(Instant::now());
+        self.screenshot_pending = Some(ShotDest::Widget(path));
+        ctx.send_viewport_cmd(egui::ViewportCommand::Screenshot(egui::UserData::default()));
+    }
+
     /// A warning asked for a radar picture: take one, as long as nothing else is mid-capture.
     ///
     /// Deliberately the live view rather than a headless render — it is the picture the user is
@@ -12947,6 +13016,7 @@ impl HookEchoApp {
                 }
                 ShotDest::Loop => self.record_loop_frame(&image),
                 ShotDest::Push(title) => self.push_snapshot(title, &image),
+                ShotDest::Widget(path) => self.save_widget_snapshot(&path, &image),
             }
         }
     }
@@ -13793,6 +13863,7 @@ impl eframe::App for HookEchoApp {
         }
 
         self.drive_snapshot_push(ctx);
+        self.drive_widget_snapshot(ctx);
         self.save_pending_screenshot(ctx);
         self.load_marker_icons(ctx);
         self.drive_loop_export(ctx);
@@ -14306,7 +14377,10 @@ impl eframe::App for HookEchoApp {
 
         // Docked desktop chrome. Declared before every floating Area so those constrain to what's
         // left of the viewport (`self.chrome_rect`) instead of covering the bars.
-        if !cfg!(target_os = "android") && !self.obs_mode {
+        // Picture-in-picture counts as chrome-free for the same reason OBS mode does: at that
+        // size the panels are the whole window, and nothing in a PiP window takes touches anyway.
+        let bare = self.obs_mode || crate::platform::in_pip();
+        if !cfg!(target_os = "android") && !bare {
             if !self.settings.hide_sidebar {
                 self.sidebar(root, ctx);
             }
@@ -14323,14 +14397,14 @@ impl eframe::App for HookEchoApp {
         // keep swallowing gestures over a sheet that closed.
         self.mobile_occlusion.clear();
         let mut actions = ui::layer_options::UiActions::default();
-        if cfg!(target_os = "android") && !self.obs_mode {
+        if cfg!(target_os = "android") && !bare {
             actions = self.mobile_chrome(root, ctx);
         }
         self.apply_ui_actions(actions, ctx);
 
         // Floating map-first chrome (desktop): a hamburger, an alert bell, the two bottom pills.
         // Everything else is one drawer behind the hamburger.
-        if !cfg!(target_os = "android") && !self.obs_mode {
+        if !cfg!(target_os = "android") && !bare {
             self.sidebar_button(ctx);
             self.info_chip(ctx);
             self.error_chip(ctx);

--- a/crates/hookecho/src/paths.rs
+++ b/crates/hookecho/src/paths.rs
@@ -70,6 +70,12 @@ pub fn import_file() -> Option<PathBuf> {
     BASE.get().map(|b| b.join("import.txt"))
 }
 
+/// Where the app writes the picture the home-screen radar widget shows (Android only). Sits at
+/// the files-dir root, which is what `Context.filesDir` resolves to on the Kotlin side.
+pub fn widget_snapshot() -> Option<PathBuf> {
+    BASE.get().map(|b| b.join("widget-radar.png"))
+}
+
 /// Cache root (tiles, vector tiles, climatology CSV).
 pub fn cache_dir() -> Option<PathBuf> {
     root("cache")

--- a/crates/hookecho/src/platform.rs
+++ b/crates/hookecho/src/platform.rs
@@ -504,6 +504,99 @@ mod android_back {
     }
 }
 
+/// Picture-in-picture: shrink the app into a floating window with the loop still playing.
+///
+/// Two directions again, same shape as predictive back: Rust asks the activity to enter PiP, and
+/// the activity calls back when the mode changes so the UI can drop its chrome — at PiP size a
+/// sidebar and a timeline leave no map, and nothing in a PiP window is touchable anyway.
+#[cfg(target_os = "android")]
+mod android_pip {
+    use jni::objects::JObject;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    static IN_PIP: AtomicBool = AtomicBool::new(false);
+
+    /// # Safety
+    /// Called by the JVM with a valid env/object pair; touches only an atomic.
+    #[unsafe(no_mangle)]
+    pub extern "system" fn Java_zip_batman_hookecho_MainActivity_nativeOnPipChanged(
+        _env: jni::JNIEnv,
+        _this: JObject,
+        in_pip: jni::sys::jboolean,
+    ) {
+        IN_PIP.store(in_pip != 0, Ordering::Relaxed);
+    }
+
+    pub fn in_pip() -> bool {
+        IN_PIP.load(Ordering::Relaxed)
+    }
+
+    /// Tell the home-screen radar widget a new picture is on disk.
+    pub fn refresh_radar_widget() {
+        if let Err(e) = refresh() {
+            log::warn!("radar widget refresh failed: {e:?}");
+        }
+    }
+
+    fn refresh() -> jni::errors::Result<()> {
+        use jni::objects::{JClass, JValue};
+        let Some(app) = super::android::app() else {
+            return Ok(());
+        };
+        let vm = unsafe { jni::JavaVM::from_raw(app.vm_as_ptr() as *mut jni::sys::JavaVM) }?;
+        let mut env = vm.attach_current_thread()?;
+        let activity = unsafe { JObject::from_raw(app.activity_as_ptr() as jni::sys::jobject) };
+        let class = env.find_class("zip/batman/hookecho/RadarWidget")?;
+        let class = JClass::from(class);
+        let res = env.call_static_method(
+            &class,
+            "refresh",
+            "(Landroid/content/Context;)V",
+            &[JValue::Object(&activity)],
+        );
+        if res.is_err() {
+            let _ = env.exception_clear();
+        }
+        res.map(|_| ())
+    }
+
+    /// Ask the activity for PiP. Failures are logged and otherwise ignored: a device without the
+    /// feature simply stays as it was.
+    pub fn enter_pip() {
+        if let Err(e) = call() {
+            log::warn!("picture-in-picture request failed: {e:?}");
+        }
+    }
+
+    fn call() -> jni::errors::Result<()> {
+        let Some(app) = super::android::app() else {
+            return Ok(());
+        };
+        let vm = unsafe { jni::JavaVM::from_raw(app.vm_as_ptr() as *mut jni::sys::JavaVM) }?;
+        let mut env = vm.attach_current_thread()?;
+        let activity = unsafe { JObject::from_raw(app.activity_as_ptr() as jni::sys::jobject) };
+        let res = env.call_method(&activity, "enterPip", "()V", &[]);
+        if res.is_err() {
+            let _ = env.exception_clear();
+        }
+        res.map(|_| ())
+    }
+}
+
+/// Whether the app is currently in a picture-in-picture window (Android only).
+#[cfg(not(target_os = "android"))]
+pub fn in_pip() -> bool {
+    false
+}
+
+/// Shrink into a picture-in-picture window (no-op off Android).
+#[cfg(not(target_os = "android"))]
+pub fn enter_pip() {}
+
+/// Nudge the Android home-screen radar widget after a new snapshot (no-op elsewhere).
+#[cfg(not(target_os = "android"))]
+pub fn refresh_radar_widget() {}
+
 /// Whether a back press/gesture is waiting to be handled (Android only).
 #[cfg(not(target_os = "android"))]
 pub fn take_back_pressed() -> bool {
@@ -959,6 +1052,8 @@ pub use android_back::{set_back_consumed, take_back_pressed};
 pub use android_ime::{clipboard_text, pump_ime, show_soft_input};
 #[cfg(target_os = "android")]
 pub use android_location::start_location;
+#[cfg(target_os = "android")]
+pub use android_pip::{enter_pip, in_pip, refresh_radar_widget};
 #[cfg(target_os = "android")]
 pub use android_tts::speak;
 


### PR DESCRIPTION
Fourth batch of the R13 feature expansion: three ways into the radar that don't
start with opening the app.

- **Radar home-screen widget** — the last view the app drew, captioned with its
  age ("4 min ago", blunt once it is stale). No network and no rendering in the
  widget: it cannot host the Rust renderer, and one that fetched volumes would
  be a second radar client on the battery. The app writes a downscaled PNG every
  few minutes while it is on screen — downscaled because `RemoteViews` ships
  bitmaps over a Binder transaction and a phone-sized one is past the limit —
  then nudges the widget over JNI.
- **Picture-in-picture** — a floating window with the loop still playing. Rust
  asks the activity to enter it; the activity calls back on mode change and the
  UI drops its chrome, for the same reason OBS mode does.
- **Quick-settings tile** — two swipes to the map, nothing more.

**Not verified on a device.** There is no Android SDK on this machine and CI
builds the Rust cdylib only, so the Kotlin, manifest and resource changes have
not been compiled anywhere yet. They need a device pass on the S24 Ultra before
this is trusted: widget placement and caption, PiP entry and chrome-drop, tile
launch. The Rust side (JNI seam, snapshot write and downscale, chrome gating)
is covered by the usual suite.

Verified: `cargo clippy --workspace --all-targets`, `cargo test --workspace`
(418 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)