### PR TITLE
Host the browser demo on Netlify too

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -11,6 +11,10 @@ jobs:
   deploy:
     name: Cloudflare Pages
     runs-on: ubuntu-latest
+    # Job level, not step level: a step's own `env:` is not visible to its own `if:`.
+    env:
+      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+      NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
     steps:
       - uses: actions/checkout@v4
 
@@ -18,9 +22,9 @@ jobs:
       # feed added to one and not the other is a demo that silently stops drawing something.
       - name: Check the proxy allowlist has not drifted
         run: |
-          hosts() { awk '/^(const ALLOWED_HOSTS)/,/^\];?$/' "$1" | grep -oE '"[a-z0-9.-]+\.[a-z]+"' | sort; }
-          diff <(hosts crates/hookecho/src/serve.rs) <(hosts web/_worker.js) || {
-            echo "::error::ALLOWED_HOSTS differs between serve.rs and web/_worker.js"
+          hosts() { awk '/^(export )?const ALLOWED_HOSTS/,/^\];?$/' "$1" | grep -oE '"[a-z0-9.-]+\.[a-z]+"' | sort; }
+          diff <(hosts crates/hookecho/src/serve.rs) <(hosts web/_worker.js/proxy-core.js) || {
+            echo "::error::ALLOWED_HOSTS differs between serve.rs and web/_worker.js/proxy-core.js"
             exit 1
           }
 
@@ -46,6 +50,12 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: npx --yes wrangler@3 pages deploy web --project-name=hookecho --branch=main
+
+      # The same bundle on Netlify. Skipped entirely when the secrets are absent, so a fork — or
+      # this repo before the site exists — still gets a green Cloudflare deploy.
+      - name: Deploy to Netlify
+        if: ${{ env.NETLIFY_AUTH_TOKEN != '' && env.NETLIFY_SITE_ID != '' }}
+        run: npx --yes netlify-cli@17 deploy --dir web --prod --message "$GITHUB_SHA"
 
       - uses: actions/setup-node@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ packaging/appimagetool-*.AppImage
 /android/app/build/
 /android/local.properties
 announce-drafts.md
+
+# Netlify CLI state (site link, local edge-function build).
+/.netlify/

--- a/README.md
+++ b/README.md
@@ -637,6 +637,34 @@ out; there is no camera, plugin or GPS support; and any feed whose host refuses
 cross-origin requests simply doesn't load. Anything that needs those is on the
 desktop and Android builds.
 
+#### Hosting it yourself
+
+The bundle is static files plus one CORS proxy — the feeds NOAA serves without
+`Access-Control-Allow-Origin` need an origin of your own in front of them, or the
+page loads and draws nothing. The proxy's rules (exact-match allowlist, GET only,
+64 MB cap, narrowed content types) live once in `web/_worker.js/proxy-core.js`;
+each host is a few lines of wiring around it.
+
+**Cloudflare Pages** — `web/_worker.js/`, deployed by
+`.github/workflows/demo.yml`. That's what `hookecho.pages.dev` is.
+
+**Netlify** — `netlify.toml` plus the edge function in `netlify/edge-functions/`.
+Either connect the repo (Netlify runs `scripts/netlify-build.sh`, ~5 minutes cold
+because it compiles `wasm-bindgen-cli`), or build once and push the result:
+
+```sh
+./scripts/web/build.sh
+npx netlify-cli deploy --dir web --prod
+```
+
+Set `NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID` as repository secrets and the demo
+workflow deploys there too, alongside Pages; leave them unset and that step is
+skipped. Both tokens are secrets — never committed.
+
+Any other host works the same way if it can run one small function on
+`/proxy/*`. A purely static host cannot: without the proxy the app opens, and
+then sits empty.
+
 ### Extending it
 
 Placefiles work as they do everywhere else — URLs, icon sheets, a layer manager with per-file

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,34 @@
+# Netlify deployment for the browser demo — the same bundle Cloudflare Pages serves.
+#
+# Two ways to deploy, and they differ only in who runs the wasm build:
+#
+#   1. From CI (recommended, and what .github/workflows/demo.yml does): the bundle is already
+#      built, so `netlify deploy --dir web --prod` uploads it in seconds.
+#   2. Git-connected: Netlify runs the build itself with the command below. It works, but a cold
+#      build spends most of its time compiling wasm-bindgen-cli.
+#
+# ponytail: no build plugin and no cache config — option 1 makes both moot, and option 2 is the
+# fallback for when nobody wants to hold a token.
+
+[build]
+  publish = "web"
+  command = "scripts/netlify-build.sh"
+
+# The proxy is an edge function, not a redirect: it has to check the allowlist before anything is
+# fetched. `path` is also declared in the function itself; this makes it visible in the config.
+[[edge_functions]]
+  path = "/proxy/*"
+  function = "proxy"
+
+# The wasm is content-hashed by nothing — it is rebuilt in place on every deploy — so it must not
+# be cached by the browser, or a returning visitor runs last week's build against this week's
+# index.html. Netlify's own CDN still caches it and revalidates on each deploy.
+[[headers]]
+  for = "/dist/*"
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"
+
+[[headers]]
+  for = "/index.html"
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"

