### PR TITLE
Android device pass — drop PiP, fix widget JNI crash and bitmap size

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -59,9 +59,8 @@
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTask"
-            android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|keyboard|keyboardHidden|navigation|uiMode|density|smallestScreenSize"
+            android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|keyboard|keyboardHidden|navigation|uiMode|density"
             android:screenOrientation="sensor"
-            android:supportsPictureInPicture="true"
             android:windowSoftInputMode="adjustResize"
             android:exported="true"
             android:label="@string/app_name">

--- a/android/app/src/main/kotlin/zip/batman/hookecho/MainActivity.kt
+++ b/android/app/src/main/kotlin/zip/batman/hookecho/MainActivity.kt
@@ -80,35 +80,6 @@ class MainActivity : GameActivity() {
         File(filesDir, "import.txt").writeText("$pendingImport\t${dest.absolutePath}")
     }
 
-    /**
-     * Called from Rust: shrink the app into a picture-in-picture window so the loop keeps playing
-     * over whatever the user does next. No-op on a device that does not support PiP.
-     */
-    @Suppress("unused")
-    fun enterPip() {
-        runOnUiThread {
-            if (!packageManager.hasSystemFeature(android.content.pm.PackageManager.FEATURE_PICTURE_IN_PICTURE)) {
-                return@runOnUiThread
-            }
-            runCatching {
-                enterPictureInPictureMode(
-                    android.app.PictureInPictureParams.Builder()
-                        .setAspectRatio(android.util.Rational(4, 3))
-                        .build()
-                )
-            }
-        }
-    }
-
-    /**
-     * The Rust side hides its chrome in PiP — at that size a sidebar and a timeline leave no map
-     * at all, and none of it is touchable through a PiP window anyway.
-     */
-    override fun onPictureInPictureModeChanged(inPip: Boolean, config: android.content.res.Configuration) {
-        super.onPictureInPictureModeChanged(inPip, config)
-        nativeOnPipChanged(inPip)
-    }
-
     /** Called from Rust when what back would do changes. */
     @Suppress("unused")
     fun setBackConsumed(consumed: Boolean) {
@@ -116,8 +87,6 @@ class MainActivity : GameActivity() {
     }
 
     private external fun nativeOnBack()
-
-    private external fun nativeOnPipChanged(inPip: Boolean)
 
     /**
      * Back out of the app and the process has to go with it.

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -12394,14 +12394,6 @@ impl HookEchoApp {
                 ui.checkbox(&mut v.show_radar, "Radar");
                 ui.checkbox(&mut v.show_legend, "Legend");
             }
-            if cfg!(target_os = "android")
-                && ui
-                    .button("\u{1f5d6} Picture-in-picture")
-                    .on_hover_text("Shrink to a floating window with the loop still playing")
-                    .clicked()
-            {
-                crate::platform::enter_pip();
-            }
             if ui
                 .checkbox(&mut self.obs_mode, "Streamer / OBS mode (F8)")
                 .on_hover_text(
@@ -12891,10 +12883,12 @@ impl HookEchoApp {
     /// Write the widget's picture, downscaled, and tell the widget about it.
     ///
     /// Downscaled because `RemoteViews.setImageViewBitmap` sends the bitmap over a Binder
-    /// transaction, and a phone-screen-sized bitmap is comfortably past the ~1 MB limit — the
-    /// widget would throw rather than draw. A home-screen tile is a few hundred pixels wide.
+    /// transaction with a ~1 MB ceiling, and the decoded bitmap is 4 bytes a pixel — so the budget
+    /// is in *pixels*, not width. 150k of them is ~600 KB decoded, and more than a home-screen
+    /// tile can show anyway. (A full-screen 1440x3120 grab is 18 MB decoded: the widget would
+    /// throw rather than draw.)
     fn save_widget_snapshot(&self, path: &std::path::Path, image: &egui::ColorImage) {
-        const MAX_W: u32 = 640;
+        const MAX_PIXELS: f32 = 150_000.0;
         let (w, h) = (image.size[0] as u32, image.size[1] as u32);
         if w == 0 || h == 0 {
             return;
@@ -12906,9 +12900,13 @@ impl HookEchoApp {
         let Some(buf) = image::RgbaImage::from_raw(w, h, rgba) else {
             return;
         };
-        let small = if w > MAX_W {
-            let nh = (h as f32 * MAX_W as f32 / w as f32).round().max(1.0) as u32;
-            image::imageops::resize(&buf, MAX_W, nh, image::imageops::FilterType::Triangle)
+        let scale = (MAX_PIXELS / (w as f32 * h as f32)).sqrt();
+        let small = if scale < 1.0 {
+            let (nw, nh) = (
+                ((w as f32 * scale).round() as u32).max(1),
+                ((h as f32 * scale).round() as u32).max(1),
+            );
+            image::imageops::resize(&buf, nw, nh, image::imageops::FilterType::Triangle)
         } else {
             buf
         };
@@ -14484,9 +14482,7 @@ impl eframe::App for HookEchoApp {
 
         // Docked desktop chrome. Declared before every floating Area so those constrain to what's
         // left of the viewport (`self.chrome_rect`) instead of covering the bars.
-        // Picture-in-picture counts as chrome-free for the same reason OBS mode does: at that
-        // size the panels are the whole window, and nothing in a PiP window takes touches anyway.
-        let bare = self.obs_mode || crate::platform::in_pip();
+        let bare = self.obs_mode;
         if !cfg!(target_os = "android") && !bare {
             if !self.settings.hide_sidebar {
                 self.sidebar(root, ctx);

--- a/crates/hookecho/src/platform.rs
+++ b/crates/hookecho/src/platform.rs
@@ -504,32 +504,10 @@ mod android_back {
     }
 }
 
-/// Picture-in-picture: shrink the app into a floating window with the loop still playing.
-///
-/// Two directions again, same shape as predictive back: Rust asks the activity to enter PiP, and
-/// the activity calls back when the mode changes so the UI can drop its chrome — at PiP size a
-/// sidebar and a timeline leave no map, and nothing in a PiP window is touchable anyway.
+/// The home-screen radar widget's one call into Java: "there is a new picture on disk".
 #[cfg(target_os = "android")]
-mod android_pip {
+mod android_widget {
     use jni::objects::JObject;
-    use std::sync::atomic::{AtomicBool, Ordering};
-
-    static IN_PIP: AtomicBool = AtomicBool::new(false);
-
-    /// # Safety
-    /// Called by the JVM with a valid env/object pair; touches only an atomic.
-    #[unsafe(no_mangle)]
-    pub extern "system" fn Java_zip_batman_hookecho_MainActivity_nativeOnPipChanged(
-        _env: jni::JNIEnv,
-        _this: JObject,
-        in_pip: jni::sys::jboolean,
-    ) {
-        IN_PIP.store(in_pip != 0, Ordering::Relaxed);
-    }
-
-    pub fn in_pip() -> bool {
-        IN_PIP.load(Ordering::Relaxed)
-    }
 
     /// Tell the home-screen radar widget a new picture is on disk.
     pub fn refresh_radar_widget() {
@@ -546,7 +524,27 @@ mod android_pip {
         let vm = unsafe { jni::JavaVM::from_raw(app.vm_as_ptr() as *mut jni::sys::JavaVM) }?;
         let mut env = vm.attach_current_thread()?;
         let activity = unsafe { JObject::from_raw(app.activity_as_ptr() as jni::sys::jobject) };
-        let class = env.find_class("zip/batman/hookecho/RadarWidget")?;
+        // The app's own ClassLoader, not `find_class`: a thread attached from Rust gets the
+        // *system* loader, which has no app dex on its path, so `find_class` leaves a pending
+        // ClassNotFoundException and the next JNI call aborts the runtime under -Xcheck:jni.
+        // (Same reason `android_alerts::try_set` does this.)
+        let loader = env
+            .call_method(
+                &activity,
+                "getClassLoader",
+                "()Ljava/lang/ClassLoader;",
+                &[],
+            )?
+            .l()?;
+        let name = env.new_string("zip.batman.hookecho.RadarWidget")?;
+        let class = env
+            .call_method(
+                &loader,
+                "loadClass",
+                "(Ljava/lang/String;)Ljava/lang/Class;",
+                &[(&name).into()],
+            )?
+            .l()?;
         let class = JClass::from(class);
         let res = env.call_static_method(
             &class,
@@ -559,39 +557,7 @@ mod android_pip {
         }
         res.map(|_| ())
     }
-
-    /// Ask the activity for PiP. Failures are logged and otherwise ignored: a device without the
-    /// feature simply stays as it was.
-    pub fn enter_pip() {
-        if let Err(e) = call() {
-            log::warn!("picture-in-picture request failed: {e:?}");
-        }
-    }
-
-    fn call() -> jni::errors::Result<()> {
-        let Some(app) = super::android::app() else {
-            return Ok(());
-        };
-        let vm = unsafe { jni::JavaVM::from_raw(app.vm_as_ptr() as *mut jni::sys::JavaVM) }?;
-        let mut env = vm.attach_current_thread()?;
-        let activity = unsafe { JObject::from_raw(app.activity_as_ptr() as jni::sys::jobject) };
-        let res = env.call_method(&activity, "enterPip", "()V", &[]);
-        if res.is_err() {
-            let _ = env.exception_clear();
-        }
-        res.map(|_| ())
-    }
 }
-
-/// Whether the app is currently in a picture-in-picture window (Android only).
-#[cfg(not(target_os = "android"))]
-pub fn in_pip() -> bool {
-    false
-}
-
-/// Shrink into a picture-in-picture window (no-op off Android).
-#[cfg(not(target_os = "android"))]
-pub fn enter_pip() {}
 
 /// Nudge the Android home-screen radar widget after a new snapshot (no-op elsewhere).
 #[cfg(not(target_os = "android"))]
@@ -1053,9 +1019,9 @@ pub use android_ime::{clipboard_text, pump_ime, show_soft_input};
 #[cfg(target_os = "android")]
 pub use android_location::start_location;
 #[cfg(target_os = "android")]
-pub use android_pip::{enter_pip, in_pip, refresh_radar_widget};
-#[cfg(target_os = "android")]
 pub use android_tts::speak;
+#[cfg(target_os = "android")]
+pub use android_widget::refresh_radar_widget;
 
 /// Timeouts for an HTTP client, where the platform has them.
 ///


### PR DESCRIPTION
The device pass PR #24 said it needed. Built with the SDK at `~/android-tools`,
run on the S24 Ultra (Android 15).

**Crash, fixed.** The app aborted on launch: `find_class` from a Rust-attached
thread resolves against the *system* classloader, which has no app dex on its
path, so `RadarWidget` was not found, the pending `ClassNotFoundException` hit
the next JNI call and `-Xcheck:jni` aborted the runtime. Now loaded through the
activity's own classloader, the way `android_alerts::try_set` already did.

**Widget bitmap, fixed.** `RemoteViews` ships bitmaps over a Binder transaction
capped near 1 MB, and a decoded bitmap is 4 bytes a pixel — so the budget is
pixels, not width. The old 640-px cap still made a 3.5 MB bitmap on a 1440x3120
screen. Now 150k pixels: 263x570, ~600 KB decoded here.

**Picture-in-picture, removed.** The transition fires and the window appears,
but the contents freeze on the frame from when the app shrank: chrome still
shown, radar never advancing, confirmed by diffing screenshots 15 s apart with
a clean process (and a `request_repaint`-every-frame attempt changed nothing).
The loop is still running — the process burns ~80% of a core in PiP — so the
surface after the transition is not the one being drawn to. Re-acquiring the
window in the native loop is a different piece of work from a menu item, and a
frozen thumbnail claiming to be a live loop is worse than no feature.

**Verified on device**
- Launches, renders live radar (KFWS), no JNI or native errors.
- `files/widget-radar.png` written on the 5-minute cadence, 263x570, and is a
  real radar view.
- Quick-settings tile: `cmd statusbar add-tile` registers it, `click-tile`
  brings the app to the foreground.
- `RadarWidget` provider registered in `dumpsys appwidget`.

**Still unverified**: the widget's own drawing on the home screen. Placing a
widget needs the launcher UI and cannot be driven over adb; the protected
`APPWIDGET_UPDATE` broadcast is refused from the shell uid.

Desktop suite: `cargo clippy --workspace --all-targets`, `cargo test
--workspace` (422 passed), wasm `cargo check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)