### PR TITLE
fix: two things the live embed smoke test found

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -2557,7 +2557,10 @@ impl HookEchoApp {
             site_dialog: None,
             wizard: {
                 let mut w = ui::wizard::Wizard::default();
-                if !settings_setup_done {
+                // Never in an embed: the host page already chose the site, and its storage is
+                // partitioned, so "first run" would be every run — a setup dialog over someone
+                // else's dashboard panel, forever.
+                if !settings_setup_done && !is_embed() {
                     w.start();
                 }
                 w
@@ -3051,6 +3054,10 @@ impl HookEchoApp {
         };
         if let Some(o) = v.as_object_mut() {
             o.insert("hookecho".into(), serde_json::json!(1));
+            // The product goes out as its share-link code ("REF"), not the serde variant name:
+            // the host hands this straight back to us in a `#goto`, and `Moment::from_code` only
+            // knows the codes. Round-tripping the variant name would silently drop the product.
+            o.insert("moment".into(), serde_json::json!(snap.moment.short_name()));
         }
         if parent
             .post_message(&wasm_bindgen::JsValue::from_str(&v.to_string()), "*")


### PR DESCRIPTION
Follow-up to #38, both found by embedding the live build in a real parent page and watching what came back.

- **The setup wizard opened over the embedded map.** An embed's `localStorage` is partitioned, so `setup_done` is never true inside one — "first run" is *every* run, and WeatherDesk's radar panel would show a four-step setup dialog forever. The host already chose the site.
- **The product didn't survive a round trip.** The posted state named it as its serde variant (`"Reflectivity"`), but the host hands that value straight back in a `#goto`, and `Moment::from_code` only knows the share-link codes (`REF`, `VEL`, …) — so it was warned about and dropped on every reload. Now posts `"REF"`.

Verified against a local wasm build in headless Chrome: chromeless map at KTLX with live reflectivity, and the parent page receives `{"basemap":"dark","hookecho":1,"lat":35.3,"lon":-97.3,"moment":"REF","site":"KTLX","srv":false,"tilt":0,"zoom":6.5}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)