### PR TITLE
fix(wasm): recover from device loss on every backend, throttle reload via URL flag

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -2395,34 +2395,33 @@ impl HookEchoApp {
         let spawner = crate::rt::Spawner::new();
 
         let render_state = cc.wgpu_render_state.as_ref().expect("wgpu backend");
-        // Safari 26+ runs us on WebGPU, where device loss is silent: the canvas simply goes black
-        // and `webglcontextlost` can never fire. Nothing can be rebuilt from inside a lost device,
-        // so reload — guarded so a device that dies on every boot doesn't loop.
+        // Device loss on wasm is unrecoverable from inside the app: WebGPU (Safari 26+) loses
+        // devices silently — black canvas, `webglcontextlost` can never fire — and on the WebGL
+        // fallback (WebKitGTK) wgpu marks the device lost for gles errors that never surface as
+        // a JS context-loss event either (seen on NVIDIA + WebKitGTK: dies at first paint, the
+        // page-level handler never fires). Reload is the only recovery on every backend.
         //
-        // WebGPU backend only: on the WebGL fallback (WebKitGTK, older Safari) wgpu-core fires
-        // this callback with `Unknown` for transient GL errors too — not just real context loss —
-        // and index.src.html's `webglcontextlost` handler already owns that path.
+        // The throttle lives in the URL, not sessionStorage — WebKit blocks storage in
+        // third-party iframes (the WeatherDesk embed), and a throttle that fails open there is a
+        // reload loop (the Ubuntu lockup). One reload per navigation: flag already present means
+        // this navigation was the retry, so stay on the dead canvas. index.src.html strips the
+        // flag after 60s of healthy running, earning a future retry.
         #[cfg(target_arch = "wasm32")]
-        if render_state.adapter.get_info().backend == wgpu::Backend::BrowserWebGpu {
-            render_state.device.set_device_lost_callback(|reason, msg| {
-                if !matches!(reason, wgpu::DeviceLostReason::Unknown) {
-                    return;
-                }
-                log::error!("wgpu device lost: {msg}");
-                let Some(win) = web_sys::window() else { return };
-                // Fail closed: no sessionStorage (WebKit blocks it in third-party iframes) means
-                // no throttle, and an unthrottled reload is a reload loop. A dead canvas is the
-                // pre-reload floor; stay there.
-                let Ok(Some(store)) = win.session_storage() else { return };
-                let now = js_sys::Date::now();
-                let last = store.get_item("hookecho_reload").ok().flatten().and_then(|v| v.parse::<f64>().ok());
-                if last.is_some_and(|t| now - t < 30_000.0) {
-                    return;
-                }
-                let _ = store.set_item("hookecho_reload", &now.to_string());
-                let _ = win.location().reload();
-            });
-        }
+        render_state.device.set_device_lost_callback(|reason, msg| {
+            // `Dropped`/`ReplacedCallback` are clean teardown, not failure.
+            if !matches!(reason, wgpu::DeviceLostReason::Unknown) {
+                return;
+            }
+            log::error!("wgpu device lost: {msg}");
+            let Some(win) = web_sys::window() else { return };
+            let search = win.location().search().unwrap_or_default();
+            if search.contains("relaunched") {
+                return;
+            }
+            let sep = if search.is_empty() { "?" } else { "&" };
+            // Setting `search` navigates; the spec keeps the fragment, so `#goto=…` survives.
+            let _ = win.location().set_search(&format!("{search}{sep}relaunched"));
+        });
         // The GPU's 2D texture-size cap: desktop/Adreno do 16384, but many mobile GPUs cap at
         // 4096. Field grids (MRMS rotation/AzShear reach 14000 px) are decimated to fit this.
         let max_texture_dim = render_state.device.limits().max_texture_dimension_2d;

--- a/web/index.src.html
+++ b/web/index.src.html
@@ -101,20 +101,19 @@
         const el = boot.isConnected ? boot : document.body.appendChild(boot);
         el.textContent = msg;
       };
