### PR TITLE
R15 pack A — knobs and robustness

### DIFF
--- a/crates/hookecho/Cargo.toml
+++ b/crates/hookecho/Cargo.toml
@@ -52,6 +52,8 @@ log.workspace = true
 env_logger = "0.11"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "ico"] }
 chrono.workspace = true
+# Deep links arrive percent-encoded from browsers and chat clients; reqwest already builds this.
+percent-encoding = "2.3"
 # `stream` gives `bytes_stream()`, which the weather-radio player reads the live MP3 body from.
 reqwest = { workspace = true, features = ["stream"] }
 serde.workspace = true

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1915,8 +1915,8 @@ pub struct HookEchoApp {
     ///
     /// A `Mutex` because `notify_alert` takes `&self` (ten call sites); a lock beats threading
     /// `&mut` through all of them.
-    // ponytail: not persisted — a quiet window that spans a restart loses its catch-up. Persist
-    // alongside the chase log if anyone misses it.
+    /// Held across a restart through `Settings::quiet_pending`, written on exit: a quiet window
+    /// that spans a relaunch still owes its catch-up.
     quiet_queue: std::sync::Mutex<Vec<(String, String)>>,
     /// Whether the last frame was inside quiet hours, so the end of the window is an edge.
     was_quiet: bool,
@@ -2363,6 +2363,8 @@ impl HookEchoApp {
         if let Some(dir) = crate::paths::cache_dir() {
             wxdata::alerts::set_zone_cache_dir(dir);
         }
+        // Whatever the last run's quiet hours were still holding when it closed.
+        let quiet_pending = settings.quiet_pending.clone();
         // The user's cap overrides, before anything that sweeps or reports against them.
         crate::tiles::set_cache_caps(settings.tile_disk_cache_mb, settings.volume_cache_mb);
         // Archived volumes are kept on disk forever within a cap; same startup sweep the tile
@@ -2614,7 +2616,7 @@ impl HookEchoApp {
             snapshot_push: None,
             rotation_alerted: std::collections::HashMap::new(),
             last_chime: None,
-            quiet_queue: std::sync::Mutex::new(Vec::new()),
+            quiet_queue: std::sync::Mutex::new(quiet_pending),
             was_quiet: false,
             screenshot_pending: None,
             share_card: None,
@@ -14291,6 +14293,12 @@ impl eframe::App for HookEchoApp {
                 });
             }
         }
+        // Anything quiet hours is still holding: it is owed to the user when the window ends, and
+        // that can be after a restart.
+        self.settings.quiet_pending = match self.quiet_queue.lock() {
+            Ok(q) => q.clone(),
+            Err(_) => Vec::new(),
+        };
         if self.settings != self.saved {
             self.settings.save();
         }

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1247,11 +1247,6 @@ pub(crate) struct PaletteEntry {
     pub key: Option<String>,
 }
 
