### PR TITLE
fix: keep radar chrome in embedded panes

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -11083,7 +11083,7 @@ impl HookEchoApp {
 
         // Per-pane product picker (multi-pane only): set THIS pane's moment directly, without
         // clicking to activate it first. Single-pane keeps using the product pill.
-        if self.views.len() > 1 && !self.obs_mode && !self.embed {
+        if self.views.len() > 1 && !self.obs_mode {
             let cur = self.views[idx].moment;
             // Same union as the sidebar uses, so this picker doesn't blink either.
             let have = self.views[idx].moments();
@@ -15475,7 +15475,10 @@ impl eframe::App for HookEchoApp {
 
         // Docked desktop chrome. Declared before every floating Area so those constrain to what's
         // left of the viewport (`self.chrome_rect`) instead of covering the bars.
-        let bare = self.obs_mode || self.embed;
+        // Embedded panes keep their chrome: without it there is no play button, no site picker and
+        // no product menu, and an iframe is exactly where a user can't reach those any other way.
+        // `embed` still buys the idle heartbeat and the state postMessage.
+        let bare = self.obs_mode;
         if !cfg!(target_os = "android") && !bare {
             if !self.settings.hide_sidebar {
                 self.sidebar(root, ctx);
@@ -16132,7 +16135,7 @@ impl eframe::App for HookEchoApp {
             }
         }
         self.follow_badge(ctx);
-        if !self.obs_mode && !self.embed {
+        if !self.obs_mode {
             self.chase_hud(ctx);
         }
         if let Some(popup) = &mut self.warning_popup {


### PR DESCRIPTION
Reported from WeatherDesk: the embedded radar has no menus and play cannot be clicked.

`?embed` was folding into the OBS `bare` path, hiding the sidebar, toolbar, product picker and chase HUD. In an iframe there is no other way to reach those controls, so embed no longer hides chrome - only OBS mode does. Embed still gets the 60s idle heartbeat and the PaneSnap postMessage, which were the actual point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)