### PR TITLE
R15 pack D — custom alert rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -758,6 +758,7 @@ cargo run --release -- --headless-indices -97.5 35.3
 cargo run --release -- --headless-glm                       # GOES satellite lightning
 cargo run --release -- --headless-fronts                    # WPC surface analysis
 cargo run --release -- --headless-hrrr uh 3 uh.png          # refc|uh|smoke
+cargo run --release -- --headless-rules KTLX                # would your alert rules fire?
 ```
 
 ```sh

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1126,6 +1126,8 @@ pub(crate) enum AppWindow {
     StormTable,
     /// What the signatures on the map are called.
     Glossary,
+    /// The user's own alert rules.
+    AlertRules,
     /// Warning verification lab (IEM Cow): how the office's warnings scored on an event day.
     Verify,
     Climatology,
@@ -1817,6 +1819,7 @@ pub struct HookEchoApp {
     video_player: Option<ui::video_window::VideoPlayer>,
     cells_window: ui::cells_window::CellsWindow,
     glossary: ui::glossary::Glossary,
+    rules_window: ui::rules_window::RulesWindow,
     /// Warning verification lab and its in-flight query.
     verify_window: ui::verify_window::VerifyWindow,
     verify_rx: Option<std::sync::mpsc::Receiver<Result<wxdata::verify::Verification, String>>>,
@@ -2582,6 +2585,7 @@ impl HookEchoApp {
             video_player: None,
             cells_window: Default::default(),
             glossary: Default::default(),
+            rules_window: Default::default(),
             verify_window: Default::default(),
             verify_rx: None,
             xsection_moment: Moment::Reflectivity,
@@ -7702,6 +7706,12 @@ impl HookEchoApp {
                 true,
             ),
             (
+                W::AlertRules,
+                "Alert rules\u{2026}",
+                "Tell the app what is worth interrupting you for",
+                false,
+            ),
+            (
                 W::Glossary,
                 "Glossary\u{2026}",
                 "What a TDS, a hail spike or a ZDR column actually is",
@@ -7952,6 +7962,7 @@ impl HookEchoApp {
                 }
                 W::StormTable => self.cells_window.toggle(),
                 W::Glossary => self.glossary.toggle(),
+                W::AlertRules => self.rules_window.toggle(),
                 W::Verify => self.open_verify(),
                 W::Volume3d => self.build_volume3d(),
                 W::Climatology => {
@@ -15830,6 +15841,9 @@ impl eframe::App for HookEchoApp {
             _ => std::collections::HashSet::new(),
         };
         ui::glossary::show(&mut self.glossary, ctx);
+        if ui::rules_window::show(&mut self.rules_window, ctx, &mut self.settings) {
+            self.settings.save();
+        }
         if let Some(id) = ui::cells_window::show(
             &mut self.cells_window,
             ctx,

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -2178,6 +2178,14 @@ pub struct HookEchoApp {
     /// Volume the rain check last ran against, so it runs per scan (what the detector's
     /// persistence and cooldown are written for) instead of per frame.
     rain_key: Option<(usize, String, usize)>,
+    /// When the flash-extent grid was last built. Its own clock, because a rule can want the
+    /// grid while the layer that used to own the cadence is off.
+    glm_fed_last: Option<Instant>,
+    /// Same per-volume guard for the user's scan rules: evaluated once per volume, not per frame.
+    rules_key: Option<(usize, String, usize)>,
+    /// When each rule last fired, keyed `"{rule id}:{place}"` — a rule watching two places gets
+    /// to speak about both.
+    rules_fired: std::collections::HashMap<String, Instant>,
     rain_eta: Vec<(String, f32)>,
     /// Minute-by-minute rain over the forecast point, and the (volume, point, motion) key it was
     /// computed for — the walk samples the whole sweep, so it runs once per volume, not per frame.
@@ -2783,6 +2791,9 @@ impl HookEchoApp {
             minute_key: None,
             rain_detector: Default::default(),
             rain_key: None,
+            glm_fed_last: None,
+            rules_key: None,
+            rules_fired: std::collections::HashMap::new(),
             rain_eta: Vec::new(),
             show_fronts: false,
             fronts: None,
@@ -3659,29 +3670,37 @@ impl HookEchoApp {
                 // A watched location always alerts + pushes: inside the polygon, or within that
                 // marker's radius of it. Home first, then the closest — a warning that clips two
                 // saved places should name the one you sleep in.
-                let hit = self
+                // Owned, not borrowed: the rule pass below needs `&mut self` while this is
+                // still in hand.
+                let hit: Option<(String, f64)> = self
                     .settings
                     .markers
                     .iter()
                     .filter_map(|m| {
                         let km = f.distance_km(m.lon, m.lat);
-                        (km <= m.alert_radius_mi * crate::geo::KM_PER_MILE).then_some((m, km))
+                        (km <= m.alert_radius_mi * crate::geo::KM_PER_MILE)
+                            .then(|| (m.name.clone(), m.home, km))
                     })
-                    .min_by(|(a, ka), (b, kb)| {
-                        b.home
-                            .cmp(&a.home)
+                    .min_by(|(_, ha, ka), (_, hb, kb)| {
+                        hb.cmp(ha)
                             .then(ka.partial_cmp(kb).unwrap_or(std::cmp::Ordering::Equal))
-                    });
+                    })
+                    .map(|(name, _, km)| (name, km));
                 // A drawn watch zone the warning polygon touches. Independent of the markers: a
                 // zone is an area you care about, not a point with a radius around it.
-                let zone = self.settings.alert_polygons.iter().find(|z| {
-                    f.rings
-                        .first()
-                        .is_some_and(|outer| wxdata::overlay::rings_intersect(outer, &z.ring))
-                });
-                if let (Some(z), true) = (zone, notify_ok) {
+                let zone: Option<String> = self
+                    .settings
+                    .alert_polygons
+                    .iter()
+                    .find(|z| {
+                        f.rings
+                            .first()
+                            .is_some_and(|outer| wxdata::overlay::rings_intersect(outer, &z.ring))
+                    })
+                    .map(|z| z.name.clone());
+                if let (Some(z), true) = (zone.as_deref(), notify_ok) {
                     self.notify_alert(
-                        &format!("⚠ {} — {}", a.event, z.name),
+                        &format!("⚠ {} — {z}", a.event),
                         if a.headline.is_empty() {
                             &a.area
                         } else {
@@ -3690,13 +3709,51 @@ impl HookEchoApp {
                         urgent,
                     );
                 }
-                let zone_name = zone.map(|z| z.name.clone());
+                // User rules that watch warnings. The id-dedupe above is their cooldown: a
+                // warning is announced once, however long it stands.
+                for rule in self.settings.alert_rules.clone() {
+                    if !rule.enabled || !crate::rules::warning_matches(&rule, &a.event) {
+                        continue;
+                    }
+                    // Anywhere: the warning polygon is somewhere on this radar. A place: the
+                    // polygon has to reach it, using the same distance the built-in alert uses.
+                    let reaches = match &rule.place {
+                        crate::settings::RulePlace::Anywhere => true,
+                        crate::settings::RulePlace::Marker { id } => self
+                            .settings
+                            .markers
+                            .iter()
+                            .find(|m| &m.id == id)
+                            .is_some_and(|m| {
+                                f.distance_km(m.lon, m.lat)
+                                    <= m.alert_radius_mi * crate::geo::KM_PER_MILE
+                            }),
+                        crate::settings::RulePlace::Zone { name } => self
+                            .settings
+                            .alert_polygons
+                            .iter()
+                            .find(|z| &z.name == name)
+                            .is_some_and(|z| {
+                                f.rings.first().is_some_and(|outer| {
+                                    wxdata::overlay::rings_intersect(outer, &z.ring)
+                                })
+                            }),
+                    };
+                    if reaches {
+                        let place = crate::rules::place_label(&rule.place, &self.settings);
+                        let title = format!("\u{25c9} {}", rule.title());
+                        let body = format!("{} at {place}", a.event);
+                        self.notify_alert(&title, &body, rule.urgent);
+                        self.banner(title, body);
+                    }
+                }
+                let zone_name = zone;
                 let (label, area) = match hit {
-                    Some((m, km)) => {
+                    Some((name, km)) => {
                         // Watched location covered → push to the phone (opt-in ntfy topic).
                         if notify_ok {
                             self.notify_alert(
-                                &format!("⚠ {} — {}", a.event, m.name),
+                                &format!("⚠ {} — {}", a.event, name),
                                 if a.headline.is_empty() {
                                     &a.area
                                 } else {
@@ -3706,9 +3763,9 @@ impl HookEchoApp {
                             );
                         }
                         let where_ = if km <= 0.05 {
-                            format!("covers {}", m.name)
+                            format!("covers {name}")
                         } else {
-                            format!("{:.0} mi from {}", km / crate::geo::KM_PER_MILE, m.name)
+                            format!("{:.0} mi from {name}", km / crate::geo::KM_PER_MILE)
                         };
                         (format!("⚠ {}", a.event), where_)
                     }
@@ -3773,6 +3830,185 @@ impl HookEchoApp {
                 }
             }
         }
+    }
+
+    /// Run the user's scan rules over one volume's detections.
+    ///
+    /// Once per volume, not per frame: the same reason `check_rain_arrival` keys on the volume.
+    /// Called with every scan detector's hits already computed — including detectors whose layer
+    /// is off, which is what makes a rule independent of what happens to be drawn.
+    fn evaluate_scan_rules(
+        &mut self,
+        idx: usize,
+        tds: &[wxdata::tds::TdsHit],
+        tbss: &[wxdata::dualpol::TbssHit],
+        zdr: &[wxdata::dualpol::ZdrColumnHit],
+        couplets: &[wxdata::rotation::CoupletHit],
+    ) {
+        use crate::rules::Detection;
+        use crate::settings::RuleTrigger as T;
+        if self.settings.alert_rules.iter().all(|r| !r.enabled) {
+            return;
+        }
+        let key = self.volume_key(idx);
+        if self.rules_key.as_ref() == Some(&key) {
+            return;
+        }
+        self.rules_key = Some(key);
+        // Strengths in the units the rule is written in: knots for rotation, and nothing for the
+        // signatures that are their own answer.
+        let hits = |t: &T| -> Vec<Detection> {
+            match t {
+                T::Tds => tds.iter().map(|h| Detection::at(h.lon, h.lat)).collect(),
+                T::Tbss => tbss.iter().map(|h| Detection::at(h.lon, h.lat)).collect(),
+                T::ZdrColumn => zdr.iter().map(|h| Detection::at(h.lon, h.lat)).collect(),
+                T::Rotation => couplets
+                    .iter()
+                    .map(|h| Detection::with_strength(h.lon, h.lat, h.vrot_ms as f64 * 1.943_844))
+                    .collect(),
+                _ => Vec::new(),
+            }
+        };
+        for rule in self.settings.alert_rules.clone() {
+            if !rule.enabled || !rule.trigger.is_scan() {
+                continue;
+            }
+            // The closest qualifying detection is the one worth naming.
+            let hit = hits(&rule.trigger)
+                .into_iter()
+                .filter(|h| crate::rules::matches(&rule, h, &self.settings))
+                .min_by(|a, b| {
+                    let d = |h: &Detection| self.distance_from_radar_km(idx, h.lon, h.lat);
+                    d(a).total_cmp(&d(b))
+                });
+            let Some(hit) = hit else { continue };
+            self.fire_rule(&rule, &hit);
+        }
+    }
+
+    /// Run the lightning-density rules over a freshly built flash-extent grid.
+    ///
+    /// The grid's own cell is the detection: a cell whose flash count clears the rule's threshold
+    /// is somewhere worth knowing about. Cooldowns are per rule and place, as everywhere else.
+    fn evaluate_grid_rules(&mut self, field: &wxdata::mrms::MrmsField) {
+        use crate::rules::Detection;
+        let rules: Vec<crate::settings::AlertRule> = self
+            .settings
+            .alert_rules
+            .iter()
+            .filter(|r| r.enabled && r.trigger == crate::settings::RuleTrigger::GlmFed)
+            .cloned()
+            .collect();
+        if rules.is_empty() || field.nx == 0 || field.ny == 0 {
+            return;
+        }
+        let (dx, dy) = (
+            (field.lon_east - field.lon_west) / field.nx as f64,
+            (field.lat_north - field.lat_south) / field.ny as f64,
+        );
+        for rule in rules {
+            // The busiest qualifying cell — a rule about lightning wants the worst of it.
+            let best = field
+                .values
+                .iter()
+                .enumerate()
+                .filter(|(_, v)| v.is_finite() && **v > 0.0)
+                .map(|(i, v)| {
+                    let (x, y) = (i % field.nx, i / field.nx);
+                    Detection::with_strength(
+                        field.lon_west + (x as f64 + 0.5) * dx,
+                        field.lat_north - (y as f64 + 0.5) * dy,
+                        *v as f64,
+                    )
+                })
+                .filter(|h| crate::rules::matches(&rule, h, &self.settings))
+                .max_by(|a, b| {
+                    a.strength
+                        .unwrap_or(0.0)
+                        .total_cmp(&b.strength.unwrap_or(0.0))
+                });
+            if let Some(hit) = best {
+                self.fire_rule(&rule, &hit);
+            }
+        }
+    }
+
+    /// Run the ProbSevere rules over the freshly fetched storm probabilities.
+    fn evaluate_probsevere_rules(&mut self, feats: &[GeoFeature]) {
+        use crate::rules::Detection;
+        let rules: Vec<crate::settings::AlertRule> = self
+            .settings
+            .alert_rules
+            .iter()
+            .filter(|r| r.enabled && r.trigger == crate::settings::RuleTrigger::ProbSevere)
+            .cloned()
+            .collect();
+        if rules.is_empty() {
+            return;
+        }
+        // One detection per storm: its centroid, carrying the Severe percentage.
+        let storms: Vec<Detection> = feats
+            .iter()
+            .filter_map(|f| {
+                let pct = crate::rules::probsevere_percent(&f.detail)?;
+                let ring = f.rings.first()?;
+                let n = ring.len().max(1) as f64;
+                let (lon, lat) = ring.iter().fold((0.0, 0.0), |(x, y), p| (x + p[0], y + p[1]));
+                Some(Detection::with_strength(lon / n, lat / n, pct))
+            })
+            .collect();
+        for rule in rules {
+            let worst = storms
+                .iter()
+                .filter(|h| crate::rules::matches(&rule, h, &self.settings))
+                .max_by(|a, b| {
+                    a.strength
+                        .unwrap_or(0.0)
+                        .total_cmp(&b.strength.unwrap_or(0.0))
+                })
+                .copied();
+            if let Some(hit) = worst {
+                self.fire_rule(&rule, &hit);
+            }
+        }
+    }
+
+    /// Kilometres from the pane's radar to a point — how "closest detection" is judged.
+    fn distance_from_radar_km(&self, idx: usize, lon: f64, lat: f64) -> f64 {
+        let Some(site) = self.views[idx]
+            .site
+            .as_deref()
+            .and_then(wxdata::sites::site_by_id)
+        else {
+            return 0.0;
+        };
+        crate::geo::great_circle([site.longitude as f64, site.latitude as f64], [lon, lat]).0
+    }
+
+    /// Deliver a rule's alert, unless its cooldown for this place is still running.
+    ///
+    /// Keyed by rule *and* place, so a rule watching two zones can speak about each of them.
+    fn fire_rule(&mut self, rule: &crate::settings::AlertRule, hit: &crate::rules::Detection) {
+        let place = crate::rules::place_label(&rule.place, &self.settings);
+        let key = format!("{}:{place}", rule.id);
+        let cooldown = std::time::Duration::from_secs(u64::from(rule.cooldown_min) * 60);
+        if self
+            .rules_fired
+            .get(&key)
+            .is_some_and(|t| t.elapsed() < cooldown)
+        {
+            return;
+        }
+        self.rules_fired.insert(key, Instant::now());
+        let title = format!("\u{25c9} {}", rule.title());
+        let body = match hit.strength {
+            Some(v) => format!("{} \u{2014} {v:.0} at {place}", rule.trigger.label()),
+            None => format!("{} at {place}", rule.trigger.label()),
+        };
+        // ponytail: no snapshot attachment (see `snapshot_push`) and no per-rule sound; the
+        // delivery fan-out in `notify_alert` is the place to add either.
+        self.notify_alert(&title, &body, rule.urgent);
+        self.banner(title, body);
     }
 
     /// Chime + push when cloud-to-ground lightning density exceeds a small threshold within ~15 km
@@ -7873,7 +8109,10 @@ impl HookEchoApp {
                         self.freezing = Some((site, h0, hm20));
                     }
                 }
-                OverlayMsg::ProbSevere(f) => self.probsevere = f,
+                OverlayMsg::ProbSevere(f) => {
+                    self.evaluate_probsevere_rules(&f);
+                    self.probsevere = f;
+                }
                 OverlayMsg::Hrrr(fc) => {
                     use crate::render::FieldLayer;
                     let upload = self.field_upload(FieldLayer::Hrrr, &fc.field);
@@ -10727,29 +10966,50 @@ impl HookEchoApp {
         } else {
             Vec::new()
         };
-        let tds_hits = if self.filters.show_tds && idx == self.active {
+        // A rule that watches a signature has to drive its detector even with the layer off —
+        // otherwise arming "hail spike near home" and then hiding the layer silently disarms it.
+        // The hits are computed here either way; only the drawing below checks the layer flag.
+        let armed = |t: &crate::settings::RuleTrigger| {
+            self.settings
+                .alert_rules
+                .iter()
+                .any(|r| r.enabled && &r.trigger == t)
+        };
+        let want_tds = self.filters.show_tds || armed(&crate::settings::RuleTrigger::Tds);
+        let want_tbss = self.filters.show_tbss || armed(&crate::settings::RuleTrigger::Tbss);
+        let want_zdr =
+            self.filters.show_zdr_columns || armed(&crate::settings::RuleTrigger::ZdrColumn);
+        let want_couplets =
+            self.filters.show_couplets || armed(&crate::settings::RuleTrigger::Rotation);
+        let tds_hits = if want_tds && idx == self.active {
             self.compute_tds(idx)
         } else {
             Vec::new()
         };
-        let tbss_hits = if self.filters.show_tbss && idx == self.active {
+        let tbss_hits = if want_tbss && idx == self.active {
             self.compute_tbss(idx)
         } else {
             Vec::new()
         };
-        let zdr_hits = if self.filters.show_zdr_columns && idx == self.active {
+        let zdr_hits = if want_zdr && idx == self.active {
             self.compute_zdr_columns(idx, ctx)
         } else {
             Vec::new()
         };
-        let couplets = if self.filters.show_couplets && idx == self.active {
+        let couplets = if want_couplets && idx == self.active {
             self.compute_couplets(idx)
         } else {
             Vec::new()
         };
         if idx == self.active {
             self.check_rain_arrival();
+            self.evaluate_scan_rules(idx, &tds_hits, &tbss_hits, &zdr_hits, &couplets);
         }
+        // Hidden layers computed only for a rule must not also be drawn.
+        let tds_hits = if self.filters.show_tds { tds_hits } else { Vec::new() };
+        let tbss_hits = if self.filters.show_tbss { tbss_hits } else { Vec::new() };
+        let zdr_hits = if self.filters.show_zdr_columns { zdr_hits } else { Vec::new() };
+        let couplets = if self.filters.show_couplets { couplets } else { Vec::new() };
 
         // --- Painter overlays (clipped to this pane) ---
         let painter = ui.painter_at(prect);
@@ -14735,7 +14995,14 @@ impl eframe::App for HookEchoApp {
         // GOES lightning: granules land every 20 s, so poll about that often. One in flight at a
         // time — a slow fetch must not queue up behind itself.
         let glm_fed_on = self.fields.get(&FL::GlmFed).is_some_and(|s| s.show);
-        if (self.show_glm || glm_fed_on)
+        // A lightning-density rule needs the flashes polled and the grid built even with the
+        // layer off, exactly like the scan signatures.
+        let glm_rule_armed = self
+            .settings
+            .alert_rules
+            .iter()
+            .any(|r| r.enabled && r.trigger == crate::settings::RuleTrigger::GlmFed);
+        if (self.show_glm || glm_fed_on || glm_rule_armed)
             && self
                 .glm_last_poll
                 .is_none_or(|t| t.elapsed().as_secs() >= 20)
@@ -14770,12 +15037,12 @@ impl eframe::App for HookEchoApp {
         // GLM flash-extent density: the same flashes the dots come from, gridded. Cheap enough
         // (one pass over a few thousand points) to do inline on the field-layer cadence rather
         // than spawning for it.
-        if glm_fed_on
-            && self.fields.get(&FL::GlmFed).is_some_and(|s| {
-                s.last_fetch
-                    .is_none_or(|t| t.elapsed().as_secs() >= field_refresh_secs(FL::GlmFed))
-            })
+        if (glm_fed_on || glm_rule_armed)
+            && self
+                .glm_fed_last
+                .is_none_or(|t| t.elapsed().as_secs() >= field_refresh_secs(FL::GlmFed))
         {
+            self.glm_fed_last = Some(Instant::now());
             if let Some(s) = self.fields.get_mut(&FL::GlmFed) {
                 s.last_fetch = Some(Instant::now());
             }
@@ -14787,7 +15054,10 @@ impl eframe::App for HookEchoApp {
                     Utc::now(),
                 )
             });
-            if let Some(field) = field {
+            if let Some(field) = &field {
+                self.evaluate_grid_rules(field);
+            }
+            if let (Some(field), true) = (field, glm_fed_on) {
                 let cap = self.field_texture_cap();
                 let _ = self
                     .overlay_tx

--- a/crates/hookecho/src/headless.rs
+++ b/crates/hookecho/src/headless.rs
@@ -585,6 +585,121 @@ pub fn run_dualpol(site: &str, h0_km: f64) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Rule verify: run the user's own alert rules against the latest volume and say, for each one,
+/// whether it would fire and why not if it wouldn't.
+///
+/// A rule that never goes off is indistinguishable from a rule that is wrong, and waiting for
+/// real weather to find out is a bad way to learn that a threshold was set too high. This replays
+/// the scan triggers against a live scan and prints the verdict.
+///
+/// ponytail: scan triggers only. ProbSevere and lightning density need their national feeds
+/// polling, which is the app's job, not a one-shot verifier's.
+pub fn run_rules(site: &str) -> anyhow::Result<()> {
+    use crate::rules::Detection;
+    use crate::settings::RuleTrigger as T;
+
+    let settings = crate::settings::Settings::load();
+    let rules: Vec<&crate::settings::AlertRule> = settings.alert_rules.iter().collect();
+    if rules.is_empty() {
+        println!("no rules configured (Ctrl+K ▸ \"Alert rules…\")");
+        return Ok(());
+    }
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+    let (z, cc, vel, zdr_tilts, z_tilts) = rt.block_on(async {
+        let scan = level2::download_latest_scan(site, chrono::Utc::now().date_naive()).await?;
+        let n = level2::elevation_angles(&scan).len();
+        let take = |m: Moment| -> Vec<wxdata::level2::BinnedSweep> {
+            (0..n)
+                .filter_map(|t| level2::bin_scan(&scan, m, t).ok())
+                .collect()
+        };
+        anyhow::Ok((
+            level2::bin_scan(&scan, Moment::Reflectivity, 0)?,
+            level2::bin_scan(&scan, Moment::CorrelationCoefficient, 0)?,
+            level2::bin_scan_opts(&scan, Moment::Velocity, 0, true)?,
+            take(Moment::DifferentialReflectivity),
+            take(Moment::Reflectivity),
+        ))
+    })?;
+    println!("{site}: {} tilts, lowest {:.2}°", z_tilts.len(), z.elevation_deg);
+
+    let d = &settings.detectors;
+    let tds = wxdata::tds::detect(&z, &cc, 0.80, 40.0, 150.0, 4);
+    let tbss = wxdata::dualpol::tbss(&z, &cc, d.tbss_core_dbz, 20.0, 0.8, 4.0, 150.0);
+    // No model freezing level out here; 4 km ARL is the usual warm-season figure and the same
+    // default `--headless-dualpol` takes.
+    let zdr = wxdata::dualpol::zdr_columns(
+        &zdr_tilts,
+        &z_tilts,
+        4.0,
+        d.zdr_min_db,
+        d.zdr_min_depth_km,
+        40.0,
+        100.0,
+    );
+    // Same thresholds the app's own couplet layer uses, so the verdict matches the app.
+    let couplets = wxdata::rotation::detect(&vel, 25.0, 15.0, 150.0, 3);
+    println!(
+        "detections: {} TDS, {} TBSS, {} ZDR columns, {} couplets",
+        tds.len(),
+        tbss.len(),
+        zdr.len(),
+        couplets.len()
+    );
+
+    for rule in rules {
+        let label = format!("{} [{}]", rule.title(), rule.trigger.label());
+        if !rule.enabled {
+            println!("  {label}: disabled");
+            continue;
+        }
+        if !rule.trigger.is_scan() {
+            println!("  {label}: needs a live feed — not replayable here");
+            continue;
+        }
+        if !crate::rules::place_exists(&rule.place, &settings) {
+            println!("  {label}: its place no longer exists — can never fire");
+            continue;
+        }
+        let hits: Vec<Detection> = match rule.trigger {
+            T::Tds => tds.iter().map(|h| Detection::at(h.lon, h.lat)).collect(),
+            T::Tbss => tbss.iter().map(|h| Detection::at(h.lon, h.lat)).collect(),
+            T::ZdrColumn => zdr.iter().map(|h| Detection::at(h.lon, h.lat)).collect(),
+            _ => couplets
+                .iter()
+                .map(|h| Detection::with_strength(h.lon, h.lat, h.vrot_ms as f64 * 1.943_844))
+                .collect(),
+        };
+        let place = crate::rules::place_label(&rule.place, &settings);
+        match hits
+            .iter()
+            .find(|h| crate::rules::matches(rule, h, &settings))
+        {
+            Some(h) => {
+                let strength = h
+                    .strength
+                    .map(|v| format!(" ({v:.0})"))
+                    .unwrap_or_default();
+                println!(
+                    "  {label}: FIRES at {:.3},{:.3}{strength} — {place}",
+                    h.lat, h.lon
+                );
+            }
+            // Say which of the two reasons it was: nothing detected at all, or nothing that got
+            // past the threshold and the place.
+            None if hits.is_empty() => println!("  {label}: quiet (nothing detected)"),
+            None => println!(
+                "  {label}: quiet ({} detections, none past the threshold at {place})",
+                hits.len()
+            ),
+        }
+    }
+    Ok(())
+}
+
 /// Rotation verify: download the latest volume, bin the dealiased velocity at the lowest tilt,
 /// run the couplet detector, and print any hits. Proves the detection pipeline on real data.
 pub fn run_rotation(site: &str) -> anyhow::Result<()> {

--- a/crates/hookecho/src/lib.rs
+++ b/crates/hookecho/src/lib.rs
@@ -49,6 +49,8 @@ pub mod render;
 pub mod render3d;
 /// Where background work goes: a tokio runtime natively, the page's event loop on the web.
 pub mod rt;
+/// User alert rules: which detections, where, are worth telling the user about.
+pub mod rules;
 /// The `--serve` HTTP endpoint (desktop only — Android has no headless mode to render from).
 #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
 pub mod serve;

--- a/crates/hookecho/src/main.rs
+++ b/crates/hookecho/src/main.rs
@@ -648,6 +648,16 @@ fn main() -> eframe::Result<()> {
         return Ok(());
     }
 
+    // Rule verify: `hookecho --headless-rules [SITE]` — would the user's own rules fire?
+    if let Some(pos) = args.iter().position(|a| a == "--headless-rules") {
+        let site = args.get(pos + 1).map(String::as_str).unwrap_or("KTLX");
+        if let Err(e) = headless::run_rules(site) {
+            eprintln!("headless rules failed: {e}");
+            std::process::exit(1);
+        }
+        return Ok(());
+    }
+
     // Rotation verify: `hookecho --headless-rotation [SITE]`.
     if let Some(pos) = args.iter().position(|a| a == "--headless-rotation") {
         let site = args.get(pos + 1).map(String::as_str).unwrap_or("KTLX");

--- a/crates/hookecho/src/rules.rs
+++ b/crates/hookecho/src/rules.rs
@@ -1,0 +1,256 @@
+//! User alert rules: does this detection, at this place, satisfy that rule?
+//!
+//! The app has five built-in alerts, and they fire on what somebody else decided was worth
+//! waking up for. A chaser wants "rotation over 45 knots anywhere near the radar"; somebody with
+//! a roof wants "a hail spike within twenty miles of home" and nothing else, ever. Same
+//! detections, different questions.
+//!
+//! Everything here is pure: the app hands in a point and a strength, this says fire or not and
+//! why. The cooldown, the notification and the layer plumbing live in `app.rs` — this file is
+//! the part that can be tested without a GPU.
+
+use crate::settings::{AlertRule, RulePlace, RuleTrigger, Settings};
+
+/// One thing a rule could fire on: where it is, and how strong it is in the trigger's own units.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Detection {
+    pub lon: f64,
+    pub lat: f64,
+    /// Vrot in knots, a ProbSevere percentage, a flash count — whatever the trigger measures.
+    /// `None` for triggers that are their own answer, like a debris signature.
+    pub strength: Option<f64>,
+}
+
+impl Detection {
+    pub fn at(lon: f64, lat: f64) -> Self {
+        Self {
+            lon,
+            lat,
+            strength: None,
+        }
+    }
+
+    pub fn with_strength(lon: f64, lat: f64, strength: f64) -> Self {
+        Self {
+            lon,
+            lat,
+            strength: Some(strength),
+        }
+    }
+}
+
+/// Does `rule` accept `hit`? Trigger matching is the caller's job — it only asks about rules
+/// whose trigger it is currently evaluating — so this answers the other two questions: is the
+/// detection strong enough, and is it somewhere this rule cares about.
+pub fn matches(rule: &AlertRule, hit: &Detection, settings: &Settings) -> bool {
+    rule.enabled && meets_threshold(rule, hit) && place_contains(&rule.place, hit, settings)
+}
+
+/// A rule with no threshold, or a trigger that takes none, accepts anything it is handed. A rule
+/// with one and a detection that cannot report its strength does not fire: silence beats a
+/// "45 kt" alert for something never measured.
+pub fn meets_threshold(rule: &AlertRule, hit: &Detection) -> bool {
+    match (rule.threshold, rule.trigger.threshold_hint()) {
+        (Some(min), Some(_)) => hit.strength.is_some_and(|v| v >= min),
+        _ => true,
+    }
+}
+
+/// Is the detection inside the rule's place?
+///
+/// A marker uses its own watch radius — the same number the built-in proximity alerts use, so a
+/// rule about home means the same distance as everything else about home. A zone is the drawn
+/// polygon itself. A place that no longer exists (deleted marker, renamed zone) never matches;
+/// the rules window shows those as dangling rather than silently firing everywhere.
+pub fn place_contains(place: &RulePlace, hit: &Detection, settings: &Settings) -> bool {
+    match place {
+        RulePlace::Anywhere => true,
+        RulePlace::Marker { id } => settings
+            .markers
+            .iter()
+            .find(|m| &m.id == id)
+            .is_some_and(|m| {
+                let (km, _) = crate::geo::great_circle([m.lon, m.lat], [hit.lon, hit.lat]);
+                km <= m.alert_radius_mi * crate::geo::KM_PER_MILE
+            }),
+        RulePlace::Zone { name } => settings
+            .alert_polygons
+            .iter()
+            .find(|z| &z.name == name)
+            .is_some_and(|z| wxdata::overlay::point_in_ring(&z.ring, hit.lon, hit.lat)),
+    }
+}
+
+/// Does a warning rule match this event name? Empty text matches every warning, which is how a
+/// rule says "anything the office issues near my house".
+pub fn warning_matches(rule: &AlertRule, event: &str) -> bool {
+    match &rule.trigger {
+        RuleTrigger::Warning { event_contains } => {
+            let want = event_contains.trim().to_ascii_lowercase();
+            want.is_empty() || event.to_ascii_lowercase().contains(&want)
+        }
+        _ => false,
+    }
+}
+
+/// What a place is called in a cooldown key and in the notification body.
+pub fn place_label(place: &RulePlace, settings: &Settings) -> String {
+    match place {
+        RulePlace::Anywhere => "anywhere".to_string(),
+        RulePlace::Marker { id } => settings
+            .markers
+            .iter()
+            .find(|m| &m.id == id)
+            .map_or_else(|| format!("marker {id}"), |m| m.name.clone()),
+        RulePlace::Zone { name } => name.clone(),
+    }
+}
+
+/// Does the place a rule names still exist? A rule pointed at a deleted marker can never fire,
+/// and saying so is better than leaving the user to wonder why it is quiet.
+pub fn place_exists(place: &RulePlace, settings: &Settings) -> bool {
+    match place {
+        RulePlace::Anywhere => true,
+        RulePlace::Marker { id } => settings.markers.iter().any(|m| &m.id == id),
+        RulePlace::Zone { name } => settings.alert_polygons.iter().any(|z| &z.name == name),
+    }
+}
+
+/// The Severe percentage out of a ProbSevere feature's detail block.
+///
+/// ponytail: parsed back out of the text the overlay already built (`probsevere.rs`, "Severe:
+/// 62%"), rather than widening `GeoFeature` with numeric fields for one consumer. Add the fields
+/// if a second one turns up.
+pub fn probsevere_percent(detail: &str) -> Option<f64> {
+    let rest = detail.split("Severe:").nth(1)?;
+    let digits: String = rest
+        .trim_start()
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+    digits.parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::{AlertPolygon, Marker};
+
+    fn settings_with_home() -> Settings {
+        let mut s = Settings::default();
+        s.markers.push(Marker {
+            id: "home1234".into(),
+            name: "Home".into(),
+            lat: 35.3,
+            lon: -97.5,
+            icon: None,
+            alert_radius_mi: 20.0,
+            video_url: String::new(),
+            home: true,
+        });
+        s.alert_polygons.push(AlertPolygon {
+            name: "The valley".into(),
+            ring: vec![
+                [-98.0, 35.0],
+                [-97.0, 35.0],
+                [-97.0, 36.0],
+                [-98.0, 36.0],
+                [-98.0, 35.0],
+            ],
+        });
+        s
+    }
+
+    fn rule(trigger: RuleTrigger, place: RulePlace) -> AlertRule {
+        let mut r = AlertRule::new(trigger);
+        r.place = place;
+        r.enabled = true;
+        r
+    }
+
+    #[test]
+    fn a_marker_rule_fires_inside_its_own_watch_radius_and_not_outside() {
+        let s = settings_with_home();
+        let r = rule(
+            RuleTrigger::Tds,
+            RulePlace::Marker {
+                id: "home1234".into(),
+            },
+        );
+        // ~9 km east of home, well inside the 20-mile radius.
+        assert!(matches(&r, &Detection::at(-97.4, 35.3), &s));
+        // ~180 km away.
+        assert!(!matches(&r, &Detection::at(-95.5, 35.3), &s));
+        // A rule pointed at a marker that no longer exists fires nowhere.
+        let orphan = rule(
+            RuleTrigger::Tds,
+            RulePlace::Marker {
+                id: "deleted0".into(),
+            },
+        );
+        assert!(!matches(&orphan, &Detection::at(-97.5, 35.3), &s));
+        assert!(!place_exists(&orphan.place, &s));
+    }
+
+    #[test]
+    fn a_zone_rule_uses_the_drawn_polygon() {
+        let s = settings_with_home();
+        let r = rule(
+            RuleTrigger::Tbss,
+            RulePlace::Zone {
+                name: "The valley".into(),
+            },
+        );
+        assert!(matches(&r, &Detection::at(-97.5, 35.5), &s));
+        assert!(!matches(&r, &Detection::at(-96.0, 35.5), &s));
+        assert_eq!(place_label(&r.place, &s), "The valley");
+    }
+
+    #[test]
+    fn thresholds_gate_the_triggers_that_measure_something() {
+        let s = Settings::default();
+        let mut r = rule(RuleTrigger::Rotation, RulePlace::Anywhere);
+        r.threshold = Some(45.0);
+        assert!(matches(&r, &Detection::with_strength(-97.5, 35.3, 52.0), &s));
+        assert!(!matches(&r, &Detection::with_strength(-97.5, 35.3, 30.0), &s));
+        // Exactly at the threshold counts — the user asked for "45 and up".
+        assert!(matches(&r, &Detection::with_strength(-97.5, 35.3, 45.0), &s));
+        // A measured trigger with nothing measured stays quiet.
+        assert!(!matches(&r, &Detection::at(-97.5, 35.3), &s));
+        // A trigger that takes no threshold ignores one that got set anyway.
+        let mut tds = rule(RuleTrigger::Tds, RulePlace::Anywhere);
+        tds.threshold = Some(99.0);
+        assert!(matches(&tds, &Detection::at(-97.5, 35.3), &s));
+    }
+
+    #[test]
+    fn a_disabled_rule_never_fires() {
+        let s = Settings::default();
+        let mut r = rule(RuleTrigger::Tds, RulePlace::Anywhere);
+        r.enabled = false;
+        assert!(!matches(&r, &Detection::at(-97.5, 35.3), &s));
+    }
+
+    #[test]
+    fn warning_rules_match_on_the_event_name() {
+        let all = AlertRule::new(RuleTrigger::Warning {
+            event_contains: String::new(),
+        });
+        assert!(warning_matches(&all, "Special Marine Warning"));
+        let tor = AlertRule::new(RuleTrigger::Warning {
+            event_contains: "tornado".into(),
+        });
+        assert!(warning_matches(&tor, "Tornado Warning"));
+        assert!(!warning_matches(&tor, "Severe Thunderstorm Warning"));
+        // A non-warning trigger is not a warning match, whatever the text says.
+        assert!(!warning_matches(&AlertRule::new(RuleTrigger::Tds), "Tornado Warning"));
+    }
+
+    #[test]
+    fn probsevere_percentages_come_back_out_of_the_detail_text() {
+        let detail = "ProbSevere storm 4213\nSevere: 62%\nTornado: 5%\nHail: 40%\nWind: 31%";
+        assert_eq!(probsevere_percent(detail), Some(62.0));
+        assert_eq!(probsevere_percent("Severe: 0%"), Some(0.0));
+        assert_eq!(probsevere_percent("no percentages here"), None);
+    }
+}

--- a/crates/hookecho/src/serve.rs
+++ b/crates/hookecho/src/serve.rs
@@ -851,6 +851,8 @@ mod tests {
         let i = ROUTES.iter().position(|r| *r == "index").unwrap();
         let before = REQUESTS[i].load(Ordering::Relaxed);
         route(&server, "/", "");
-        assert_eq!(REQUESTS[i].load(Ordering::Relaxed), before + 1);
+        // Counters are process-wide and the test threads share them, so this asserts movement
+        // rather than an exact delta — another test routing "/" must not fail this one.
+        assert!(REQUESTS[i].load(Ordering::Relaxed) > before);
     }
 }

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -258,6 +258,10 @@ pub struct Settings {
     /// background service reads this file too, so the name is load-bearing across the boundary.
     #[serde(default)]
     pub alert_polygons: Vec<AlertPolygon>,
+    /// User-written alert rules (see [`AlertRule`]). Empty by default: the five built-in alerts
+    /// are what the app fires on until somebody says otherwise.
+    #[serde(default)]
+    pub alert_rules: Vec<AlertRule>,
     /// External-process plugins that emit placefiles (desktop only). Off by default and empty:
     /// each entry is a command the user chose to run.
     #[serde(default)]
@@ -588,6 +592,148 @@ pub struct AlertPolygon {
     pub ring: Vec<[f64; 2]>,
 }
 
+/// What a rule watches for. The scan signatures are the ones the app already computes per
+/// volume; the rest ride on feeds it already polls.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum RuleTrigger {
+    /// Tornado debris signature.
+    Tds,
+    /// Three-body scatter spike (hail).
+    Tbss,
+    /// A ZDR column above the freezing level.
+    ZdrColumn,
+    /// A velocity couplet; the threshold is minimum Vrot in knots.
+    Rotation,
+    /// NOAA ProbSevere; the threshold is the minimum Severe percentage.
+    ProbSevere,
+    /// GLM flash-extent density; the threshold is minimum flashes per cell per window.
+    GlmFed,
+    /// An NWS warning whose event name contains this text, case-insensitively. Empty matches
+    /// every warning.
+    Warning { event_contains: String },
+}
+
+impl RuleTrigger {
+    /// Every trigger, with the defaults a fresh rule starts on — menu order.
+    pub const ALL: [RuleTrigger; 7] = [
+        RuleTrigger::Tds,
+        RuleTrigger::Tbss,
+        RuleTrigger::ZdrColumn,
+        RuleTrigger::Rotation,
+        RuleTrigger::ProbSevere,
+        RuleTrigger::GlmFed,
+        RuleTrigger::Warning {
+            event_contains: String::new(),
+        },
+    ];
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            RuleTrigger::Tds => "Debris signature (TDS)",
+            RuleTrigger::Tbss => "Hail spike (TBSS)",
+            RuleTrigger::ZdrColumn => "ZDR column",
+            RuleTrigger::Rotation => "Rotation",
+            RuleTrigger::ProbSevere => "ProbSevere",
+            RuleTrigger::GlmFed => "Lightning density",
+            RuleTrigger::Warning { .. } => "NWS warning",
+        }
+    }
+
+    /// What the threshold means for this trigger, and its default — `None` where the trigger is
+    /// its own answer (a debris signature does not come in degrees).
+    pub fn threshold_hint(&self) -> Option<(&'static str, f64)> {
+        match self {
+            RuleTrigger::Rotation => Some(("kt Vrot", 40.0)),
+            RuleTrigger::ProbSevere => Some(("% severe", 50.0)),
+            RuleTrigger::GlmFed => Some(("flashes", 20.0)),
+            _ => None,
+        }
+    }
+
+    /// Whether this trigger is answered by a per-volume scan of the active pane's radar, as
+    /// opposed to a national feed. Scan triggers are what the headless verifier can replay.
+    pub fn is_scan(&self) -> bool {
+        matches!(
+            self,
+            RuleTrigger::Tds | RuleTrigger::Tbss | RuleTrigger::ZdrColumn | RuleTrigger::Rotation
+        )
+    }
+}
+
+/// Where a rule is allowed to fire.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub enum RulePlace {
+    /// Anywhere the active radar can see. Loud by design — worth pairing with a cooldown.
+    #[default]
+    Anywhere,
+    /// Within a marker's own `alert_radius_mi`. Keyed by [`Marker::id`], so renaming the marker
+    /// does not silently detach the rule.
+    Marker { id: String },
+    /// Touching a drawn watch zone, by [`AlertPolygon::name`].
+    Zone { name: String },
+}
+
+/// One user rule: "if this signature shows up there, tell me".
+///
+/// The five built-in alerts are fixed — they fire on what somebody else decided was worth
+/// waking up for. This is the same machinery pointed at the user's own question.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AlertRule {
+    /// Stable id; the cooldown map keys on it, so renaming a rule does not re-arm it.
+    pub id: String,
+    /// What the user calls it. Empty falls back to the trigger's label.
+    #[serde(default)]
+    pub name: String,
+    pub trigger: RuleTrigger,
+    /// Trigger-dependent minimum (see [`RuleTrigger::threshold_hint`]); ignored where the
+    /// trigger takes none.
+    #[serde(default)]
+    pub threshold: Option<f64>,
+    #[serde(default)]
+    pub place: RulePlace,
+    /// Push past quiet hours. Off by default: the user decides what is worth waking up for, and
+    /// the default answer is "not this".
+    #[serde(default)]
+    pub urgent: bool,
+    /// Minutes before the same rule may fire for the same place again.
+    #[serde(default = "default_rule_cooldown")]
+    pub cooldown_min: u16,
+    /// Rules are created switched off, and armed deliberately.
+    #[serde(default)]
+    pub enabled: bool,
+}
+
+/// Ten minutes, matching the built-in proximity alerts' own cooldown.
+pub fn default_rule_cooldown() -> u16 {
+    10
+}
+
+impl AlertRule {
+    /// A fresh, disabled rule.
+    pub fn new(trigger: RuleTrigger) -> Self {
+        let threshold = trigger.threshold_hint().map(|(_, d)| d);
+        Self {
+            id: new_marker_id(),
+            name: String::new(),
+            trigger,
+            threshold,
+            place: RulePlace::Anywhere,
+            urgent: false,
+            cooldown_min: default_rule_cooldown(),
+            enabled: false,
+        }
+    }
+
+    /// What to call it in a notification.
+    pub fn title(&self) -> String {
+        if self.name.trim().is_empty() {
+            self.trigger.label().to_string()
+        } else {
+            self.name.clone()
+        }
+    }
+}
+
 pub fn default_lightning_minutes() -> u16 {
     5
 }
@@ -732,6 +878,7 @@ impl Default for Settings {
         Self {
             default_site: "KTLX".to_string(),
             detectors: DetectorTuning::default(),
+            alert_rules: Vec::new(),
             serve_token: String::new(),
             quiet_pending: Vec::new(),
             volume_cache_mb: 0,
@@ -1021,6 +1168,25 @@ mod tests {
     use super::*;
 
     #[test]
+    fn rules_are_absent_from_old_settings_and_start_disabled() {
+        let old: Settings = serde_json::from_str(r#"{"default_site":"KTLX"}"#).unwrap();
+        assert!(old.alert_rules.is_empty());
+
+        let r = AlertRule::new(RuleTrigger::Rotation);
+        assert!(!r.enabled, "a new rule must not start armed");
+        assert_eq!(r.cooldown_min, 10);
+        assert_eq!(r.threshold, Some(40.0));
+        assert_eq!(r.title(), "Rotation");
+
+        let mut s = Settings::default();
+        s.alert_rules.push(r.clone());
+        let back: Settings = serde_json::from_str(&serde_json::to_string(&s).unwrap()).unwrap();
+        assert_eq!(back.alert_rules, vec![r]);
+        // A trigger with no numeric meaning gets no threshold to be confused by.
+        assert_eq!(AlertRule::new(RuleTrigger::Tds).threshold, None);
+    }
+
+    #[test]
     fn markers_get_distinct_ids_and_old_files_still_load() {
         // A settings file from before ids existed.
         let old: Settings = serde_json::from_str(
@@ -1091,6 +1257,7 @@ mod tests {
     fn roundtrips() {
         let s = Settings {
             detectors: DetectorTuning::default(),
+            alert_rules: Vec::new(),
             serve_token: String::new(),
             quiet_pending: Vec::new(),
             volume_cache_mb: 0,

--- a/crates/hookecho/src/ui/mod.rs
+++ b/crates/hookecho/src/ui/mod.rs
@@ -93,6 +93,7 @@ pub mod marker_popup;
 pub mod marker_window;
 pub mod palette_editor;
 pub mod placefile_window;
+pub mod rules_window;
 pub mod sensor_window;
 pub mod settings_window;
 pub mod site_dialog;

--- a/crates/hookecho/src/ui/rules_window.rs
+++ b/crates/hookecho/src/ui/rules_window.rs
@@ -1,0 +1,277 @@
+//! The rules table: what the user wants to be told about, in their own terms.
+//!
+//! One row per rule, edited in place. Adding a rule creates it switched *off* — a rule armed the
+//! instant it appears would start pushing before its threshold and place had been chosen, which
+//! is exactly the behaviour that teaches people to ignore notifications.
+//!
+//! ponytail: delete-and-re-add rather than a modal editor, the same stance `AlertPolygon` takes.
+//! Every field is on the row already; there is nothing a dialog would add but a dialog.
+
+use crate::settings::{AlertRule, RulePlace, RuleTrigger, Settings};
+
+#[derive(Default)]
+pub struct RulesWindow {
+    pub open: bool,
+}
+
+impl RulesWindow {
+    pub fn toggle(&mut self) {
+        self.open = !self.open;
+    }
+}
+
+pub fn show(state: &mut RulesWindow, ctx: &egui::Context, settings: &mut Settings) -> bool {
+    if !state.open {
+        return false;
+    }
+    let mut open = state.open;
+    let mut changed = false;
+    let window = egui::Window::new("Alert rules")
+        .open(&mut open)
+        .default_width(720.0)
+        .resizable(true);
+    crate::ui::phone_surface(ctx, window).show(ctx, |ui| {
+        ui.weak(
+            "Tell the app what is worth interrupting you for. New rules start switched off — \
+             set the threshold and the place, then arm it.",
+        );
+        ui.separator();
+
+        let places = place_options(settings);
+        let mut remove: Option<usize> = None;
+        egui::Grid::new("rules_grid")
+            .num_columns(7)
+            .spacing([8.0, 6.0])
+            .striped(true)
+            .show(ui, |ui| {
+                ui.label("On");
+                ui.label("Name");
+                ui.label("Trigger");
+                ui.label("At least");
+                ui.label("Where");
+                ui.label("Urgent");
+                ui.label("Cooldown");
+                ui.end_row();
+
+                for i in 0..settings.alert_rules.len() {
+                    let dangling = {
+                        let r = &settings.alert_rules[i];
+                        !crate::rules::place_exists(&r.place, settings)
+                    };
+                    let rule = &mut settings.alert_rules[i];
+                    changed |= ui.checkbox(&mut rule.enabled, "").changed();
+
+                    let name = ui.add(
+                        egui::TextEdit::singleline(&mut rule.name)
+                            .hint_text(rule.trigger.label())
+                            .desired_width(120.0),
+                    );
+                    changed |= name.changed();
+
+                    changed |= trigger_combo(ui, i, rule);
+                    changed |= threshold_widget(ui, rule);
+                    changed |= place_combo(ui, i, rule, &places);
+
+                    changed |= ui
+                        .checkbox(&mut rule.urgent, "")
+                        .on_hover_text("Push through quiet hours")
+                        .changed();
+
+                    ui.horizontal(|ui| {
+                        changed |= ui
+                            .add(
+                                egui::DragValue::new(&mut rule.cooldown_min)
+                                    .range(1..=240)
+                                    .suffix(" min"),
+                            )
+                            .on_hover_text("How long before this rule may fire for the same place again")
+                            .changed();
+                        if ui.button("🗑").on_hover_text("Delete this rule").clicked() {
+                            remove = Some(i);
+                        }
+                    });
+                    ui.end_row();
+
+                    if dangling {
+                        ui.label("");
+                        ui.colored_label(
+                            egui::Color32::from_rgb(240, 170, 60),
+                            "⚠ that place no longer exists — this rule can never fire",
+                        );
+                        ui.end_row();
+                    }
+                }
+            });
+
+        if let Some(i) = remove {
+            settings.alert_rules.remove(i);
+            changed = true;
+        }
+
+        ui.add_space(6.0);
+        ui.horizontal(|ui| {
+            if ui.button("➕ Add rule").clicked() {
+                settings.alert_rules.push(AlertRule::new(RuleTrigger::Tds));
+                changed = true;
+            }
+            ui.weak(format!(
+                "{} armed of {}",
+                settings.alert_rules.iter().filter(|r| r.enabled).count(),
+                settings.alert_rules.len()
+            ));
+        });
+        if settings.alert_rules.is_empty() {
+            ui.add_space(4.0);
+            ui.weak(
+                "Nothing here yet. The five built-in alerts (warnings, debris signatures, \
+                 rotation, lightning and rain arrival) keep working regardless.",
+            );
+        }
+    });
+    state.open = open;
+    changed
+}
+
+/// Every place a rule can name: anywhere, each marker, each drawn zone.
+fn place_options(settings: &Settings) -> Vec<(RulePlace, String)> {
+    let mut out = vec![(RulePlace::Anywhere, "Anywhere".to_string())];
+    for m in &settings.markers {
+        out.push((
+            RulePlace::Marker { id: m.id.clone() },
+            format!("{} ({:.0} mi)", m.name, m.alert_radius_mi),
+        ));
+    }
+    for z in &settings.alert_polygons {
+        out.push((
+            RulePlace::Zone {
+                name: z.name.clone(),
+            },
+            format!("zone: {}", z.name),
+        ));
+    }
+    out
+}
+
+fn trigger_combo(ui: &mut egui::Ui, i: usize, rule: &mut AlertRule) -> bool {
+    let mut changed = false;
+    egui::ComboBox::from_id_salt(("rule_trigger", i))
+        .selected_text(rule.trigger.label())
+        .width(170.0)
+        .show_ui(ui, |ui| {
+            for t in RuleTrigger::ALL {
+                let label = t.label();
+                // Same variant, different payload: a warning rule keeps whatever text it has.
+                let selected = std::mem::discriminant(&rule.trigger) == std::mem::discriminant(&t);
+                if ui.selectable_label(selected, label).clicked() && !selected {
+                    rule.threshold = t.threshold_hint().map(|(_, d)| d);
+                    rule.trigger = t;
+                    changed = true;
+                }
+            }
+        });
+    // A warning rule needs its text, and it is meaningless on any other trigger.
+    if let RuleTrigger::Warning { event_contains } = &mut rule.trigger {
+        changed |= ui
+            .add(
+                egui::TextEdit::singleline(event_contains)
+                    .hint_text("any warning")
+                    .desired_width(110.0),
+            )
+            .on_hover_text("Matches when the event name contains this — e.g. \"tornado\"")
+            .changed();
+    }
+    changed
+}
+
+/// The threshold cell: a number in the trigger's own units, or a dash where it has none.
+fn threshold_widget(ui: &mut egui::Ui, rule: &mut AlertRule) -> bool {
+    match rule.trigger.threshold_hint() {
+        Some((suffix, default)) => {
+            let mut v = rule.threshold.unwrap_or(default);
+            let changed = ui
+                .add(
+                    egui::DragValue::new(&mut v)
+                        .range(0.0..=200.0)
+                        .suffix(format!(" {suffix}")),
+                )
+                .changed();
+            if changed {
+                rule.threshold = Some(v);
+            }
+            changed
+        }
+        None => {
+            ui.weak("—");
+            false
+        }
+    }
+}
+
+fn place_combo(
+    ui: &mut egui::Ui,
+    i: usize,
+    rule: &mut AlertRule,
+    places: &[(RulePlace, String)],
+) -> bool {
+    let mut changed = false;
+    let current = places
+        .iter()
+        .find(|(p, _)| p == &rule.place)
+        .map(|(_, l)| l.clone())
+        .unwrap_or_else(|| "(missing)".to_string());
+    egui::ComboBox::from_id_salt(("rule_place", i))
+        .selected_text(current)
+        .width(170.0)
+        .show_ui(ui, |ui| {
+            for (place, label) in places {
+                if ui
+                    .selectable_label(&rule.place == place, label)
+                    .clicked()
+                {
+                    rule.place = place.clone();
+                    changed = true;
+                }
+            }
+        });
+    changed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::{AlertPolygon, Marker};
+
+    #[test]
+    fn the_place_list_offers_anywhere_then_every_marker_and_zone() {
+        let mut s = Settings::default();
+        s.markers.push(Marker {
+            id: "abc12345".into(),
+            name: "Home".into(),
+            lat: 35.3,
+            lon: -97.5,
+            icon: None,
+            alert_radius_mi: 20.0,
+            video_url: String::new(),
+            home: true,
+        });
+        s.alert_polygons.push(AlertPolygon {
+            name: "The valley".into(),
+            ring: vec![[-98.0, 35.0], [-97.0, 35.0], [-97.0, 36.0], [-98.0, 35.0]],
+        });
+        let places = place_options(&s);
+        assert_eq!(places[0].0, RulePlace::Anywhere);
+        assert_eq!(
+            places[1].0,
+            RulePlace::Marker {
+                id: "abc12345".into()
+            }
+        );
+        assert!(places[1].1.contains("Home") && places[1].1.contains("20 mi"));
+        assert_eq!(
+            places[2].0,
+            RulePlace::Zone {
+                name: "The valley".into()
+            }
+        );
+    }
+}

--- a/crates/wxdata/src/overlay.rs
+++ b/crates/wxdata/src/overlay.rs
@@ -233,7 +233,7 @@ fn segments_cross(p1: [f64; 2], p2: [f64; 2], q1: [f64; 2], q2: [f64; 2]) -> boo
 }
 
 /// Even-odd point-in-polygon test on a `[lon, lat]` ring.
-fn point_in_ring(ring: &[[f64; 2]], lon: f64, lat: f64) -> bool {
+pub fn point_in_ring(ring: &[[f64; 2]], lon: f64, lat: f64) -> bool {
     let mut inside = false;
     let n = ring.len();
     if n < 3 {


### PR DESCRIPTION
Last of four packs, and the flagship. Depends on pack B's stable marker ids.

Until now the app had five fixed alerts, firing on what somebody else decided was worth waking up for. A chaser wants "rotation over 45 knots anywhere near the radar"; somebody with a roof wants "a hail spike within twenty miles of home" and nothing else, ever. Same detections, different questions.

**The model.** A rule is a trigger (TDS, hail spike, ZDR column, rotation, ProbSevere, lightning density, or an NWS warning matched by event name), an optional threshold in the trigger's own units, a place (anywhere, a marker's own watch radius, or a drawn zone), a cooldown and an urgent flag. Places key on the marker id from pack B, so renaming a marker cannot silently detach a rule from it.

**The engine** (`src/rules.rs`) is pure and unit-tested: given a detection and a rule, does it fire. It reuses the geometry already in the tree — `great_circle`, `point_in_ring`, `rings_intersect`, `distance_km` — and adds none.

**The wiring** is where the care went. Those detectors only ran when their layer was switched on, so arming "hail spike near home" and then hiding the layer would have silently disarmed the rule. An armed rule now drives its own detector, with drawing still following the layer flag; the flash-extent grid gets its own clock for the same reason. Cooldowns key on rule *and* place, so one rule watching two zones can speak about both. Delivery goes through the existing `notify_alert` fan-out, so every channel the app already has works unchanged.

**Storm guards**, because a rule engine's failure mode is a notification storm: rules are created switched off and armed deliberately, default to a ten-minute cooldown, are deduped per volume, and `urgent` (the quiet-hours bypass) is off by default.

**`--headless-rules SITE`** replays the scan triggers against a live volume and says, per rule, whether it fires and why not if it doesn't. Verified against KTLX: a 0-knot rotation rule reports `FIRES at 34.645,-96.875 (26) — anywhere`, while a 150-knot one reports `quiet (1 detections, none past the threshold)`, and rules that are disabled, non-replayable or pointed at a deleted place each say so.

Also fixes a pre-existing race in the route-counter test — the counters are process-wide and a sibling test routing `/` could break an exact-delta assertion.

Verification: clippy clean, `cargo test --workspace` 457 passed (three consecutive runs), wasm check clean, `shoot.sh check` passed, plus the live verifier run above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)