-/// GLM flash-extent density grid: cell size in degrees (~5 km), and how far back it counts.
-/// Both fixed — they are legibility choices, not tuning knobs.
-const GLM_FED_CELL_DEG: f64 = 0.05;
-const GLM_FED_WINDOW_MIN: i64 = 15;
-
 /// Refresh cadence (seconds) for a national field layer's product.
 fn field_refresh_secs(layer: crate::render::FieldLayer) -> u64 {
     use crate::render::FieldLayer as FL;
@@ -1289,8 +1284,12 @@ fn field_refresh_secs(layer: crate::render::FieldLayer) -> u64 {
 
 /// The ZDR-column cache: the volume it was computed for, its columns, and the bright band the
 /// same pass found.
+/// A volume key with the detector thresholds folded in, so moving a slider recomputes instead of
+/// handing back the answer to the previous question.
+type TunedKey = ((usize, String, usize), u64);
+
 type ZdrCache = (
-    (usize, String, usize),
+    TunedKey,
     Vec<wxdata::dualpol::ZdrColumnHit>,
     Option<wxdata::dualpol::BrightBand>,
 );
@@ -1678,7 +1677,7 @@ pub struct HookEchoApp {
     )>,
     tds_cache: Option<((usize, String, usize), Vec<wxdata::tds::TdsHit>)>,
     /// Same shape as `tds_cache`, for the hail-spike detector.
-    tbss_cache: Option<((usize, String, usize), Vec<wxdata::dualpol::TbssHit>)>,
+    tbss_cache: Option<(TunedKey, Vec<wxdata::dualpol::TbssHit>)>,
     /// ZDR columns, plus the bright band read off the same volume's CC — both cost a full pass
     /// over every tilt, so they share one cache and are computed together.
     zdr_cache: Option<ZdrCache>,
@@ -4895,6 +4894,18 @@ impl HookEchoApp {
         )
     }
 
+    /// [`Self::volume_key`] plus a fingerprint of the detector thresholds, for the caches whose
+    /// answer changes when the user moves a slider.
+    fn tuned_key(&self, idx: usize) -> TunedKey {
+        use std::hash::{Hash, Hasher};
+        let d = &self.settings.detectors;
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        d.tbss_core_dbz.to_bits().hash(&mut h);
+        d.zdr_min_db.to_bits().hash(&mut h);
+        d.zdr_min_depth_km.to_bits().hash(&mut h);
+        (self.volume_key(idx), h.finish())
+    }
+
     fn compute_nowcast_uncached(&mut self, idx: usize) -> Vec<(f64, f64, egui::Color32)> {
         let Some((dir, kt)) = self.scit_mean_motion() else {
             return Vec::new();
@@ -4944,7 +4955,8 @@ impl HookEchoApp {
     /// Hail spikes (TBSS) for the active pane's lowest tilt, cached per volume like the TDS
     /// detector. Display-only: a spike is context about hail, not a reason to make noise.
     fn compute_tbss(&mut self, idx: usize) -> Vec<wxdata::dualpol::TbssHit> {
-        let key = self.volume_key(idx);
+        let key = self.tuned_key(idx);
+        let core_dbz = self.settings.detectors.tbss_core_dbz;
         if let Some((k, v)) = &self.tbss_cache {
             if *k == key {
                 return v.clone();
@@ -4961,7 +4973,9 @@ impl HookEchoApp {
             .and_then(|v| v.binned(Moment::CorrelationCoefficient, 0, false).ok())
             .cloned();
         let out = match (z, cc) {
-            (Some(z), Some(cc)) => wxdata::dualpol::tbss(&z, &cc, 60.0, 20.0, 0.8, 4.0, 150.0),
+            (Some(z), Some(cc)) => {
+                wxdata::dualpol::tbss(&z, &cc, core_dbz, 20.0, 0.8, 4.0, 150.0)
+            }
             _ => Vec::new(),
         };
         self.tbss_cache = Some((key, out.clone()));
@@ -4978,7 +4992,11 @@ impl HookEchoApp {
         idx: usize,
         ctx: &egui::Context,
     ) -> Vec<wxdata::dualpol::ZdrColumnHit> {
-        let key = self.volume_key(idx);
+        let key = self.tuned_key(idx);
+        let (min_zdr, min_depth) = (
+            self.settings.detectors.zdr_min_db,
+            self.settings.detectors.zdr_min_depth_km,
+        );
         if let Some((k, v, _)) = &self.zdr_cache {
             if *k == key {
                 return v.clone();
@@ -5003,7 +5021,7 @@ impl HookEchoApp {
         let zdr = vol.moment_tilts(Moment::DifferentialReflectivity);
         let z = vol.moment_tilts(Moment::Reflectivity);
         let cc = vol.moment_tilts(Moment::CorrelationCoefficient);
-        let hits = wxdata::dualpol::zdr_columns(&zdr, &z, h0_km, 1.0, 1.0, 40.0, 100.0);
+        let hits = wxdata::dualpol::zdr_columns(&zdr, &z, h0_km, min_zdr, min_depth, 40.0, 100.0);
         // The mid tilts are the ones that cut the melting layer at a range where the beam is
         // still narrow enough to mean something.
         let mid = |v: &[wxdata::level2::BinnedSweep]| -> Vec<wxdata::level2::BinnedSweep> {
@@ -5923,6 +5941,7 @@ impl HookEchoApp {
                                     &mut self.settings.glm_goes_west,
                                     self.show_spotters,
                                     &mut self.settings.spotter_range_km,
+                                    &mut self.settings.detectors,
                                     Some(mosaic.as_str()),
                                     &mut opts,
                                 );
@@ -14666,8 +14685,8 @@ impl eframe::App for HookEchoApp {
             let field = self.glm.lock().ok().and_then(|f| {
                 wxdata::glm::flash_density(
                     f.flashes(),
-                    GLM_FED_CELL_DEG,
-                    chrono::Duration::minutes(GLM_FED_WINDOW_MIN),
+                    self.settings.detectors.glm_fed_cell_deg,
+                    chrono::Duration::minutes(self.settings.detectors.glm_fed_window_min),
                     Utc::now(),
                 )
             });

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1506,9 +1506,14 @@ struct Goto {
 /// `SITE` flies to the site itself; the site may be empty when lon/lat are given.
 fn parse_goto(v: &str) -> Option<Goto> {
     let v = v.trim().strip_prefix(GOTO_SCHEME).unwrap_or(v.trim());
-    let p: Vec<&str> = v.split(',').map(str::trim).collect();
+    // Chat clients and mail readers hand the link back percent-encoded, commas and the time's
+    // colons included, so decode the whole thing before splitting. No field here can legitimately
+    // hold a comma, which is what makes decoding first the safe direction. Anything that isn't a
+    // valid escape survives as typed, so a stray `%` doesn't lose the link.
+    let decoded = percent_encoding::percent_decode_str(v).decode_utf8_lossy();
+    let p: Vec<String> = decoded.split(',').map(|s| s.trim().to_string()).collect();
     let mut g = if p.len() == 1 {
-        let s = wxdata::sites::site_by_id(p[0])?;
+        let s = wxdata::sites::site_by_id(&p[0])?;
         // Same zoom a cold start picks for the default site.
         Goto {
             site: p[0].to_ascii_uppercase(),
@@ -2876,7 +2881,8 @@ impl HookEchoApp {
 
     /// The browser's own deep link: `https://…/#goto=KTLX,-97.3,35.3,9`. Read once at boot — a
     /// fragment change afterwards is someone editing the URL bar, not a share being opened.
-    /// ponytail: no percent-decoding; fragments carry `,` and `:` verbatim.
+    /// Percent-escapes are decoded by `parse_goto`, so a fragment that came back from a chat
+    /// client with its commas and colons escaped still opens.
     #[cfg(target_arch = "wasm32")]
     fn apply_goto_hash(&mut self) {
         let Some(h) = web_sys::window().and_then(|w| w.location().hash().ok()) else {
@@ -16182,6 +16188,18 @@ mod tests {
         }
         assert!(parse_goto("").is_none());
         assert!(parse_goto("garbage").is_none());
+    }
+
+    #[test]
+    fn goto_survives_a_percent_encoded_round_trip() {
+        // What a chat client hands back after eating the link.
+        let g = parse_goto("KTLX%2C-97.3%2C35.3%2C9%2C2013-05-20T20%3A00%3A00Z").unwrap();
+        assert_eq!(g.site, "KTLX");
+        assert_eq!(g.zoom, 9.0);
+        assert_eq!(g.time.unwrap().to_rfc3339(), "2013-05-20T20:00:00+00:00");
+        // Encoded spaces around the fields, and a stray `%` that is not an escape at all.
+        assert_eq!(parse_goto("%20ktlx%20").unwrap().site, "KTLX");
+        assert!(parse_goto("%GG").is_none());
     }
 
     #[test]

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -2358,6 +2358,8 @@ impl HookEchoApp {
         if let Some(dir) = crate::paths::cache_dir() {
             wxdata::alerts::set_zone_cache_dir(dir);
         }
+        // The user's cap overrides, before anything that sweeps or reports against them.
+        crate::tiles::set_cache_caps(settings.tile_disk_cache_mb, settings.volume_cache_mb);
         // Archived volumes are kept on disk forever within a cap; same startup sweep the tile
         // caches get, for the same reason (mid-session deletion would race the fetch tasks).
         if let Some(root) = crate::paths::cache_dir().map(|d| d.join("volumes")) {
@@ -2365,7 +2367,7 @@ impl HookEchoApp {
                 crate::tiles::sweep_cache_dir(
                     &root,
                     "volume cache",
-                    crate::tiles::VOLUME_CACHE_BYTES,
+                    crate::tiles::volume_cache_bytes(),
                 )
             });
         }

--- a/crates/hookecho/src/app/mobile/mod.rs
+++ b/crates/hookecho/src/app/mobile/mod.rs
@@ -570,6 +570,7 @@ impl super::HookEchoApp {
                     &mut self.settings.glm_goes_west,
                     self.show_spotters,
                     &mut self.settings.spotter_range_km,
+                    &mut self.settings.detectors,
                     Some(mosaic.as_str()),
                     actions,
                 );

--- a/crates/hookecho/src/cloud.rs
+++ b/crates/hookecho/src/cloud.rs
@@ -25,7 +25,15 @@ const REMOTE_NAME: &str = "settings.json";
 
 /// Settings fields that belong to *this* machine and must survive a sync from another one.
 /// Everything else — markers, placefiles, palettes, theme, API keys — is shared.
-pub const DEVICE_LOCAL: [&str; 4] = ["ui_scale", "share_name", "background_alerts", "share_relay"];
+pub const DEVICE_LOCAL: [&str; 5] = [
+    "ui_scale",
+    "share_name",
+    "background_alerts",
+    "share_relay",
+    // Pushes this machine held back during quiet hours. They are owed to whoever is sitting at
+    // this device, and would arrive as somebody else's stale summary if they travelled.
+    "quiet_pending",
+];
 
 /// What Google gave us. Stored beside settings.json but never inside it: these are credentials,
 /// and the whole point of the settings blob is that it travels.
@@ -579,6 +587,9 @@ mod tests {
 
     #[test]
     fn shareable_strips_device_local_fields() {
+        // Held-back pushes belong to the machine that held them, not to the next device to sync.
+        let s = shareable(&json!({"quiet_pending": [["Tornado Warning", "…"]]}));
+        assert!(s.get("quiet_pending").is_none());
         let s = shareable(&json!({"ui_scale": 1.5, "mapbox_key": "pk.x"}));
         assert!(s.get("ui_scale").is_none());
         assert_eq!(s["mapbox_key"], "pk.x"); // keys do sync — the user asked for that

--- a/crates/hookecho/src/elevation.rs
+++ b/crates/hookecho/src/elevation.rs
@@ -78,7 +78,7 @@ pub fn tile_path(root: &std::path::Path, x: u32, y: u32) -> std::path::PathBuf {
 
 /// Slippy tile and in-tile pixel for a lon/lat at [`DEM_ZOOM`], or `None` outside the Mercator
 /// latitude band.
-fn tile_of(lon: f64, lat: f64) -> Option<(u32, u32, usize, usize)> {
+fn tile_of(lon: f64, lat: f64) -> Option<(u32, u32, f64, f64)> {
     if !(-85.05..=85.05).contains(&lat) || !lon.is_finite() {
         return None;
     }
@@ -90,22 +90,40 @@ fn tile_of(lon: f64, lat: f64) -> Option<(u32, u32, usize, usize)> {
         return None;
     }
     let (tx, ty) = (fx.floor(), fy.floor());
-    // ponytail: nearest pixel, no bilinear. Add bilinear if banding shows on shallow slopes.
-    let px = ((fx - tx) * 256.0) as usize;
-    let py = ((fy - ty) * 256.0) as usize;
+    // Pixel coordinates kept fractional: the caller interpolates between the four neighbours.
+    let px = ((fx - tx) * 256.0).clamp(0.0, 255.0);
+    let py = ((fy - ty) * 256.0).clamp(0.0, 255.0);
     Some((
         (tx as i64).rem_euclid(1i64 << zoom()) as u32,
         ty as u32,
-        px.min(255),
-        py.min(255),
+        px,
+        py,
     ))
+}
+
+/// Bilinear height at fractional pixel `(px, py)` in a 256x256 Terrarium tile.
+///
+/// A DEM pixel at z10 is ~150 m across, and taking the nearest one quantized every beam-blockage
+/// profile into terraces that were an artifact of the sampling, not the terrain.
+///
+/// ponytail: neighbours are clamped to this tile, so the outermost half-pixel of a tile edge is
+/// nearest-neighbour. Blend across tiles only if a seam ever shows.
+fn bilinear(heights: &[f32], px: f64, py: f64) -> f32 {
+    let (x0, y0) = (px.floor(), py.floor());
+    let (fx, fy) = ((px - x0) as f32, (py - y0) as f32);
+    let (x0, y0) = (x0 as usize, y0 as usize);
+    let (x1, y1) = ((x0 + 1).min(255), (y0 + 1).min(255));
+    let at = |x: usize, y: usize| heights[y * 256 + x];
+    let top = at(x0, y0) * (1.0 - fx) + at(x1, y0) * fx;
+    let bottom = at(x0, y1) * (1.0 - fx) + at(x1, y1) * fx;
+    top * (1.0 - fy) + bottom * fy
 }
 
 /// Terrain height above sea level (metres) at `(lat, lon)`, or `None` if the covering DEM tile is
 /// unavailable (offline and not packed, or ocean-edge).
 pub async fn elevation_m(client: &reqwest::Client, lat: f64, lon: f64) -> Option<f32> {
     let (tx, ty, px, py) = tile_of(lon, lat)?;
-    let sample = |t: &Option<Arc<Vec<f32>>>| t.as_ref().map(|v| v[py * 256 + px]);
+    let sample = |t: &Option<Arc<Vec<f32>>>| t.as_ref().map(|v| bilinear(v, px, py));
     // Guard dropped before the await below — a fetch must not hold the whole cache.
     if let Some(hit) = cache()
         .lock()
@@ -332,11 +350,23 @@ mod tests {
     }
 
     #[test]
+    fn bilinear_reads_between_the_pixels() {
+        // A tile whose height is its column index: the midpoint between two pixels is their mean,
+        // and a whole-pixel coordinate still reads that pixel exactly.
+        let heights: Vec<f32> = (0..256 * 256).map(|i| (i % 256) as f32).collect();
+        assert_eq!(bilinear(&heights, 10.0, 4.0), 10.0);
+        assert_eq!(bilinear(&heights, 10.5, 4.0), 10.5);
+        assert_eq!(bilinear(&heights, 10.25, 200.0), 10.25);
+        // The last half-pixel clamps to the edge rather than reading off the end.
+        assert_eq!(bilinear(&heights, 255.5, 255.5), 255.0);
+    }
+
+    #[test]
     fn tile_of_lands_in_range() {
         let _g = ZOOM_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let (x, y, px, py) = tile_of(-97.28, 35.33).unwrap();
         assert!(x < 1 << zoom() && y < 1 << zoom());
-        assert!(px < 256 && py < 256);
+        assert!((0.0..=255.0).contains(&px) && (0.0..=255.0).contains(&py));
         // Antimeridian wraps rather than panicking; poles are outside the Mercator band.
         assert!(tile_of(180.0, 0.0).is_some());
         assert!(tile_of(0.0, 89.0).is_none());

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -410,6 +410,40 @@ pub struct Settings {
     /// and a renamed action just falls back to its default place.
     #[serde(default)]
     pub layer_order: Vec<String>,
+    /// Thresholds the signature detectors fire at (see [`DetectorTuning`]).
+    #[serde(default)]
+    pub detectors: DetectorTuning,
+}
+
+/// Where the dual-pol signature detectors and the GLM flash-extent grid draw their lines.
+///
+/// Every one of these was a constant, which is fine until you point the app at a radar whose
+/// calibration or season disagrees: a ZDR floor that is right in May over Oklahoma is noise in
+/// December over Buffalo. The defaults are the values the detectors shipped with.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DetectorTuning {
+    /// Reflectivity (dBZ) a core must reach before a hail spike behind it is looked for.
+    pub tbss_core_dbz: f32,
+    /// Differential reflectivity (dB) a gate must reach to count toward a ZDR column.
+    pub zdr_min_db: f32,
+    /// How far a column must extend above the freezing level (km) to be reported.
+    pub zdr_min_depth_km: f64,
+    /// GLM flash-extent density grid cell size, in degrees (~5 km at the default).
+    pub glm_fed_cell_deg: f64,
+    /// How far back the flash-extent density grid counts, in minutes.
+    pub glm_fed_window_min: i64,
+}
+
+impl Default for DetectorTuning {
+    fn default() -> Self {
+        Self {
+            tbss_core_dbz: 60.0,
+            zdr_min_db: 1.0,
+            zdr_min_depth_km: 1.0,
+            glm_fed_cell_deg: 0.05,
+            glm_fed_window_min: 15,
+        }
+    }
 }
 
 impl Settings {
@@ -661,6 +695,7 @@ impl Default for Settings {
     fn default() -> Self {
         Self {
             default_site: "KTLX".to_string(),
+            detectors: DetectorTuning::default(),
             share_card: true,
             hide_sidebar: false,
             hide_toolbar: false,
@@ -937,6 +972,19 @@ mod tests {
     use super::*;
 
     #[test]
+    fn detector_tuning_survives_a_settings_file_that_predates_it() {
+        // Settings written before the knobs existed must load with the shipped thresholds.
+        let old: Settings = serde_json::from_str(r#"{"default_site":"KTLX"}"#).unwrap();
+        assert_eq!(old.detectors, DetectorTuning::default());
+        assert_eq!(old.detectors.tbss_core_dbz, 60.0);
+
+        let mut s = Settings::default();
+        s.detectors.zdr_min_db = 2.5;
+        let back: Settings = serde_json::from_str(&serde_json::to_string(&s).unwrap()).unwrap();
+        assert_eq!(back.detectors.zdr_min_db, 2.5);
+    }
+
+    #[test]
     fn field_opacity_roundtrips_and_defaults() {
         let mut s = Settings::default();
         assert!(s.field_opacity.is_empty(), "no entry = fully opaque");
@@ -965,6 +1013,7 @@ mod tests {
     #[test]
     fn roundtrips() {
         let s = Settings {
+            detectors: DetectorTuning::default(),
             workspaces: Vec::new(),
             seeded_workspaces: false,
             smooth_radar: false,

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -413,6 +413,13 @@ pub struct Settings {
     /// Thresholds the signature detectors fire at (see [`DetectorTuning`]).
     #[serde(default)]
     pub detectors: DetectorTuning,
+    /// Cap for the on-disk radar-volume cache, in MB. 0 = the platform default (2 GB desktop,
+    /// 300 MB Android). Applied by the startup sweep, so a change takes effect next launch.
+    #[serde(default)]
+    pub volume_cache_mb: u32,
+    /// Cap for each on-disk map-tile cache (raster and vector), in MB. 0 = platform default.
+    #[serde(default)]
+    pub tile_disk_cache_mb: u32,
 }
 
 /// Where the dual-pol signature detectors and the GLM flash-extent grid draw their lines.
@@ -696,6 +703,8 @@ impl Default for Settings {
         Self {
             default_site: "KTLX".to_string(),
             detectors: DetectorTuning::default(),
+            volume_cache_mb: 0,
+            tile_disk_cache_mb: 0,
             share_card: true,
             hide_sidebar: false,
             hide_toolbar: false,
@@ -1014,6 +1023,8 @@ mod tests {
     fn roundtrips() {
         let s = Settings {
             detectors: DetectorTuning::default(),
+            volume_cache_mb: 0,
+            tile_disk_cache_mb: 0,
             workspaces: Vec::new(),
             seeded_workspaces: false,
             smooth_radar: false,

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -413,6 +413,11 @@ pub struct Settings {
     /// Thresholds the signature detectors fire at (see [`DetectorTuning`]).
     #[serde(default)]
     pub detectors: DetectorTuning,
+    /// Pushes quiet hours held back, kept across a restart so the catch-up summary still arrives
+    /// when the window ends. Device-local (see `cloud::DEVICE_LOCAL`): they are owed to whoever
+    /// is at this machine.
+    #[serde(default)]
+    pub quiet_pending: Vec<(String, String)>,
     /// Cap for the on-disk radar-volume cache, in MB. 0 = the platform default (2 GB desktop,
     /// 300 MB Android). Applied by the startup sweep, so a change takes effect next launch.
     #[serde(default)]
@@ -703,6 +708,7 @@ impl Default for Settings {
         Self {
             default_site: "KTLX".to_string(),
             detectors: DetectorTuning::default(),
+            quiet_pending: Vec::new(),
             volume_cache_mb: 0,
             tile_disk_cache_mb: 0,
             share_card: true,
@@ -981,6 +987,17 @@ mod tests {
     use super::*;
 
     #[test]
+    fn quiet_pending_round_trips_and_defaults_empty() {
+        let old: Settings = serde_json::from_str(r#"{"default_site":"KTLX"}"#).unwrap();
+        assert!(old.quiet_pending.is_empty());
+        let mut s = Settings::default();
+        s.quiet_pending
+            .push(("Severe Thunderstorm Warning".into(), "Cleveland Co.".into()));
+        let back: Settings = serde_json::from_str(&serde_json::to_string(&s).unwrap()).unwrap();
+        assert_eq!(back.quiet_pending, s.quiet_pending);
+    }
+
+    #[test]
     fn detector_tuning_survives_a_settings_file_that_predates_it() {
         // Settings written before the knobs existed must load with the shipped thresholds.
         let old: Settings = serde_json::from_str(r#"{"default_site":"KTLX"}"#).unwrap();
@@ -1023,6 +1040,7 @@ mod tests {
     fn roundtrips() {
         let s = Settings {
             detectors: DetectorTuning::default(),
+            quiet_pending: Vec::new(),
             volume_cache_mb: 0,
             tile_disk_cache_mb: 0,
             workspaces: Vec::new(),

--- a/crates/hookecho/src/storage.rs
+++ b/crates/hookecho/src/storage.rs
@@ -39,12 +39,12 @@ pub fn report() -> Vec<Entry> {
     let Some(root) = crate::paths::cache_dir() else {
         return Vec::new();
     };
-    let tiles = crate::tiles::DISK_CACHE_BYTES;
+    let tiles = crate::tiles::tile_cache_bytes();
     let small = crate::tiles::SMALL_CACHE_BYTES;
     [
         ("Map tiles", "tiles", Some(tiles)),
         ("Vector tiles", "vector", Some(tiles)),
-        ("Radar volumes", "volumes", Some(crate::tiles::VOLUME_CACHE_BYTES)),
+        ("Radar volumes", "volumes", Some(crate::tiles::volume_cache_bytes())),
         ("Zone geometry", "zones", Some(small)),
         ("Soundings (RAOB)", "raob", Some(small)),
         ("Server snapshots", "snapshots", Some(small)),

--- a/crates/hookecho/src/tiles.rs
+++ b/crates/hookecho/src/tiles.rs
@@ -1019,9 +1019,40 @@ pub(crate) const DISK_CACHE_BYTES: u64 = if cfg!(target_os = "android") {
     500 * 1024 * 1024
 };
 
-/// Trim the on-disk tile cache to [`DISK_CACHE_BYTES`], oldest-touched first.
+/// Trim the on-disk tile cache to [`tile_cache_bytes`], oldest-touched first.
 pub(crate) fn sweep_tile_cache(root: &std::path::Path) {
-    sweep_cache_dir(root, "tile cache", DISK_CACHE_BYTES);
+    sweep_cache_dir(root, "tile cache", tile_cache_bytes());
+}
+
+/// User overrides for the two disk caps, in bytes; 0 means "use the platform default".
+///
+/// Globals because the sweeps run from three places that construct before — and without — the
+/// settings: the raster and vector tile managers, and the startup volume sweep. One `set` at
+/// startup beats threading a cap through every constructor.
+static TILE_CAP: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+static VOLUME_CAP: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Apply the user's cap settings (in MB, 0 = platform default). Call once, before the managers.
+pub(crate) fn set_cache_caps(tile_mb: u32, volume_mb: u32) {
+    use std::sync::atomic::Ordering::Relaxed;
+    TILE_CAP.store(u64::from(tile_mb) * 1024 * 1024, Relaxed);
+    VOLUME_CAP.store(u64::from(volume_mb) * 1024 * 1024, Relaxed);
+}
+
+/// Cap for each on-disk tile cache (raster and vector are swept separately, to this same figure).
+pub(crate) fn tile_cache_bytes() -> u64 {
+    match TILE_CAP.load(std::sync::atomic::Ordering::Relaxed) {
+        0 => DISK_CACHE_BYTES,
+        n => n,
+    }
+}
+
+/// Cap for the on-disk radar-volume cache.
+pub(crate) fn volume_cache_bytes() -> u64 {
+    match VOLUME_CAP.load(std::sync::atomic::Ordering::Relaxed) {
+        0 => VOLUME_CACHE_BYTES,
+        n => n,
+    }
 }
 
 /// Trim `root` to `cap` bytes, deleting oldest-touched files first.
@@ -1071,10 +1102,9 @@ pub(crate) fn sweep_cache_dir(root: &std::path::Path, label: &str, cap: u64) {
     );
 }
 
-/// Largest the on-disk volume cache may get. An Archive II volume is 3-8 MB, so the desktop cap
+/// Default cap for the on-disk volume cache. An Archive II volume is 3-8 MB, so the desktop cap
 /// holds a few hundred — an afternoon of scrubbing one event — and the phone cap a couple of dozen.
-///
-/// ponytail: a constant, not a setting. Expose a slider if anyone runs out of disk.
+/// The Storage tab can override it; see [`volume_cache_bytes`].
 pub(crate) const VOLUME_CACHE_BYTES: u64 = if cfg!(target_os = "android") {
     300 * 1024 * 1024
 } else {
@@ -1196,6 +1226,17 @@ pub fn start_pack_download(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cache_caps_fall_back_to_the_platform_default_at_zero() {
+        assert_eq!(tile_cache_bytes(), DISK_CACHE_BYTES);
+        assert_eq!(volume_cache_bytes(), VOLUME_CACHE_BYTES);
+        set_cache_caps(64, 128);
+        assert_eq!(tile_cache_bytes(), 64 * 1024 * 1024);
+        assert_eq!(volume_cache_bytes(), 128 * 1024 * 1024);
+        set_cache_caps(0, 0);
+        assert_eq!(tile_cache_bytes(), DISK_CACHE_BYTES);
+    }
 
     #[test]
     fn pack_tile_count_covers_expected() {

--- a/crates/hookecho/src/ui/layer_options.rs
+++ b/crates/hookecho/src/ui/layer_options.rs
@@ -78,6 +78,8 @@ pub(crate) fn show(
     // Spotter Network dots: on-state, and how far from the radar to draw them (0 = whole feed).
     show_spotters: bool,
     spotter_range_km: &mut f64,
+    // Where the signature detectors draw their lines; only rendered for the ones that are on.
+    detectors: &mut crate::settings::DetectorTuning,
     // One line about the live composite: contributing sites and the age of its oldest scan, or
     // why there isn't one. Radars scan on their own schedules, so a composite is always a little
     // ragged in time and the honest thing is to show by how much.
@@ -442,6 +444,52 @@ pub(crate) fn show(
                 .on_hover_text("Reflectivity that counts as the storm top (18.5 = NWS EET)")
                 .changed();
         });
+    }
+
+    // Detector thresholds. Each block only appears with its own detector on, and the defaults are
+    // what the detectors shipped with — the reset button is there because a slider you can't get
+    // back from is worse than no slider.
+    if filters.show_tbss {
+        header(ui, "Hail spike (TBSS)");
+        ui.add(
+            egui::Slider::new(&mut detectors.tbss_core_dbz, 50.0..=70.0)
+                .text("Core")
+                .suffix(" dBZ"),
+        )
+        .on_hover_text("How strong the core must be before a spike behind it is looked for");
+    }
+    if filters.show_zdr_columns {
+        header(ui, "ZDR columns");
+        ui.add(
+            egui::Slider::new(&mut detectors.zdr_min_db, 0.5..=3.0)
+                .text("Minimum ZDR")
+                .suffix(" dB"),
+        );
+        ui.add(
+            egui::Slider::new(&mut detectors.zdr_min_depth_km, 0.5..=3.0)
+                .text("Depth above freezing")
+                .suffix(" km"),
+        );
+    }
+    if show_glm {
+        header(ui, "Flash-extent density");
+        ui.add(
+            egui::Slider::new(&mut detectors.glm_fed_cell_deg, 0.02..=0.2)
+                .text("Cell size")
+                .suffix("°"),
+        )
+        .on_hover_text("Grid resolution: 0.05° is about 5 km");
+        ui.add(
+            egui::Slider::new(&mut detectors.glm_fed_window_min, 5..=30)
+                .text("Window")
+                .suffix(" min"),
+        );
+        ui.weak("Takes effect on the next flash-density refresh.");
+    }
+    if (filters.show_tbss || filters.show_zdr_columns || show_glm)
+        && ui.button("Reset detector thresholds").clicked()
+    {
+        *detectors = crate::settings::DetectorTuning::default();
     }
 
     if [FL::Vil, FL::EchoTops, FL::Hca]

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -130,7 +130,7 @@ impl SettingsWindow {
                     Tab::Hotkeys => self.hotkeys_tab(ui, settings, entries),
                     Tab::Sync => action = sync_tab(ui, settings, &sync),
                     #[cfg(not(target_arch = "wasm32"))]
-                    Tab::Storage => self.storage_tab(ui),
+                    Tab::Storage => self.storage_tab(ui, settings),
                 }
             });
         self.capturing = self.rebinding.is_some() && open;
@@ -143,7 +143,7 @@ impl SettingsWindow {
 
     /// What the app has written to disk, and the buttons that take it back.
     #[cfg(not(target_arch = "wasm32"))]
-    fn storage_tab(&mut self, ui: &mut egui::Ui) {
+    fn storage_tab(&mut self, ui: &mut egui::Ui, settings: &mut Settings) {
         // Kick off one measurement per tab visit; the walk lands over a channel a frame or two
         // later, and the rows stay put until Refresh or a Clear asks for a fresh one.
         if self.storage.is_none() && self.storage_rows.is_none() {
@@ -214,6 +214,38 @@ impl SettingsWindow {
         if recheck {
             self.storage_rows = None;
         }
+
+        // The caps themselves. The sweep runs at startup (deleting mid-session would race the
+        // fetch tasks writing into the same directories), so a change lands on the next launch.
+        ui.separator();
+        ui.label(egui::RichText::new("Limits").small().strong());
+        for (label, mb, hint) in [
+            (
+                "Radar volumes",
+                &mut settings.volume_cache_mb,
+                "0 uses the platform default: 2 GB on the desktop, 300 MB on Android.",
+            ),
+            (
+                "Map tiles (each cache)",
+                &mut settings.tile_disk_cache_mb,
+                "Applies to the raster and vector tile caches separately. 0 = platform default.",
+            ),
+        ] {
+            ui.horizontal(|ui| {
+                ui.label(label);
+                ui.add(
+                    egui::DragValue::new(mb)
+                        .range(0..=64_000)
+                        .speed(50.0)
+                        .suffix(" MB"),
+                )
+                .on_hover_text(hint);
+                if *mb == 0 {
+                    ui.weak("default");
+                }
+            });
+        }
+        ui.weak("New limits apply at the next start.");
     }
 
     /// Rebindable keyboard shortcuts. Rows come from the binding table itself, so anything the


### PR DESCRIPTION
First of four packs from the external gap sweep. Smallest-risk-first: no new network hosts, no new UI surfaces, five self-contained commits.

**Detector thresholds are sliders now.** The hail-spike core dBZ, the ZDR column floor and depth, and the GLM flash-extent grid's cell size and window were constants. They are judgement calls that depend on the radar, the season and the user's noise tolerance. The detector caches key on the thresholds as well as the volume, so moving a slider recomputes instead of returning the answer to the previous question.

**Disk cache caps are settable** from the Storage tab, in MB, 0 meaning the platform default. The caps are process globals because the three sweeps that read them run from places that construct before the settings do; the sweep stays at startup, so a new limit applies at the next launch.

**Percent-encoded deep links work.** A shared link that goes through a chat client comes back with its commas and colons escaped, and the parser split on a comma that was no longer there — the link silently did nothing.

**DEM sampling is bilinear.** A z10 pixel is ~150 m across, and nearest-neighbour quantized every beam-blockage profile into terraces that came from the sampling, not the terrain.

**Quiet hours survives a restart.** The held-push queue is persisted (device-local, excluded from the sync blob), so quitting mid-window no longer throws away the catch-up summary.

Verification: `cargo clippy --workspace --all-targets` clean, `cargo test --workspace` 446 passed, wasm `cargo check` clean, `shoot.sh check` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)