--- a/netlify/edge-functions/proxy.js
+++ b/netlify/edge-functions/proxy.js
@@ -1,0 +1,20 @@
+// The same CORS proxy, as a Netlify edge function (Deno). Everything that matters — allowlist,
+// GET-only, size cap, content-type narrowing — is in web/_worker.js/proxy-core.js, shared with the
+// Cloudflare Worker. Deno has no `cf` fetch option, so the cache hint is a response header
+// instead: `netlify-cdn-cache-control` is what Netlify's CDN reads, and `cache-control` is what
+// the browser reads.
+
+import { cacheSeconds, handleProxy } from "../../web/_worker.js/proxy-core.js";
+
+export default async (request) =>
+  handleProxy(request, {
+    extraHeaders: (host) => {
+      const ttl = cacheSeconds(host);
+      return {
+        "cache-control": `public, max-age=${ttl}`,
+        "netlify-cdn-cache-control": `public, s-maxage=${ttl}, durable`,
+      };
+    },
+  });
+
+export const config = { path: "/proxy/*" };

--- a/scripts/netlify-build.sh
+++ b/scripts/netlify-build.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Build the browser bundle inside Netlify's build image.
+#
+# Only used by a git-connected deploy; a CI deploy has already run scripts/web/build.sh and
+# uploads web/ as-is. Netlify's image ships rustup but no wasm target and no wasm-bindgen, so
+# both get installed here. Expect ~5 minutes cold.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+if ! command -v rustup >/dev/null; then
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+  # shellcheck disable=SC1091
+  source "$HOME/.cargo/env"
+fi
+
+rustup target add wasm32-unknown-unknown
+command -v wasm-bindgen >/dev/null || cargo install wasm-bindgen-cli --locked
+
+scripts/web/build.sh

--- a/web/_worker.js/index.js
+++ b/web/_worker.js/index.js
@@ -1,0 +1,18 @@
+// The CORS proxy as a Cloudflare Pages Worker. The checks and the allowlist live in
+// proxy-core.js, shared with the Netlify edge function; this file is only the Pages wiring —
+// static assets through `env.ASSETS`, and Cloudflare's own cache hints on the upstream fetch.
+//
+// This is a `_worker.js/` directory rather than a single file on purpose: Pages only bundles
+// imported modules in the directory form.
+
+import { cacheSeconds, handleProxy } from "./proxy-core.js";
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    if (!url.pathname.startsWith("/proxy/")) return env.ASSETS.fetch(request);
+    return handleProxy(request, {
+      fetchInit: (host) => ({ cf: { cacheTtl: cacheSeconds(host), cacheEverything: true } }),
+    });
+  },
+};

--- a/web/_worker.js/proxy-core.js
+++ b/web/_worker.js/proxy-core.js
@@ -1,4 +1,4 @@
-// The CORS proxy the browser build needs, as a Cloudflare Pages Worker.
+// The CORS proxy the browser build needs, host-agnostic.
 //
 // The wasm build rewrites every feed URL to `{origin}/proxy/{host}/{path}` (crates/wxdata/src/
 // net.rs), because NOAA's buckets and the NWS API send no `Access-Control-Allow-Origin`. A static
@@ -7,10 +7,14 @@
 // allowlist exactly, only GET is issued upstream, no client header is forwarded, and the response
 // is capped and stripped down to a known content type.
 //
+// Two deployments import this: web/_worker.js/index.js (Cloudflare Pages) and
+// netlify/edge-functions/proxy.js (Netlify, Deno). They differ only in how they ask their own CDN
+// to cache — the allowlist and the checks live here once, so they cannot drift apart.
+//
 // The ALLOWED_HOSTS list below is checked against serve.rs by .github/workflows/demo.yml — the two
 // must stay identical, and the deploy fails if they drift.
 