-      // Reload rather than sit on a dead canvas — but only once per 30s, or a GPU that dies on
-      // every boot turns into a reload loop.
+      // Reload rather than sit on a dead canvas — but at most once, or a GPU that dies on every
+      // boot turns into a reload loop.
       document.getElementById("hookecho").addEventListener("webglcontextlost", (e) => {
         e.preventDefault();
-        // WebKit throws on sessionStorage access in third-party iframes. No storage means no
-        // reload throttle, so fail closed: message instead of a possible reload loop.
-        let store = null;
-        try { store = sessionStorage; } catch (_) {}
-        if (!store || Date.now() - (+store.getItem("hookecho_reload") || 0) < 30000) {
+        // Throttle in the URL, not sessionStorage — WebKit blocks storage in third-party
+        // iframes, and a throttle that fails open is a reload loop. One reload per navigation.
+        const url = new URL(location.href);
+        if (url.searchParams.has("relaunched")) {
           dead("Graphics context lost — reload the page.");
           return;
         }
-        store.setItem("hookecho_reload", String(Date.now()));
-        location.reload();
+        url.searchParams.append("relaunched", "1");
+        location.href = url.href;
       });
       addEventListener("error", (e) => {
         if (String(e.message || "").includes("unreachable")) dead("Hook Echo-WX stopped: " + e.message);
@@ -125,6 +124,15 @@
         await init({ module_or_path: module });
         await start("hookecho");
         boot.remove();
+        // A recovery reload leaves ?relaunched in the URL, which is our one retry spent. 60s of
+        // healthy running earns it back.
+        if (new URL(location.href).searchParams.has("relaunched")) {
+          setTimeout(() => {
+            const u = new URL(location.href);
+            u.searchParams.delete("relaunched");
+            history.replaceState(null, "", u);
+          }, 60000);
+        }
       } catch (e) {
         // Nearly always one of two things: a browser with neither WebGPU nor WebGL2, or the
         // wasm being served with the wrong MIME type. Say which rather than showing a blank page.


### PR DESCRIPTION
## Problem

After #46 deployed, the WeatherDesk radar iframe (WebKitGTK, NVIDIA) is **black with no text at all**, app sluggish but alive. No boot text means `start()` succeeded — the device died at or just after first paint. No "Graphics context lost" text means the page-level `webglcontextlost` handler never fired.

That's the bug: on WebKitGTK the loss is reported at the wgpu/gles level (`Device::lose()` with `DeviceLostReason::Unknown` from the swapchain-configure / create-buffer paths) and never surfaces as a JS context-loss event. The Rust callback was the only observer of it, and #46 gated that callback to `Backend::BrowserWebGpu`. #45's reload had been the accidental recovery on this path.

Same defect degraded Safari: ITP blocks `sessionStorage` in third-party iframes, so #46's fail-closed throttle left Safari with a dead canvas and no recovery either.

## Fix

- Callback runs on **all** wasm backends again.
- Throttle moves from `sessionStorage` to the URL: append `relaunched` and navigate; if the flag is already present, this navigation *was* the retry, so stay on the dead canvas. A loop is impossible by construction — the reloaded page carries the flag. George's Ubuntu worst case is one reload per navigation, not a loop.
- After 60s of healthy running, `index.src.html` strips the flag with `history.replaceState`, earning a future retry. Rust reads live `location.search`, so the strip re-arms both paths.
- `is_embed()` splits `location.search` on `&` and exact-matches `"embed"`, so the extra param is inert. Setting `location.search` preserves the fragment, so `#goto=…` survives the recovery reload.

## Verification

- `cargo check -p hookecho --lib --target wasm32-unknown-unknown` clean.
- `scripts/web/build.sh`: 4663428 gzipped, budget 4800000.
- Served the fixed bundle locally and pointed WeatherDesk's `RADAR` at it under `cargo tauri dev` (WebKitGTK): **radar pane renders map + returns**, no device-lost lines, app responsive. Reverted the RADAR edit afterwards.
- Not exercised: an actual induced device loss, so the reload-once path is verified by construction/review, not observed end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)