### PR TITLE
fix(ui): clicking a radar site in the picker did nothing

### DIFF
--- a/crates/hookecho/src/ui/site_dialog.rs
+++ b/crates/hookecho/src/ui/site_dialog.rs
@@ -96,6 +96,10 @@ pub fn show(
         .open(&mut open)
         .default_size([460.0, 520.0])
         .show(ctx, |ui| {
+            // Selectable label text senses clicks and drags of its own, and a row is made of
+            // nothing but labels — so every click on a row went into selecting the city name and
+            // `row.response().clicked()` never fired. Clicking a site did nothing at all.
+            ui.style_mut().interaction.selectable_labels = false;
             ui.horizontal(|ui| {
                 ui.label("Filter:");
                 // The field's default width plus two buttons overflows a phone, pushing None/Home


### PR DESCRIPTION
Reported: "I should be able to click KFWS and load that radar. It sort of loads right now, but it's very glitchy."

## Cause

Every cell in the site table is a label, and egui labels are text-selectable by default. The label senses the click and the drag, so `row.response().clicked()` never fires — no site can be picked from the dialog at all. A double-click highlights the city name instead of switching radars.

The site *does* still change through other paths (deep link, map marker, command palette), which is why it reads as "sort of works, very glitchy" rather than "broken".

## Fix

Turn off text selection inside the dialog. One line.

## Verification

Driven over the DevTools protocol against a real wasm build — open the picker with F3, filter to `KFWS`, click the row:

- **Before:** single click, ID-cell click and double-click all do nothing; the dialog stays open, the timeline still reads `KTLX`, and the double-click selects the text "Dallas".
- **After:** one click closes the dialog, the sidebar and timeline read `KFWS`, the camera recenters on Dallas/Fort Worth, and the volume loads.

`cargo test -p hookecho`: 242 passed.

The Android branch below the table (a plain scrollable button list) carries a comment saying table row clicks "don't register under touch (nested scroll eats them)" — almost certainly this same bug, but it isn't touched here; that wants a device to test on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)