-const ALLOWED_HOSTS = [
+export const ALLOWED_HOSTS = [
   // NEXRAD / TDWR archives and the live chunk stream.
   "unidata-nexrad-level2.s3.amazonaws.com",
   "unidata-nexrad-level2-chunks.s3.amazonaws.com",
@@ -60,17 +64,23 @@ const ALLOWED_HOSTS = [
   "cwwp2.dot.ca.gov",
 ];
 
-const MAX_BYTES = 64 * 1024 * 1024;
+export const MAX_BYTES = 64 * 1024 * 1024;
 
-// Live feeds go stale in seconds; everything else can sit in Cloudflare's cache for five minutes,
+// Live feeds go stale in seconds; everything else can sit in the CDN cache for five minutes,
 // which is what keeps a front-page demo off NOAA's rate limits.
 // ponytail: two classes, not a per-host map — add one if a specific feed complains.
-const LIVE_HOSTS = new Set([
+export const LIVE_HOSTS = new Set([
   "unidata-nexrad-level2-chunks.s3.amazonaws.com",
   "api.weather.gov",
 ]);
 
-function contentType(upstream) {
+export const cacheSeconds = (host) => (LIVE_HOSTS.has(host) ? 15 : 300);
+
+// The User-Agent the app identifies itself with everywhere else (wxdata::alerts::USER_AGENT);
+// api.weather.gov refuses a request without one.
+export const USER_AGENT = "hookecho (github.com/d4vid87/hookecho, davidmay87@gmail.com)";
+
+export function contentType(upstream) {
   switch ((upstream.split(";")[0] || "").trim()) {
     case "application/json":
     case "application/geo+json":
@@ -103,6 +113,12 @@ const refused = (why) =>
     headers: { "content-type": "application/json" },
   });
 
+const badGateway = () =>
+  new Response(JSON.stringify({ error: "upstream fetch failed" }), {
+    status: 502,
+    headers: { "content-type": "application/json" },
+  });
+
 // Stop a hostile or broken upstream mid-stream rather than after buffering it.
 function capped(body) {
   let seen = 0;
@@ -117,46 +133,37 @@ function capped(body) {
   );
 }
 
-export default {
-  async fetch(request, env) {
-    const url = new URL(request.url);
-    if (!url.pathname.startsWith("/proxy/")) return env.ASSETS.fetch(request);
+/// Handle one `/proxy/{host}/{path}` request. `fetchInit(host)` lets a platform add its own cache
+/// hints to the upstream call, `extraHeaders(host)` the same for the response we send back.
+export async function handleProxy(request, { fetchInit = () => ({}), extraHeaders = () => ({}) } = {}) {
+  const url = new URL(request.url);
+  const rest = url.pathname.slice("/proxy/".length);
+  const slash = rest.indexOf("/");
+  if (slash < 0) return refused("no path after host");
+  const host = rest.slice(0, slash);
+  if (!ALLOWED_HOSTS.includes(host)) return refused("host not in allowlist");
+  if (request.method !== "GET") return refused("GET only");
 
-    const rest = url.pathname.slice("/proxy/".length);
-    const slash = rest.indexOf("/");
-    if (slash < 0) return refused("no path after host");
-    const host = rest.slice(0, slash);
-    if (!ALLOWED_HOSTS.includes(host)) return refused("host not in allowlist");
-    if (request.method !== "GET") return refused("GET only");
-
-    const target = `https://${host}/${rest.slice(slash + 1)}${url.search}`;
-    let upstream;
-    try {
-      // No client header is forwarded — this is a fresh request, not a rewrite of theirs. The one
-      // header set here is the User-Agent the app identifies itself with everywhere else
-      // (wxdata::alerts::USER_AGENT); api.weather.gov refuses a request without one.
-      upstream = await fetch(target, {
-        headers: { "user-agent": "hookecho (github.com/d4vid87/hookecho, davidmay87@gmail.com)" },
-        cf: { cacheTtl: LIVE_HOSTS.has(host) ? 15 : 300, cacheEverything: true },
-      });
-    } catch (e) {
-      return new Response(JSON.stringify({ error: "upstream fetch failed" }), {
-        status: 502,
-        headers: { "content-type": "application/json" },
-      });
-    }
-    if (!upstream.ok) {
-      return new Response(JSON.stringify({ error: "upstream fetch failed" }), {
-        status: 502,
-        headers: { "content-type": "application/json" },
-      });
-    }
-
-    const length = Number(upstream.headers.get("content-length") || 0);
-    if (length > MAX_BYTES) return refused("response over cap");
-
-    return new Response(upstream.body ? capped(upstream.body) : null, {
-      headers: { "content-type": contentType(upstream.headers.get("content-type") || "") },
+  const target = `https://${host}/${rest.slice(slash + 1)}${url.search}`;
+  let upstream;
+  try {
+    // No client header is forwarded — this is a fresh request, not a rewrite of theirs.
+    upstream = await fetch(target, {
+      headers: { "user-agent": USER_AGENT },
+      ...fetchInit(host),
     });
-  },
-};
+  } catch {
+    return badGateway();
+  }
+  if (!upstream.ok) return badGateway();
+
+  const length = Number(upstream.headers.get("content-length") || 0);
+  if (length > MAX_BYTES) return refused("response over cap");
+
+  return new Response(upstream.body ? capped(upstream.body) : null, {
+    headers: {
+      "content-type": contentType(upstream.headers.get("content-type") || ""),
+      ...extraHeaders(host),
+    },
+  });
+}


### PR DESCRIPTION
Shares the CORS proxy between Cloudflare Pages and a new Netlify edge function so the allowlist cannot drift, and adds the Netlify config, build script and an optional deploy step.

- `web/_worker.js/proxy-core.js` — allowlist, GET-only, 64 MB cap, content-type narrowing, imported by both hosts. Pages worker is now a directory, the form that bundles imports.
- `netlify/edge-functions/proxy.js` — same checks, Netlify CDN cache headers instead of Cloudflare `cf:` fetch options.
- `netlify.toml` + `scripts/netlify-build.sh` — git-connected deploys build the wasm themselves; CI deploys upload the prebuilt bundle.
- Demo workflow deploys to Netlify only when `NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID` exist.

Verified locally against the real proxy path: disallowed host 403, POST 403, `api.weather.gov/alerts/active/count` 200 with the cache header set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)