### PR TITLE
R14 pack 2 — desktop comforts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,11 +40,28 @@ jobs:
             --headless-icon /tmp/icon.png
           test -s /tmp/icon.png
 
+      # The .deb is built on the same runner: it wants the same glibc floor, the same release
+      # binary, and `$auto` resolves its dependencies against whatever libs this image carries.
+      - name: Install cargo-deb
+        run: cargo install cargo-deb --locked --version ^3.7
+
+      - name: Build .deb
+        run: |
+          bash packaging/build-deb.sh
+          cp target/debian/*.deb dist/
+          dpkg -c dist/*.deb
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: Hook_Echo-WX-x86_64.AppImage
           path: dist/Hook_Echo-WX-x86_64.AppImage
+
+      - name: Upload .deb artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: hookecho-deb
+          path: dist/*.deb
 
       # The tag's own CHANGELOG section becomes the release body. Empty means the section is
       # missing, which is worth failing the release over — a release with no notes is the state
@@ -66,7 +83,9 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           body_path: notes.md
-          files: dist/Hook_Echo-WX-x86_64.AppImage
+          files: |
+            dist/Hook_Echo-WX-x86_64.AppImage
+            dist/*.deb
 
       # Every push to main refreshes a rolling "latest" prerelease, so the Releases page always
       # carries current builds. Before this, artifacts only ever reached Releases on a tag push,
@@ -82,7 +101,9 @@ jobs:
           body: |
             Rolling build of `main` — rebuilt and re-published on every push, so this
             is always the newest code. Older releases are kept as drafts.
-          files: dist/Hook_Echo-WX-x86_64.AppImage
+          files: |
+            dist/Hook_Echo-WX-x86_64.AppImage
+            dist/*.deb
 
   windows:
     name: Windows zip

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ built from NOAA's free GRIB grids, so it needs no API key.</sub>
 ## Install
 
 - **Linux**: download `Hook_Echo-WX-x86_64.AppImage` from
-  [Releases](../../releases), `chmod +x`, run.
+  [Releases](../../releases), `chmod +x`, run. Debian/Ubuntu users can install
+  `hookecho_<version>_amd64.deb` from the same place
+  (`sudo apt install ./hookecho_*.deb`) to get the menu entry and icon.
 - **Windows**: grab the installer from [Releases](../../releases) —
   `Hook_Echo-WX-setup-x86_64.exe` (setup wizard) or `Hook_Echo-WX-x86_64.msi`
   (MSI, for scripted/enterprise installs). A portable

--- a/crates/hookecho/Cargo.toml
+++ b/crates/hookecho/Cargo.toml
@@ -150,3 +150,26 @@ android_logger = "0.14"
 # System clipboard bridge (paste into egui text fields); the soft-keyboard calls go through
 # android-activity's built-in helpers instead.
 jni = "0.21"
+
+# Debian package (`cargo deb -p hookecho`). Same payload as the AppImage — binary, desktop entry,
+# AppStream metainfo, icon — but installed into the system so the distro's own menu, icon cache and
+# updater handle it. The icon is rendered by the built binary (`--headless-icon`) into
+# `target/deb-assets/`, so no PNG is committed; `packaging/build-deb.sh` does that first.
+[package.metadata.deb]
+maintainer = "d4vid87 <davidmay87@gmail.com>"
+copyright = "2026, Hook Echo-WX contributors"
+license-file = ["../../LICENSE", "0"]
+extended-description = """\
+Hook Echo-WX renders NEXRAD Level II and Level III radar with dual-pol moments, \
+storm-relative velocity, derived products, warnings, satellite and lightning — \
+locally, with no account and no central server."""
+section = "science"
+priority = "optional"
+depends = "$auto"
+assets = [
+    ["../../target/release/hookecho", "usr/bin/", "755"],
+    ["../../packaging/hookecho.desktop", "usr/share/applications/", "644"],
+    ["../../packaging/zip.batman.hookecho.metainfo.xml", "usr/share/metainfo/", "644"],
+    ["../../target/deb-assets/hookecho-256.png", "usr/share/icons/hicolor/256x256/apps/hookecho.png", "644"],
+    ["../../target/deb-assets/hookecho-128.png", "usr/share/icons/hicolor/128x128/apps/hookecho.png", "644"],
+]

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1867,6 +1867,15 @@ pub struct HookEchoApp {
     rotation_alerted: std::collections::HashMap<String, Instant>,
     /// Volume start time of the last new-scan chime (see `scan_chime`).
     last_chime: Option<chrono::DateTime<Utc>>,
+    /// Pushes held back by quiet hours, replayed as one summary when the window ends.
+    ///
+    /// A `Mutex` because `notify_alert` takes `&self` (ten call sites); a lock beats threading
+    /// `&mut` through all of them.
+    // ponytail: not persisted — a quiet window that spans a restart loses its catch-up. Persist
+    // alongside the chase log if anyone misses it.
+    quiet_queue: std::sync::Mutex<Vec<(String, String)>>,
+    /// Whether the last frame was inside quiet hours, so the end of the window is an edge.
+    was_quiet: bool,
     /// Where a requested screenshot should go once the image event arrives.
     screenshot_pending: Option<ShotDest>,
     /// A capture waiting on the share-card footer to be on screen: the destination, and how many
@@ -2553,6 +2562,8 @@ impl HookEchoApp {
             snapshot_push: None,
             rotation_alerted: std::collections::HashMap::new(),
             last_chime: None,
+            quiet_queue: std::sync::Mutex::new(Vec::new()),
+            was_quiet: false,
             screenshot_pending: None,
             share_card: None,
             loop_export: None,
@@ -4105,6 +4116,11 @@ impl HookEchoApp {
         // machine and what makes noise, not what the app knows.
         if !urgent && self.in_quiet_hours() {
             log::debug!("quiet hours: holding push {title:?}");
+            if let Ok(mut q) = self.quiet_queue.lock() {
+                if q.len() < QUIET_QUEUE_MAX {
+                    q.push((title.to_string(), body.to_string()));
+                }
+            }
             return;
         }
         let http = self.http.clone();
@@ -14184,6 +14200,21 @@ impl eframe::App for HookEchoApp {
                 self.spawn_overlay(ctx, OverlaySource::HrrrLayer(layer, fh));
             }
         }
+        // Quiet hours just ended: replay what it held back as one push, so waking up to a silent
+        // night does not mean waking up to no idea what happened during it.
+        let now_quiet = self.in_quiet_hours();
+        if self.was_quiet && !now_quiet {
+            let held = match self.quiet_queue.lock() {
+                Ok(mut q) => std::mem::take(&mut *q),
+                Err(_) => Vec::new(),
+            };
+            if !held.is_empty() {
+                let (title, body) = quiet_summary(&held);
+                self.notify_alert(&title, &body, false);
+            }
+        }
+        self.was_quiet = now_quiet;
+
         // GOES lightning: granules land every 20 s, so poll about that often. One in flight at a
         // time — a slow fetch must not queue up behind itself.
         if self.show_glm
@@ -15368,6 +15399,65 @@ impl eframe::App for HookEchoApp {
             100
         };
         ctx.request_repaint_after(std::time::Duration::from_millis(idle));
+    }
+}
+
+/// How many held-back pushes the quiet-hours queue keeps. A long quiet window over a big outbreak
+/// can queue hundreds; the summary only names a handful anyway.
+const QUIET_QUEUE_MAX: usize = 50;
+
+/// Fold the pushes quiet hours held back into one catch-up notification: `(title, body)`.
+///
+/// Named headlines are capped so the body stays inside what a phone push will show; the rest are
+/// counted.
+fn quiet_summary(held: &[(String, String)]) -> (String, String) {
+    const NAMED: usize = 4;
+    let title = if held.len() == 1 {
+        "1 alert while you were away".to_string()
+    } else {
+        format!("{} alerts while you were away", held.len())
+    };
+    let mut body: String = held
+        .iter()
+        .take(NAMED)
+        .map(|(t, _)| t.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    if held.len() > NAMED {
+        body.push_str(&format!("\n(+{} more)", held.len() - NAMED));
+    }
+    (title, body)
+}
+
+#[cfg(test)]
+mod quiet_summary_tests {
+    use super::quiet_summary;
+
+    fn held(n: usize) -> Vec<(String, String)> {
+        (0..n)
+            .map(|i| (format!("alert {i}"), "body".to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn one_alert_reads_singular() {
+        let (title, body) = quiet_summary(&held(1));
+        assert_eq!(title, "1 alert while you were away");
+        assert_eq!(body, "alert 0");
+    }
+
+    #[test]
+    fn many_alerts_name_a_few_and_count_the_rest() {
+        let (title, body) = quiet_summary(&held(9));
+        assert_eq!(title, "9 alerts while you were away");
+        assert!(body.starts_with("alert 0\nalert 1\nalert 2\nalert 3\n"));
+        assert!(body.ends_with("(+5 more)"));
+    }
+
+    #[test]
+    fn exactly_the_named_count_has_no_tail() {
+        let (_, body) = quiet_summary(&held(4));
+        assert!(!body.contains("more"));
     }
 }
 

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1023,6 +1023,8 @@ pub(crate) enum OverlayToggle {
     GlmLightning,
     Wind,
     LinkCameras,
+    /// The always-on-top mini-loop window (desktop only).
+    MiniLoop,
     /// Beam-vs-terrain blockage shading for the displayed tilt (chase mode).
     Blockage,
 }
@@ -1041,7 +1043,7 @@ pub(crate) struct BlockageKey {
 impl OverlayToggle {
     /// Every toggle, for the persistence sweep. A new variant belongs here too, or it silently
     /// stops being remembered across restarts.
-    pub(crate) const ALL: [OverlayToggle; 33] = [
+    pub(crate) const ALL: [OverlayToggle; 34] = [
         Self::AlertPanel,
         Self::StormReports,
         Self::Spotters,
@@ -1074,8 +1076,16 @@ impl OverlayToggle {
         Self::GlmLightning,
         Self::Wind,
         Self::LinkCameras,
+        Self::MiniLoop,
         Self::Blockage,
     ];
+
+    /// Toggles that describe this session's window arrangement rather than a layer: camera
+    /// linking is about the panes on screen right now, and the mini loop is a window. Neither is
+    /// persisted or captured into a workspace.
+    pub(crate) fn session_only(self) -> bool {
+        matches!(self, Self::LinkCameras | Self::MiniLoop)
+    }
 
     /// Stable name used in the settings file. Persisted as a string, not as the enum: an unknown
     /// name written by a newer build has to be skippable, and a failed `Settings` parse takes the
@@ -1884,6 +1894,8 @@ pub struct HookEchoApp {
     loop_export: Option<LoopExport>,
     /// When true, all panes share the active pane's camera.
     link_cameras: bool,
+    /// The always-on-top mini-loop window is open (desktop only; see `mini_loop_viewport`).
+    mini_loop: bool,
     /// National gridded field layers (MRMS mosaic, rotation, MESH, AzShear, lightning), each with
     /// its own toggle + pending GPU upload + refresh throttle. Keyed by [`crate::render::FieldLayer`].
     fields: std::collections::HashMap<crate::render::FieldLayer, FieldState>,
@@ -2568,6 +2580,7 @@ impl HookEchoApp {
             share_card: None,
             loop_export: None,
             link_cameras: false,
+            mini_loop: false,
             cells_site: None,
             cell_trends: std::collections::HashMap::new(),
             fields: crate::render::FieldLayer::DRAW_ORDER
@@ -6446,6 +6459,7 @@ impl HookEchoApp {
             T::Pireps => &mut self.show_pireps,
             T::Recon => &mut self.show_recon,
             T::LinkCameras => &mut self.link_cameras,
+            T::MiniLoop => &mut self.mini_loop,
             T::Blockage => &mut self.show_blockage,
         }
     }
@@ -7018,6 +7032,13 @@ impl HookEchoApp {
                 "Reference",
                 "Link pane cameras",
                 "Pan and zoom every pane together",
+                false,
+            ),
+            (
+                T::MiniLoop,
+                "Reference",
+                "Mini loop window",
+                "A small always-on-top window showing the active pane",
                 false,
             ),
         ] {
@@ -9641,6 +9662,115 @@ impl HookEchoApp {
                 self.views[idx].error = Some(e.to_string());
                 (None, false)
             }
+        }
+    }
+
+    /// The always-on-top mini loop: a small undecorated window showing the active pane, so the
+    /// radar stays visible over whatever else is on screen.
+    ///
+    /// An *immediate* viewport, not a deferred one: deferred viewports run their closure on the
+    /// egui side and demand `'static + Send + Sync`, which `HookEchoApp` is not (wgpu handles,
+    /// `Rc`s in the tile caches). Immediate renders inline on this thread, which is exactly what
+    /// reusing [`Self::render_pane`] needs.
+    // ponytail: shares the active pane's camera, so panning in the mini loop pans the main window
+    // too. Give it its own MapView if that turns out to be the point of it. Not persisted either:
+    // it is a window, not a layer (see `OverlayToggle::session_only`).
+    #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
+    fn mini_loop_viewport(&mut self, ctx: &egui::Context) {
+        if !self.mini_loop {
+            return;
+        }
+        let idx = self.active.min(self.views.len() - 1);
+        let style = self.views[idx].basemap;
+        let is_vector = matches!(
+            style,
+            crate::tiles::BasemapStyle::Dark | crate::tiles::BasemapStyle::Light
+        );
+        let is_raster = style.is_raster();
+        let caption = {
+            let v = &self.views[idx];
+            let time = v
+                .volume
+                .as_ref()
+                .map_or_else(|| "—".to_string(), |vol| vol.time.format("%H:%MZ").to_string());
+            format!(
+                "{} {} {time}",
+                v.site.as_deref().unwrap_or("—"),
+                v.moment.short_name()
+            )
+        };
+        let builder = egui::ViewportBuilder::default()
+            .with_title("Hook Echo-WX — mini loop")
+            .with_inner_size([340.0, 260.0])
+            .with_decorations(false)
+            // ponytail: GNOME's Wayland compositor ignores this by policy; X11 and KDE honour it.
+            .with_always_on_top();
+        let mut close = false;
+        ctx.show_viewport_immediate(
+            egui::ViewportId::from_hash_of("mini-loop"),
+            builder,
+            |ctx, _class| {
+                egui::CentralPanel::default()
+                    .frame(egui::Frame::NONE)
+                    .show(ctx, |ui| {
+                        let full = ui.max_rect();
+                        // Undecorated, so we draw our own caption strip: label, drag handle, close.
+                        let (bar, prect) = (
+                            egui::Rect::from_min_max(
+                                full.min,
+                                egui::pos2(full.max.x, full.min.y + 18.0),
+                            ),
+                            egui::Rect::from_min_max(
+                                egui::pos2(full.min.x, full.min.y + 18.0),
+                                full.max,
+                            ),
+                        );
+                        ui.painter()
+                            .rect_filled(bar, 0.0, egui::Color32::from_gray(24));
+                        let handle = ui.interact(
+                            bar,
+                            egui::Id::new("mini-loop-bar"),
+                            egui::Sense::click_and_drag(),
+                        );
+                        if handle.drag_started() {
+                            ui.ctx().send_viewport_cmd(egui::ViewportCommand::StartDrag);
+                        }
+                        ui.painter().text(
+                            bar.left_center() + egui::vec2(6.0, 0.0),
+                            egui::Align2::LEFT_CENTER,
+                            &caption,
+                            egui::FontId::proportional(11.0),
+                            egui::Color32::from_gray(190),
+                        );
+                        let x = egui::Rect::from_center_size(
+                            bar.right_center() - egui::vec2(10.0, 0.0),
+                            egui::vec2(16.0, 16.0),
+                        );
+                        if ui
+                            .interact(x, egui::Id::new("mini-loop-close"), egui::Sense::click())
+                            .clicked()
+                        {
+                            close = true;
+                        }
+                        ui.painter().text(
+                            x.center(),
+                            egui::Align2::CENTER_CENTER,
+                            "✕",
+                            egui::FontId::proportional(11.0),
+                            egui::Color32::from_gray(190),
+                        );
+                        let vctx = ui.ctx().clone();
+                        self.render_pane(
+                            ui, &vctx, idx, prect, is_vector, is_raster, false, false, false, &[],
+                        );
+                    });
+                if ctx.input(|i| i.viewport().close_requested()) {
+                    close = true;
+                }
+            },
+        );
+        if close {
+            self.mini_loop = false;
         }
     }
 
@@ -12292,7 +12422,7 @@ impl HookEchoApp {
     fn capture_workspace(&mut self) -> crate::workspace::Workspace {
         let overlays_on: Vec<String> = OverlayToggle::ALL
             .into_iter()
-            .filter(|t| *t != OverlayToggle::LinkCameras && *self.overlay_flag(*t))
+            .filter(|t| !t.session_only() && *self.overlay_flag(*t))
             .map(|t| t.slug())
             .collect();
         crate::workspace::Workspace {
@@ -12343,7 +12473,7 @@ impl HookEchoApp {
         self.link_cameras = ws.link_cameras;
         // Overlay names this build doesn't know are skipped, same as the settings restore.
         for t in OverlayToggle::ALL {
-            if t == OverlayToggle::LinkCameras {
+            if t.session_only() {
                 continue;
             }
             *self.overlay_flag(t) = ws.overlays_on.iter().any(|s| *s == t.slug());
@@ -15349,7 +15479,7 @@ impl eframe::App for HookEchoApp {
             let on: Vec<String> = OverlayToggle::ALL
                 .into_iter()
                 // Camera linking is a session decision about the panes on screen, not a layer.
-                .filter(|t| *t != OverlayToggle::LinkCameras && *self.overlay_flag(*t))
+                .filter(|t| !t.session_only() && *self.overlay_flag(*t))
                 .map(|t| t.slug())
                 .collect();
             self.settings.overlays_on = on;
@@ -15387,6 +15517,9 @@ impl eframe::App for HookEchoApp {
                     });
             }
         }
+
+        #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
+        self.mini_loop_viewport(ctx);
 
         // Idle heartbeat so clocks (volume age, countdowns) tick without input. Data arrivals and
         // animations (pulse, banners) request faster repaints on their own. Slower on Android to

--- a/packaging/build-deb.sh
+++ b/packaging/build-deb.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Build the Debian package of Hook Echo-WX.
+#
+# cargo-deb does the packaging; this script only does the two things it can't: build the release
+# binary and render the icons out of it (`--headless-icon`), which is why no PNG is committed. The
+# asset list lives in `crates/hookecho/Cargo.toml` under `[package.metadata.deb]`.
+#
+# Usage: packaging/build-deb.sh
+# Output: target/debian/hookecho_<version>_amd64.deb
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+echo "==> building release binary"
+cargo build --release -p hookecho
+
+echo "==> rendering icons"
+mkdir -p target/deb-assets
+for px in 128 256; do
+  ./target/release/hookecho --headless-icon "target/deb-assets/hookecho-${px}.png" "$px"
+done
+
+echo "==> packaging"
+# --no-build: we just built it, and cargo-deb's own build would not reuse the profile above.
+cargo deb -p hookecho --no-build
+
+ls -l target/debian/*.deb


### PR DESCRIPTION
Three independent desktop-side improvements.

**Quiet-hours catch-up.** Non-urgent pushes held back by quiet hours were dropped on the floor, so a quiet night meant waking up with no idea what the app had seen. They now go into a bounded queue (50) and, on the edge where the window ends, one summary push names the first four and counts the rest. `quiet_summary` is a pure function with unit tests.

**Debian package.** `cargo deb -p hookecho` from `[package.metadata.deb]`, driven by `packaging/build-deb.sh`, which builds the release binary and renders the icons out of it (`--headless-icon`) so no PNG is committed. Built on the same ubuntu-22.04 runner as the AppImage — same glibc floor, and `$auto` resolves depends there. Attached to tagged and rolling `latest` releases.

Verified locally:
```
$ dpkg -I target/debian/hookecho_0.8.0-1_amd64.deb | grep -E 'Section|Depends'
 Section: science
 Depends: libasound2t64 (>= 1.0.29), libc6 (>= 2.43)
```
with `usr/bin/hookecho`, the desktop entry, the AppStream metainfo and 128/256 px hicolor icons in the payload.

**Mini loop window.** A small undecorated always-on-top viewport rendering the active pane through the same `render_pane` path, with its own caption strip (drag, close). Toggle: "Mini loop window" in the command palette / layers panel. Desktop only.

It must be an *immediate* viewport — deferred viewports require `'static + Send + Sync`, which `HookEchoApp` is not. The mini loop shares the active pane's camera (noted in a `ponytail:` comment) and is session-only, not persisted, alongside `LinkCameras`.

Smoke-tested under Xvfb: both windows map, the pane renders in the small one, no crash. `with_always_on_top()` is ignored by GNOME's Wayland compositor by policy; X11 and KDE honour it.

## Verification

```
cargo clippy --workspace --all-targets   # clean
cargo test --workspace                   # 425 passed, 27 ignored
RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check --target wasm32-unknown-unknown -p hookecho --lib
./scripts/shots/shoot.sh check           # passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)