### PR TITLE
R14 pack 3 — GLM flash-extent density

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1227,6 +1227,11 @@ pub(crate) struct PaletteEntry {
     pub key: Option<String>,
 }
 
+/// GLM flash-extent density grid: cell size in degrees (~5 km), and how far back it counts.
+/// Both fixed — they are legibility choices, not tuning knobs.
+const GLM_FED_CELL_DEG: f64 = 0.05;
+const GLM_FED_WINDOW_MIN: i64 = 15;
+
 /// Refresh cadence (seconds) for a national field layer's product.
 fn field_refresh_secs(layer: crate::render::FieldLayer) -> u64 {
     use crate::render::FieldLayer as FL;
@@ -1257,6 +1262,8 @@ fn field_refresh_secs(layer: crate::render::FieldLayer) -> u64 {
         FL::Cape | FL::Srh => 900,
         // Derived products cost no network: they recompute when the volume does, not on a clock.
         FL::VilLocal | FL::VilDensity | FL::EtopLocal | FL::HailMehs | FL::HailPosh => 60,
+        // Gridded from the GLM feed the app already polls every 20 s; regridding is local work.
+        FL::GlmFed => 60,
     }
 }
 
@@ -5751,6 +5758,8 @@ impl HookEchoApp {
                         egui::CollapsingHeader::new("Layer options")
                             .default_open(false)
                             .show(ui, |ui| {
+                                let glm_options = self.show_glm
+                                    || self.fields.get(&crate::render::FieldLayer::GlmFed).is_some_and(|s| s.show);
                                 crate::ui::layer_options::show(
                                     ui,
                                     &mut self.filters,
@@ -5774,7 +5783,7 @@ impl HookEchoApp {
                                     &mut self.diff_field,
                                     self.diff_valid.as_ref(),
                                     &mut self.settings.lightning_minutes,
-                                    self.show_glm,
+                                    glm_options,
                                     &mut self.settings.glm_goes_west,
                                     self.show_spotters,
                                     &mut self.settings.spotter_range_km,
@@ -6617,6 +6626,13 @@ impl HookEchoApp {
                 "National",
                 "Hydrometeor class (L3)",
                 "What the radar thinks it's seeing: rain, hail, debris",
+                false,
+            ),
+            (
+                FL::GlmFed,
+                "National",
+                "Flash density (GLM)",
+                "Where the satellite flashes are densest \u{2014} the total-lightning field                  behind the individual dots, and where a lightning jump shows up first.",
                 false,
             ),
             (
@@ -14052,6 +14068,7 @@ impl eframe::App for HookEchoApp {
                     | FL::Snowfall
                     | FL::SnowAnalysis
                     | FL::ModelDiff
+                    | FL::GlmFed
             ) {
                 continue;
             }
@@ -14098,7 +14115,8 @@ impl eframe::App for HookEchoApp {
                     | FL::GlobalTemp2m
                     | FL::GlobalWind10m
                     | FL::GlobalPrecip
-                    | FL::ModelDiff => unreachable!(),
+                    | FL::ModelDiff
+                    | FL::GlmFed => unreachable!(),
                 };
                 self.spawn_overlay(ctx, OverlaySource::Field(layer, product));
             }
@@ -14186,7 +14204,8 @@ impl eframe::App for HookEchoApp {
         }
         // GOES lightning: granules land every 20 s, so poll about that often. One in flight at a
         // time — a slow fetch must not queue up behind itself.
-        if self.show_glm
+        let glm_fed_on = self.fields.get(&FL::GlmFed).is_some_and(|s| s.show);
+        if (self.show_glm || glm_fed_on)
             && self
                 .glm_last_poll
                 .is_none_or(|t| t.elapsed().as_secs() >= 20)
@@ -14216,6 +14235,34 @@ impl eframe::App for HookEchoApp {
                 }
                 busy.store(false, std::sync::atomic::Ordering::Relaxed);
             });
+        }
+
+        // GLM flash-extent density: the same flashes the dots come from, gridded. Cheap enough
+        // (one pass over a few thousand points) to do inline on the field-layer cadence rather
+        // than spawning for it.
+        if glm_fed_on
+            && self.fields.get(&FL::GlmFed).is_some_and(|s| {
+                s.last_fetch
+                    .is_none_or(|t| t.elapsed().as_secs() >= field_refresh_secs(FL::GlmFed))
+            })
+        {
+            if let Some(s) = self.fields.get_mut(&FL::GlmFed) {
+                s.last_fetch = Some(Instant::now());
+            }
+            let field = self.glm.lock().ok().and_then(|f| {
+                wxdata::glm::flash_density(
+                    f.flashes(),
+                    GLM_FED_CELL_DEG,
+                    chrono::Duration::minutes(GLM_FED_WINDOW_MIN),
+                    Utc::now(),
+                )
+            });
+            if let Some(field) = field {
+                let cap = self.field_texture_cap();
+                let _ = self
+                    .overlay_tx
+                    .send(OverlayMsg::Field(FL::GlmFed, field.decimated(cap)));
+            }
         }
 
         // Wind particles. HRRR posts hourly, so this gets its own 15-minute clock rather than

--- a/crates/hookecho/src/app/mobile/mod.rs
+++ b/crates/hookecho/src/app/mobile/mod.rs
@@ -541,6 +541,8 @@ impl super::HookEchoApp {
                 let l3_site = self.l3grid_site.clone();
                 let tz = self.active_tz();
                 let mosaic = self.mosaic_status();
+                let glm_options = self.show_glm
+                    || self.fields.get(&crate::render::FieldLayer::GlmFed).is_some_and(|s| s.show);
                 crate::ui::layer_options::show(
                     ui,
                     &mut self.filters,
@@ -564,7 +566,7 @@ impl super::HookEchoApp {
                     &mut self.diff_field,
                     self.diff_valid.as_ref(),
                     &mut self.settings.lightning_minutes,
-                    self.show_glm,
+                    glm_options,
                     &mut self.settings.glm_goes_west,
                     self.show_spotters,
                     &mut self.settings.spotter_range_km,

--- a/crates/hookecho/src/main.rs
+++ b/crates/hookecho/src/main.rs
@@ -403,6 +403,30 @@ fn main() -> eframe::Result<()> {
                         );
                     }
                 }
+                // The gridded half: the same flashes as the flash-density field layer sees.
+                match wxdata::glm::flash_density(
+                    f,
+                    0.05,
+                    chrono::Duration::minutes(15),
+                    chrono::Utc::now(),
+                ) {
+                    Some(g) => {
+                        let mut cells: Vec<f32> =
+                            g.values.iter().copied().filter(|v| !v.is_nan()).collect();
+                        cells.sort_by(|a, b| b.total_cmp(a));
+                        println!(
+                            "  density {}x{} cells, {} lit, max {}",
+                            g.nx,
+                            g.ny,
+                            cells.len(),
+                            cells.first().copied().unwrap_or(0.0)
+                        );
+                        let top: Vec<String> =
+                            cells.iter().take(5).map(|v| format!("{v:.0}")).collect();
+                        println!("  busiest cells: {}", top.join(", "));
+                    }
+                    None => println!("  density: no flashes in the window"),
+                }
             }
             Err(e) => {
                 eprintln!("headless glm failed: {e}");

--- a/crates/hookecho/src/render/field_ramps.rs
+++ b/crates/hookecho/src/render/field_ramps.rs
@@ -288,6 +288,25 @@ static VIL_DENSITY: FieldRamp = ramp!(
     ]
 );
 
+/// GLM flash-extent density: flashes per cell over the last 15 minutes. One flash is worth
+/// showing (it is the first one), and a vigorous updraft runs into the tens, so the scale is
+/// short and warms fast.
+static GLM_FED: FieldRamp = ramp!(
+    "Flash density",
+    "flashes/15 min",
+    1.0,
+    30.0,
+    RampScale::Linear,
+    220,
+    &[
+        (0.0, [60, 60, 160]),
+        (0.35, [90, 180, 230]),
+        (0.6, [240, 230, 60]),
+        (0.8, [240, 140, 40]),
+        (1.0, [255, 60, 60]),
+    ]
+);
+
 /// Probability of severe hail. 50% is Witt's warning threshold, so the scale turns warm there.
 static POSH: FieldRamp = ramp!(
     "Severe hail probability",
@@ -586,6 +605,7 @@ pub fn ramp_for(layer: FieldLayer) -> Option<&'static FieldRamp> {
         FL::GlobalWind10m => &GLOBAL_WIND_10M,
         FL::GlobalPrecip => &GLOBAL_PRECIP,
         FL::Hca => &HCA,
+        FL::GlmFed => &GLM_FED,
         FL::Mrms | FL::Mosaic | FL::Hrrr | FL::Lightning | FL::ModelDiff => return None,
     })
 }

