### PR TITLE
fix(web): recover from silent WebGPU device loss on Safari

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -2395,6 +2395,26 @@ impl HookEchoApp {
         let spawner = crate::rt::Spawner::new();
 
         let render_state = cc.wgpu_render_state.as_ref().expect("wgpu backend");
+        // Safari 26+ runs us on WebGPU, where device loss is silent: the canvas simply goes black
+        // and `webglcontextlost` can never fire. Nothing can be rebuilt from inside a lost device,
+        // so reload — guarded so a device that dies on every boot doesn't loop.
+        #[cfg(target_arch = "wasm32")]
+        render_state.device.set_device_lost_callback(|reason, msg| {
+            if !matches!(reason, wgpu::DeviceLostReason::Unknown) {
+                return;
+            }
+            log::error!("wgpu device lost: {msg}");
+            let Some(win) = web_sys::window() else { return };
+            let now = js_sys::Date::now();
+            if let Ok(Some(store)) = win.session_storage() {
+                let last = store.get_item("hookecho_reload").ok().flatten().and_then(|v| v.parse::<f64>().ok());
+                if last.is_some_and(|t| now - t < 30_000.0) {
+                    return;
+                }
+                let _ = store.set_item("hookecho_reload", &now.to_string());
+            }
+            let _ = win.location().reload();
+        });
         // The GPU's 2D texture-size cap: desktop/Adreno do 16384, but many mobile GPUs cap at
         // 4096. Field grids (MRMS rotation/AzShear reach 14000 px) are decimated to fit this.
         let max_texture_dim = render_state.device.limits().max_texture_dimension_2d;

--- a/crates/hookecho/src/tiles.rs
+++ b/crates/hookecho/src/tiles.rs
@@ -1004,9 +1004,13 @@ pub(crate) async fn load_tile_bytes(
 }
 
 /// How many uploaded raster tiles to keep. A 256x256 RGBA tile is ~256 KB on the GPU, so 512 is
-/// ~134 MB on a desktop and 128 keeps a phone near 34 MB.
+/// ~134 MB on a desktop and 128 keeps a phone near 34 MB. In a browser — especially an iframe on
+/// Safari, where a Retina raster_bias quadruples the tile count — a desktop budget gets the whole
+/// device recycled out from under us, so wasm gets ~50 MB.
 const RASTER_TILE_CACHE: usize = if cfg!(target_os = "android") {
     128
+} else if cfg!(target_arch = "wasm32") {
+    192
 } else {
     512
 };

--- a/web/index.src.html
+++ b/web/index.src.html
@@ -101,9 +101,17 @@
         const el = boot.isConnected ? boot : document.body.appendChild(boot);
         el.textContent = msg;
       };
+      // Reload rather than sit on a dead canvas — but only once per 30s, or a GPU that dies on
+      // every boot turns into a reload loop.
       document.getElementById("hookecho").addEventListener("webglcontextlost", (e) => {
         e.preventDefault();
-        dead("Graphics context lost — reload the page.");
+        const last = +sessionStorage.getItem("hookecho_reload") || 0;
+        if (Date.now() - last < 30000) {
+          dead("Graphics context lost — reload the page.");
+          return;
+        }
+        sessionStorage.setItem("hookecho_reload", String(Date.now()));
+        location.reload();
       });
       addEventListener("error", (e) => {
         if (String(e.message || "").includes("unreachable")) dead("Hook Echo-WX stopped: " + e.message);


### PR DESCRIPTION
Reported by Rett Campbell: macOS 27 Safari, "browser flashing black every few seconds" after zooming in on an embedded radar loop; clears on reload at the original zoom.

**Cause.** Safari 26+ runs the viewer on WebGPU. WebGPU device loss is silent — the canvas just goes black — and the only loss handler here was `webglcontextlost`, which that backend can never fire. The pressure that triggers the loss is the tile budget: wasm was using the desktop `RASTER_TILE_CACHE = 512` (~134 MB resting), quadrupled again by the Retina `raster_bias`, inside a third-party iframe.

**Fix.**
- `tiles.rs`: wasm gets its own budget of 192 (~50 MB).
- `app.rs`: wasm-only `set_device_lost_callback` that reloads the page on `DeviceLostReason::Unknown`.
- `web/index.src.html`: `webglcontextlost` reloads too.

Both reload paths are guarded by a 30s `sessionStorage` stamp, so a GPU that dies on every boot degrades to today's "Graphics context lost" message rather than looping.

Checked: `cargo check` native + `scripts/web/build.sh` (wasm build clean, under size budget). The Safari repro is user-side — asking Rett to re-test after deploy before claiming it fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)