### PR TITLE
R13 batch E — SPC Day 4-8 and TAFs

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1670,7 +1670,8 @@ pub struct HookEchoApp {
     arch_lsr: LruCache<i64, Vec<wxdata::spc::StormReport>>,
     arch_lsr_inflight: Option<i64>,
     arch_lsr_shown: Option<i64>,
-    outlook_features: [Vec<GeoFeature>; 3],
+    /// One slot per SPC outlook day, 1..=8 (Days 4–8 are the experimental probability layer).
+    outlook_features: [Vec<GeoFeature>; 8],
     md_features: Vec<GeoFeature>,
     /// Winter Storm Severity Index polygons for the selected day.
     wssi_features: Vec<GeoFeature>,
@@ -2427,7 +2428,7 @@ impl HookEchoApp {
             arch_lsr: LruCache::new(NonZeroUsize::new(50).unwrap()),
             arch_lsr_inflight: None,
             arch_lsr_shown: None,
-            outlook_features: [Vec::new(), Vec::new(), Vec::new()],
+            outlook_features: std::array::from_fn(|_| Vec::new()),
             md_features: Vec::new(),
             wssi_features: Vec::new(),
             ero_features: Vec::new(),
@@ -3072,7 +3073,7 @@ impl HookEchoApp {
             self.spawn_overlay(ctx, OverlaySource::Ero(self.filters.ero_day));
         }
         // Only fetch the SPC outlook the user has selected (off = day 0 fetches nothing).
-        if (1..=3).contains(&self.filters.outlook_day) {
+        if (1..=8).contains(&self.filters.outlook_day) {
             self.spawn_overlay(
                 ctx,
                 OverlaySource::Outlook(self.filters.outlook_day, self.outlook_kind_for_day()),
@@ -5444,7 +5445,7 @@ impl HookEchoApp {
         if actions.overlays_changed {
             // Selecting an outlook day/kind that hasn't been fetched yet pulls it on demand.
             let day = self.filters.outlook_day;
-            if (1..=3).contains(&day) && self.outlook_features[(day - 1) as usize].is_empty() {
+            if (1..=8).contains(&day) && self.outlook_features[(day - 1) as usize].is_empty() {
                 self.spawn_overlay(
                     ctx,
                     OverlaySource::Outlook(day, self.outlook_kind_for_day()),
@@ -8511,7 +8512,7 @@ impl HookEchoApp {
     /// Reassemble the displayed overlay set from the fetched sources and current filters.
     fn rebuild_overlays(&mut self) {
         let mut v = Vec::new();
-        if (1..=3).contains(&self.filters.outlook_day) {
+        if (1..=8).contains(&self.filters.outlook_day) {
             v.extend(
                 self.outlook_features[(self.filters.outlook_day - 1) as usize]
                     .iter()

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -195,7 +195,10 @@ enum OverlayMsg {
     /// Archived storm-based warnings for a 5-min UTC bucket (feature W).
     ArchiveWarnings(i64, Vec<GeoFeature>),
     /// Surface observations (METAR station plots) for the requested bbox (feature U).
-    Metar(Vec<wxdata::metar::SurfaceOb>),
+    Metar(
+        Vec<wxdata::metar::SurfaceOb>,
+        std::collections::HashMap<String, String>,
+    ),
     /// FAA camera sites for the requested bbox.
     Webcams(Vec<wxdata::webcams::CamSite>),
     /// Wildfire perimeters + incident points for the requested bbox.
@@ -608,7 +611,16 @@ impl OverlaySource {
                     Ok(buoys) => obs.extend(buoys),
                     Err(e) => note_feed_error("Buoy observations", e),
                 }
-                OverlayMsg::Metar(obs)
+                // Terminal forecasts for the same box, riding along with the obs they belong
+                // beside. A TAF outage costs the tooltips their forecast line, nothing more.
+                let tafs = match wxdata::metar::fetch_tafs(http, lat0, lon0, lat1, lon1).await {
+                    Ok(t) => t,
+                    Err(e) => {
+                        note_feed_error("Terminal forecasts (TAF)", e);
+                        Default::default()
+                    }
+                };
+                OverlayMsg::Metar(obs, tafs)
             }
             OverlaySource::Webcams(min_lon, min_lat, max_lon, max_lat, windy_key) => {
                 // Both networks, merged: the FAA is keyless but US-only, Windy covers the rest of
@@ -1887,6 +1899,8 @@ pub struct HookEchoApp {
     /// Surface obs (METAR station plots, feature U): toggle, current obs, fetch clock + bbox.
     show_metar: bool,
     metars: Vec<wxdata::metar::SurfaceOb>,
+    /// Raw TAF text by ICAO, for the station tooltips (empty where a station files none).
+    tafs: std::collections::HashMap<String, String>,
     metar_last_fetch: Option<Instant>,
     /// The `(lat0, lon0, lat1, lon1)` bbox the current `metars` were fetched for.
     metar_bounds: Option<(f64, f64, f64, f64)>,
@@ -2552,6 +2566,7 @@ impl HookEchoApp {
             freezing_last_fetch: None,
             show_metar: false,
             metars: Vec::new(),
+            tafs: Default::default(),
             metar_last_fetch: None,
             metar_bounds: None,
             show_gauges: false,
@@ -7640,7 +7655,10 @@ impl HookEchoApp {
                         self.arch_warn_inflight = None;
                     }
                 }
-                OverlayMsg::Metar(obs) => self.metars = obs,
+                OverlayMsg::Metar(obs, tafs) => {
+                    self.metars = obs;
+                    self.tafs = tafs;
+                }
                 OverlayMsg::Webcams(sites) => {
                     // Drop the cached stills with the list they belonged to. Windy's free-tier
                     // image URLs expire after ten minutes, and a kept texture would otherwise
@@ -11442,7 +11460,13 @@ impl HookEchoApp {
                 // Hover → the raw METAR text.
                 let hit = egui::Rect::from_center_size(p, egui::vec2(16.0, 16.0));
                 if response.hover_pos().is_some_and(|hp| hit.contains(hp)) && !ob.raw.is_empty() {
-                    response.clone().show_tooltip_text(&ob.raw);
+                    // Observation first, then the terminal forecast where the station files one:
+                    // what it is doing, then what it is expected to do.
+                    let text = match self.tafs.get(&ob.icao) {
+                        Some(taf) => format!("{}\n\n{taf}", ob.raw),
+                        None => ob.raw.clone(),
+                    };
+                    response.clone().show_tooltip_text(text);
                 }
             }
         }

--- a/crates/hookecho/src/headless.rs
+++ b/crates/hookecho/src/headless.rs
@@ -1438,7 +1438,18 @@ pub fn run_metar(site: &str) -> anyhow::Result<()> {
         let client = reqwest::Client::new();
         wxdata::metar::fetch_bbox(&client, lat - 2.5, lon - 2.5, lat + 2.5, lon + 2.5).await
     })?;
-    println!("{site}: {} surface obs within ±2.5°", obs.len());
+    let tafs = rt.block_on(async {
+        let client = reqwest::Client::new();
+        wxdata::metar::fetch_tafs(&client, lat - 2.5, lon - 2.5, lat + 2.5, lon + 2.5).await
+    })?;
+    println!(
+        "{site}: {} surface obs, {} terminal forecasts within ±2.5°",
+        obs.len(),
+        tafs.len()
+    );
+    if let Some((icao, taf)) = tafs.iter().next() {
+        println!("  TAF {icao}: {taf}");
+    }
     for ob in obs.iter().take(3) {
         println!(
             "  {:<5} {:>6.2},{:>7.2}  {}kt @ {}  T {} Td {}  [{}]",

--- a/crates/hookecho/src/headless.rs
+++ b/crates/hookecho/src/headless.rs
@@ -1396,6 +1396,36 @@ pub fn run_tropical() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Fetch + print every SPC outlook day, so a change to the Day 1-3 or the Day 4-8 URL forms
+/// fails here rather than as an empty map: `hookecho --headless-outlooks`.
+pub fn run_outlooks() -> anyhow::Result<()> {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+    let client = reqwest::Client::new();
+    for day in 1u8..=8 {
+        let feats = rt.block_on(wxdata::spc::fetch_outlook(&client, day));
+        match feats {
+            Ok(f) => {
+                let labels: Vec<&str> = f.iter().map(|x| x.title.as_str()).take(4).collect();
+                println!(
+                    "day {day}: {} polygon(s) {}",
+                    f.len(),
+                    if labels.is_empty() {
+                        "(nothing outlooked)".to_string()
+                    } else {
+                        format!("— {}", labels.join(", "))
+                    }
+                );
+            }
+            // A day with no product yet is a 404, which is data rather than a bug; anything else
+            // is worth the non-zero exit.
+            Err(e) => println!("day {day}: {e}"),
+        }
+    }
+    Ok(())
+}
+
 /// Fetch + print surface obs (METAR) near a site (feature U).
 pub fn run_metar(site: &str) -> anyhow::Result<()> {
     let s =

--- a/crates/hookecho/src/main.rs
+++ b/crates/hookecho/src/main.rs
@@ -219,6 +219,15 @@ fn main() -> eframe::Result<()> {
         return Ok(());
     }
 
+    // SPC outlook verify (all eight days): `hookecho --headless-outlooks`.
+    if args.iter().any(|a| a == "--headless-outlooks") {
+        if let Err(e) = headless::run_outlooks() {
+            eprintln!("headless outlooks failed: {e}");
+            std::process::exit(1);
+        }
+        return Ok(());
+    }
+
     // Surface-obs verify: `hookecho --headless-metar [SITE]`.
     if let Some(pos) = args.iter().position(|a| a == "--headless-metar") {
         let site = args

--- a/crates/hookecho/src/ui/layer_options.rs
+++ b/crates/hookecho/src/ui/layer_options.rs
@@ -179,9 +179,11 @@ pub(crate) fn show(
 
     // SPC outlook: a four-way day selector whose own "Off" is the off-state, so it can't wear the
     // registry's ON/OFF pill. It lives here rather than in the layer list.
-    ui.horizontal(|ui| {
+    // Days 4–8 are SPC's experimental severe probability, one layer per day; the row wraps
+    // rather than growing a second control for "which kind of day this is".
+    ui.horizontal_wrapped(|ui| {
         ui.label("SPC Outlook:");
-        for day in 0u8..=3 {
+        for day in 0u8..=8 {
             let label = if day == 0 {
                 "Off".to_string()
             } else {

--- a/crates/wxdata/src/metar.rs
+++ b/crates/wxdata/src/metar.rs
@@ -8,6 +8,7 @@
 use crate::alerts::USER_AGENT;
 
 const METAR_URL: &str = "https://aviationweather.gov/api/data/metar";
+const TAF_URL: &str = "https://aviationweather.gov/api/data/taf";
 
 /// One surface observation (station plot).
 #[derive(Debug, Clone, PartialEq)]
@@ -108,6 +109,54 @@ pub async fn fetch_bbox(
     Ok(obs)
 }
 
+/// Fetch the current TAFs over the same bbox as [`fetch_bbox`], as `ICAO -> raw TAF text`.
+///
+/// Raw text, not the decoded `fcsts` array: a TAF is written to be read as a TAF, and every pilot
+/// and chaser who wants one can already read it. Decoding it into rows would be a second forecast
+/// renderer for no extra information.
+pub async fn fetch_tafs(
+    client: &reqwest::Client,
+    lat0: f64,
+    lon0: f64,
+    lat1: f64,
+    lon1: f64,
+) -> anyhow::Result<std::collections::HashMap<String, String>> {
+    let bbox = format!("{lat0},{lon0},{lat1},{lon1}");
+    let body = client
+        .get(crate::net::fetch_url(TAF_URL))
+        .query(&[("bbox", bbox.as_str()), ("format", "json")])
+        .header("User-Agent", USER_AGENT)
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+    Ok(parse_tafs(&body))
+}
+
+/// Parse the TAF JSON array into `ICAO -> raw text`. Tolerant, like [`parse`]: an entry missing
+/// either field is skipped rather than failing the batch.
+pub fn parse_tafs(json: &str) -> std::collections::HashMap<String, String> {
+    let mut out = std::collections::HashMap::new();
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(json) else {
+        return out;
+    };
+    for t in v.as_array().map(Vec::as_slice).unwrap_or(&[]) {
+        let icao = str_of(t, "icaoId");
+        let raw = str_of(t, "rawTAF");
+        if icao.is_empty() || raw.is_empty() {
+            continue;
+        }
+        // Several bulletins can share a station; `mostRecent` marks the one to keep, and where it
+        // is absent the later entry is the newer one.
+        let recent = t.get("mostRecent").and_then(|m| m.as_i64()).unwrap_or(1);
+        if recent != 0 || !out.contains_key(&icao) {
+            out.insert(icao, raw);
+        }
+    }
+    out
+}
+
 /// Generate wind-barb segments in a unit frame: origin at the station, shaft along +Y. US
 /// convention — pennant/flag = 50 kt, full barb = 10 kt, half barb = 5 kt, rounded to nearest 5.
 /// Calm (< 2.5 kt) returns no segments (the caller draws a hollow calm ring instead).
@@ -153,6 +202,22 @@ pub fn barb_segments(wspd_kt: f32) -> Vec<([f32; 2], [f32; 2])> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn taf_parse_keeps_the_most_recent_bulletin() {
+        let json = r#"[
+            {"icaoId":"KOKC","rawTAF":"TAF KOKC 101120Z old","mostRecent":0},
+            {"icaoId":"KOKC","rawTAF":"TAF KOKC 102320Z new","mostRecent":1},
+            {"icaoId":"KTIK","rawTAF":"TAF KTIK 110100Z ..."},
+            {"icaoId":"KBAD"},
+            {"rawTAF":"TAF ... no station"}
+        ]"#;
+        let tafs = parse_tafs(json);
+        assert_eq!(tafs.len(), 2, "entries missing a field are skipped");
+        assert!(tafs["KOKC"].contains("new"), "superseded bulletin won");
+        assert!(tafs.contains_key("KTIK"));
+        assert!(parse_tafs("not json").is_empty());
+    }
 
     #[test]
     fn parses_vrb_wind_and_missing_temp() {

--- a/crates/wxdata/src/spc.rs
+++ b/crates/wxdata/src/spc.rs
@@ -1,4 +1,5 @@
-//! SPC convective products: Day 1–3 categorical outlooks and Mesoscale Discussions.
+//! SPC convective products: Day 1–3 outlooks, the Day 4–8 severe probabilities, and Mesoscale
+//! Discussions.
 //!
 //! Outlooks come as static GeoJSON that already carries per-feature `fill`/`stroke` colors
 //! and a risk `LABEL2`; MDs come from the NWS map service as GeoJSON. Both decode into the
@@ -8,6 +9,10 @@ use crate::alerts::USER_AGENT;
 use crate::overlay::{for_each_feature, polygons_of, FeatureKind, GeoFeature};
 
 const OUTLOOK_BASE: &str = "https://www.spc.noaa.gov/products/outlook";
+/// Days 4-8 live under the experimental products path and are one probabilistic layer per day
+/// (no hazard split, no categorical risk — that far out SPC forecasts a single severe
+/// probability, or says predictability is too low and means it).
+const OUTLOOK_EXPER_BASE: &str = "https://www.spc.noaa.gov/products/exper/day4-8";
 const MD_URL: &str = "https://mapservices.weather.noaa.gov/vector/rest/services/outlooks/spc_mesoscale_discussion/MapServer/0/query?where=1%3D1&outFields=*&f=geojson";
 
 /// Fill color for a categorical risk label, when the GeoJSON doesn't supply one.
@@ -209,18 +214,23 @@ pub fn parse_md(json: &str) -> anyhow::Result<Vec<GeoFeature>> {
     Ok(out)
 }
 
-/// Fetch the categorical outlook for `day` (1–3).
+/// Fetch the categorical outlook for `day` (1–3), or the severe probability for a Day 4–8.
 pub async fn fetch_outlook(client: &reqwest::Client, day: u8) -> anyhow::Result<Vec<GeoFeature>> {
     fetch_outlook_kind(client, day, OutlookKind::Categorical).await
 }
 
-/// Fetch an outlook for `day` and hazard `kind` (probabilistic layers are Day-1 only).
+/// Fetch an outlook for `day` and hazard `kind`. Probabilistic hazard layers are Day-1 only;
+/// Days 4–8 ignore `kind` and fetch the single experimental probability layer.
 pub async fn fetch_outlook_kind(
     client: &reqwest::Client,
     day: u8,
     kind: OutlookKind,
 ) -> anyhow::Result<Vec<GeoFeature>> {
-    let url = format!("{OUTLOOK_BASE}/day{day}otlk_{}.lyr.geojson", kind.slug());
+    let url = if day >= 4 {
+        format!("{OUTLOOK_EXPER_BASE}/day{day}prob.lyr.geojson")
+    } else {
+        format!("{OUTLOOK_BASE}/day{day}otlk_{}.lyr.geojson", kind.slug())
+    };
     let body = client
         .get(crate::net::fetch_url(&url))
         .header("User-Agent", USER_AGENT)


### PR DESCRIPTION
Fifth batch of the R13 feature expansion: two feeds, one commit each.

- **SPC Day 4–8 severe probabilities.** The outlook day selector runs to D8.
  Days 4–8 are SPC's experimental single probability layer (no hazard split, no
  categorical risk — that far out it is one severe probability, or
  "predictability too low"), so only the URL form differs and the existing
  parser handles the rest. New `--headless-outlooks` prints all eight days, so a
  change to either URL form fails there rather than as an empty map.
- **TAFs on the station tooltips.** Hovering a station shows the observation and
  then the terminal forecast. Same bbox and same job as the observations, so it
  is one extra request per refresh; an outage costs the tooltip its forecast
  line and nothing else. Raw text, not decoded rows — a TAF is written to be
  read as a TAF.

**Not in this batch, and why**

- *SPC watch parallelograms*: the watch itself already arrives through the NWS
  alert feed and draws today; the parallelogram is a second geometry source for
  a polygon the user can already see. Worth doing, not worth doing first.
- *NWS text-product browser*: generalising the AFD window over
  `api.weather.gov/products` is a window's worth of work, not a small commit.
- *USGS earthquakes*: needs a new point layer, its own draw code and a toggle;
  the value in a radar app did not justify it ahead of the other two.
- *HMS smoke plumes*: still shapefile/KML daily with no ArcGIS REST mirror
  found, which the plan pre-authorised deferring.

Verified: `cargo clippy --workspace --all-targets`, `cargo test --workspace`
(419 passed), wasm `cargo check`, `./scripts/shots/shoot.sh check`, and both
new feeds against live data (`--headless-outlooks`, `--headless-metar KTLX`:
62 obs, 16 TAFs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)