--- a/crates/hookecho/src/render/mod.rs
+++ b/crates/hookecho/src/render/mod.rs
@@ -103,6 +103,8 @@ pub enum FieldLayer {
     GlobalWind10m,
     /// Global model precipitable water / total precipitation.
     GlobalPrecip,
+    /// GLM flash-extent density — the recent satellite flashes gridded into a density field.
+    GlmFed,
     /// One model minus another — which field, and therefore which pair, is `app.diff_field`.
     ModelDiff,
 }
@@ -131,7 +133,7 @@ impl FieldLayer {
     }
 
     /// Fixed bottom-to-top paint order within each band.
-    pub const DRAW_ORDER: [FieldLayer; 32] = [
+    pub const DRAW_ORDER: [FieldLayer; 33] = [
         // Below-radar context band (bottom to top). The global models sit at the very bottom:
         // they are the synoptic backdrop everything else is drawn against.
         FieldLayer::GlobalMslp,
@@ -167,6 +169,7 @@ impl FieldLayer {
         FieldLayer::Mesh,
         FieldLayer::AzShear,
         FieldLayer::Lightning,
+        FieldLayer::GlmFed,
     ];
 
     /// Stable name for saved files — a workspace records which layers were on by slug, so a file
@@ -205,6 +208,7 @@ impl FieldLayer {
             FieldLayer::GlobalWind10m => "global-wind10m",
             FieldLayer::GlobalPrecip => "global-precip",
             FieldLayer::ModelDiff => "model-diff",
+            FieldLayer::GlmFed => "glm-fed",
         }
     }
 

--- a/crates/wxdata/src/glm.rs
+++ b/crates/wxdata/src/glm.rs
@@ -253,6 +253,114 @@ impl GlmFeed {
     }
 }
 
