### PR TITLE
basemap: true per-pane styles

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -10460,12 +10460,6 @@ impl HookEchoApp {
             return;
         }
         let idx = self.active.min(self.views.len() - 1);
-        let style = self.views[idx].basemap;
-        let is_vector = matches!(
-            style,
-            crate::tiles::BasemapStyle::Dark | crate::tiles::BasemapStyle::Light
-        );
-        let is_raster = style.is_raster();
         let caption = {
             let v = &self.views[idx];
             let time = v
@@ -10548,7 +10542,9 @@ impl HookEchoApp {
                             .unwrap_or(self.views[idx].camera);
                         let pane_cam = std::mem::replace(&mut self.views[idx].camera, mine);
                         self.render_pane(
-                            ui, &vctx, idx, prect, is_vector, is_raster, false, false, false, &[],
+                            // `first`/`last` false: the mini-loop viewport is a passenger — the
+                            // main window's pane loop owns draining and evicting the tile caches.
+                            ui, &vctx, idx, prect, false, false, false, false, &[],
                         );
                         self.mini_cam =
                             Some(std::mem::replace(&mut self.views[idx].camera, pane_cam));
@@ -10574,14 +10570,17 @@ impl HookEchoApp {
         ctx: &egui::Context,
         idx: usize,
         prect: egui::Rect,
-        is_vector: bool,
-        is_raster: bool,
         clear_tiles: bool,
         clear_vector: bool,
         first: bool,
+        last: bool,
         placefile_labels: &[PlaceLabel],
     ) {
         use crate::tiles::BasemapStyle;
+        // This pane's own basemap: panes are independent, the tile caches are keyed by style.
+        let pane_style = self.views[idx].basemap;
+        let is_vector = matches!(pane_style, BasemapStyle::Dark | BasemapStyle::Light);
+        let is_raster = pane_style.is_raster();
         let vp = (prect.width(), prect.height());
         let response = ui.interact(
             prect,
@@ -11085,7 +11084,7 @@ impl HookEchoApp {
         } else {
             1.0
         };
-        let raster_bias = if self.views[idx].basemap.tiles_are_512() {
+        let raster_bias = if pane_style.tiles_are_512() {
             // 512-px providers already carry the extra detail in the tile itself; biasing on top
             // would fetch four of them per screen tile for nothing.
             0.0
@@ -11097,8 +11096,9 @@ impl HookEchoApp {
                 .clamp(0.0, bias_cap) as f64
         };
         let visible = if is_raster {
-            let vis = self.tiles.visible(&cam, vp, raster_bias);
-            self.tiles.request_missing(&vis);
+            let vis = self.tiles.visible(pane_style, &cam, vp, raster_bias);
+            self.tiles.request_missing(pane_style, &vis);
+            self.tiles.promote_visible(pane_style, &vis);
             vis
         } else {
             Vec::new()
@@ -11133,8 +11133,10 @@ impl HookEchoApp {
         // Drain finished fetches once (on the first pane) — they upload into the shared cache.
         // Eviction lives with the tile manager (it also owns `requested`/`uploaded`), and only
         // the first pane runs it so a multi-pane frame doesn't evict what a later pane needs.
-        let drop_tiles = if first && is_raster {
-            self.tiles.touch_visible(&visible)
+        // Eviction runs once per frame, on the last pane — after every pane has promoted its own
+        // visible tiles, so a multi-pane frame can't evict what a pane it already drew still needs.
+        let drop_tiles = if last {
+            self.tiles.evict_excess()
         } else {
             Vec::new()
         };
@@ -11195,6 +11197,7 @@ impl HookEchoApp {
             camera_scale: scale,
             new_tiles,
             visible,
+            basemap_key: pane_style.key(),
             radar_upload,
             draw_radar,
             overlay_upload: if first {
@@ -16388,15 +16391,22 @@ impl eframe::App for HookEchoApp {
                 }
             }
 
-            // Global basemap style is driven by the active pane.
+            // Each pane fetches and draws its own `View::basemap` (see `render_pane`). Two things
+            // stay global for now: the GOES frame cursor and the vector palette, both driven by
+            // the active pane.
+            // ponytail: one GOES cursor + one vector palette for all panes; split them when
+            // someone actually wants two satellite times or two vector palettes side by side.
             use crate::tiles::BasemapStyle;
             let style = self.views[self.active.min(n - 1)].basemap;
             let is_vector = matches!(style, BasemapStyle::Dark | BasemapStyle::Light);
-            let is_raster = style.is_raster();
-            let raster_style = if is_raster { style } else { BasemapStyle::None };
+            let raster_style = if style.is_raster() {
+                style
+            } else {
+                BasemapStyle::None
+            };
             self.tiles
                 .set_keys(&self.settings.mapbox_key, &self.settings.maptiler_key);
-            let mut clear_tiles = self.tiles.set_style(raster_style);
+            let mut clear_tiles = false;
             // GOES sub-hourly scrub: fetch the available frame times when a GOES style becomes
             // active, and apply the selected frame (None = latest).
             if raster_style.goes_layer().is_some() {
@@ -16450,11 +16460,10 @@ impl eframe::App for HookEchoApp {
                     ctx,
                     i,
                     *prect,
-                    is_vector,
-                    is_raster,
                     clear_tiles && first,
                     clear_vector && first,
                     first,
+                    i + 1 == n,
                     &placefile_labels,
                 );
             }

--- a/crates/hookecho/src/headless.rs
+++ b/crates/hookecho/src/headless.rs
@@ -68,9 +68,8 @@ fn national_basemap(
         let style = crate::tiles::BasemapStyle::from_slug(&slug);
         if style.is_raster() {
             let settings = crate::settings::Settings::load();
-            let mut tm = TileManager::new(crate::rt::Spawner::new(rt.handle().clone()));
-            tm.set_style(style);
-            let vis = tm.visible(camera, vp, 0.0);
+            let tm = TileManager::new(crate::rt::Spawner::new(rt.handle().clone()));
+            let vis = tm.visible(style, camera, vp, 0.0);
             let tiles = rt.block_on(crate::tiles::fetch_visible(
                 &client,
                 style,
@@ -198,9 +197,9 @@ pub fn run(
     let settings = crate::settings::Settings::load();
     let is_vector = matches!(basemap, BasemapStyle::Dark | BasemapStyle::Light);
     let (new_tiles, visible) = if basemap.is_raster() {
-        let mut tm = TileManager::new(crate::rt::Spawner::new(rt.handle().clone()));
-        tm.set_style(basemap); // so the zoom cap matches this source (GOES layers top out early)
-        let vis = tm.visible(&camera, vp, 0.0);
+        let tm = TileManager::new(crate::rt::Spawner::new(rt.handle().clone()));
+        // Style is passed per call so the zoom cap matches this source (GOES layers top out early).
+        let vis = tm.visible(basemap, &camera, vp, 0.0);
         let tiles = rt.block_on(crate::tiles::fetch_visible(
             &client,
             basemap,
@@ -252,6 +251,7 @@ pub fn run(
         camera_scale: scale,
         new_tiles,
         visible,
+        basemap_key: basemap.key(),
         radar_upload: Some(crate::app::to_upload(
             &sweep, &table, None, smooth, storm_uv,
         )),
@@ -302,6 +302,7 @@ pub fn run_multipane(site: &str, out_a: &str, out_b: &str) -> anyhow::Result<()>
             pane,
             camera_center: center,
             camera_scale: scale,
+            basemap_key: 0,
             new_tiles: Vec::new(),
             visible: Vec::new(),
             radar_upload: Some(crate::app::to_upload(&sweep, &table, None, false, None)),
@@ -952,6 +953,7 @@ pub fn run_live(out_path: &str, site: &str, moment: Moment) -> anyhow::Result<()
         pane: 0,
         camera_center: center,
         camera_scale: scale,
+        basemap_key: 0,
         new_tiles: Vec::new(),
         visible: Vec::new(),
         radar_upload: Some(crate::app::to_upload(&sweep, &table, None, false, None)),
@@ -1031,6 +1033,7 @@ pub fn run_placefile(path: &str, out_path: &str) -> anyhow::Result<()> {
         pane: 0,
         camera_center: center,
         camera_scale: scale,
+        basemap_key: 0,
         new_tiles: Vec::new(),
         visible: Vec::new(),
         radar_upload: None,
@@ -1089,6 +1092,7 @@ pub fn run_overlay(out_path: &str) -> anyhow::Result<()> {
         pane: 0,
         camera_center: center,
         camera_scale: scale,
+        basemap_key: 0,
         new_tiles,
         visible,
         radar_upload: None,
@@ -1188,6 +1192,7 @@ pub fn run_mrms(out_path: &str) -> anyhow::Result<()> {
         pane: 0,
         camera_center: center,
         camera_scale: scale,
+        basemap_key: 0,
         new_tiles,
         visible,
         radar_upload: None,
@@ -1241,6 +1246,7 @@ pub fn run_lightning(out_path: &str) -> anyhow::Result<()> {
         pane: 0,
         camera_center: center,
         camera_scale: scale,
+        basemap_key: 0,
         new_tiles,
         visible,
         radar_upload: None,
@@ -1310,6 +1316,7 @@ pub fn run_field(slug: &str, out_path: &str) -> anyhow::Result<()> {
         pane: 0,
         camera_center: center,
         camera_scale: scale,
+        basemap_key: 0,
         new_tiles,
         visible,
         radar_upload: None,
@@ -1407,6 +1414,7 @@ pub fn run_global(model: &str, slug: &str, out_path: &str) -> anyhow::Result<()>
         pane: 0,
         camera_center: center,
         camera_scale: scale,
+        basemap_key: 0,
         new_tiles,
         visible,
         radar_upload: None,
@@ -1519,6 +1527,7 @@ pub fn run_diff(slug: &str, out_path: &str) -> anyhow::Result<()> {
         pane: 0,
         camera_center: center,
         camera_scale: scale,
+        basemap_key: 0,
         new_tiles,
         visible,
         radar_upload: None,
@@ -1836,6 +1845,7 @@ pub fn run_l3grid(kind: &str, site: &str, out_path: &str) -> anyhow::Result<()> 
         pane: 0,
         camera_center: center,
         camera_scale: scale,
+        basemap_key: 0,
         new_tiles,
         visible,
         radar_upload: None,
@@ -1907,6 +1917,7 @@ pub fn run_env(slug: &str, out_path: &str) -> anyhow::Result<()> {
         pane: 0,
         camera_center: center,
         camera_scale: scale,
+        basemap_key: 0,
         new_tiles,
         visible,
         radar_upload: None,
@@ -2087,6 +2098,7 @@ pub fn run_hrrr_layer(
         pane: 0,
         camera_center: center,
         camera_scale: scale,
+        basemap_key: 0,
         new_tiles,
         visible,
         radar_upload: None,
@@ -2121,6 +2133,7 @@ fn render_field_png(
         pane: 0,
         camera_center: center,
         camera_scale: scale,
+        basemap_key: 0,
         new_tiles,
         visible,
         radar_upload: None,
@@ -2844,6 +2857,7 @@ mod golden_tests {
             pane: 0,
             camera_center: center,
             camera_scale: scale,
+            basemap_key: 0,
             new_tiles: Vec::new(),
             visible: Vec::new(),
             radar_upload: Some(crate::app::to_upload(&sweep, &table, None, false, None)),

--- a/crates/hookecho/src/render/mod.rs
+++ b/crates/hookecho/src/render/mod.rs
@@ -12,11 +12,18 @@ use wgpu::util::DeviceExt;
 /// XYZ tile id.
 pub type TileId = (u8, u32, u32);
 
+/// A tile plus which basemap style it came from. Panes can show different basemaps at once, so
+/// the same `(z, x, y)` may be resident twice with different imagery; the style key keeps them
+/// apart in the GPU cache.
+pub type TileKey = (u8, TileId);
+
 const MAX_TILE_VERTS: u64 = 512 * 6; // up to 512 visible tiles per frame
 
 /// A decoded RGBA tile the app wants uploaded this frame.
 pub struct PendingTile {
     pub id: TileId,
+    /// Basemap style this tile was fetched for ([`crate::tiles::BasemapStyle::key`]).
+    pub style: u8,
     pub rgba: Vec<u8>,
     pub width: u32,
     pub height: u32,
@@ -280,6 +287,8 @@ pub struct MapCallback {
     pub camera_scale: [f32; 2],
     pub new_tiles: Vec<PendingTile>,
     pub visible: Vec<VisibleTile>,
+    /// Which basemap style this pane draws ([`crate::tiles::BasemapStyle::key`]).
+    pub basemap_key: u8,
     pub radar_upload: Option<RadarUpload>,
     pub draw_radar: bool,
     /// `Some` only when the overlay geometry changed (else the last upload is reused).
@@ -289,7 +298,7 @@ pub struct MapCallback {
     pub clear_tiles: bool,
     /// Individual tiles the tile manager evicted; freed before this frame's uploads. Eviction is
     /// decided there, not here, so both sides agree on what is resident.
-    pub drop_tiles: Vec<TileId>,
+    pub drop_tiles: Vec<TileKey>,
     /// Field layers whose grid changed this frame (uploaded now); others reuse the last upload.
     pub field_uploads: Vec<(FieldLayer, MrmsUpload)>,
     /// Which field layers to paint this frame, with their opacity (0..1).
@@ -366,7 +375,7 @@ struct PaneGpu {
     radar: Option<RadarGpu>,
     /// Ids of the tiles this frame's quads draw, in quad order. Not the same as the visible list:
     /// a missing tile is stood in for by resident children or an ancestor.
-    frame_visible: Vec<TileId>,
+    frame_visible: Vec<TileKey>,
     frame_visible_vector: Vec<TileId>,
     frame_draw_radar: bool,
     frame_draw_overlay: bool,
@@ -389,7 +398,7 @@ pub struct RenderResources {
     // the ids to free (`drop_tiles`). Evicting here instead was a bug — the manager went on
     // believing an evicted tile was still uploaded and never re-sent it, so zooming back to an
     // area left black squares where those tiles used to be.
-    tiles: HashMap<TileId, TileGpu>,
+    tiles: HashMap<TileKey, TileGpu>,
     vector_tiles: HashMap<TileId, OverlayGpu>,
     overlay: Option<OverlayGpu>,
     fields: HashMap<FieldLayer, MrmsGpu>,
@@ -699,10 +708,14 @@ impl RenderResources {
     /// this the whole basemap blanks every time the integer zoom level changes, even though the
     /// pixels to show are sitting on the GPU.
     #[allow(clippy::type_complexity)] // one call site; a struct here would be ceremony
-    fn tile_quads(&self, v: &VisibleTile) -> Vec<(TileId, [f32; 2], [f32; 2], [f32; 2], [f32; 2])> {
+    fn tile_quads(
+        &self,
+        style: u8,
+        v: &VisibleTile,
+    ) -> Vec<(TileKey, [f32; 2], [f32; 2], [f32; 2], [f32; 2])> {
         const FULL: ([f32; 2], [f32; 2]) = ([0.0, 0.0], [1.0, 1.0]);
-        if self.tiles.contains_key(&v.id) {
-            return vec![(v.id, v.world_min, v.world_max, FULL.0, FULL.1)];
+        if self.tiles.contains_key(&(style, v.id)) {
+            return vec![((style, v.id), v.world_min, v.world_max, FULL.0, FULL.1)];
         }
         let (z, x, y) = v.id;
         let [x0, y0] = v.world_min;
@@ -711,7 +724,7 @@ impl RenderResources {
         let kids: Vec<_> = [(0u32, 0u32), (1, 0), (0, 1), (1, 1)]
             .into_iter()
             .filter_map(|(dx, dy)| {
-                let id = (z + 1, x * 2 + dx, y * 2 + dy);
+                let id = (style, (z + 1, x * 2 + dx, y * 2 + dy));
                 self.tiles.contains_key(&id).then(|| {
                     let (qx0, qx1) = if dx == 0 { (x0, mx) } else { (mx, x1) };
                     let (qy0, qy1) = if dy == 0 { (y0, my) } else { (my, y1) };
@@ -726,7 +739,7 @@ impl RenderResources {
             if up > z {
                 break;
             }
-            let id = (z - up, x >> up, y >> up);
+            let id = (style, (z - up, x >> up, y >> up));
             if self.tiles.contains_key(&id) {
                 let (uv_min, uv_max) = ancestor_uv(x, y, up);
                 return vec![(id, v.world_min, v.world_max, uv_min, uv_max)];
@@ -782,7 +795,7 @@ impl RenderResources {
             ],
         });
         self.tiles.insert(
-            t.id,
+            (t.style, t.id),
             TileGpu {
                 _tex: tex,
                 bind_group,
@@ -967,9 +980,9 @@ impl RenderResources {
         // Build the tile quad list against the shared tile cache before mutably borrowing the pane
         // — a tile with no texture yet borrows one from the tiles around it (see `tile_quads`).
         let mut tverts: Vec<TileVertex> = Vec::new();
-        let mut visible: Vec<TileId> = Vec::new();
+        let mut visible: Vec<TileKey> = Vec::new();
         for v in &cb.visible {
-            for (id, wmin, wmax, uvmin, uvmax) in self.tile_quads(v) {
+            for (id, wmin, wmax, uvmin, uvmax) in self.tile_quads(cb.basemap_key, v) {
                 if tverts.len() as u64 + 6 > MAX_TILE_VERTS {
                     break;
                 }

--- a/crates/hookecho/src/tiles.rs
+++ b/crates/hookecho/src/tiles.rs
@@ -369,6 +369,12 @@ impl BasemapStyle {
         self
     }
 
+    /// Stable small id for this style, used to key the GPU/fetch caches so panes showing
+    /// different basemaps don't overwrite each other's tiles. Index into [`Self::ALL`].
+    pub fn key(self) -> u8 {
+        Self::ALL.iter().position(|s| *s == self).unwrap_or(0) as u8
+    }
+
     /// Per-style cache subdir so sources don't collide on disk. Keys never appear here.
     fn provider(self) -> String {
         // 512-px tiles share the tile grid with the 256-px ones they replace, so a cache written
@@ -601,13 +607,14 @@ pub async fn fetch_goes_times(
 
 struct FetchedTile {
     id: TileId,
+    style: u8,
     rgba: Vec<u8>,
     width: u32,
     height: u32,
 }
 
 /// A finished fetch, or the id of one that failed (so it can leave `requested` and be retried).
-type TileResult = Result<FetchedTile, TileId>;
+type TileResult = Result<FetchedTile, crate::render::TileKey>;
 
 /// How many tile fetches may be in flight at once. A screenful is ~28 tiles, and firing all of
 /// them at a CDN at once means 28 TLS handshakes competing for the same radio: the first tile
@@ -629,15 +636,16 @@ pub struct TileManager {
     /// Fetches currently in flight, shared with the tasks so they can decrement on the way out.
     inflight: std::sync::Arc<std::sync::atomic::AtomicUsize>,
     /// Tiles whose fetch failed, and when. Retried after [`RETRY_AFTER`].
-    failed: std::collections::HashMap<TileId, wxdata::clock::Instant>,
-    requested: HashSet<TileId>,
+    failed: std::collections::HashMap<crate::render::TileKey, wxdata::clock::Instant>,
+    requested: HashSet<crate::render::TileKey>,
     /// Tiles believed to be live on the GPU, newest-touched first. This mirrors the renderer's
     /// tile map exactly: the CPU side decides what gets evicted and tells the renderer, so the
     /// two can never disagree about whether a tile still exists.
-    uploaded: LruCache<TileId, ()>,
+    uploaded: LruCache<crate::render::TileKey, ()>,
     /// Ids evicted by the last `touch_visible`, handed to the renderer to drop.
-    evicted: Vec<TileId>,
-    style: BasemapStyle,
+    evicted: Vec<crate::render::TileKey>,
+    /// Tiles counted visible across all panes this frame; drives the eviction high-water mark.
+    frame_visible: usize,
     cache_root: Option<std::path::PathBuf>,
     mapbox_key: String,
     maptiler_key: String,
@@ -667,7 +675,7 @@ impl TileManager {
             requested: HashSet::new(),
             uploaded: LruCache::new(NonZeroUsize::new(RASTER_TILE_CACHE).unwrap()),
             evicted: Vec::new(),
-            style: BasemapStyle::Dark,
+            frame_visible: 0,
             cache_root,
             mapbox_key: String::new(),
             maptiler_key: String::new(),
@@ -698,39 +706,29 @@ impl TileManager {
         }
     }
 
-    /// Switch basemap source. Returns true if the style changed (caller should clear the GPU
-    /// tile cache so stale tiles from the old source aren't shown).
-    pub fn set_style(&mut self, style: BasemapStyle) -> bool {
-        if self.style == style {
-            return false;
-        }
-        self.style = style;
-        self.requested.clear();
-        self.uploaded.clear();
-        true
-    }
-
     /// Integer tile ids covering the current view, and their world-space rects. `zoom_bias`
     /// pulls sharper tiles on high-DPI displays (see [`tile_cover`]).
     pub fn visible(
         &self,
+        style: BasemapStyle,
         cam: &Camera,
         viewport_px: (f32, f32),
         zoom_bias: f64,
     ) -> Vec<VisibleTile> {
-        tile_cover(cam, viewport_px, self.style.max_raster_z(), zoom_bias)
+        tile_cover(cam, viewport_px, style.max_raster_z(), zoom_bias)
     }
 
     /// Kick off fetches for any visible tiles not yet requested.
-    pub fn request_missing(&mut self, visible: &[VisibleTile]) {
+    pub fn request_missing(&mut self, style: BasemapStyle, visible: &[VisibleTile]) {
         use std::sync::atomic::Ordering;
+        let skey = style.key();
         for v in visible {
-            if self.requested.contains(&v.id) {
+            if self.requested.contains(&(skey, v.id)) {
                 continue;
             }
             if self
                 .failed
-                .get(&v.id)
+                .get(&(skey, v.id))
                 .is_some_and(|t| t.elapsed() < RETRY_AFTER)
             {
                 continue;
@@ -740,15 +738,13 @@ impl TileManager {
                 break;
             }
             let (z, x, y) = v.id;
-            let Some(mut url) = self
-                .style
-                .url(z, x, y, &self.mapbox_key, &self.maptiler_key)
+            let Some(mut url) = style.url(z, x, y, &self.mapbox_key, &self.maptiler_key)
             else {
                 continue;
             };
             // GOES frame time: rewrite the `default` time slot in the GIBS URL and tag the cache
             // dir so different frames don't collide. Latest (`None`) keeps `default`.
-            let time_tag = match (self.style.goes_layer(), self.goes_time) {
+            let time_tag = match (style.goes_layer(), self.goes_time) {
                 (Some(_), Some(t)) => {
                     let iso = t.format("%Y-%m-%dT%H:%M:%SZ").to_string();
                     url = url.replace(
@@ -759,9 +755,9 @@ impl TileManager {
                 }
                 _ => "default".to_string(),
             };
-            self.requested.insert(v.id);
+            self.requested.insert((skey, v.id));
             let path = self.cache_root.as_ref().map(|d| {
-                d.join(self.style.provider())
+                d.join(style.provider())
                     .join(&time_tag)
                     .join(format!("{z}/{x}/{y}"))
             });
@@ -784,12 +780,13 @@ impl TileManager {
                             let (w, h) = rgba.dimensions();
                             FetchedTile {
                                 id: (z, x, y),
+                                style: skey,
                                 rgba: rgba.into_raw(),
                                 width: w,
                                 height: h,
                             }
                         });
-                    let _ = tx.send(decoded.ok_or((z, x, y)));
+                    let _ = tx.send(decoded.ok_or((skey, (z, x, y))));
                     inflight.fetch_sub(1, Ordering::Relaxed);
                     if let Some(ctx) = ctx {
                         ctx.request_repaint();
@@ -885,11 +882,12 @@ impl TileManager {
                     continue;
                 }
             };
-            self.failed.remove(&t.id);
+            let key = (t.style, t.id);
+            self.failed.remove(&key);
             // `push` (not `put`) hands back whatever it evicted, so the renderer can free the
             // texture instead of leaking it.
-            let evicted = self.uploaded.push(t.id, ());
-            if let Some((id, _)) = evicted.filter(|(id, _)| *id != t.id) {
+            let evicted = self.uploaded.push(key, ());
+            if let Some((id, _)) = evicted.filter(|(id, _)| *id != key) {
                 self.requested.remove(&id);
                 self.evicted.push(id);
             } else if evicted.is_some() {
@@ -897,6 +895,7 @@ impl TileManager {
             }
             ready.push(PendingTile {
                 id: t.id,
+                style: t.style,
                 rgba: t.rgba,
                 width: t.width,
                 height: t.height,
@@ -910,16 +909,26 @@ impl TileManager {
         self.ctx = Some(ctx);
     }
 
-    /// Mark this frame's tiles as most-recently-used and return anything that fell out of the
-    /// cache, so the renderer can free it. Tiles on screen are touched first and so can never be
-    /// the ones evicted; an evicted tile also drops out of `requested`, so revisiting that area
-    /// re-fetches it (from disk, usually) instead of leaving a black square.
-    pub fn touch_visible(&mut self, visible: &[VisibleTile]) -> Vec<TileId> {
-        // Grow to fit a wide view: the cap is a resting size, not a per-frame limit.
-        let want = RASTER_TILE_CACHE.max(visible.len() + 16);
+    /// Mark this frame's tiles as most-recently-used. Called once per pane, because panes can
+    /// show different basemaps and each pane's tiles must survive the others' eviction pass.
+    /// Eviction itself runs once per frame in [`Self::evict_excess`], after every pane has been
+    /// counted — evicting mid-frame would drop tiles a later pane still needs.
+    pub fn promote_visible(&mut self, style: BasemapStyle, visible: &[VisibleTile]) {
+        let skey = style.key();
         for v in visible {
-            self.uploaded.promote(&v.id);
+            self.uploaded.promote(&(skey, v.id));
         }
+        self.frame_visible += visible.len();
+    }
+
+    /// Shrink the cache back to its resting size and return what fell out, so the renderer can
+    /// free those textures. Run after the last pane's [`Self::promote_visible`].
+    pub fn evict_excess(&mut self) -> Vec<crate::render::TileKey> {
+        // Grow to fit a wide (or multi-pane) frame: the cap is a resting size, not a per-frame
+        // limit. An evicted tile also drops out of `requested`, so revisiting that area re-fetches
+        // it (from disk, usually) instead of leaving a black square.
+        let want = RASTER_TILE_CACHE.max(self.frame_visible + 16);
+        self.frame_visible = 0;
         // Pop down to size FIRST: shrinking an `LruCache` evicts silently, and a silently evicted
         // tile is a texture the renderer never hears about again.
         while self.uploaded.len() > want {
@@ -963,6 +972,7 @@ pub async fn fetch_visible(
                     let (w, h) = rgba.dimensions();
                     out.push(PendingTile {
                         id: v.id,
+                        style: style.key(),
                         rgba: rgba.into_raw(),
                         width: w,
                         height: h,
@@ -1230,6 +1240,18 @@ pub fn start_pack_download(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Panes render their own basemap, so the caches are keyed by style as well as tile id. Two
+    /// styles must never collapse onto the same key — that is what put one pane's imagery under
+    /// another pane's radar.
+    #[test]
+    fn style_keys_are_unique() {
+        let mut seen = std::collections::HashSet::new();
+        for s in BasemapStyle::ALL {
+            assert!(seen.insert(s.key()), "duplicate style key for {s:?}");
+        }
+        assert_eq!(seen.len(), BasemapStyle::ALL.len());
+    }
 
     #[test]
     fn cache_caps_fall_back_to_the_platform_default_at_zero() {


### PR DESCRIPTION
R17 wave A, PR 1 of 14.

## Problem

`View::basemap` was already per pane, but rendering was not: the active pane drove one `TileManager` style and one GPU tile cache, so every pane drew the active pane's imagery. Splitting into four panes to compare products meant you could not also compare them over satellite vs. vector.

## Change

- `render::TileKey = (u8, TileId)` — the raster GPU cache, `requested`, `failed` and the upload LRU are all keyed by style as well as tile id, so two panes can hold the same `(z, x, y)` from different sources at once.
- `TileManager` no longer holds a style. `visible`, `request_missing` and the new `promote_visible` take it per call; `set_style` is gone.
- `render_pane` computes `is_vector`/`is_raster` from its own pane's basemap; `MapCallback` carries `basemap_key`.
- Eviction moved from the first pane to the last (`evict_excess`): every pane promotes its visible tiles first, so a multi-pane frame cannot evict tiles a pane it already drew still needs. The budget stays one shared resting cap, not one per pane.

Still global, deliberately (`ponytail` at the call site): the GOES frame cursor and the vector palette, both driven by the active pane.

## Verification

- `cargo clippy --workspace --all-targets` — clean
- `cargo test --workspace` — pass, incl. new `style_keys_are_unique`
- `RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check --target wasm32-unknown-unknown -p hookecho --lib` — pass
- `./scripts/shots/shoot.sh check` — pass
- Manual: two-pane KTLX 2013-05-20 archive under Xvfb. Left pane satellite-streets, right pane cycled twice (outdoors, then dark) — left never changed, per-pane attribution correct, no imagery bleed between panes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)