### PR TITLE
R14 pack 1 — dual-pol signature trio

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -121,6 +121,10 @@ pub struct OverlayFilters {
     pub show_tds: bool,
     /// Flag velocity rotation couplets (client-side gate-to-gate azimuthal shear).
     pub show_couplets: bool,
+    /// Flag three-body scatter spikes (hail spikes) off the lowest tilt.
+    pub show_tbss: bool,
+    /// Flag ZDR columns — rain lofted above the freezing level, an updraft proxy.
+    pub show_zdr_columns: bool,
 }
 
 impl Default for OverlayFilters {
@@ -141,6 +145,8 @@ impl Default for OverlayFilters {
             nowcast_lead_min: 15,
             show_tds: false,
             show_couplets: false,
+            show_tbss: false,
+            show_zdr_columns: false,
         }
     }
 }
@@ -1014,6 +1020,8 @@ pub(crate) enum OverlayToggle {
     Nowcast,
     Tds,
     Couplets,
+    Tbss,
+    ZdrColumns,
     Alerts,
     Mds,
     Mping,
@@ -1043,7 +1051,7 @@ pub(crate) struct BlockageKey {
 impl OverlayToggle {
     /// Every toggle, for the persistence sweep. A new variant belongs here too, or it silently
     /// stops being remembered across restarts.
-    pub(crate) const ALL: [OverlayToggle; 34] = [
+    pub(crate) const ALL: [OverlayToggle; 36] = [
         Self::AlertPanel,
         Self::StormReports,
         Self::Spotters,
@@ -1067,6 +1075,8 @@ impl OverlayToggle {
         Self::Nowcast,
         Self::Tds,
         Self::Couplets,
+        Self::Tbss,
+        Self::ZdrColumns,
         Self::Alerts,
         Self::Mds,
         Self::Mping,
@@ -1269,6 +1279,14 @@ fn field_refresh_secs(layer: crate::render::FieldLayer) -> u64 {
         FL::VilLocal | FL::VilDensity | FL::EtopLocal | FL::HailMehs | FL::HailPosh => 60,
     }
 }
+
+/// The ZDR-column cache: the volume it was computed for, its columns, and the bright band the
+/// same pass found.
+type ZdrCache = (
+    (usize, String, usize),
+    Vec<wxdata::dualpol::ZdrColumnHit>,
+    Option<wxdata::dualpol::BrightBand>,
+);
 
 /// Per-field-layer UI + fetch state (toggle, pending upload, refresh clock).
 #[derive(Default)]
@@ -1652,6 +1670,11 @@ pub struct HookEchoApp {
         Vec<(f64, f64, egui::Color32)>,
     )>,
     tds_cache: Option<((usize, String, usize), Vec<wxdata::tds::TdsHit>)>,
+    /// Same shape as `tds_cache`, for the hail-spike detector.
+    tbss_cache: Option<((usize, String, usize), Vec<wxdata::dualpol::TbssHit>)>,
+    /// ZDR columns, plus the bright band read off the same volume's CC — both cost a full pass
+    /// over every tilt, so they share one cache and are computed together.
+    zdr_cache: Option<ZdrCache>,
     couplet_cache: Option<((usize, String, usize), Vec<wxdata::rotation::CoupletHit>)>,
     site_dialog: Option<ui::site_dialog::SiteDialog>,
     wizard: ui::wizard::Wizard,
@@ -2431,6 +2454,8 @@ impl HookEchoApp {
             vlabel_cache: None,
             nowcast_cache: None,
             tds_cache: None,
+            tbss_cache: None,
+            zdr_cache: None,
             couplet_cache: None,
             site_dialog: None,
             wizard: {
@@ -4903,6 +4928,82 @@ impl HookEchoApp {
         out
     }
 
+    /// Hail spikes (TBSS) for the active pane's lowest tilt, cached per volume like the TDS
+    /// detector. Display-only: a spike is context about hail, not a reason to make noise.
+    fn compute_tbss(&mut self, idx: usize) -> Vec<wxdata::dualpol::TbssHit> {
+        let key = self.volume_key(idx);
+        if let Some((k, v)) = &self.tbss_cache {
+            if *k == key {
+                return v.clone();
+            }
+        }
+        let z = self.views[idx]
+            .volume
+            .as_mut()
+            .and_then(|v| v.binned(Moment::Reflectivity, 0, false).ok())
+            .cloned();
+        let cc = self.views[idx]
+            .volume
+            .as_mut()
+            .and_then(|v| v.binned(Moment::CorrelationCoefficient, 0, false).ok())
+            .cloned();
+        let out = match (z, cc) {
+            (Some(z), Some(cc)) => wxdata::dualpol::tbss(&z, &cc, 60.0, 20.0, 0.8, 4.0, 150.0),
+            _ => Vec::new(),
+        };
+        self.tbss_cache = Some((key, out.clone()));
+        out
+    }
+
+    /// ZDR columns and the bright band, both from a full pass over the active pane's tilts.
+    ///
+    /// The freezing level comes from the same model analysis the hail grids use, so this needs a
+    /// live pane with that fetch already done; without it there is nothing to be "above" and the
+    /// answer is empty.
+    fn compute_zdr_columns(
+        &mut self,
+        idx: usize,
+        ctx: &egui::Context,
+    ) -> Vec<wxdata::dualpol::ZdrColumnHit> {
+        let key = self.volume_key(idx);
+        if let Some((k, v, _)) = &self.zdr_cache {
+            if *k == key {
+                return v.clone();
+            }
+        }
+        // Model heights are above sea level; beam heights are above the radar.
+        let site = self.views[idx].site.clone();
+        let radar_km = site
+            .as_deref()
+            .and_then(wxdata::sites::site_by_id)
+            .map_or(0.0, |s| s.elevation_meters as f64 / 1000.0);
+        let h0_km = match (&self.freezing, &site) {
+            (Some((s, h0, _)), Some(cur)) if s == cur => *h0 / 1000.0 - radar_km,
+            _ => {
+                self.fetch_freezing_levels(ctx);
+                return Vec::new();
+            }
+        };
+        let Some(vol) = self.views[idx].volume.as_mut() else {
+            return Vec::new();
+        };
+        let zdr = vol.moment_tilts(Moment::DifferentialReflectivity);
+        let z = vol.moment_tilts(Moment::Reflectivity);
+        let cc = vol.moment_tilts(Moment::CorrelationCoefficient);
+        let hits = wxdata::dualpol::zdr_columns(&zdr, &z, h0_km, 1.0, 1.0, 40.0, 100.0);
+        // The mid tilts are the ones that cut the melting layer at a range where the beam is
+        // still narrow enough to mean something.
+        let mid = |v: &[wxdata::level2::BinnedSweep]| -> Vec<wxdata::level2::BinnedSweep> {
+            v.iter()
+                .filter(|s| (2.0..=10.0).contains(&s.elevation_deg))
+                .cloned()
+                .collect()
+        };
+        let bb = wxdata::dualpol::bright_band(&mid(&cc), &mid(&z), 6.0);
+        self.zdr_cache = Some((key, hits.clone(), bb));
+        hits
+    }
+
     /// Auto TDS detection for the active pane's lowest tilt: bin reflectivity + CC and flag debris
     /// signatures (low CC in high Z). Fires a chime + banner on the rising edge of a new detection.
     fn compute_tds(&mut self, idx: usize) -> Vec<wxdata::tds::TdsHit> {
@@ -6452,6 +6553,8 @@ impl HookEchoApp {
             T::ArrivalCones => &mut self.filters.show_arrival_cones,
             T::Nowcast => &mut self.filters.show_nowcast,
             T::Tds => &mut self.filters.show_tds,
+            T::Tbss => &mut self.filters.show_tbss,
+            T::ZdrColumns => &mut self.filters.show_zdr_columns,
             T::Couplets => &mut self.filters.show_couplets,
             T::Alerts => &mut self.filters.show_alerts,
             T::Mds => &mut self.filters.show_mds,
@@ -6821,6 +6924,22 @@ impl HookEchoApp {
                 "Rotation couplets",
                 "Flag tight rotation that could produce a tornado",
                 true,
+            ),
+            (
+                T::Tbss,
+                "Severe",
+                "Hail spikes (TBSS)",
+                "Flag three-body scatter spikes \u{2014} near-proof of large hail in the core \
+                 they point away from",
+                false,
+            ),
+            (
+                T::ZdrColumns,
+                "Severe",
+                "ZDR columns",
+                "Flag rain carried above the freezing level \u{2014} an updraft proxy that \
+                 deepens before a storm intensifies",
+                false,
             ),
             (
                 T::Tds,
@@ -10460,6 +10579,16 @@ impl HookEchoApp {
         } else {
             Vec::new()
         };
+        let tbss_hits = if self.filters.show_tbss && idx == self.active {
+            self.compute_tbss(idx)
+        } else {
+            Vec::new()
+        };
+        let zdr_hits = if self.filters.show_zdr_columns && idx == self.active {
+            self.compute_zdr_columns(idx, ctx)
+        } else {
+            Vec::new()
+        };
         let couplets = if self.filters.show_couplets && idx == self.active {
             self.compute_couplets(idx)
         } else {
@@ -10857,6 +10986,78 @@ impl HookEchoApp {
                     egui::FontId::proportional(11.0),
                     m,
                 );
+            }
+
+            // Hail spikes: a hollow triangle at the core the spike points away from. Yellow, not
+            // magenta — this is a hail flag, and nothing here should read like a debris signature.
+            for h in &tbss_hits {
+                let p = to_screen(h.lon, h.lat);
+                if !prect.contains(p) {
+                    continue;
+                }
+                let col = egui::Color32::from_rgb(250, 210, 60);
+                let s = 7.0;
+                painter.add(egui::Shape::closed_line(
+                    vec![
+                        p + egui::vec2(0.0, -s),
+                        p + egui::vec2(s, s),
+                        p + egui::vec2(-s, s),
+                    ],
+                    egui::Stroke::new(2.0, col),
+                ));
+                painter.text(
+                    p + egui::vec2(0.0, -s - 2.0),
+                    egui::Align2::CENTER_BOTTOM,
+                    format!("TBSS {:.0} dBZ", h.core_dbz),
+                    egui::FontId::proportional(11.0),
+                    col,
+                );
+            }
+
+            // ZDR columns: an upward arrow with the depth above the freezing level.
+            for h in &zdr_hits {
+                let p = to_screen(h.lon, h.lat);
+                if !prect.contains(p) {
+                    continue;
+                }
+                let col = egui::Color32::from_rgb(120, 230, 160);
+                let s = 8.0;
+                painter.line_segment(
+                    [p + egui::vec2(0.0, s), p + egui::vec2(0.0, -s)],
+                    egui::Stroke::new(2.0, col),
+                );
+                painter.add(egui::Shape::convex_polygon(
+                    vec![
+                        p + egui::vec2(0.0, -s - 4.0),
+                        p + egui::vec2(-4.0, -s + 1.0),
+                        p + egui::vec2(4.0, -s + 1.0),
+                    ],
+                    col,
+                    egui::Stroke::NONE,
+                ));
+                painter.text(
+                    p + egui::vec2(6.0, 0.0),
+                    egui::Align2::LEFT_CENTER,
+                    format!("ZDR +{:.1} km", h.depth_km),
+                    egui::FontId::proportional(11.0),
+                    col,
+                );
+            }
+
+            // Where the melting layer is, read off the same volume's CC. One line, because the
+            // number is the whole product: it tells you which "heavy rain" is a bright band.
+            if self.filters.show_zdr_columns && idx == self.active {
+                if let Some((_, _, Some(bb))) = &self.zdr_cache {
+                    let text = format!("melting layer ~{:.1} km (bright band)", bb.height_km);
+                    let font = egui::FontId::proportional(12.0);
+                    painter.text(
+                        egui::pos2(prect.left() + 8.0, prect.bottom() - 8.0),
+                        egui::Align2::LEFT_BOTTOM,
+                        text,
+                        font,
+                        egui::Color32::from_rgb(160, 200, 230),
+                    );
+                }
             }
 
             // Rotation couplets: a ring at each cluster — solid red at strong-TVS strength
@@ -15125,10 +15326,28 @@ impl eframe::App for HookEchoApp {
         } else {
             &self.storm_cells
         };
+        // A cell within 15 km of a ZDR column owns it — the column marks the updraft, and the
+        // updraft belongs to the storm the table is already listing.
+        let zdr_cells: std::collections::HashSet<String> = match &self.zdr_cache {
+            Some((_, hits, _)) if self.filters.show_zdr_columns => cells
+                .iter()
+                .filter(|c| {
+                    hits.iter().any(|h| {
+                        // Small distances: a flat-earth step is plenty and needs no helper.
+                        let dy = (h.lat - c.lat) * 111.0;
+                        let dx = (h.lon - c.lon) * 111.0 * c.lat.to_radians().cos();
+                        (dx * dx + dy * dy).sqrt() <= 15.0
+                    })
+                })
+                .map(|c| c.id.clone())
+                .collect(),
+            _ => std::collections::HashSet::new(),
+        };
         if let Some(id) = ui::cells_window::show(
             &mut self.cells_window,
             ctx,
             cells,
+            &zdr_cells,
             crate::theme::accent(self.settings.theme),
         ) {
             if let Some(c) = self

--- a/crates/hookecho/src/headless.rs
+++ b/crates/hookecho/src/headless.rs
@@ -516,6 +516,75 @@ pub fn run_tds(site: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Dual-pol signature verify: download the latest volume and run all three of the
+/// [`wxdata::dualpol`] detectors on it — three-body scatter spikes at the lowest tilt, ZDR columns
+/// through every tilt, and the CC bright band. `h0_km` is the freezing level above radar level;
+/// there is no model fetch here, so it is a CLI argument.
+pub fn run_dualpol(site: &str, h0_km: f64) -> anyhow::Result<()> {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+    let (z0, cc0, zdr_tilts, z_tilts, cc_tilts) = rt.block_on(async {
+        let scan = level2::download_latest_scan(site, chrono::Utc::now().date_naive()).await?;
+        let n = level2::elevation_angles(&scan).len();
+        let z0 = level2::bin_scan(&scan, Moment::Reflectivity, 0)?;
+        let cc0 = level2::bin_scan(&scan, Moment::CorrelationCoefficient, 0)?;
+        let take = |m: Moment| -> Vec<wxdata::level2::BinnedSweep> {
+            (0..n).filter_map(|t| level2::bin_scan(&scan, m, t).ok()).collect()
+        };
+        anyhow::Ok((
+            z0,
+            cc0,
+            take(Moment::DifferentialReflectivity),
+            take(Moment::Reflectivity),
+            take(Moment::CorrelationCoefficient),
+        ))
+    })?;
+    println!(
+        "{site}: {} ZDR tilts, {} Z tilts, {} CC tilts; freezing level {h0_km:.1} km ARL",
+        zdr_tilts.len(),
+        z_tilts.len(),
+        cc_tilts.len()
+    );
+
+    let spikes = wxdata::dualpol::tbss(&z0, &cc0, 60.0, 20.0, 0.8, 4.0, 150.0);
+    println!("TBSS (hail spikes) at {:.2}deg: {}", z0.elevation_deg, spikes.len());
+    for h in spikes.iter().take(8) {
+        println!(
+            "  {:.3},{:.3}  core {:.0} dBZ  spike {:.1} km  min CC {:.2}",
+            h.lat, h.lon, h.core_dbz, h.len_km, h.min_cc
+        );
+    }
+
+    let columns = wxdata::dualpol::zdr_columns(&zdr_tilts, &z_tilts, h0_km, 1.0, 1.0, 40.0, 100.0);
+    println!("ZDR columns (>1 dB, >=1 km above the freezing level): {}", columns.len());
+    for h in columns.iter().take(8) {
+        println!(
+            "  {:.3},{:.3}  depth {:.1} km  top {:.1} km  max {:.1} dB",
+            h.lat, h.lon, h.depth_km, h.top_km, h.max_zdr
+        );
+    }
+
+    // The low tilts see the band only at long range, where the beam is too wide to say anything.
+    let mid: Vec<wxdata::level2::BinnedSweep> = cc_tilts
+        .into_iter()
+        .filter(|s| (2.0..=10.0).contains(&s.elevation_deg))
+        .collect();
+    let mid_z: Vec<wxdata::level2::BinnedSweep> = z_tilts
+        .iter()
+        .filter(|s| (2.0..=10.0).contains(&s.elevation_deg))
+        .cloned()
+        .collect();
+    match wxdata::dualpol::bright_band(&mid, &mid_z, 6.0) {
+        Some(bb) => println!(
+            "bright band: {:.2} km ARL, mean CC {:.2}, {} gates",
+            bb.height_km, bb.mean_cc, bb.samples
+        ),
+        None => println!("bright band: none found (no melting layer in view, or clean CC)"),
+    }
+    Ok(())
+}
+
 /// Rotation verify: download the latest volume, bin the dealiased velocity at the lowest tilt,
 /// run the couplet detector, and print any hits. Proves the detection pipeline on real data.
 pub fn run_rotation(site: &str) -> anyhow::Result<()> {

--- a/crates/hookecho/src/main.rs
+++ b/crates/hookecho/src/main.rs
@@ -604,6 +604,17 @@ fn main() -> eframe::Result<()> {
         return Ok(());
     }
 
+    // Dual-pol signature verify: `hookecho --headless-dualpol [SITE] [H0_KM]`.
+    if let Some(pos) = args.iter().position(|a| a == "--headless-dualpol") {
+        let site = args.get(pos + 1).map(String::as_str).unwrap_or("KTLX");
+        let h0 = args.get(pos + 2).and_then(|s| s.parse().ok()).unwrap_or(4.0);
+        if let Err(e) = headless::run_dualpol(site, h0) {
+            eprintln!("headless dualpol failed: {e}");
+            std::process::exit(1);
+        }
+        return Ok(());
+    }
+
     // Rotation verify: `hookecho --headless-rotation [SITE]`.
     if let Some(pos) = args.iter().position(|a| a == "--headless-rotation") {
         let site = args.get(pos + 1).map(String::as_str).unwrap_or("KTLX");

--- a/crates/hookecho/src/ui/cells_window.rs
+++ b/crates/hookecho/src/ui/cells_window.rs
@@ -152,6 +152,9 @@ pub fn show(
     w: &mut CellsWindow,
     ctx: &egui::Context,
     cells: &[Cell],
+    // Cell ids with a ZDR column detected near them — an updraft the storm table cannot see on
+    // its own, badged next to the rotation flags it already carries.
+    zdr_cells: &std::collections::HashSet<String>,
     accent: egui::Color32,
 ) -> Option<String> {
     if !w.open {
@@ -307,6 +310,18 @@ pub fn show(
                                                 .small()
                                                 .strong()
                                                 .color(egui::Color32::from_rgb(235, 70, 70)),
+                                        );
+                                    }
+                                    if zdr_cells.contains(&c.id) {
+                                        ui.label(
+                                            RichText::new("Z\u{25b2}")
+                                                .small()
+                                                .strong()
+                                                .color(egui::Color32::from_rgb(120, 230, 160)),
+                                        )
+                                        .on_hover_text(
+                                            "A ZDR column reaches above the freezing level here \
+                                             \u{2014} the updraft is deep",
                                         );
                                     }
                                     if c.meso.is_some() {

--- a/crates/wxdata/src/dualpol.rs
+++ b/crates/wxdata/src/dualpol.rs
@@ -1,0 +1,542 @@
+//! Dual-polarization signatures that are not debris: three-body scatter spikes, ZDR columns, and
+//! the melting-layer bright band.
+//!
+//! [`crate::tds`] flags the one signature that means a tornado may be on the ground. These are the
+//! other three an operational eye looks for, and none of them is an alarm:
+//!
+//! * **TBSS** — a "hail spike": a hail core so reflective that energy bounces off the ground and
+//!   back through the hail before returning, painting a weak, low-CC spike *behind* the core along
+//!   the same radial. It cannot be caused by anything else, so it is near-proof of large hail.
+//! * **ZDR column** — oblate raindrops carried above the freezing level by an updraft, seen as a
+//!   plume of positive ZDR reaching over the melting layer. It is an updraft proxy, and it tends
+//!   to deepen before a storm intensifies.
+//! * **Bright band** — the melting layer itself: partly-melted snow looks huge and wet to the
+//!   radar, giving a ring of depressed CC (roughly 0.7–0.97) at one height. Knowing where it is
+//!   tells you which "heavy rain" is really the melting layer seen edge-on.
+//!
+//! All three are display-only context. They deliberately raise nothing.
+
+use crate::level2::{BinnedSweep, Moment};
+use crate::tds::{dest, decode};
+use crate::xsection::column_samples;
+
+/// Geographic cluster cell, ~4 km — the same lattice [`crate::tds`] clusters on, so a signature
+/// reports as one hit rather than a few hundred gates.
+const CELL: f64 = 0.04;
+
+/// A three-body scatter spike: the hail core it points away from, and how long the spike runs.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TbssHit {
+    /// The core the spike came off, not the spike itself — that is where the hail is.
+    pub lon: f64,
+    pub lat: f64,
+    /// Peak reflectivity of the core (dBZ).
+    pub core_dbz: f32,
+    /// Length of the weak-echo, low-CC run downrange of the core (km).
+    pub len_km: f32,
+    /// Lowest CC seen inside the spike.
+    pub min_cc: f32,
+}
+
+/// A ZDR column: an updraft carrying rain above the freezing level.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ZdrColumnHit {
+    pub lon: f64,
+    pub lat: f64,
+    /// How far the ZDR > threshold layer reaches above the freezing level (km).
+    pub depth_km: f64,
+    /// Height the column tops out at, above radar level (km).
+    pub top_km: f64,
+    /// Peak ZDR inside the column (dB).
+    pub max_zdr: f32,
+}
+
+/// The melting layer, as read off the CC field.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BrightBand {
+    /// Height above radar level of the CC minimum (km).
+    pub height_km: f64,
+    /// How many gates voted for that height — small counts are noise, not a melting layer.
+    pub samples: usize,
+    /// Mean CC in the winning height bin.
+    pub mean_cc: f32,
+}
+
+/// One cluster cell while accumulating: `lon`/`lat` are running sums, averaged at the end.
+#[derive(Default)]
+struct TbssCell {
+    n: usize,
+    lon: f64,
+    lat: f64,
+    core_dbz: f32,
+    len_km: f32,
+    min_cc: f32,
+}
+
+/// The same, for ZDR columns: the deepest column in the cell wins.
+#[derive(Default)]
+struct ZdrCell {
+    n: usize,
+    lon: f64,
+    lat: f64,
+    depth_km: f64,
+    top_km: f64,
+    max_zdr: f32,
+}
+
+/// Detect three-body scatter spikes.
+///
+/// Walks each radial outward: at the strongest gate at or above `core_dbz`, look downrange for a
+/// run of gates that are both weak (`< weak_dbz`, or no echo at all) and depolarized
+/// (`CC < cc_max`). A run of at least `min_len_km` is the spike. Ordinary weak echo behind a core
+/// fails the CC half; ordinary low CC fails the "must sit behind a 60 dBZ core" half.
+///
+/// Hits are the *cores*, clustered on the ~4 km lattice and sorted by core reflectivity.
+#[allow(clippy::too_many_arguments)]
+pub fn tbss(
+    z: &BinnedSweep,
+    cc: &BinnedSweep,
+    core_dbz: f32,
+    weak_dbz: f32,
+    cc_max: f32,
+    min_len_km: f32,
+    max_range_km: f32,
+) -> Vec<TbssHit> {
+    debug_assert_eq!(z.moment, Moment::Reflectivity);
+    debug_assert_eq!(cc.moment, Moment::CorrelationCoefficient);
+    if z.az_bins == 0 || z.gate_count == 0 || cc.gate_count == 0 {
+        return Vec::new();
+    }
+    use std::collections::HashMap;
+    let mut cells: HashMap<(i64, i64), TbssCell> = HashMap::new();
+    let (rlon, rlat) = (z.radar_lon as f64, z.radar_lat as f64);
+
+    for az in 0..z.az_bins {
+        let az_deg = az as f64 * 360.0 / z.az_bins as f64;
+        // Strongest gate on this radial, within range.
+        let mut core: Option<(usize, f32)> = None;
+        for gate in 0..z.gate_count {
+            let range = z.first_gate_km + gate as f32 * z.gate_interval_km;
+            if range > max_range_km {
+                break;
+            }
+            let Some(v) = decode(z, z.data[az * z.gate_count + gate]) else {
+                continue;
+            };
+            if v >= core_dbz && core.is_none_or(|(_, best)| v > best) {
+                core = Some((gate, v));
+            }
+        }
+        let Some((core_gate, core_val)) = core else {
+            continue;
+        };
+
+        // The spike begins where the storm ends: walk off the back of the core through whatever
+        // echo is still attached to it, and start counting at the first weak gate.
+        let mut start = core_gate + 1;
+        while start < z.gate_count
+            && decode(z, z.data[az * z.gate_count + start]).is_some_and(|v| v >= weak_dbz)
+        {
+            start += 1;
+        }
+
+        // The spike must then be contiguous.
+        let mut len_gates = 0usize;
+        let mut min_cc = 1.05f32;
+        for gate in start..z.gate_count {
+            let range = z.first_gate_km + gate as f32 * z.gate_interval_km;
+            let zv = decode(z, z.data[az * z.gate_count + gate]);
+            // No echo at all still counts as weak — a spike often trails off into nothing.
+            if zv.is_some_and(|v| v >= weak_dbz) {
+                break;
+            }
+            let ci = ((range - cc.first_gate_km) / cc.gate_interval_km).round() as i64;
+            if ci < 0 || ci as usize >= cc.gate_count {
+                break;
+            }
+            let Some(cc_val) = decode(cc, cc.data[az * cc.gate_count + ci as usize]) else {
+                break; // depolarization is the point; a gate with no CC is not evidence of it
+            };
+            if cc_val >= cc_max {
+                break;
+            }
+            len_gates += 1;
+            min_cc = min_cc.min(cc_val);
+        }
+        let len_km = len_gates as f32 * z.gate_interval_km;
+        if len_km < min_len_km {
+            continue;
+        }
+
+        let core_range = z.first_gate_km + core_gate as f32 * z.gate_interval_km;
+        let (lon, lat) = dest(rlon, rlat, az_deg, core_range as f64);
+        let key = ((lon / CELL).round() as i64, (lat / CELL).round() as i64);
+        let e = cells.entry(key).or_insert(TbssCell {
+            min_cc: 1.05,
+            ..Default::default()
+        });
+        e.n += 1;
+        e.lon += lon;
+        e.lat += lat;
+        e.core_dbz = e.core_dbz.max(core_val);
+        e.len_km = e.len_km.max(len_km);
+        e.min_cc = e.min_cc.min(min_cc);
+    }
+
+    let mut hits: Vec<TbssHit> = cells
+        .into_values()
+        .map(|c| TbssHit {
+            lon: c.lon / c.n as f64,
+            lat: c.lat / c.n as f64,
+            core_dbz: c.core_dbz,
+            len_km: c.len_km,
+            min_cc: c.min_cc,
+        })
+        .collect();
+    hits.sort_by(|a, b| b.core_dbz.total_cmp(&a.core_dbz));
+    hits
+}
+
+/// Detect ZDR columns above `h0_km` (freezing level, above *radar* level).
+///
+/// Samples a coarse polar lattice — every 4th azimuth, 2 km steps — through
+/// [`column_samples`], the same vertical-profile machinery the derived products use. A column
+/// qualifies when ZDR stays above `min_zdr_db` from at or below the freezing level up to at least
+/// `min_depth_km` above it, and there is real echo (`>= min_core_dbz`) there to carry it.
+///
+/// Hits are clustered on the ~4 km lattice, deepest first.
+#[allow(clippy::too_many_arguments)]
+pub fn zdr_columns(
+    zdr_tilts: &[BinnedSweep],
+    z_tilts: &[BinnedSweep],
+    h0_km: f64,
+    min_zdr_db: f32,
+    min_depth_km: f64,
+    min_core_dbz: f32,
+    max_range_km: f64,
+) -> Vec<ZdrColumnHit> {
+    let Some(first) = zdr_tilts.first() else {
+        return Vec::new();
+    };
+    if h0_km <= 0.0 {
+        return Vec::new(); // freezing level at or below the radar: nothing to be "above"
+    }
+    use std::collections::HashMap;
+    let mut cells: HashMap<(i64, i64), ZdrCell> = HashMap::new();
+    let (rlon, rlat) = (first.radar_lon as f64, first.radar_lat as f64);
+    let mut zdr_samples: Vec<(f64, f32)> = Vec::with_capacity(zdr_tilts.len());
+    let mut z_samples: Vec<(f64, f32)> = Vec::with_capacity(z_tilts.len());
+
+    // ponytail: coarse lattice on the calling thread — ~9k columns, tens of ms. If it ever shows
+    // up in a frame time, it moves to spawn_blocking like `derived::derive` did.
+    let az_step = 4;
+    for az_bin in (0..first.az_bins).step_by(az_step) {
+        let az = az_bin as f64 * 360.0 / first.az_bins as f64;
+        let mut ground = 4.0f64;
+        while ground <= max_range_km {
+            let g = ground;
+            ground += 2.0;
+            column_samples(zdr_tilts, g, az, &mut zdr_samples);
+            if zdr_samples.len() < 2 {
+                continue;
+            }
+            // The column has to start at or below the freezing level: positive ZDR that only
+            // exists aloft is not rain that was lifted there.
+            if !zdr_samples
+                .iter()
+                .any(|(h, v)| *h <= h0_km && *v >= min_zdr_db)
+            {
+                continue;
+            }
+            // Contiguous run of ZDR >= threshold reaching above h0.
+            let mut top = 0.0f64;
+            let mut max_zdr = f32::MIN;
+            let mut run_alive = true;
+            for (h, v) in zdr_samples.iter().filter(|(h, _)| *h > h0_km) {
+                if !run_alive {
+                    break;
+                }
+                if *v >= min_zdr_db {
+                    top = *h;
+                    max_zdr = max_zdr.max(*v);
+                } else {
+                    run_alive = false;
+                }
+            }
+            let depth = top - h0_km;
+            if depth < min_depth_km {
+                continue;
+            }
+            // Real echo up there, so a noisy ZDR gate in clear air can't invent a column.
+            column_samples(z_tilts, g, az, &mut z_samples);
+            if !z_samples
+                .iter()
+                .any(|(h, v)| *h >= h0_km && *v >= min_core_dbz)
+            {
+                continue;
+            }
+
+            let (lon, lat) = dest(rlon, rlat, az, g);
+            let key = ((lon / CELL).round() as i64, (lat / CELL).round() as i64);
+            let e = cells.entry(key).or_insert(ZdrCell {
+                max_zdr: f32::MIN,
+                ..Default::default()
+            });
+            e.n += 1;
+            e.lon += lon;
+            e.lat += lat;
+            if depth > e.depth_km {
+                e.depth_km = depth;
+                e.top_km = top;
+            }
+            e.max_zdr = e.max_zdr.max(max_zdr);
+        }
+    }
+
+    let mut hits: Vec<ZdrColumnHit> = cells
+        .into_values()
+        .map(|c| ZdrColumnHit {
+            lon: c.lon / c.n as f64,
+            lat: c.lat / c.n as f64,
+            depth_km: c.depth_km,
+            top_km: c.top_km,
+            max_zdr: c.max_zdr,
+        })
+        .collect();
+    hits.sort_by(|a, b| b.depth_km.total_cmp(&a.depth_km));
+    hits
+}
+
+/// Estimate the melting-layer height from the CC bright band.
+///
+/// Melting snow depolarizes: CC drops into roughly 0.7–0.97 in a thin layer and is above 0.97
+/// in both the rain below and the snow above. Histogram those gates by beam height in 250 m bins
+/// and take the modal bin — with enough votes in it that a few noisy gates cannot pass for a
+/// melting layer.
+///
+/// Tilts at or below ~1° see the band only at long range where the beam is enormous, so callers
+/// should pass the mid tilts (roughly 2°–10°).
+// ponytail: display-only. The hail algorithm still takes its freezing level from the model rather
+// than from this — an estimator this new gets watched against real events before anything is
+// computed from it.
+pub fn bright_band(cc_tilts: &[BinnedSweep], max_height_km: f64) -> Option<BrightBand> {
+    const BIN_KM: f64 = 0.25;
+    const MIN_SAMPLES: usize = 200;
+    let nbins = (max_height_km / BIN_KM).ceil() as usize;
+    let mut counts = vec![0usize; nbins];
+    let mut sums = vec![0f64; nbins];
+
+    for s in cc_tilts {
+        if s.moment != Moment::CorrelationCoefficient || s.gate_count == 0 {
+            continue;
+        }
+        let e = s.elevation_deg as f64;
+        for az in 0..s.az_bins {
+            for gate in 0..s.gate_count {
+                let Some(v) = decode(s, s.data[az * s.gate_count + gate]) else {
+                    continue;
+                };
+                if !(0.7..0.97).contains(&v) {
+                    continue;
+                }
+                let slant = (s.first_gate_km + gate as f32 * s.gate_interval_km) as f64;
+                let h = crate::xsection::beam_height_km(slant, e);
+                if h < 0.0 || h >= max_height_km {
+                    continue;
+                }
+                let b = (h / BIN_KM) as usize;
+                counts[b] += 1;
+                sums[b] += v as f64;
+            }
+        }
+    }
+
+    let (b, n) = counts
+        .iter()
+        .copied()
+        .enumerate()
+        .max_by_key(|(_, n)| *n)
+        .filter(|(_, n)| *n >= MIN_SAMPLES)?;
+    Some(BrightBand {
+        height_km: (b as f64 + 0.5) * BIN_KM,
+        samples: n,
+        mean_cc: (sums[b] / n as f64) as f32,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A sweep whose `hot` index fills a wedge of azimuths/gates; everything else is `cold`.
+    fn sweep(
+        moment: Moment,
+        hot: u8,
+        cold: u8,
+        hot_az: std::ops::Range<usize>,
+        hot_gate: std::ops::Range<usize>,
+    ) -> BinnedSweep {
+        let (az_bins, gate_count) = (720usize, 400usize);
+        let mut data = vec![cold; az_bins * gate_count];
+        for az in hot_az.clone() {
+            for g in hot_gate.clone() {
+                data[az * gate_count + g] = hot;
+            }
+        }
+        let (lo, hi) = moment.value_range();
+        BinnedSweep {
+            moment,
+            az_bins,
+            gate_count,
+            data,
+            first_gate_km: 2.0,
+            gate_interval_km: 0.25,
+            radar_lat: 35.0,
+            radar_lon: -97.5,
+            elevation_deg: 0.5,
+            value_min: lo,
+            value_max: hi,
+        }
+    }
+
+    fn idx(moment: Moment, v: f32) -> u8 {
+        let (lo, hi) = moment.value_range();
+        (2.0 + (v - lo) / (hi - lo) * 253.0).round() as u8
+    }
+
+    /// Reflectivity: a 65 dBZ core at gates 100..108, weak echo behind it; CC low behind the core.
+    fn spike_sweeps(cc_behind: f32) -> (BinnedSweep, BinnedSweep) {
+        let mut z = sweep(
+            Moment::Reflectivity,
+            idx(Moment::Reflectivity, 65.0),
+            idx(Moment::Reflectivity, 5.0),
+            100..104,
+            100..108,
+        );
+        // Behind the core: 8 dBZ, i.e. weak but present.
+        for az in 100..104 {
+            for g in 108..160 {
+                z.data[az * z.gate_count + g] = idx(Moment::Reflectivity, 8.0);
+            }
+        }
+        let mut cc = sweep(
+            Moment::CorrelationCoefficient,
+            idx(Moment::CorrelationCoefficient, 0.98),
+            idx(Moment::CorrelationCoefficient, 0.98),
+            0..0,
+            0..0,
+        );
+        for az in 100..104 {
+            for g in 108..160 {
+                cc.data[az * cc.gate_count + g] = idx(Moment::CorrelationCoefficient, cc_behind);
+            }
+        }
+        (z, cc)
+    }
+
+    #[test]
+    fn flags_a_weak_depolarized_spike_behind_a_big_core() {
+        let (z, cc) = spike_sweeps(0.5);
+        let hits = tbss(&z, &cc, 60.0, 20.0, 0.8, 4.0, 150.0);
+        assert!(!hits.is_empty(), "spike should be flagged");
+        assert!(hits[0].core_dbz >= 60.0);
+        assert!(hits[0].len_km >= 4.0);
+        assert!(hits[0].min_cc < 0.8);
+    }
+
+    #[test]
+    fn meteorological_cc_behind_the_core_is_not_a_spike() {
+        // Same geometry, but the echo behind the core is ordinary rain: CC 0.98.
+        let (z, cc) = spike_sweeps(0.98);
+        assert!(tbss(&z, &cc, 60.0, 20.0, 0.8, 4.0, 150.0).is_empty());
+    }
+
+    #[test]
+    fn no_big_core_means_no_spike() {
+        let z = sweep(
+            Moment::Reflectivity,
+            idx(Moment::Reflectivity, 45.0),
+            idx(Moment::Reflectivity, 5.0),
+            100..104,
+            100..108,
+        );
+        let cc = sweep(
+            Moment::CorrelationCoefficient,
+            idx(Moment::CorrelationCoefficient, 0.5),
+            idx(Moment::CorrelationCoefficient, 0.5),
+            0..0,
+            0..0,
+        );
+        assert!(tbss(&z, &cc, 60.0, 20.0, 0.8, 4.0, 150.0).is_empty());
+    }
+
+    /// Uniform sweeps at a ladder of elevations, so a column exists everywhere.
+    fn tilts(moment: Moment, value: f32, elevations: &[f32]) -> Vec<BinnedSweep> {
+        elevations
+            .iter()
+            .map(|e| {
+                let mut s = sweep(moment, idx(moment, value), idx(moment, value), 0..0, 0..0);
+                s.elevation_deg = *e;
+                s
+            })
+            .collect()
+    }
+
+    #[test]
+    fn deep_positive_zdr_over_the_freezing_level_is_a_column() {
+        let els = [0.5, 1.5, 2.4, 3.4, 4.3, 6.0, 9.9, 14.6, 19.5];
+        let zdr = tilts(Moment::DifferentialReflectivity, 2.5, &els);
+        let z = tilts(Moment::Reflectivity, 50.0, &els);
+        let hits = zdr_columns(&zdr, &z, 3.0, 1.0, 1.0, 40.0, 60.0);
+        assert!(!hits.is_empty(), "uniform 2.5 dB ZDR should qualify");
+        assert!(hits[0].depth_km >= 1.0);
+        assert!(hits[0].top_km > 3.0);
+    }
+
+    #[test]
+    fn zdr_that_never_gets_above_the_freezing_level_is_not_a_column() {
+        let els = [0.5, 1.5, 2.4, 3.4];
+        let zdr = tilts(Moment::DifferentialReflectivity, 2.5, &els);
+        let z = tilts(Moment::Reflectivity, 50.0, &els);
+        // Freezing level well above every beam these tilts reach at this range.
+        assert!(zdr_columns(&zdr, &z, 12.0, 1.0, 1.0, 40.0, 60.0).is_empty());
+    }
+
+    #[test]
+    fn weak_zdr_is_not_a_column() {
+        let els = [0.5, 1.5, 2.4, 3.4, 4.3, 6.0, 9.9];
+        let zdr = tilts(Moment::DifferentialReflectivity, 0.2, &els);
+        let z = tilts(Moment::Reflectivity, 50.0, &els);
+        assert!(zdr_columns(&zdr, &z, 3.0, 1.0, 1.0, 40.0, 60.0).is_empty());
+    }
+
+    #[test]
+    fn a_ring_of_depressed_cc_reads_as_the_melting_layer() {
+        // One tilt of uniform CC 0.93: every gate lands in the band, at that tilt's own heights.
+        let mut s = sweep(
+            Moment::CorrelationCoefficient,
+            idx(Moment::CorrelationCoefficient, 0.93),
+            idx(Moment::CorrelationCoefficient, 0.93),
+            0..0,
+            0..0,
+        );
+        s.elevation_deg = 4.0;
+        let bb = bright_band(&[s], 6.0).expect("melting layer");
+        assert!(bb.height_km > 0.0 && bb.height_km < 6.0);
+        assert!((bb.mean_cc - 0.93).abs() < 0.02);
+        assert!(bb.samples >= 200);
+    }
+
+    #[test]
+    fn clean_meteorological_cc_has_no_bright_band() {
+        let mut s = sweep(
+            Moment::CorrelationCoefficient,
+            idx(Moment::CorrelationCoefficient, 0.995),
+            idx(Moment::CorrelationCoefficient, 0.995),
+            0..0,
+            0..0,
+        );
+        s.elevation_deg = 4.0;
+        assert!(bright_band(&[s], 6.0).is_none());
+    }
+}

--- a/crates/wxdata/src/dualpol.rs
+++ b/crates/wxdata/src/dualpol.rs
@@ -319,18 +319,37 @@ pub fn zdr_columns(
 // ponytail: display-only. The hail algorithm still takes its freezing level from the model rather
 // than from this — an estimator this new gets watched against real events before anything is
 // computed from it.
-pub fn bright_band(cc_tilts: &[BinnedSweep], max_height_km: f64) -> Option<BrightBand> {
+pub fn bright_band(
+    cc_tilts: &[BinnedSweep],
+    z_tilts: &[BinnedSweep],
+    max_height_km: f64,
+) -> Option<BrightBand> {
     const BIN_KM: f64 = 0.25;
     const MIN_SAMPLES: usize = 200;
+    /// Ground clutter and the radome sit in the first few km and depolarize just like melting
+    /// snow does; nothing that close is evidence of a melting layer.
+    const MIN_RANGE_KM: f64 = 20.0;
+    /// A melting layer below this is either clutter or a beam so low it is scraping the ground.
+    const MIN_HEIGHT_KM: f64 = 0.5;
     let nbins = (max_height_km / BIN_KM).ceil() as usize;
     let mut counts = vec![0usize; nbins];
     let mut sums = vec![0f64; nbins];
+
+    const Z_MIN_DBZ: f32 = 20.0;
+    const Z_MAX_DBZ: f32 = 45.0;
 
     for s in cc_tilts {
         if s.moment != Moment::CorrelationCoefficient || s.gate_count == 0 {
             continue;
         }
         let e = s.elevation_deg as f64;
+        // The reflectivity sweep from the same cut, so "is there rain here" is answerable.
+        let Some(z) = z_tilts
+            .iter()
+            .find(|t| (t.elevation_deg - s.elevation_deg).abs() < 0.15)
+        else {
+            continue;
+        };
         for az in 0..s.az_bins {
             for gate in 0..s.gate_count {
                 let Some(v) = decode(s, s.data[az * s.gate_count + gate]) else {
@@ -340,8 +359,22 @@ pub fn bright_band(cc_tilts: &[BinnedSweep], max_height_km: f64) -> Option<Brigh
                     continue;
                 }
                 let slant = (s.first_gate_km + gate as f32 * s.gate_interval_km) as f64;
+                if slant < MIN_RANGE_KM {
+                    continue;
+                }
                 let h = crate::xsection::beam_height_km(slant, e);
-                if h < 0.0 || h >= max_height_km {
+                if h < MIN_HEIGHT_KM || h >= max_height_km {
+                    continue;
+                }
+                // Same range in the reflectivity sweep, through its own gate spacing.
+                let zi = ((slant as f32 - z.first_gate_km) / z.gate_interval_km).round() as i64;
+                if zi < 0 || zi as usize >= z.gate_count {
+                    continue;
+                }
+                let Some(zv) = decode(z, z.data[az * z.gate_count + zi as usize]) else {
+                    continue;
+                };
+                if !(Z_MIN_DBZ..=Z_MAX_DBZ).contains(&zv) {
                     continue;
                 }
                 let b = (h / BIN_KM) as usize;
@@ -521,7 +554,15 @@ mod tests {
             0..0,
         );
         s.elevation_deg = 4.0;
-        let bb = bright_band(&[s], 6.0).expect("melting layer");
+        let mut z = sweep(
+            Moment::Reflectivity,
+            idx(Moment::Reflectivity, 30.0),
+            idx(Moment::Reflectivity, 30.0),
+            0..0,
+            0..0,
+        );
+        z.elevation_deg = 4.0;
+        let bb = bright_band(&[s], &[z], 6.0).expect("melting layer");
         assert!(bb.height_km > 0.0 && bb.height_km < 6.0);
         assert!((bb.mean_cc - 0.93).abs() < 0.02);
         assert!(bb.samples >= 200);
@@ -537,6 +578,14 @@ mod tests {
             0..0,
         );
         s.elevation_deg = 4.0;
-        assert!(bright_band(&[s], 6.0).is_none());
+        let mut z = sweep(
+            Moment::Reflectivity,
+            idx(Moment::Reflectivity, 30.0),
+            idx(Moment::Reflectivity, 30.0),
+            0..0,
+            0..0,
+        );
+        z.elevation_deg = 4.0;
+        assert!(bright_band(&[s], &[z], 6.0).is_none());
     }
 }

--- a/crates/wxdata/src/lib.rs
+++ b/crates/wxdata/src/lib.rs
@@ -10,6 +10,7 @@ pub mod contour;
 pub mod dat;
 pub mod dealias;
 pub mod derived;
+pub mod dualpol;
 pub mod dotcams;
 pub mod efield;
 pub mod ero;

--- a/crates/wxdata/src/tds.rs
+++ b/crates/wxdata/src/tds.rs
@@ -24,7 +24,7 @@ pub struct TdsHit {
 
 /// Decode a binned `u8` gate index back to its physical value, or `None` for below-threshold /
 /// range-folded gates (indices 0/1).
-fn decode(sweep: &BinnedSweep, idx: u8) -> Option<f32> {
+pub(crate) fn decode(sweep: &BinnedSweep, idx: u8) -> Option<f32> {
     if idx < 2 {
         return None;
     }
@@ -33,7 +33,7 @@ fn decode(sweep: &BinnedSweep, idx: u8) -> Option<f32> {
 }
 
 /// Great-circle destination point (used to place a gate at its azimuth/range).
-fn dest(lon: f64, lat: f64, bearing_deg: f64, dist_km: f64) -> (f64, f64) {
+pub(crate) fn dest(lon: f64, lat: f64, bearing_deg: f64, dist_km: f64) -> (f64, f64) {
     let r = 6371.0;
     let ad = dist_km / r;
     let (br, la1, lo1) = (bearing_deg.to_radians(), lat.to_radians(), lon.to_radians());


### PR DESCRIPTION
Three dual-pol signatures an operational eye looks for that the app did not compute. New `crates/wxdata/src/dualpol.rs`, modelled on `tds.rs` — same ~4 km clustering lattice, same synthetic-sweep tests.

**TBSS (hail spike).** Walks each radial: at the strongest gate ≥ 60 dBZ, walk off the back of the core and look for a run of weak (< 20 dBZ) *and* depolarized (CC < 0.8) gates ≥ 4 km. Ordinary weak echo behind a core fails the CC half; ordinary low CC fails the "must sit behind a big core" half. A spike cannot be caused by anything but hail, so the hit is placed on the core, not the spike.

**ZDR columns.** Coarse polar lattice (every 4th azimuth, 2 km steps) through `xsection::column_samples`, the same vertical-profile machinery `derived::derive` uses. Qualifies on a contiguous ZDR > 1 dB run reaching ≥ 1 km above the freezing level with ≥ 40 dBZ echo up there to carry it. Freezing level comes from the model analysis the hail grids already fetch, converted to above-radar-level.

**Bright band.** Histograms CC gates in 0.7–0.97 by 4/3-earth beam height in 250 m bins and takes the modal bin. Gated on stratiform-looking reflectivity (20–45 dBZ at the same gate) and ≥ 20 km range: without that filter a summer afternoon reads its own insect-filled boundary layer as a melting layer, which is exactly what the first live run did (it reported 0.38 km). Display-only this release — `hail()` keeps taking its freezing level from the model until this has been watched against real events.

**App side.** Two off-by-default toggles under Severe, per-volume caches shaped like `tds_cache`, map markers (hollow yellow triangle for a spike, green arrow with depth for a column), a one-line bright-band caption, and a `Z▲` badge on storm-table cells within 15 km of a column. **No new alert sounds** — a spike is context about hail and a column is context about an updraft; the only detection here that alarms is still the one that means debris is in the air.

## Verification

`--headless-dualpol SITE [H0_KM]`, live:

```
$ hookecho --headless-dualpol KJAX 4.5
KJAX: 12 ZDR tilts, 12 Z tilts, 12 CC tilts; freezing level 4.5 km ARL
TBSS (hail spikes) at 0.48deg: 0
ZDR columns (>1 dB, >=1 km above the freezing level): 1
  31.002,-81.408  depth 1.4 km  top 5.9 km  max 2.5 dB
bright band: none found (no melting layer in view, or clean CC)
```

A real column on a real storm. Also run clean (no false positives) against KHGX, KMOB, KAMX, KTBW, KMLB, KBGM, KLOT, KMPX, KOKX, KABR. No live bright band turned up — August convection is the wrong regime for one — so that path rests on its unit tests for now, which is why it stays display-only.

Toggles smoke-tested under Xvfb (Severe category 13 → 15, app renders).

```
cargo clippy --workspace --all-targets   # clean
cargo test --workspace                   # 433 passed, 27 ignored (8 new)
RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check --target wasm32-unknown-unknown -p hookecho --lib
./scripts/shots/shoot.sh check           # passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)