+/// Grid the recent flashes into flash-extent density: how many flashes fell in each cell over the
+/// last `window`.
+///
+/// Individual flash dots answer "is it electrified"; density answers "where is it electrified
+/// *most*", which is the part that tracks an updraft and the part a jump shows up in. The result
+/// is a plate-carrée [`mrms::MrmsField`], so the existing warp/draw path renders it with no new
+/// pipeline — empty cells stay `NaN` and draw as nothing, per that type's convention.
+///
+/// `None` when no flash falls inside the window.
+// ponytail: fixed cell size and window, no user knob. Both are legible-at-a-glance choices, not
+// tuning parameters; add settings if anyone actually wants a different one.
+pub fn flash_density(
+    flashes: &VecDeque<Flash>,
+    cell_deg: f64,
+    window: chrono::Duration,
+    now: DateTime<Utc>,
+) -> Option<crate::mrms::MrmsField> {
+    let cutoff = now - window;
+    let recent: Vec<&Flash> = flashes.iter().filter(|f| f.time >= cutoff).collect();
+    let first = recent.first()?;
+
+    // Snap the bounds to the cell lattice so a cell covers the same ground from frame to frame —
+    // otherwise the whole grid slides half a cell every time the extremes change.
+    let snap = |v: f64| (v / cell_deg).floor() * cell_deg;
+    let (mut w, mut e, mut s, mut n) = (first.lon, first.lon, first.lat, first.lat);
+    for f in &recent {
+        w = w.min(f.lon);
+        e = e.max(f.lon);
+        s = s.min(f.lat);
+        n = n.max(f.lat);
+    }
+    let (lon_west, lat_south) = (snap(w), snap(s));
+    let nx = (((e - lon_west) / cell_deg).floor() as usize) + 1;
+    let ny = (((n - lat_south) / cell_deg).floor() as usize) + 1;
+    let (lon_east, lat_north) = (
+        lon_west + nx as f64 * cell_deg,
+        lat_south + ny as f64 * cell_deg,
+    );
+
+    let mut values = vec![f32::NAN; nx * ny];
+    for f in &recent {
+        let ix = ((f.lon - lon_west) / cell_deg).floor() as usize;
+        // Row 0 is the northernmost latitude, matching MRMS.
+        let iy = ((lat_north - f.lat) / cell_deg).floor() as usize;
+        let (ix, iy) = (ix.min(nx - 1), iy.min(ny - 1));
+        let cell = &mut values[iy * nx + ix];
+        *cell = if cell.is_nan() { 1.0 } else { *cell + 1.0 };
+    }
+
+    Some(crate::mrms::MrmsField {
+        values,
+        nx,
+        ny,
+        lon_west,
+        lon_east,
+        lat_north,
+        lat_south,
+        time: now,
+    })
+}
+
+#[cfg(test)]
+mod density_tests {
+    use super::*;
+
+    fn at(lon: f64, lat: f64, min_ago: i64) -> Flash {
+        Flash {
+            lon,
+            lat,
+            energy: 1.0,
+            time: Utc::now() - chrono::Duration::minutes(min_ago),
+        }
+    }
+
+    #[test]
+    fn flashes_in_one_cell_stack_and_stale_ones_drop_out() {
+        let flashes: VecDeque<Flash> = [
+            at(-97.01, 35.01, 1),
+            at(-97.02, 35.02, 2),
+            at(-97.03, 35.03, 3),
+            at(-97.01, 35.01, 60), // outside the window
+        ]
+        .into_iter()
+        .collect();
+        let f = flash_density(&flashes, 0.05, chrono::Duration::minutes(15), Utc::now()).unwrap();
+        let total: f32 = f.values.iter().filter(|v| !v.is_nan()).sum();
+        assert_eq!(total, 3.0);
+        assert_eq!(f.values.iter().filter(|v| **v == 3.0).count(), 1);
+    }
+
+    #[test]
+    fn separate_cells_stay_separate() {
+        let flashes: VecDeque<Flash> = [at(-97.0, 35.0, 1), at(-96.5, 35.4, 1)]
+            .into_iter()
+            .collect();
+        let f = flash_density(&flashes, 0.05, chrono::Duration::minutes(15), Utc::now()).unwrap();
+        assert_eq!(f.values.iter().filter(|v| **v == 1.0).count(), 2);
+        assert!(f.lon_west <= -97.0 && f.lon_east >= -96.5);
+        assert!(f.lat_south <= 35.0 && f.lat_north >= 35.4);
+    }
+
+    #[test]
+    fn nothing_recent_is_no_grid() {
+        let flashes: VecDeque<Flash> = [at(-97.0, 35.0, 90)].into_iter().collect();
+        assert!(flash_density(&flashes, 0.05, chrono::Duration::minutes(15), Utc::now()).is_none());
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
The GLM feed already ingests individual flashes and draws them as dots. Dots answer "is it electrified"; density answers "where is it electrified *most*" — the field that tracks an updraft, and where a lightning jump shows up first.

**`wxdata::glm::flash_density`** grids the flashes already in the feed: 0.05° cells (~5 km), fixed 15-minute window, one pass. The result is a plate-carrée `MrmsField`, so the existing warp/upload/draw path renders it with no new pipeline — empty cells stay `NaN` and draw as nothing, per that type's convention. Bounds are snapped to the cell lattice so a cell covers the same ground frame to frame. Cell size and window are fixed on purpose (`ponytail:` note); they are legibility choices, not tuning knobs.

**`FieldLayer::GlmFed`** ("Flash density (GLM)", under National, off by default) follows the locally-derived layers: the GLM poll gate opens when either the dots or the grid is on, the grid is rebuilt inline on the 60 s field cadence (one pass over a few thousand points — not worth a spawn), and the GOES-West option appears for either. `DRAW_ORDER` grows to 33 with the new layer just above `Lightning`; the slug round-trip test covers `glm-fed`.

**No new network hosts** — this is the feed the app already polls.

## Verification

`--headless-glm` now prints the gridded half too, against live GOES-19:

```
GLM: 3509 flashes ingested, 3509 in the window
  span 22:04:22Z .. 22:06:27Z  (newest 34s old)
  lat [-40.3, 55.6]  lon [-128.1, -20.2]
  density 2160x1919 cells, 1709 lit, max 40
  busiest cells: 40, 26, 26, 17, 16
```

```
cargo clippy --workspace --all-targets   # clean
cargo test --workspace                   # 425 passed, 27 ignored (3 new density tests)
RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check --target wasm32-unknown-unknown -p hookecho --lib
./scripts/shots/shoot.sh check           # passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)