### PR TITLE
R15 pack B — identity and comforts

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -11473,6 +11473,20 @@ impl HookEchoApp {
         if self.show_webcams {
             let show_labels = cam.zoom >= 8.0;
             let col = egui::Color32::from_rgb(110, 180, 240);
+            // A camera under a tornado or severe-thunderstorm warning is the one worth opening,
+            // and it looks exactly like the other forty until you click them all. Ring it.
+            // Polygons the alert layer already holds; no extra fetch and no extra geometry.
+            let threat: Vec<&GeoFeature> = self
+                .alert_features
+                .iter()
+                .filter(|f| {
+                    f.kind == overlay::FeatureKind::Warning
+                        && f.alert.as_ref().is_some_and(|a| {
+                            let e = a.event.to_ascii_lowercase();
+                            e.contains("tornado") || e.contains("severe thunderstorm")
+                        })
+                })
+                .collect();
             for site in &self.webcams {
                 let w = crate::render::mercator::lonlat_to_world(site.lon, site.lat);
                 let (sx, sy) = cam.world_to_screen(w, vp);
@@ -11486,6 +11500,17 @@ impl HookEchoApp {
                     4.0,
                     egui::Stroke::new(1.0, egui::Color32::from_black_alpha(170)),
                 );
+                // `distance_km` is 0 inside the polygon, which is the test we want here.
+                if threat
+                    .iter()
+                    .any(|f| f.distance_km(site.lon, site.lat) == 0.0)
+                {
+                    painter.circle_stroke(
+                        p,
+                        7.0,
+                        egui::Stroke::new(1.5, egui::Color32::from_rgb(255, 120, 60)),
+                    );
+                }
                 if show_labels {
                     painter.text(
                         p + egui::vec2(6.0, -5.0),

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1943,6 +1943,9 @@ pub struct HookEchoApp {
     link_cameras: bool,
     /// The always-on-top mini-loop window is open (desktop only; see `mini_loop_viewport`).
     mini_loop: bool,
+    /// The mini loop's own camera while it is open; `None` until it borrows the pane's.
+    #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
+    mini_cam: Option<crate::render::mercator::Camera>,
     /// The report left by a previous run that panicked, shown once until dismissed.
     crash_report: Option<String>,
     /// National gridded field layers (MRMS mosaic, rotation, MESH, AzShear, lightning), each with
@@ -2636,6 +2639,8 @@ impl HookEchoApp {
             loop_export: None,
             link_cameras: false,
             mini_loop: false,
+            #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
+            mini_cam: None,
             #[cfg(not(target_arch = "wasm32"))]
             crash_report: crate::crash::take_report(),
             #[cfg(target_arch = "wasm32")]
@@ -9913,9 +9918,10 @@ impl HookEchoApp {
     /// egui side and demand `'static + Send + Sync`, which `HookEchoApp` is not (wgpu handles,
     /// `Rc`s in the tile caches). Immediate renders inline on this thread, which is exactly what
     /// reusing [`Self::render_pane`] needs.
-    // ponytail: shares the active pane's camera, so panning in the mini loop pans the main window
-    // too. Give it its own MapView if that turns out to be the point of it. Not persisted either:
-    // it is a window, not a layer (see `OverlayToggle::session_only`).
+    /// The loop keeps its own camera, cloned from the active pane when the window opens and
+    /// swapped in for the duration of the render — panning the little window is how you look
+    /// somewhere else while the main map stays where it was.
+    // ponytail: not persisted; it is a window, not a layer (see `OverlayToggle::session_only`).
     #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
     fn mini_loop_viewport(&mut self, ctx: &egui::Context) {
         if !self.mini_loop {
@@ -10001,9 +10007,19 @@ impl HookEchoApp {
                             egui::Color32::from_gray(190),
                         );
                         let vctx = ui.ctx().clone();
+                        // Swap this window's camera in around the render, and take back whatever
+                        // the pointer did to it. Nothing returns early in between, so the pane
+                        // always gets its own camera back.
+                        let mine = self
+                            .mini_cam
+                            .take()
+                            .unwrap_or_else(|| self.views[idx].camera.clone());
+                        let pane_cam = std::mem::replace(&mut self.views[idx].camera, mine);
                         self.render_pane(
                             ui, &vctx, idx, prect, is_vector, is_raster, false, false, false, &[],
                         );
+                        self.mini_cam =
+                            Some(std::mem::replace(&mut self.views[idx].camera, pane_cam));
                     });
                 if ctx.input(|i| i.viewport().close_requested()) {
                     close = true;
@@ -10012,6 +10028,9 @@ impl HookEchoApp {
         );
         if close {
             self.mini_loop = false;
+            // Reopening should frame what the main map is looking at now, not where the loop was
+            // pointed an hour ago.
+            self.mini_cam = None;
         }
     }
 

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1124,6 +1124,8 @@ pub(crate) enum AppWindow {
     Cappi,
     Volume3d,
     StormTable,
+    /// What the signatures on the map are called.
+    Glossary,
     /// Warning verification lab (IEM Cow): how the office's warnings scored on an event day.
     Verify,
     Climatology,
@@ -1814,6 +1816,7 @@ pub struct HookEchoApp {
     // ponytail: one at a time; a Vec of players when someone wants a wall of streams.
     video_player: Option<ui::video_window::VideoPlayer>,
     cells_window: ui::cells_window::CellsWindow,
+    glossary: ui::glossary::Glossary,
     /// Warning verification lab and its in-flight query.
     verify_window: ui::verify_window::VerifyWindow,
     verify_rx: Option<std::sync::mpsc::Receiver<Result<wxdata::verify::Verification, String>>>,
@@ -2570,6 +2573,7 @@ impl HookEchoApp {
             pending_spotter: None,
             video_player: None,
             cells_window: Default::default(),
+            glossary: Default::default(),
             verify_window: Default::default(),
             verify_rx: None,
             xsection_moment: Moment::Reflectivity,
@@ -7462,6 +7466,12 @@ impl HookEchoApp {
                 true,
             ),
             (
+                W::Glossary,
+                "Glossary\u{2026}",
+                "What a TDS, a hail spike or a ZDR column actually is",
+                false,
+            ),
+            (
                 W::Verify,
                 "Warning verification…",
                 "Score an office's warnings against what actually happened",
@@ -7705,6 +7715,7 @@ impl HookEchoApp {
                     self.cappi_key = None; // force a re-slice on open
                 }
                 W::StormTable => self.cells_window.toggle(),
+                W::Glossary => self.glossary.toggle(),
                 W::Verify => self.open_verify(),
                 W::Volume3d => self.build_volume3d(),
                 W::Climatology => {
@@ -10013,7 +10024,7 @@ impl HookEchoApp {
                         let mine = self
                             .mini_cam
                             .take()
-                            .unwrap_or_else(|| self.views[idx].camera.clone());
+                            .unwrap_or(self.views[idx].camera);
                         let pane_cam = std::mem::replace(&mut self.views[idx].camera, mine);
                         self.render_pane(
                             ui, &vctx, idx, prect, is_vector, is_raster, false, false, false, &[],
@@ -15548,6 +15559,7 @@ impl eframe::App for HookEchoApp {
                 .collect(),
             _ => std::collections::HashSet::new(),
         };
+        ui::glossary::show(&mut self.glossary, ctx);
         if let Some(id) = ui::cells_window::show(
             &mut self.cells_window,
             ctx,

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1284,6 +1284,19 @@ fn field_refresh_secs(layer: crate::render::FieldLayer) -> u64 {
 
 /// The ZDR-column cache: the volume it was computed for, its columns, and the bright band the
 /// same pass found.
+/// A place the proximity alerts watch: a saved marker, or wherever the GPS says you are.
+struct WatchedPoint {
+    /// The marker's stable id; cooldowns key on this, never on the name.
+    id: String,
+    name: String,
+    lon: f64,
+    lat: f64,
+    radius_mi: f64,
+}
+
+/// Cooldown key for the follow-GPS pseudo-marker, which has no entry in the settings.
+const GPS_POINT_ID: &str = "gps";
+
 /// A volume key with the detector thresholds folded in, so moving a slider recomputes instead of
 /// handing back the answer to the previous question.
 type TunedKey = ((usize, String, usize), u64);
@@ -3446,21 +3459,28 @@ impl HookEchoApp {
     ///
     /// The GPS entry is deliberately not a real marker — a marker that moves would drag its way
     /// through the saved list, and it must vanish the moment the fix or the setting does.
-    fn watched_points(&self) -> Vec<(String, f64, f64, f64)> {
-        let mut out: Vec<(String, f64, f64, f64)> = self
+    fn watched_points(&self) -> Vec<WatchedPoint> {
+        let mut out: Vec<WatchedPoint> = self
             .settings
             .markers
             .iter()
-            .map(|m| (m.name.clone(), m.lon, m.lat, m.alert_radius_mi))
+            .map(|m| WatchedPoint {
+                id: m.id.clone(),
+                name: m.name.clone(),
+                lon: m.lon,
+                lat: m.lat,
+                radius_mi: m.alert_radius_mi,
+            })
             .collect();
         if self.settings.alert_follow_gps {
             if let Some((lon, lat)) = self.chase_pos {
-                out.push((
-                    "my location".to_string(),
+                out.push(WatchedPoint {
+                    id: GPS_POINT_ID.to_string(),
+                    name: "my location".to_string(),
                     lon,
                     lat,
-                    crate::settings::default_alert_radius_mi(),
-                ));
+                    radius_mi: crate::settings::default_alert_radius_mi(),
+                });
             }
         }
         out
@@ -3757,22 +3777,22 @@ impl HookEchoApp {
         const DENSITY_MIN: f32 = 0.05; // strikes/km²/min — any recent CG activity nearby
         const COOLDOWN: std::time::Duration = std::time::Duration::from_secs(600);
         let mut fired = false;
-        // Names first: the alert calls below need `&mut self`.
-        let near: Vec<String> = self
+        // Collected first: the alert calls below need `&mut self`.
+        let near: Vec<(String, String)> = self
             .watched_points()
             .into_iter()
-            .filter(|(_, lon, lat, _)| field.max_within_km(*lon, *lat, RADIUS_KM) >= DENSITY_MIN)
-            .map(|(name, ..)| name)
+            .filter(|p| field.max_within_km(p.lon, p.lat, RADIUS_KM) >= DENSITY_MIN)
+            .map(|p| (p.id, p.name))
             .collect();
-        for name in near {
+        for (id, name) in near {
             let recent = self
                 .lightning_alerted
-                .get(&name)
+                .get(&id)
                 .is_some_and(|t| t.elapsed() < COOLDOWN);
             if recent {
                 continue;
             }
-            self.lightning_alerted.insert(name.clone(), Instant::now());
+            self.lightning_alerted.insert(id, Instant::now());
             self.notify_alert(
                 &format!("⚡ Lightning near {name}"),
                 &format!("Cloud-to-ground strikes within {RADIUS_KM:.0} km of {name}"),
@@ -3852,21 +3872,26 @@ impl HookEchoApp {
         if self.rain_key.as_ref() == Some(&key) {
             return;
         }
-        // Watched points: every saved marker, plus where you are if chase mode knows.
-        let mut points: Vec<(String, [f64; 2])> = self
+        // Watched points: every saved marker, plus where you are if chase mode knows. Tracked by
+        // id — the detector's per-place persistence must not follow a rename or a reused name.
+        let mut points: Vec<(String, String, [f64; 2])> = self
             .settings
             .markers
             .iter()
-            .map(|m| (m.name.clone(), [m.lon, m.lat]))
+            .map(|m| (m.id.clone(), m.name.clone(), [m.lon, m.lat]))
             .collect();
         if let Some((lon, lat)) = self.chase_pos {
-            points.push(("your location".to_string(), [lon, lat]));
+            points.push((
+                GPS_POINT_ID.to_string(),
+                "your location".to_string(),
+                [lon, lat],
+            ));
         }
         if points.is_empty() {
             return;
         }
-        let names: Vec<String> = points.iter().map(|(n, _)| n.clone()).collect();
-        self.rain_detector.retain(&names);
+        let ids: Vec<String> = points.iter().map(|(id, ..)| id.clone()).collect();
+        self.rain_detector.retain(&ids);
 
         let tilt = self.views[idx].tilt;
         let Some(sweep) = self.views[idx]
@@ -3883,7 +3908,7 @@ impl HookEchoApp {
 
         let mut fired = false;
         self.rain_eta.clear();
-        for (name, at) in &points {
+        for (id, name, at) in &points {
             let eta = upstream_eta(
                 &sample,
                 *at,
@@ -3894,7 +3919,7 @@ impl HookEchoApp {
             if let Some(min) = eta {
                 self.rain_eta.push((name.clone(), min));
             }
-            if let Verdict::Fire(min) = self.rain_detector.update(name, eta) {
+            if let Verdict::Fire(min) = self.rain_detector.update(id, eta) {
                 self.notify_alert(
                     &format!("\u{1f327} Rain reaching {name}"),
                     &format!("About {min:.0} minutes out"),
@@ -5170,30 +5195,30 @@ impl HookEchoApp {
             return;
         }
         // Strongest couplet within each watched radius, if any.
-        let near: Vec<(String, f64, f32)> = self
+        let near: Vec<(String, String, f64, f32)> = self
             .watched_points()
             .into_iter()
-            .filter_map(|(name, lon, lat, radius_mi)| {
-                let radius_km = radius_mi * crate::geo::KM_PER_MILE;
+            .filter_map(|p| {
+                let radius_km = p.radius_mi * crate::geo::KM_PER_MILE;
                 hits.iter()
                     .filter_map(|h| {
-                        let (km, _) = crate::geo::great_circle([lon, lat], [h.lon, h.lat]);
+                        let (km, _) = crate::geo::great_circle([p.lon, p.lat], [h.lon, h.lat]);
                         (km <= radius_km).then_some((km, h.vrot_ms))
                     })
                     .min_by(|a, b| a.0.total_cmp(&b.0))
-                    .map(|(km, vrot)| (name, km, vrot))
+                    .map(|(km, vrot)| (p.id, p.name, km, vrot))
             })
             .collect();
         let mut fired = false;
-        for (name, km, vrot_ms) in near {
+        for (id, name, km, vrot_ms) in near {
             if self
                 .rotation_alerted
-                .get(&name)
+                .get(&id)
                 .is_some_and(|t| t.elapsed() < COOLDOWN)
             {
                 continue;
             }
-            self.rotation_alerted.insert(name.clone(), Instant::now());
+            self.rotation_alerted.insert(id, Instant::now());
             let kt = vrot_ms as f64 * 1.943_844;
             let mi = km / crate::geo::KM_PER_MILE;
             self.banner(
@@ -10305,6 +10330,7 @@ impl HookEchoApp {
                     MapTool::Marker => {
                         let n = self.settings.markers.len() + 1;
                         self.settings.markers.push(crate::settings::Marker {
+                            id: crate::settings::new_marker_id(),
                             name: format!("Marker {n}"),
                             lat,
                             lon,
@@ -15192,6 +15218,7 @@ impl eframe::App for HookEchoApp {
             match res {
                 Ok((name, lat, lon)) => {
                     self.settings.markers.push(crate::settings::Marker {
+                        id: crate::settings::new_marker_id(),
                         name: name.clone(),
                         lat,
                         lon,

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -594,6 +594,12 @@ pub fn default_spotter_range_km() -> f64 {
 /// A named location marker at a geographic point.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Marker {
+    /// Stable identity, independent of the name. Names are the display field and are not unique
+    /// — "Marker 3" comes back after a delete — so anything that remembers a marker between
+    /// frames (alert cooldowns, most of all) keys on this instead. Empty in files written before
+    /// ids existed; [`Settings::load`] fills those in once.
+    #[serde(default)]
+    pub id: String,
     pub name: String,
     pub lat: f64,
     pub lon: f64,
@@ -613,6 +619,19 @@ pub struct Marker {
     /// At most one marker has this set (the marker editor enforces it).
     #[serde(default)]
     pub home: bool,
+}
+
+/// A fresh marker id: 8 hex characters from the system's randomness, which is plenty for a list
+/// a person types by hand.
+pub fn new_marker_id() -> String {
+    let mut b = [0u8; 4];
+    // A duplicate id would only collapse two markers' alert cooldowns; falling back to a
+    // time-based id beats refusing to make the marker.
+    if getrandom::fill(&mut b).is_err() {
+        let t = chrono::Utc::now().timestamp_subsec_nanos();
+        b = t.to_le_bytes();
+    }
+    b.iter().map(|x| format!("{x:02x}")).collect()
 }
 
 /// Default watch radius for a marker, in miles.
@@ -881,6 +900,15 @@ impl Settings {
         if cfg!(target_os = "android") && (loaded.ui_scale - 1.3).abs() < 0.001 {
             loaded.ui_scale = 1.0;
         }
+        // Markers saved before ids existed get one now, and keep it: written straight back so the
+        // Android alert service reads the same identities this process does.
+        let filled = loaded.markers.iter().any(|m| m.id.is_empty());
+        for m in loaded.markers.iter_mut().filter(|m| m.id.is_empty()) {
+            m.id = new_marker_id();
+        }
+        if filled {
+            loaded.save();
+        }
         loaded
     }
 
@@ -987,6 +1015,23 @@ mod tests {
     use super::*;
 
     #[test]
+    fn markers_get_distinct_ids_and_old_files_still_load() {
+        // A settings file from before ids existed.
+        let old: Settings = serde_json::from_str(
+            r#"{"markers":[{"name":"Home","lat":35.3,"lon":-97.3},
+                           {"name":"Home","lat":36.1,"lon":-96.9}]}"#,
+        )
+        .unwrap();
+        assert_eq!(old.markers.len(), 2);
+        assert!(old.markers.iter().all(|m| m.id.is_empty()));
+        // Two places can share a name; ids are what tell them apart.
+        let ids: Vec<String> = (0..64).map(|_| new_marker_id()).collect();
+        assert!(ids.iter().all(|id| id.len() == 8));
+        let unique: std::collections::HashSet<&String> = ids.iter().collect();
+        assert_eq!(unique.len(), ids.len());
+    }
+
+    #[test]
     fn quiet_pending_round_trips_and_defaults_empty() {
         let old: Settings = serde_json::from_str(r#"{"default_site":"KTLX"}"#).unwrap();
         assert!(old.quiet_pending.is_empty());
@@ -1074,6 +1119,7 @@ mod tests {
                 opacity: 1.0,
             }],
             markers: vec![Marker {
+                id: new_marker_id(),
                 name: "Home".to_string(),
                 lat: 35.3,
                 lon: -97.5,
@@ -1244,6 +1290,7 @@ mod tests {
     fn kotlin_alert_service_field_names_survive() {
         let json = serde_json::to_string(&Settings {
             markers: vec![Marker {
+                id: new_marker_id(),
                 name: "Home".to_string(),
                 lat: 35.0,
                 lon: -97.0,

--- a/crates/hookecho/src/status.rs
+++ b/crates/hookecho/src/status.rs
@@ -437,6 +437,7 @@ mod tests {
     fn explicit_point_beats_markers() {
         let mut settings = crate::settings::Settings::default();
         settings.markers.push(crate::settings::Marker {
+                id: crate::settings::new_marker_id(),
             name: "Home".into(),
             lat: 1.0,
             lon: 2.0,
@@ -457,6 +458,7 @@ mod tests {
         let mut settings = crate::settings::Settings::default();
         settings.markers = vec![
             crate::settings::Marker {
+                id: crate::settings::new_marker_id(),
                 name: "Cabin".into(),
                 lat: 1.0,
                 lon: 2.0,
@@ -466,6 +468,7 @@ mod tests {
                 home: false,
             },
             crate::settings::Marker {
+                id: crate::settings::new_marker_id(),
                 name: "Home".into(),
                 lat: 3.0,
                 lon: 4.0,

--- a/crates/hookecho/src/ui/glossary.rs
+++ b/crates/hookecho/src/ui/glossary.rs
@@ -1,0 +1,188 @@
+//! What the signatures on the map are called, and what they mean.
+//!
+//! The app draws TDS rings, hail spikes and ZDR columns, and names them the way a warning
+//! meteorologist would. That is the right vocabulary — but somebody who installed this to watch
+//! the storm over their own house has no way to look any of it up without leaving the app for a
+//! forum post of unknown vintage. Fifteen entries, searchable, no network.
+
+/// One term: what it is called, and the two or three sentences that make it useful.
+struct Entry {
+    term: &'static str,
+    /// What it is, in the plainest words that stay true.
+    body: &'static str,
+}
+
+const ENTRIES: &[Entry] = &[
+    Entry {
+        term: "Hook echo",
+        body: "The comma-shaped notch on the back-right of a supercell's reflectivity, where the \
+               storm's rotating updraft wraps precipitation around itself. Where the app gets its \
+               name. A hook is a reason to look at velocity, not a tornado by itself.",
+    },
+    Entry {
+        term: "TDS — tornado debris signature",
+        body: "Lofted debris seen by dual-pol: high reflectivity, near-zero velocity couplet, and \
+               correlation coefficient dropping below about 0.8 because chunks of building are \
+               nothing like raindrops. A TDS is confirmation that something on the ground is \
+               being destroyed, so it is the one detection this app treats as urgent.",
+    },
+    Entry {
+        term: "TBSS — three-body scatter spike (hail spike)",
+        body: "A spike of weak echo pointing directly away from the radar behind a very strong \
+               core. Radar energy bounces off large hail down to the ground and back up, arriving \
+               late, so the radar paints it further out than it is. It is an artifact — and a \
+               reliable sign of big hail.",
+    },
+    Entry {
+        term: "ZDR column",
+        body: "A plume of high differential reflectivity extending above the freezing level, \
+               which means liquid raindrops are being carried up where only ice belongs. That \
+               takes a strong updraft, and the column usually deepens ten to twenty minutes \
+               before the storm produces.",
+    },
+    Entry {
+        term: "Bright band",
+        body: "A ring of enhanced reflectivity at the melting level in stratiform rain: snow \
+               melts into a wet coating that looks huge to the radar, then collapses into \
+               raindrops. Reads as a false ring of heavy rain around the radar in winter.",
+    },
+    Entry {
+        term: "BWER — bounded weak echo region",
+        body: "A pocket of weak echo inside a storm with strong echo above and around it. The \
+               updraft there is so strong that precipitation has not had time to form. A \
+               classic supercell signature, best seen in a vertical cross-section.",
+    },
+    Entry {
+        term: "Bow echo",
+        body: "A line segment that bulges downwind, driven by a rear-inflow jet. The apex is \
+               where the strongest straight-line winds are. Bows are a wind threat first; \
+               tornadoes, when they happen, come from the ends.",
+    },
+    Entry {
+        term: "MARC — mid-altitude radial convergence",
+        body: "A band of strong inbound-next-to-outbound velocity a few kilometres up along a \
+               squall line, where the rear-inflow jet meets the front-to-rear flow. Often shows \
+               ten to thirty minutes before damaging wind reaches the ground.",
+    },
+    Entry {
+        term: "Velocity couplet",
+        body: "Inbound and outbound velocities side by side, which is rotation. What matters is \
+               how strong (Vrot), how tight, and how low — a tight couplet at the lowest tilt \
+               close to the radar is a very different thing from a broad one at 20,000 feet.",
+    },
+    Entry {
+        term: "Outflow boundary",
+        body: "The leading edge of cold air spreading out from a storm's downdraft, drawn as a \
+               thin line of weak echo. Storms that cross one often intensify: the boundary adds \
+               low-level spin the updraft can tilt upright.",
+    },
+    Entry {
+        term: "VIL — vertically integrated liquid",
+        body: "How much water the radar sees in a column, in kg/m². High VIL means a deep, wet \
+               storm. VIL density (VIL divided by echo top) is the better hail discriminator, \
+               because it asks whether that water is packed into a short column.",
+    },
+    Entry {
+        term: "MESO and TVS badges",
+        body: "The radar's own algorithm output: MESO flags a mesocyclone-strength circulation, \
+               TVS a tornadic vortex signature. They are pattern matches, not verdicts — plenty \
+               of TVS flags never produce, and plenty of tornadoes never get one.",
+    },
+    Entry {
+        term: "SRM — storm-relative velocity",
+        body: "Velocity with the storm's own motion subtracted, so a rotation that is being \
+               carried along at 50 knots stops hiding inside the translation. Turn it on when a \
+               couplet looks like it might just be the storm moving.",
+    },
+    Entry {
+        term: "Dual-pol moments",
+        body: "The radar transmits horizontally and vertically. ZDR (differential reflectivity) \
+               says whether targets are wide or tall — big raindrops flatten, hail tumbles. CC \
+               (correlation coefficient) says whether they are all the same kind of thing; low \
+               CC means a mixture, like debris. KDP tracks liquid water content and sees through \
+               attenuation.",
+    },
+    Entry {
+        term: "Hail spike vs hail core",
+        body: "The core is the actual hail: a small area of very high reflectivity. The spike is \
+               the artifact it throws behind itself, away from the radar. If you are judging \
+               hail size, judge the core; the spike only tells you the core is serious.",
+    },
+];
+
+#[derive(Default)]
+pub struct Glossary {
+    pub open: bool,
+    query: String,
+}
+
+impl Glossary {
+    pub fn toggle(&mut self) {
+        self.open = !self.open;
+    }
+}
+
+pub fn show(state: &mut Glossary, ctx: &egui::Context) {
+    if !state.open {
+        return;
+    }
+    let mut open = state.open;
+    let window = egui::Window::new("Glossary")
+        .open(&mut open)
+        .default_width(430.0)
+        .default_height(480.0)
+        .resizable(true);
+    crate::ui::phone_surface(ctx, window).show(ctx, |ui| {
+        ui.horizontal(|ui| {
+            ui.label("Find");
+            ui.text_edit_singleline(&mut state.query);
+            if !state.query.is_empty() && ui.button("✕").clicked() {
+                state.query.clear();
+            }
+        });
+        ui.separator();
+        let q = state.query.trim().to_ascii_lowercase();
+        // Search the bodies too: someone who only knows "the debris thing" should still land on
+        // TDS without knowing to type three letters.
+        let hits: Vec<&Entry> = ENTRIES
+            .iter()
+            .filter(|e| {
+                q.is_empty()
+                    || e.term.to_ascii_lowercase().contains(&q)
+                    || e.body.to_ascii_lowercase().contains(&q)
+            })
+            .collect();
+        egui::ScrollArea::vertical().show(ui, |ui| {
+            if hits.is_empty() {
+                ui.weak("Nothing matches that.");
+            }
+            for e in hits {
+                ui.label(egui::RichText::new(e.term).strong());
+                ui.label(e.body);
+                ui.add_space(8.0);
+            }
+        });
+    });
+    state.open = open;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_entry_is_filled_in_and_named_once() {
+        let mut seen = std::collections::HashSet::new();
+        for e in ENTRIES {
+            assert!(!e.term.is_empty() && !e.body.is_empty(), "{}", e.term);
+            assert!(seen.insert(e.term), "duplicate term {}", e.term);
+        }
+        // The signatures the app itself draws must be in here, or the glossary is decoration.
+        for must in ["TDS", "TBSS", "ZDR column", "Bright band"] {
+            assert!(
+                ENTRIES.iter().any(|e| e.term.contains(must)),
+                "missing {must}"
+            );
+        }
+    }
+}

--- a/crates/hookecho/src/ui/marker_window.rs
+++ b/crates/hookecho/src/ui/marker_window.rs
@@ -78,6 +78,7 @@ impl MarkerWindow {
                 if ui.button("➕ Add blank marker").clicked() {
                     let n = settings.markers.len() + 1;
                     settings.markers.push(Marker {
+                        id: crate::settings::new_marker_id(),
                         name: format!("Marker {n}"),
                         lat: 0.0,
                         lon: 0.0,

--- a/crates/hookecho/src/ui/mod.rs
+++ b/crates/hookecho/src/ui/mod.rs
@@ -81,6 +81,7 @@ pub mod detail_window;
 pub mod digest_window;
 pub mod event_window;
 pub mod forecast_window;
+pub mod glossary;
 pub mod hodograph_window;
 pub mod layer_options;
 pub mod layer_window;

--- a/crates/hookecho/src/ui/wizard.rs
+++ b/crates/hookecho/src/ui/wizard.rs
@@ -221,6 +221,7 @@ fn card_alerts(ui: &mut egui::Ui, settings: &mut Settings, icon_tex: &IconTextur
             .unwrap_or((0.0, 0.0));
         let offset = 0.05 * n as f64;
         settings.markers.push(crate::settings::Marker {
+            id: crate::settings::new_marker_id(),
             name: format!("Location {n}"),
             lat: lat + offset,
             lon: lon + offset,


### PR DESCRIPTION
Second of four packs. Depends on nothing in pack A beyond sharing a base; pack D's per-marker rules will depend on the marker ids landed here.

**Markers have a stable id.** Names are a display field: two places can share one, and "Marker 3" comes back after a delete. Every map that remembered a marker between frames — lightning, rotation and rain-arrival cooldowns — was keyed on that name, so a rename silently reset the cooldowns and a duplicate name made two places share one. Files written before ids get them filled in once and written straight back, so the Android alert service reads the same identities.

**The mini loop has its own camera.** It rendered the active pane through the pane's camera, so panning the little always-on-top window panned the main map underneath it.

**Cameras under a warning are ringed.** Forty webcam dots look identical, and the one worth opening is the one with a tornado or severe-thunderstorm polygon over it. Uses polygons the alert layer already holds.

**A glossary.** The app names things the way a warning meteorologist would; fifteen searchable entries explain them without leaving the app. Search covers the bodies, so "debris" finds TDS.

Verification: `cargo clippy --workspace --all-targets` clean, `cargo test --workspace` 448 passed, wasm `cargo check` clean, `shoot.sh check` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)