### PR TITLE
fix(web): don't reload on WebGL device loss, and fail closed without storage

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -2398,23 +2398,31 @@ impl HookEchoApp {
         // Safari 26+ runs us on WebGPU, where device loss is silent: the canvas simply goes black
         // and `webglcontextlost` can never fire. Nothing can be rebuilt from inside a lost device,
         // so reload — guarded so a device that dies on every boot doesn't loop.
+        //
+        // WebGPU backend only: on the WebGL fallback (WebKitGTK, older Safari) wgpu-core fires
+        // this callback with `Unknown` for transient GL errors too — not just real context loss —
+        // and index.src.html's `webglcontextlost` handler already owns that path.
         #[cfg(target_arch = "wasm32")]
-        render_state.device.set_device_lost_callback(|reason, msg| {
-            if !matches!(reason, wgpu::DeviceLostReason::Unknown) {
-                return;
-            }
-            log::error!("wgpu device lost: {msg}");
-            let Some(win) = web_sys::window() else { return };
-            let now = js_sys::Date::now();
-            if let Ok(Some(store)) = win.session_storage() {
+        if render_state.adapter.get_info().backend == wgpu::Backend::BrowserWebGpu {
+            render_state.device.set_device_lost_callback(|reason, msg| {
+                if !matches!(reason, wgpu::DeviceLostReason::Unknown) {
+                    return;
+                }
+                log::error!("wgpu device lost: {msg}");
+                let Some(win) = web_sys::window() else { return };
+                // Fail closed: no sessionStorage (WebKit blocks it in third-party iframes) means
+                // no throttle, and an unthrottled reload is a reload loop. A dead canvas is the
+                // pre-reload floor; stay there.
+                let Ok(Some(store)) = win.session_storage() else { return };
+                let now = js_sys::Date::now();
                 let last = store.get_item("hookecho_reload").ok().flatten().and_then(|v| v.parse::<f64>().ok());
                 if last.is_some_and(|t| now - t < 30_000.0) {
                     return;
                 }
                 let _ = store.set_item("hookecho_reload", &now.to_string());
-            }
-            let _ = win.location().reload();
-        });
+                let _ = win.location().reload();
+            });
+        }
         // The GPU's 2D texture-size cap: desktop/Adreno do 16384, but many mobile GPUs cap at
         // 4096. Field grids (MRMS rotation/AzShear reach 14000 px) are decimated to fit this.
         let max_texture_dim = render_state.device.limits().max_texture_dimension_2d;

--- a/web/index.src.html
+++ b/web/index.src.html
@@ -105,12 +105,15 @@
       // every boot turns into a reload loop.
       document.getElementById("hookecho").addEventListener("webglcontextlost", (e) => {
         e.preventDefault();
-        const last = +sessionStorage.getItem("hookecho_reload") || 0;
-        if (Date.now() - last < 30000) {
+        // WebKit throws on sessionStorage access in third-party iframes. No storage means no
+        // reload throttle, so fail closed: message instead of a possible reload loop.
+        let store = null;
+        try { store = sessionStorage; } catch (_) {}
+        if (!store || Date.now() - (+store.getItem("hookecho_reload") || 0) < 30000) {
           dead("Graphics context lost — reload the page.");
           return;
         }
-        sessionStorage.setItem("hookecho_reload", String(Date.now()));
+        store.setItem("hookecho_reload", String(Date.now()));
         location.reload();
       });
       addEventListener("error", (e) => {


### PR DESCRIPTION
Follow-up to #45, which regressed embedded/WebGL users.

**Backend gate.** #45 registered `set_device_lost_callback` under `#[cfg(target_arch = "wasm32")]` with no backend check. On the WebGL fallback wgpu-core's `Device::lose()` fires that callback with a hardcoded `DeviceLostReason::Unknown` for transient gles hal errors (swapchain configure, `create_buffer`, null `map_buffer`) — the exact value the filter lets through. Errors that used to be inert now reload the page. WebGL context loss already has the `webglcontextlost` handler in `index.src.html`; the Rust callback was only needed for WebGPU's silent loss on Safari 26+. Now gated on `Backend::BrowserWebGpu`.

**Fail closed.** Both throttles skipped their guard when sessionStorage is unavailable and reloaded anyway. WebKit throws SecurityError on sessionStorage in third-party iframes, so in an embed the 30s guard never applied — an unthrottled reload loop, each cycle recompiling the ~4.6 MB wasm in the embedder's web process and hanging the host UI. Reported by a WeatherDesk user on Ubuntu 26.04 (WebKitGTK, radar pane is an iframe onto hookecho.netlify.app): app loads, shows the first screen, then locks up. No storage now means no reload — the pre-#45 dead-canvas message.

Safari's original fix is preserved: the callback still registers on WebGPU.

Verified: `cargo check -p hookecho`, `scripts/web/build.sh` (4663309 gzipped, budget 4800000).

🤖 Generated with [Claude Code](https://claude.com/claude-code)