### PR TITLE
R15 pack C — --serve and Home Assistant

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,5 +33,6 @@ VOLUME ["/root/.config/hookecho", "/root/.cache/hookecho"]
 EXPOSE 8080
 
 # 0.0.0.0 inside the container is the whole point of the container; publish the port deliberately
-# (`-p 127.0.0.1:8080:8080` to keep it on the host's loopback).
+# (`-p 127.0.0.1:8080:8080` to keep it on the host's loopback). Publishing it anywhere else wants
+# a token: set `serve_token` in the mounted settings.json, or add `--serve-token <secret>` here.
 ENTRYPOINT ["hookecho", "--serve", "8080", "--bind", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -534,7 +534,9 @@ hookecho --serve 9000 --bind 0.0.0.0
 | `/status.json` | conditions and nearby alerts for every saved location |
 | `/alerts.json` | alerts only |
 | `/obs.json` | conditions only |
-| `/snapshot.png?site=KTLX` | a radar render — `&product=VEL`, `&basemap=none`, `&size=512` (256–2048), `&zoom=6.5` |
+| `/cells.json?site=KTLX` | every storm cell the radar's algorithms track — hail size, tops, VIL, TVS, forecast track |
+| `/health.json` | version, uptime and how stale the answers are, for a container health check |
+| `/snapshot.png?site=KTLX` | a radar render — `&product=VEL`, `&basemap=none`, `&size=512` (256–2048), `&zoom=6.5`, `&tilt=1` |
 
 JSON answers are cached for a minute and snapshots for five, so polling it every
 30 seconds costs the upstream services nothing extra.

--- a/README.md
+++ b/README.md
@@ -541,6 +541,20 @@ hookecho --serve 9000 --bind 0.0.0.0
 JSON answers are cached for a minute and snapshots for five, so polling it every
 30 seconds costs the upstream services nothing extra.
 
+The server binds loopback and answers anyone who asks. Putting it on a network
+(`--bind 0.0.0.0`, or a container port that isn't `127.0.0.1:`) means publishing
+where you live, so set a token first — `serve_token` in settings.json, or
+`--serve-token` on the command line, which wins:
+
+```sh
+curl -H 'Authorization: Bearer hunter2' http://boxname:8080/status.json
+curl 'http://boxname:8080/snapshot.png?site=KTLX&token=hunter2'
+```
+
+Every route is behind it, `/metrics` and the CORS proxy included. The
+`?token=` form is there for dashboards that can only fetch a URL and have no
+place to put a header.
+
 For a desktop widget rather than a server, `--snapshot` writes the same render
 straight to a file:
 

--- a/README.md
+++ b/README.md
@@ -594,8 +594,14 @@ there's a custom component in [`custom_components/hookecho`](custom_components/h
 point it at a machine running `--serve` and you get, per saved location, a
 device carrying temperature, dewpoint, humidity, wind, gust and pressure
 sensors, an **alert count** sensor and an **alert active** binary sensor
-(attributes: event, expiry, distance, escalation tier), plus one **radar
+(attributes: event, expiry, distance, escalation tier), a **nearest storm**
+sensor giving the distance to the closest cell the radar is tracking
+(attributes: cell id, bearing, max dBZ, hail size, TVS), plus one **radar
 camera** entity showing the live snapshot.
+
+The nearest-storm sensor is the one to automate on: it answers "is a storm
+coming" minutes before anybody issues a warning, and goes unavailable — never
+zero — when nothing is being tracked.
 
 Install via HACS as a custom repository, or copy the `custom_components/hookecho`
 directory into your Home Assistant `config/custom_components/` and restart. Then
@@ -604,7 +610,7 @@ which is the server's own cache window.
 
 Remember the server has to be reachable from Home Assistant — that means
 `--bind 0.0.0.0` (or the container), and a network you're willing to expose your
-saved locations on.
+saved locations on. Set `serve_token` if that network is not one you control.
 
 ### In a browser
 

--- a/crates/hookecho/src/cloud.rs
+++ b/crates/hookecho/src/cloud.rs
@@ -25,7 +25,7 @@ const REMOTE_NAME: &str = "settings.json";
 
 /// Settings fields that belong to *this* machine and must survive a sync from another one.
 /// Everything else — markers, placefiles, palettes, theme, API keys — is shared.
-pub const DEVICE_LOCAL: [&str; 5] = [
+pub const DEVICE_LOCAL: [&str; 6] = [
     "ui_scale",
     "share_name",
     "background_alerts",
@@ -33,6 +33,9 @@ pub const DEVICE_LOCAL: [&str; 5] = [
     // Pushes this machine held back during quiet hours. They are owed to whoever is sitting at
     // this device, and would arrive as somebody else's stale summary if they travelled.
     "quiet_pending",
+    // This machine's server credential. Copying it to a laptop would mean two boxes sharing one
+    // token, and one of them changing it locks the other out.
+    "serve_token",
 ];
 
 /// What Google gave us. Stored beside settings.json but never inside it: these are credentials,

--- a/crates/hookecho/src/main.rs
+++ b/crates/hookecho/src/main.rs
@@ -83,8 +83,14 @@ fn main() -> eframe::Result<()> {
         let bind = flag_value(&args, "--bind").unwrap_or("127.0.0.1");
         // `--web-root DIR` also serves the browser build sitting in that directory.
         let web_root = flag_value(&args, "--web-root").map(std::path::PathBuf::from);
-        let spots = hookecho::status::spots(&settings::Settings::load(), None);
-        if let Err(e) = hookecho::serve::run(spots, bind, port, web_root) {
+        let saved = settings::Settings::load();
+        // `--serve-token` wins over the setting, so a container can pass one in without editing
+        // the settings file it mounted read-only.
+        let token = flag_value(&args, "--serve-token")
+            .map(str::to_string)
+            .unwrap_or_else(|| saved.serve_token.clone());
+        let spots = hookecho::status::spots(&saved, None);
+        if let Err(e) = hookecho::serve::run(spots, bind, port, web_root, token) {
             eprintln!("serve failed: {e}");
             std::process::exit(1);
         }

--- a/crates/hookecho/src/serve.rs
+++ b/crates/hookecho/src/serve.rs
@@ -27,6 +27,9 @@ const SNAPSHOT_TTL: Duration = Duration::from_secs(300);
 
 struct Server {
     spots: Vec<Spot>,
+    /// Bearer token every request must carry, or empty for the open behaviour. A user secret:
+    /// it lives in settings.json (or the flag) and is never committed.
+    token: String,
     /// Directory of static files to serve (the browser build), if this was started with one.
     web_root: Option<std::path::PathBuf>,
     rt: tokio::runtime::Runtime,
@@ -43,11 +46,13 @@ pub fn run(
     bind: &str,
     port: u16,
     web_root: Option<std::path::PathBuf>,
+    token: String,
 ) -> anyhow::Result<()> {
     let _ = STARTED.set(Instant::now());
     let listener = TcpListener::bind((bind, port))?;
     let server = Arc::new(Server {
         spots,
+        token,
         web_root,
         // One runtime and one client for the process, not one per request like the headless
         // verifiers build — this one stays up.
@@ -60,7 +65,11 @@ pub fn run(
     });
     log::info!("serving on http://{bind}:{port}");
     if bind == "0.0.0.0" {
-        log::warn!("bound to all interfaces — anyone on this network can read your locations");
+        if server.token.is_empty() {
+            log::warn!("bound to all interfaces — anyone on this network can read your locations");
+        } else {
+            log::info!("bound to all interfaces, bearer token required");
+        }
     }
     for stream in listener.incoming() {
         match stream {
@@ -79,8 +88,9 @@ pub fn run(
 }
 
 fn handle(server: &Server, mut stream: TcpStream) -> anyhow::Result<()> {
+    let mut reader = BufReader::new(stream.try_clone()?);
     let mut line = String::new();
-    BufReader::new(stream.try_clone()?).read_line(&mut line)?;
+    reader.read_line(&mut line)?;
     // "GET /status.json?x=1 HTTP/1.1"
     let target = line.split_whitespace().nth(1).unwrap_or("/");
     let (path, query) = match target.split_once('?') {
@@ -88,7 +98,41 @@ fn handle(server: &Server, mut stream: TcpStream) -> anyhow::Result<()> {
         None => (target, ""),
     };
 
-    let (status, ctype, body) = route(server, path, query);
+    // The headers were ignored until there was a token to read out of them. Bounded: a client
+    // that never sends the blank line, or sends a header wall, is hung up on rather than humoured.
+    let mut authorized = server.token.is_empty();
+    if !authorized {
+        let supplied = query_token(query);
+        for _ in 0..64 {
+            let mut h = String::new();
+            if reader.read_line(&mut h)? == 0 || h.trim().is_empty() {
+                break;
+            }
+            if let Some((name, value)) = h.split_once(':') {
+                if name.trim().eq_ignore_ascii_case("authorization") {
+                    if let Some(bearer) = value.trim().strip_prefix("Bearer ") {
+                        authorized |= constant_time_eq(bearer.trim(), &server.token);
+                    }
+                }
+            }
+        }
+        // A dashboard that can only put things in a URL (a picture element, a widget) has no
+        // header to set, so `?token=` is accepted too — on loopback, and for a token the user
+        // chose to hand out.
+        if let Some(t) = supplied {
+            authorized |= constant_time_eq(&t, &server.token);
+        }
+    }
+    let (status, ctype, body) = if authorized {
+        route(server, path, query)
+    } else {
+        count("denied");
+        (
+            "401 Unauthorized",
+            "application/json",
+            br#"{"error":"missing or bad bearer token"}"#.to_vec(),
+        )
+    };
     stream.write_all(
         format!(
             "HTTP/1.1 {status}\r\nContent-Type: {ctype}\r\nContent-Length: {}\r\n\
@@ -139,6 +183,20 @@ fn route(server: &Server, path: &str, query: &str) -> (&'static str, &'static st
         _ if server.web_root.is_some() => static_file(server, path),
         _ => not_found(),
     }
+}
+
+/// The `token=` query parameter, if the request carried one.
+fn query_token(query: &str) -> Option<String> {
+    crate::cloud::param(query, "token")
+}
+
+/// Compare without leaking where the two differ through timing. Length is not a secret here (the
+/// user chose it), but the content is.
+fn constant_time_eq(a: &str, b: &str) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.bytes().zip(b.bytes()).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
 }
 
 fn not_found() -> (&'static str, &'static str, Vec<u8>) {
@@ -417,8 +475,8 @@ fn snapshot(server: &Server, query: &str) -> anyhow::Result<Vec<u8>> {
 }
 
 /// The route labels `/metrics` reports, in counter order.
-const ROUTES: [&str; 7] = [
-    "index", "json", "cells", "snapshot", "metrics", "proxy", "other",
+const ROUTES: [&str; 8] = [
+    "index", "json", "cells", "snapshot", "metrics", "proxy", "denied", "other",
 ];
 /// One counter per label in [`ROUTES`], bumped on every request in [`route`].
 ///
@@ -677,9 +735,24 @@ mod tests {
     use super::*;
 
     #[test]
+    fn the_token_check_is_exact_and_length_safe() {
+        assert!(constant_time_eq("hunter2", "hunter2"));
+        assert!(!constant_time_eq("hunter2", "hunter3"));
+        assert!(!constant_time_eq("hunter2", "hunter22"));
+        assert!(!constant_time_eq("", "x"));
+        // An empty configured token means the server is open; that decision is made before this
+        // is ever called, but two empties must not compare unequal.
+        assert!(constant_time_eq("", ""));
+        // A dashboard's `?token=` form.
+        assert_eq!(query_token("site=KTLX&token=abc"), Some("abc".to_string()));
+        assert_eq!(query_token("site=KTLX"), None);
+    }
+
+    #[test]
     fn unknown_paths_404() {
         // A server with no spots: routing is independent of what it would report.
         let server = Server {
+            token: String::new(),
             spots: Vec::new(),
             web_root: None,
             rt: tokio::runtime::Builder::new_current_thread()
@@ -701,6 +774,7 @@ mod tests {
     #[test]
     fn static_serving_refuses_to_walk_out_of_the_web_root() {
         let server = Server {
+            token: String::new(),
             spots: Vec::new(),
             web_root: Some(std::path::PathBuf::from("/var/empty")),
             rt: tokio::runtime::Builder::new_current_thread()
@@ -728,6 +802,7 @@ mod tests {
     #[test]
     fn proxy_refuses_hosts_that_are_not_on_the_list() {
         let server = Server {
+            token: String::new(),
             spots: Vec::new(),
             web_root: None,
             rt: tokio::runtime::Builder::new_current_thread()
@@ -763,6 +838,7 @@ mod tests {
     #[test]
     fn requests_are_counted_by_route() {
         let server = Server {
+            token: String::new(),
             spots: Vec::new(),
             web_root: None,
             rt: tokio::runtime::Builder::new_current_thread()

--- a/crates/hookecho/src/serve.rs
+++ b/crates/hookecho/src/serve.rs
@@ -44,6 +44,7 @@ pub fn run(
     port: u16,
     web_root: Option<std::path::PathBuf>,
 ) -> anyhow::Result<()> {
+    let _ = STARTED.set(Instant::now());
     let listener = TcpListener::bind((bind, port))?;
     let server = Arc::new(Server {
         spots,
@@ -103,7 +104,8 @@ fn handle(server: &Server, mut stream: TcpStream) -> anyhow::Result<()> {
 fn route(server: &Server, path: &str, query: &str) -> (&'static str, &'static str, Vec<u8>) {
     count(match path {
         "/" => "index",
-        "/status.json" | "/alerts.json" | "/obs.json" => "json",
+        "/status.json" | "/alerts.json" | "/obs.json" | "/health.json" => "json",
+        "/cells.json" => "cells",
         "/snapshot.png" => "snapshot",
         "/metrics" => "metrics",
         _ if path.starts_with("/proxy/") => "proxy",
@@ -113,6 +115,14 @@ fn route(server: &Server, path: &str, query: &str) -> (&'static str, &'static st
         "/" if server.web_root.is_some() => static_file(server, "/index.html"),
         "/" => ("200 OK", "text/html; charset=utf-8", index().into_bytes()),
         "/status.json" | "/alerts.json" | "/obs.json" => match cached_json(server, path) {
+            Ok(body) => ("200 OK", "application/json", body),
+            Err(e) => error_json(e),
+        },
+        "/cells.json" => match cells_json(server, query) {
+            Ok(body) => ("200 OK", "application/json", body),
+            Err(e) => error_json(e),
+        },
+        "/health.json" => match health_json(server) {
             Ok(body) => ("200 OK", "application/json", body),
             Err(e) => error_json(e),
         },
@@ -223,9 +233,109 @@ fn cached_json(server: &Server, path: &str) -> anyhow::Result<Vec<u8>> {
     Ok(body)
 }
 
+/// `GET /cells.json?site=KTLX` — every SCIT storm cell the radar's own algorithms are tracking.
+///
+/// The same four Level 3 products the storm-attributes table reads, in the same fields, plus the
+/// position and forecast track a map needs. What `/status.json` cannot answer: it speaks for
+/// saved locations, and "what storms exist near this radar" is a different question.
+fn cells_json(server: &Server, query: &str) -> anyhow::Result<Vec<u8>> {
+    let site = crate::cloud::param(query, "site").unwrap_or_else(|| "KTLX".to_string());
+    if !site.chars().all(|c| c.is_ascii_alphanumeric()) {
+        anyhow::bail!("bad site");
+    }
+    let site = site.to_ascii_uppercase();
+    let key = format!("/cells.json?{site}");
+    if let Some(hit) = server
+        .cache
+        .lock()
+        .unwrap()
+        .get(&key)
+        .filter(|(when, _)| when.elapsed() < JSON_TTL)
+    {
+        return Ok(hit.1.clone());
+    }
+    let cells = server
+        .rt
+        .block_on(wxdata::level3::fetch_cells(&server.http, &site));
+    let body = serde_json::to_vec(&serde_json::json!({
+        "site": site,
+        "cells": cells.iter().map(cell_json).collect::<Vec<_>>(),
+    }))?;
+    server
+        .cache
+        .lock()
+        .unwrap()
+        .insert(key, (Instant::now(), body.clone()));
+    Ok(body)
+}
+
+/// One cell on the wire. Hand-written rather than derived: the wire format is a promise to
+/// whatever is polling this, and it should not move because a struct field was renamed.
+fn cell_json(c: &wxdata::level3::Cell) -> serde_json::Value {
+    serde_json::json!({
+        "id": c.title,
+        "lon": c.lon,
+        "lat": c.lat,
+        "azimuth_deg": c.az_deg,
+        "range_nm": c.range_nm,
+        "movement_deg": c.mvt_deg,
+        "movement_kt": c.mvt_kt,
+        "max_dbz": c.max_dbz,
+        "top_kft": c.top_kft,
+        "vil": c.vil,
+        "poh": c.poh,
+        "posh": c.posh,
+        "hail_in": c.hail_in,
+        "tvs": c.tvs,
+        "meso": c.meso,
+        "track": c.track.iter().map(|t| serde_json::json!({
+            "minutes": t.minutes,
+            "lon": t.lon,
+            "lat": t.lat,
+        })).collect::<Vec<_>>(),
+    })
+}
+
+/// `GET /health.json` — is this instance actually answering with fresh data?
+///
+/// A container that is up but has not reached a feed in an hour looks exactly like a healthy one
+/// from the outside, which is the failure worth catching. Ages are in seconds; `null` means that
+/// answer has never been built in this process.
+fn health_json(server: &Server) -> anyhow::Result<Vec<u8>> {
+    let age = |path: &str| -> Option<f64> {
+        server
+            .cache
+            .lock()
+            .unwrap()
+            .get(path)
+            .map(|(when, _)| when.elapsed().as_secs_f64())
+    };
+    // Ask for a status build if nothing has yet, so a fresh container reports on real feeds
+    // rather than on never having tried.
+    let feeds_ok = cached_json(server, "/status.json").is_ok();
+    let body = serde_json::to_vec(&serde_json::json!({
+        "version": env!("CARGO_PKG_VERSION"),
+        "uptime_secs": STARTED.get().map(|t| t.elapsed().as_secs()),
+        "spots": server.spots.len(),
+        "feeds_ok": feeds_ok,
+        "status_age_secs": age("/status.json"),
+        "snapshot_cached": server
+            .cache
+            .lock()
+            .unwrap()
+            .keys()
+            .filter(|k| k.starts_with("/snapshot.png"))
+            .count(),
+    }))?;
+    Ok(body)
+}
+
+/// When this process started serving, for `/health.json`.
+static STARTED: std::sync::OnceLock<Instant> = std::sync::OnceLock::new();
+
 /// A radar PNG through the same off-screen renderer the `--headless` verifier uses.
 ///
-// ponytail: one render at a time; tilt and palette are still fixed. Add them when someone asks.
+// ponytail: one render at a time; the palette is still fixed. Add it when someone asks.
 fn snapshot(server: &Server, query: &str) -> anyhow::Result<Vec<u8>> {
     let site = crate::cloud::param(query, "site").unwrap_or_else(|| "KTLX".to_string());
     let product = crate::cloud::param(query, "product").unwrap_or_else(|| "REF".to_string());
@@ -246,9 +356,15 @@ fn snapshot(server: &Server, query: &str) -> anyhow::Result<Vec<u8>> {
     let zoom: Option<f64> = crate::cloud::param(query, "zoom").and_then(|v| v.parse().ok());
     let px = size.unwrap_or(1000).clamp(256, 2048);
     let zoom_tag = zoom.map_or_else(|| "auto".to_string(), |z| format!("{z:.2}"));
+    // Elevation index, not degrees: the same number the app's tilt picker uses. A volume has at
+    // most a couple of dozen sweeps, and asking past the end is a missing render, not a crash.
+    let tilt: usize = crate::cloud::param(query, "tilt")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0)
+        .min(30);
 
     let key = format!(
-        "/snapshot.png?{site}&{product}&{}&{px}&{zoom_tag}",
+        "/snapshot.png?{site}&{product}&{}&{px}&{zoom_tag}&{tilt}",
         basemap.slug()
     );
     if let Some(hit) = server
@@ -268,7 +384,7 @@ fn snapshot(server: &Server, query: &str) -> anyhow::Result<Vec<u8>> {
     let dir = dir.join("snapshots");
     std::fs::create_dir_all(&dir)?;
     let out = dir.join(format!(
-        "snapshot-{site}-{product}-{}-{px}-{zoom_tag}.png",
+        "snapshot-{site}-{product}-{}-{px}-{zoom_tag}-{tilt}.png",
         basemap.slug()
     ));
     {
@@ -281,7 +397,7 @@ fn snapshot(server: &Server, query: &str) -> anyhow::Result<Vec<u8>> {
             out.to_string_lossy().as_ref(),
             &site,
             moment,
-            0,
+            tilt,
             true,
             None,
             None,
@@ -301,7 +417,9 @@ fn snapshot(server: &Server, query: &str) -> anyhow::Result<Vec<u8>> {
 }
 
 /// The route labels `/metrics` reports, in counter order.
-const ROUTES: [&str; 6] = ["index", "json", "snapshot", "metrics", "proxy", "other"];
+const ROUTES: [&str; 7] = [
+    "index", "json", "cells", "snapshot", "metrics", "proxy", "other",
+];
 /// One counter per label in [`ROUTES`], bumped on every request in [`route`].
 ///
 // ponytail: flat process-lifetime counters, no histograms or per-status buckets; the ceiling is

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -413,6 +413,11 @@ pub struct Settings {
     /// Thresholds the signature detectors fire at (see [`DetectorTuning`]).
     #[serde(default)]
     pub detectors: DetectorTuning,
+    /// Bearer token `--serve` requires on every request; empty leaves the server open, which is
+    /// what loopback-only has always been. A user secret: settings.json only, never committed,
+    /// and device-local so it does not travel to machines that are not this server.
+    #[serde(default)]
+    pub serve_token: String,
     /// Pushes quiet hours held back, kept across a restart so the catch-up summary still arrives
     /// when the window ends. Device-local (see `cloud::DEVICE_LOCAL`): they are owed to whoever
     /// is at this machine.
@@ -727,6 +732,7 @@ impl Default for Settings {
         Self {
             default_site: "KTLX".to_string(),
             detectors: DetectorTuning::default(),
+            serve_token: String::new(),
             quiet_pending: Vec::new(),
             volume_cache_mb: 0,
             tile_disk_cache_mb: 0,
@@ -1085,6 +1091,7 @@ mod tests {
     fn roundtrips() {
         let s = Settings {
             detectors: DetectorTuning::default(),
+            serve_token: String::new(),
             quiet_pending: Vec::new(),
             volume_cache_mb: 0,
             tile_disk_cache_mb: 0,

--- a/crates/hookecho/src/status.rs
+++ b/crates/hookecho/src/status.rs
@@ -49,6 +49,25 @@ pub struct SpotStatus {
     pub wind_dir: Option<String>,
     pub pressure_in: Option<f32>,
     pub alerts: Vec<AlertBrief>,
+    /// The closest storm cell the nearest radar's algorithms are tracking, if there is one.
+    /// Absent — not zero — when nothing is being tracked: "no storms" and "the feed is down"
+    /// must not both read as a distance of nought.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nearest_cell: Option<CellBrief>,
+}
+
+/// A storm cell, as much of it as a dashboard needs.
+#[derive(Debug, Clone, Serialize)]
+pub struct CellBrief {
+    /// SCIT id, e.g. "O7".
+    pub id: String,
+    pub distance_km: f64,
+    /// Bearing from the spot to the cell, degrees clockwise from north.
+    pub bearing_deg: f64,
+    pub max_dbz: Option<f32>,
+    pub hail_in: Option<f32>,
+    /// Present when the radar flagged a tornadic vortex signature on this cell.
+    pub tvs: Option<String>,
 }
 
 /// How to print the report.
@@ -119,6 +138,9 @@ pub async fn collect(http: &reqwest::Client, spots: &[Spot]) -> anyhow::Result<V
     let points: Vec<(f64, f64)> = spots.iter().map(|s| (s.lat, s.lon)).collect();
     let feats = wxdata::alerts::fetch_active(http, &points).await?;
     let mut out = Vec::with_capacity(spots.len());
+    // One Level 3 fetch per radar, however many spots that radar covers.
+    let mut cells: std::collections::HashMap<String, Vec<wxdata::level3::Cell>> =
+        std::collections::HashMap::new();
     for spot in spots {
         let mut alerts: Vec<AlertBrief> = Vec::new();
         let mut seen = std::collections::HashSet::new();
@@ -136,9 +158,50 @@ pub async fn collect(http: &reqwest::Client, spots: &[Spot]) -> anyhow::Result<V
                 .cmp(&a.escalation)
                 .then(a.distance_km.total_cmp(&b.distance_km))
         });
-        out.push(status_for(spot, observation(http, spot).await, alerts));
+        let cell = nearest_cell(http, spot, &mut cells).await;
+        out.push(status_for(
+            spot,
+            observation(http, spot).await,
+            alerts,
+            cell,
+        ));
     }
     Ok(out)
+}
+
+/// The closest tracked storm to `spot`, from the radar that covers it.
+///
+/// Cells are fetched per radar, not per spot, and memoized in `by_site` for this pass: three
+/// markers in one county share one set of Level 3 round trips. A radar with nothing to say — or a
+/// feed that is down — yields `None` rather than a zero.
+async fn nearest_cell(
+    http: &reqwest::Client,
+    spot: &Spot,
+    by_site: &mut std::collections::HashMap<String, Vec<wxdata::level3::Cell>>,
+) -> Option<CellBrief> {
+    let site = crate::geo::nearest_site_id(spot.lon, spot.lat)?;
+    if !by_site.contains_key(&site) {
+        let cells = wxdata::level3::fetch_cells(http, &site).await;
+        by_site.insert(site.clone(), cells);
+    }
+    by_site
+        .get(&site)?
+        .iter()
+        // Standalone detections carry no cell id; they are not a storm to point at.
+        .filter(|c| !c.title.is_empty())
+        .map(|c| {
+            let (km, bearing) = crate::geo::great_circle([spot.lon, spot.lat], [c.lon, c.lat]);
+            (km, bearing, c)
+        })
+        .min_by(|a, b| a.0.total_cmp(&b.0))
+        .map(|(km, bearing, c)| CellBrief {
+            id: c.title.clone(),
+            distance_km: km,
+            bearing_deg: bearing,
+            max_dbz: c.max_dbz,
+            hail_in: c.hail_in,
+            tvs: c.tvs.clone(),
+        })
 }
 
 /// The nearest station's latest observation, or `None` when there isn't one (offshore, OCONUS,
@@ -173,6 +236,7 @@ fn status_for(
     spot: &Spot,
     ob: Option<(String, wxdata::obs::Observation)>,
     alerts: Vec<AlertBrief>,
+    nearest_cell: Option<CellBrief>,
 ) -> SpotStatus {
     let (station, o) = match ob {
         Some((id, o)) => (Some(id), Some(o)),
@@ -198,6 +262,7 @@ fn status_for(
             .and_then(|o| o.slp_pa.or(o.pressure_pa))
             .map(|pa| pa / 3386.389),
         alerts,
+        nearest_cell,
     }
 }
 
@@ -361,8 +426,9 @@ mod tests {
                 &spot("Home", true),
                 Some(("KOKC".into(), ob())),
                 vec![warning()],
+                None,
             ),
-            status_for(&spot("Cabin", false), None, vec![]),
+            status_for(&spot("Cabin", false), None, vec![], None),
         ];
         let text = human(&report);
         assert_eq!(
@@ -374,11 +440,12 @@ mod tests {
     #[test]
     fn line_reports_home_even_when_it_is_not_first() {
         let report = vec![
-            status_for(&spot("Cabin", false), None, vec![]),
+            status_for(&spot("Cabin", false), None, vec![], None),
             status_for(
                 &spot("Home", true),
                 Some(("KOKC".into(), ob())),
                 vec![warning()],
+                None,
             ),
         ];
         assert_eq!(
@@ -393,6 +460,7 @@ mod tests {
             &spot("Home", true),
             Some(("KOKC".into(), ob())),
             vec![],
+            None,
         )];
         assert_eq!(line(&report), "74°F 62%rh SW 12kt");
         assert!(line(&[]).is_empty());
@@ -404,6 +472,7 @@ mod tests {
             &spot("Home", true),
             Some(("KOKC".into(), ob())),
             vec![warning()],
+            None,
         )];
         let v: serde_json::Value =
             serde_json::from_str(&serde_json::to_string(&report).unwrap()).unwrap();
@@ -415,9 +484,29 @@ mod tests {
         assert_eq!(v[0]["alerts"][0]["event"], "Tornado Warning");
         assert_eq!(v[0]["alerts"][0]["escalation"], 2);
         // A station that reported nothing serializes as null, not as a zero.
-        let empty = status_for(&spot("Cabin", false), None, vec![]);
+        let empty = status_for(&spot("Cabin", false), None, vec![], None);
         let v = serde_json::to_value(&empty).unwrap();
         assert!(v["temp_f"].is_null() && v["station"].is_null());
+        // No tracked storms: the key is absent, so a consumer says "unavailable" rather than
+        // reading a distance of zero as "on top of you".
+        assert!(v.get("nearest_cell").is_none());
+        let stormy = status_for(
+            &spot("Home", true),
+            None,
+            vec![],
+            Some(CellBrief {
+                id: "O7".into(),
+                distance_km: 12.5,
+                bearing_deg: 220.0,
+                max_dbz: Some(62.0),
+                hail_in: Some(1.75),
+                tvs: None,
+            }),
+        );
+        let v = serde_json::to_value(&stormy).unwrap();
+        assert_eq!(v["nearest_cell"]["id"], "O7");
+        assert_eq!(v["nearest_cell"]["distance_km"], 12.5);
+        assert_eq!(v["nearest_cell"]["hail_in"], 1.75);
     }
 
     #[test]
@@ -429,7 +518,7 @@ mod tests {
         let mut sparse = sparse;
         sparse.rh = None;
         sparse.wind_kmh = None;
-        let s = status_for(&spot("Home", true), Some(("KXYZ".into(), sparse)), vec![]);
+        let s = status_for(&spot("Home", true), Some(("KXYZ".into(), sparse)), vec![], None);
         assert_eq!(conditions(&s), "50°F");
     }
 

--- a/custom_components/hookecho/const.py
+++ b/custom_components/hookecho/const.py
@@ -25,6 +25,14 @@ KEY_ALERT_UNTIL = "until"
 KEY_ALERT_DISTANCE = "distance_km"
 KEY_ALERT_ESCALATION = "escalation"
 
+KEY_NEAREST_CELL = "nearest_cell"
+KEY_CELL_ID = "id"
+KEY_CELL_DISTANCE = "distance_km"
+KEY_CELL_BEARING = "bearing_deg"
+KEY_CELL_MAX_DBZ = "max_dbz"
+KEY_CELL_HAIL = "hail_in"
+KEY_CELL_TVS = "tvs"
+
 # (json key, sensor key, name suffix, unit, device class, state class)
 MEASUREMENTS = [
     ("temp_f", "temperature", "temperature", "°F", "temperature", "measurement"),

--- a/custom_components/hookecho/manifest.json
+++ b/custom_components/hookecho/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/d4vid87/hookecho/issues",
   "requirements": [],
-  "version": "0.5.0"
+  "version": "0.6.0"
 }

--- a/custom_components/hookecho/sensor.py
+++ b/custom_components/hookecho/sensor.py
@@ -12,6 +12,13 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from . import HookEchoCoordinator
 from .const import (
     DOMAIN,
+    KEY_CELL_BEARING,
+    KEY_CELL_DISTANCE,
+    KEY_CELL_HAIL,
+    KEY_CELL_ID,
+    KEY_CELL_MAX_DBZ,
+    KEY_CELL_TVS,
+    KEY_NEAREST_CELL,
     KEY_ALERT_DISTANCE,
     KEY_ALERT_ESCALATION,
     KEY_ALERT_EVENT,
@@ -32,6 +39,7 @@ async def async_setup_entry(
             HookEchoMeasurement(coordinator, spot, *m) for m in MEASUREMENTS
         ]
         entities.append(HookEchoAlertCount(coordinator, spot))
+        entities.append(HookEchoNearestStorm(coordinator, spot))
     async_add_entities(entities)
 
 
@@ -122,4 +130,48 @@ class HookEchoAlertCount(HookEchoEntity, SensorEntity):
             "until": worst.get(KEY_ALERT_UNTIL),
             "distance_km": worst.get(KEY_ALERT_DISTANCE),
             "escalation": worst.get(KEY_ALERT_ESCALATION),
+        }
+
+
+class HookEchoNearestStorm(HookEchoEntity, SensorEntity):
+    """How far away the closest tracked storm cell is, and what the radar says about it.
+
+    An alert count answers "has an office issued something". This answers "is there a
+    storm coming", which is the automation people actually want — close the awning at
+    fifteen kilometres, not when a warning is finally drawn.
+    """
+
+    _attr_name = "nearest storm"
+    _attr_icon = "mdi:weather-lightning-rainy"
+    _attr_native_unit_of_measurement = "km"
+    _attr_device_class = "distance"
+    _attr_state_class = "measurement"
+
+    def __init__(self, coordinator: HookEchoCoordinator, spot: str) -> None:
+        super().__init__(coordinator, spot)
+        self._attr_unique_id = f"hookecho_{spot}_nearest_storm"
+
+    @property
+    def _cell(self) -> dict:
+        return self.spot.get(KEY_NEAREST_CELL) or {}
+
+    @property
+    def available(self) -> bool:
+        # Nothing tracked, or the Level 3 feed is down: unavailable. Reporting 0 km would
+        # read as a storm directly overhead, which is the one wrong answer here.
+        return super().available and bool(self._cell)
+
+    @property
+    def native_value(self) -> float | None:
+        return self._cell.get(KEY_CELL_DISTANCE)
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        cell = self._cell
+        return {
+            "cell": cell.get(KEY_CELL_ID),
+            "bearing_deg": cell.get(KEY_CELL_BEARING),
+            "max_dbz": cell.get(KEY_CELL_MAX_DBZ),
+            "hail_in": cell.get(KEY_CELL_HAIL),
+            "tvs": cell.get(KEY_CELL_TVS),
         }

--- a/scripts/shots/shoot.sh
+++ b/scripts/shots/shoot.sh
@@ -462,7 +462,7 @@ check() {
   grep -q '"mapbox_key": ""' "$REPO/scripts/shots/settings.template.json" \
     || { echo "LEAK: settings.template.json has a non-empty mapbox_key"; fail=1; }
   # Secrets that must never reach the committed template: absent or empty, nothing else.
-  for k in discord_webhook slack_webhook matrix_token; do
+  for k in discord_webhook slack_webhook matrix_token serve_token; do
     v="$(jq -r --arg k "$k" '.[$k] // ""' "$REPO/scripts/shots/settings.template.json")"
     [ -z "$v" ] || { echo "LEAK: settings.template.json has a non-empty $k"; fail=1; }
   done


### PR DESCRIPTION
Third of four packs. No new network hosts — everything reuses fetchers the app already calls.

**`/cells.json?site=KTLX`** answers what `/status.json` cannot: status speaks for saved locations, and "what storms exist near this radar" is a different question. The same four Level 3 products the storm-attributes table reads, plus position and forecast track. The wire format is hand-written rather than derived from the internal struct, so it does not move when a field is renamed.

**`/health.json`** is the container answer: an instance that is up but has not reached a feed in an hour looks healthy from outside, which is the failure worth catching.

**`tilt=` on `/snapshot.png`** — the renderer already took an elevation index; the server was passing 0.

**An optional bearer token.** The server answers anyone who asks, which is fine on loopback and not fine the moment somebody publishes the container port. Empty `serve_token` keeps today's behaviour exactly; a non-empty one is checked in `handle()` before routing, so it covers `/metrics` and the CORS proxy too. Constant-time compare, denials counted as their own route. This needed the request headers, which the server had never read past the request line — bounded at 64. A `?token=` form is accepted for dashboards that fetch a URL with nowhere to put a header. The token is a user secret: settings.json only, device-local so it cannot travel through sync, and `shoot.sh check` now asserts it is empty in the committed template.

**A Home Assistant nearest-storm sensor.** `status.json` gains `nearest_cell` — the closest tracked cell with distance, bearing, max dBZ, hail size and TVS. One Level 3 fetch per radar per pass, so several markers in one county share it. Absent when nothing is tracked, and the sensor goes unavailable rather than reporting 0 km, which would read as a storm overhead. Component version bumped to 0.6.0.

Verification: clippy clean, `cargo test --workspace` passing, wasm check clean, `shoot.sh check` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)