### PR TITLE
tiles: sharp, and never blank

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -11084,9 +11084,9 @@ impl HookEchoApp {
         } else {
             1.0
         };
-        let raster_bias = if pane_style.tiles_are_512() {
-            // 512-px providers already carry the extra detail in the tile itself; biasing on top
-            // would fetch four of them per screen tile for nothing.
+        let raster_bias = if pane_style.tiles_are_512() || self.tiles.is_retina(pane_style) {
+            // 512-px and `@2x` providers already carry the extra detail in the tile itself;
+            // biasing on top would fetch four of them per screen tile for nothing.
             0.0
         } else {
             ctx.pixels_per_point()
@@ -16406,7 +16406,12 @@ impl eframe::App for HookEchoApp {
             };
             self.tiles
                 .set_keys(&self.settings.mapbox_key, &self.settings.maptiler_key);
-            let mut clear_tiles = false;
+            // Ask for `@2x` tiles where the provider serves them: same tile count, twice the
+            // pixels, labels drawn for the density instead of magnified. Off on a metered link —
+            // a double-resolution tile is roughly double the bytes.
+            let mut clear_tiles = self.tiles.set_retina(
+                ctx.pixels_per_point() > 1.0 && !crate::platform::is_metered(),
+            );
             // GOES sub-hourly scrub: fetch the available frame times when a GOES style becomes
             // active, and apply the selected frame (None = latest).
             if raster_style.goes_layer().is_some() {

--- a/crates/hookecho/src/tiles.rs
+++ b/crates/hookecho/src/tiles.rs
@@ -328,16 +328,38 @@ impl BasemapStyle {
         )
     }
 
-    /// Max zoom the raster source serves; deeper views upscale rather than fetch 404s. GIBS
-    /// GOES layers top out at their matrix level; the USGS ArcGIS services cap at 16.
+    /// Max zoom the raster source serves; deeper views upscale rather than fetch 404s. GIBS GOES
+    /// layers top out at their matrix level.
+    ///
+    /// Every value below was checked against the live endpoint over Dallas: one level past the
+    /// number here either 404s or returns the provider's fixed "no data" placeholder (OpenTopoMap
+    /// hands back the same 4343-byte image at 18, 19 and 20). Guessing high is not free — a 404
+    /// leaves a hole until an ancestor tile happens to be resident, which is what made the USGS
+    /// satellite basemap blank out on close zoom: it served nothing past 16 but was asked for 18.
     fn max_raster_z(self) -> u8 {
         if let Some((_, level)) = self.goes_layer() {
             return level;
         }
         match self {
-            BasemapStyle::UsgsTopo | BasemapStyle::UsgsImageryTopo => 16,
-            _ => 18,
+            // USGS ArcGIS services (imagery and topo alike) stop at 16.
+            BasemapStyle::Satellite | BasemapStyle::UsgsTopo | BasemapStyle::UsgsImageryTopo => 16,
+            BasemapStyle::OpenTopoMap => 17,
+            BasemapStyle::OsmHot => 18,
+            BasemapStyle::OsmStandard | BasemapStyle::CyclOsm => 19,
+            BasemapStyle::CartoPositron | BasemapStyle::CartoDarkMatter | BasemapStyle::CartoVoyager => 20,
+            BasemapStyle::EsriImagery | BasemapStyle::EsriStreets | BasemapStyle::EsriTopo => 20,
+            _ => 20, // Mapbox and MapTiler raster both serve past 20; the vector styles never get here.
         }
+    }
+
+    /// Whether this source serves a true double-resolution tile at the same grid position (the
+    /// `@2x` suffix). Worth more than the retina zoom bias it replaces: same tile count, twice the
+    /// pixels, and the labels are drawn for the higher density instead of being magnified.
+    fn has_2x(self) -> bool {
+        matches!(
+            self,
+            BasemapStyle::CartoPositron | BasemapStyle::CartoDarkMatter | BasemapStyle::CartoVoyager
+        )
     }
 
     /// Whether this style's tiles are 512 px rather than 256. Mapbox and MapTiler both serve the
@@ -376,11 +398,14 @@ impl BasemapStyle {
     }
 
     /// Per-style cache subdir so sources don't collide on disk. Keys never appear here.
-    fn provider(self) -> String {
+    fn provider(self, retina: bool) -> String {
         // 512-px tiles share the tile grid with the 256-px ones they replace, so a cache written
-        // before the switch would keep serving blurry 256s from the same paths. Separate dir.
+        // before the switch would keep serving blurry 256s from the same paths. Separate dir —
+        // and `@2x` tiles get their own for the same reason.
         if self.tiles_are_512() {
             format!("{}-512", self.slug())
+        } else if retina && self.has_2x() {
+            format!("{}-2x", self.slug())
         } else {
             self.slug().to_string()
         }
@@ -409,7 +434,17 @@ impl BasemapStyle {
 
     /// Raster tile URL for `(z, x, y)`. Built-in Dark/Light are the vector MVT basemap and return
     /// `None` here. Provider styles inject the matching key (never logged/cached in a path).
-    fn url(self, z: u8, x: u32, y: u32, mapbox_key: &str, maptiler_key: &str) -> Option<String> {
+    fn url(
+        self,
+        z: u8,
+        x: u32,
+        y: u32,
+        retina: bool,
+        mapbox_key: &str,
+        maptiler_key: &str,
+    ) -> Option<String> {
+        // `@2x` on the sources that serve it; empty everywhere else, so the URL is unchanged.
+        let hi = if retina && self.has_2x() { "@2x" } else { "" };
         match self.provider_kind() {
             Provider::Builtin => match self {
                 // ArcGIS MapServer tiles (public). All use `{z}/{y}/{x}` order and serve JPEG.
@@ -440,13 +475,13 @@ impl BasemapStyle {
                     Some(format!("https://a.tile.opentopomap.org/{z}/{x}/{y}.png"))
                 }
                 BasemapStyle::CartoPositron => {
-                    Some(format!("https://basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"))
+                    Some(format!("https://basemaps.cartocdn.com/light_all/{z}/{x}/{y}{hi}.png"))
                 }
                 BasemapStyle::CartoDarkMatter => {
-                    Some(format!("https://basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png"))
+                    Some(format!("https://basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{hi}.png"))
                 }
                 BasemapStyle::CartoVoyager => {
-                    Some(format!("https://basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"))
+                    Some(format!("https://basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{hi}.png"))
                 }
                 BasemapStyle::OsmHot => {
                     Some(format!("https://a.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png"))
@@ -651,6 +686,8 @@ pub struct TileManager {
     maptiler_key: String,
     /// Selected GOES frame time (`None` = latest/`default`). Only affects GOES styles.
     goes_time: Option<chrono::DateTime<chrono::Utc>>,
+    /// Ask sources that serve them for `@2x` tiles (high-DPI screen, unmetered link).
+    retina: bool,
 }
 
 impl TileManager {
@@ -680,6 +717,7 @@ impl TileManager {
             mapbox_key: String::new(),
             maptiler_key: String::new(),
             goes_time: None,
+            retina: false,
         }
     }
 
@@ -693,6 +731,24 @@ impl TileManager {
         self.requested.clear();
         self.uploaded.clear();
         true
+    }
+
+    /// Turn `@2x` tiles on or off (high-DPI screen, and not on a metered link). Returns true if it
+    /// changed, so the caller can clear the GPU cache: the old tiles are a different size.
+    pub fn set_retina(&mut self, retina: bool) -> bool {
+        if self.retina == retina {
+            return false;
+        }
+        self.retina = retina;
+        self.requested.clear();
+        self.uploaded.clear();
+        true
+    }
+
+    /// Whether `style` is being fetched at double resolution right now — the caller drops its
+    /// retina zoom bias when this is true, since the extra pixels are already in the tile.
+    pub fn is_retina(&self, style: BasemapStyle) -> bool {
+        self.retina && style.has_2x()
     }
 
     /// Update the provider API keys (from Settings). Clears fetch state if a key changed so the
@@ -738,7 +794,8 @@ impl TileManager {
                 break;
             }
             let (z, x, y) = v.id;
-            let Some(mut url) = style.url(z, x, y, &self.mapbox_key, &self.maptiler_key)
+            let Some(mut url) =
+                style.url(z, x, y, self.retina, &self.mapbox_key, &self.maptiler_key)
             else {
                 continue;
             };
@@ -757,7 +814,7 @@ impl TileManager {
             };
             self.requested.insert((skey, v.id));
             let path = self.cache_root.as_ref().map(|d| {
-                d.join(style.provider())
+                d.join(style.provider(self.retina))
                     .join(&time_tag)
                     .join(format!("{z}/{x}/{y}"))
             });
@@ -807,7 +864,7 @@ impl TileManager {
     pub fn packable(&self, style: BasemapStyle) -> bool {
         style.goes_layer().is_none()
             && style
-                .url(0, 0, 0, &self.mapbox_key, &self.maptiler_key)
+                .url(0, 0, 0, false, &self.mapbox_key, &self.maptiler_key)
                 .is_some()
     }
 
@@ -832,11 +889,12 @@ impl TileManager {
             return Vec::new();
         }
         let z_hi = z_hi.min(style.max_raster_z());
-        let dir = root.join(style.provider()).join("default");
+        // Packs are always 1x: a pack is written once and read on whatever device opens it later.
+        let dir = root.join(style.provider(false)).join("default");
         pack_tile_ids(min_lon, min_lat, max_lon, max_lat, z_lo, z_hi)
             .into_iter()
             .filter_map(|(z, x, y)| {
-                let url = style.url(z, x, y, &self.mapbox_key, &self.maptiler_key)?;
+                let url = style.url(z, x, y, false, &self.mapbox_key, &self.maptiler_key)?;
                 Some((url, dir.join(format!("{z}/{x}/{y}"))))
             })
             .collect()
@@ -962,7 +1020,7 @@ pub async fn fetch_visible(
     let mut out = Vec::new();
     for v in visible {
         let (z, x, y) = v.id;
-        let Some(url) = style.url(z, x, y, mapbox_key, maptiler_key) else {
+        let Some(url) = style.url(z, x, y, false, mapbox_key, maptiler_key) else {
             continue;
         };
         match load_tile_bytes(client, &url, None).await {
@@ -1002,7 +1060,16 @@ pub(crate) async fn load_tile_bytes(
             return Ok(bytes);
         }
     }
-    let resp = client.get(url).send().await?.error_for_status()?;
+    // Browser builds cannot fetch most tile hosts directly — they send no CORS header — so the
+    // request goes to the page's own `/proxy/{host}/...` instead, which also means one visitor's
+    // tile is the next visitor's edge-cache hit. `fetch_url` leaves the keyed providers alone:
+    // api.mapbox.com and api.maptiler.com answer CORS themselves, and proxying them would put a
+    // user's API key in a shared cache. Native builds get the URL back unchanged.
+    let resp = client
+        .get(wxdata::net::fetch_url(url))
+        .send()
+        .await?
+        .error_for_status()?;
     let bytes = resp.bytes().await?.to_vec();
     if let Some(p) = path {
         if let Some(parent) = p.parent() {
@@ -1347,18 +1414,47 @@ mod tests {
         for s in keyless {
             assert!(s.is_raster(), "{s:?} should be raster");
             assert!(
-                s.url(6, 15, 25, "", "").is_some(),
+                s.url(6, 15, 25, false, "", "").is_some(),
                 "{s:?} should have a keyless URL"
             );
         }
         // ArcGIS services use {z}/{y}/{x}: y before x in the path.
-        let esri = BasemapStyle::EsriImagery.url(6, 15, 25, "", "").unwrap();
+        let esri = BasemapStyle::EsriImagery.url(6, 15, 25, false, "", "").unwrap();
         assert!(esri.ends_with("/6/25/15"), "Esri y/x order: {esri}");
         // Standard slippy tiles use {z}/{x}/{y}.
-        let osm = BasemapStyle::OsmStandard.url(6, 15, 25, "", "").unwrap();
+        let osm = BasemapStyle::OsmStandard.url(6, 15, 25, false, "", "").unwrap();
         assert!(osm.ends_with("/6/15/25.png"), "OSM x/y order: {osm}");
         // Mapbox nav styles stay key-gated.
-        assert!(BasemapStyle::MapboxNavDay.url(6, 15, 25, "", "").is_none());
-        assert!(BasemapStyle::MapboxNavDay.url(6, 15, 25, "k", "").is_some());
+        assert!(BasemapStyle::MapboxNavDay.url(6, 15, 25, false, "", "").is_none());
+        assert!(BasemapStyle::MapboxNavDay.url(6, 15, 25, false, "k", "").is_some());
+    }
+
+    /// Retina asks for the `@2x` tile only where the provider serves one, and those tiles get
+    /// their own cache directory so a 1x and a 2x tile never overwrite each other on disk.
+    #[test]
+    fn retina_only_changes_the_sources_that_serve_2x() {
+        let carto = BasemapStyle::CartoDarkMatter;
+        assert!(carto.url(6, 15, 25, true, "", "").unwrap().ends_with("@2x.png"));
+        assert!(carto.url(6, 15, 25, false, "", "").unwrap().ends_with("/25.png"));
+        assert_ne!(carto.provider(true), carto.provider(false));
+        // No `@2x` upstream: the URL and the cache path are identical either way.
+        let osm = BasemapStyle::OsmStandard;
+        assert_eq!(osm.url(6, 15, 25, true, "", ""), osm.url(6, 15, 25, false, "", ""));
+        assert_eq!(osm.provider(true), osm.provider(false));
+    }
+
+    /// The USGS satellite basemap serves nothing past zoom 16; asking for 17 got a 404 and left a
+    /// hole in the map, which is what "blurry, then blank, when you zoom in" turned out to be.
+    #[test]
+    fn max_zoom_matches_what_the_providers_actually_serve() {
+        assert_eq!(BasemapStyle::Satellite.max_raster_z(), 16);
+        assert_eq!(BasemapStyle::OpenTopoMap.max_raster_z(), 17);
+        assert_eq!(BasemapStyle::OsmStandard.max_raster_z(), 19);
+        assert_eq!(BasemapStyle::CartoDarkMatter.max_raster_z(), 20);
+        // GOES layers keep their own matrix level, whatever the table above says.
+        assert_eq!(
+            BasemapStyle::GoesEast.max_raster_z(),
+            BasemapStyle::GoesEast.goes_layer().unwrap().1
+        );
     }
 }

--- a/crates/wxdata/src/net.rs
+++ b/crates/wxdata/src/net.rs
@@ -12,6 +12,23 @@
 /// does not parse as `https://host/...`, and any page with no reachable `window`, is left alone
 /// and fails the same way it would today.
 ///
+/// Hosts that answer a cross-origin browser fetch on their own, so the browser build asks them
+/// directly instead of going through `/proxy/`.
+///
+/// The two keyed tile providers are here for a second reason as well: their tile URLs carry the
+/// user's API key in the query string, and the proxy is a *shared* edge cache. Routing them
+/// through it would store one user's key against a cacheable URL. They must stay direct.
+// The live-chunk bucket is here rather than proxied on purpose: those objects are seconds old and
+// fetched one at a time as the radar writes them, so an extra hop buys nothing and costs latency.
+// The *archive* bucket is not in this list — it goes through the proxy, so one visitor's volume
+// download is the next visitor's cache hit.
+pub const CORS_OK: &[&str] = &[
+    "api.open-meteo.com",
+    "api.mapbox.com",
+    "api.maptiler.com",
+    "unidata-nexrad-level2-chunks.s3.amazonaws.com",
+];
+
 // ponytail: string surgery over a URL crate, and a short known-good list rather than a preflight
 // probe; the ceiling is "the app's own feeds", and any host it cannot parse just goes unproxied.
 pub fn fetch_url(url: &str) -> String {
@@ -21,17 +38,6 @@ pub fn fetch_url(url: &str) -> String {
     }
     #[cfg(target_arch = "wasm32")]
     {
-        /// Hosts that answer a cross-origin browser fetch on their own.
-        // The live-chunk bucket is here rather than proxied on purpose: those objects are seconds
-        // old and fetched one at a time as the radar writes them, so an extra hop buys nothing and
-        // costs latency. The *archive* bucket is not in this list — it goes through the proxy, so
-        // one visitor's volume download is the next visitor's cache hit.
-        const CORS_OK: &[&str] = &[
-            "api.open-meteo.com",
-            "api.mapbox.com",
-            "api.maptiler.com",
-            "unidata-nexrad-level2-chunks.s3.amazonaws.com",
-        ];
         let Some(rest) = url.strip_prefix("https://") else {
             return url.to_string();
         };
@@ -60,6 +66,18 @@ pub fn install_s3_proxy_rewriter() {
 
 #[cfg(test)]
 mod tests {
+    /// A keyed tile URL must never be rewritten to `/proxy/…`: the proxy is a shared edge cache
+    /// and the key rides in the query string.
+    #[test]
+    fn keyed_tile_hosts_are_never_proxied() {
+        for host in ["api.mapbox.com", "api.maptiler.com"] {
+            assert!(
+                super::CORS_OK.contains(&host),
+                "{host} must stay direct — proxying it would cache a user's API key"
+            );
+        }
+    }
+
     #[test]
     fn native_urls_are_left_alone() {
         let url = "https://api.weather.gov/alerts/active";


### PR DESCRIPTION
R17 wave A, PR 2 of 14. Stacked on #48 (`feat/per-pane-basemaps`) — review that first.

## What was actually wrong

Planned as "add an overzoom fallback". It turned out the fallback already exists (`tile_quads` borrows from resident children, then up to three ancestor levels, with a UV sub-rect) and `tile_cover` already clamps past the cap. The bug was one line up: `max_raster_z` special-cased the two USGS **topo** styles at 16 and gave everything else a flat 18. The USGS **satellite** basemap serves nothing past 16, so zooming in fetched 17 and 18, took 404s, and left holes wherever no ancestor happened to be resident.

## Change

- **Zoom caps checked against the live endpoints**, not guessed. One level past each value either 404s or returns the provider's fixed placeholder — OpenTopoMap returns the same 4343-byte image at 18, 19 and 20, so it caps at 17. Satellite/USGS 16, OpenTopoMap 17, OSM HOT 18, OSM + CyclOSM 19, Carto + Esri 20.
- **Real `@2x` tiles** where the provider serves them (the three Carto styles): same tile count, twice the pixels, labels drawn for the density instead of magnified. Replaces the retina zoom bias for those styles, which fetched 4 tiles to fake it. Own `-2x` cache directory; off on a metered link; packs stay 1x since a pack is read on whatever device opens it later.
- **Browser tiles go through `/proxy/`** like every other feed, so they no longer depend on the host sending CORS, and one visitor's tile is the next visitor's edge-cache hit. The hosts were already in both allowlists.

### Key-leak guard

`CORS_OK` moves out of the wasm-only block so a test can assert `api.mapbox.com` and `api.maptiler.com` are in it. Those two must stay **direct**: their tile URLs carry the user's API key in the query string, and `/proxy/` is a shared edge cache. `fetch_url` already skips them; the test makes it hard to undo by accident. DEM tiles are untouched and still fetched direct.

## Verification

- `cargo clippy --workspace --all-targets` — clean
- `cargo test --workspace` — pass, incl. new `max_zoom_matches_what_the_providers_actually_serve`, `retina_only_changes_the_sources_that_serve_2x`, `keyed_tile_hosts_are_never_proxied`
- `RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check --target wasm32-unknown-unknown -p hookecho --lib` — pass
- `./scripts/shots/shoot.sh check` — pass
- `scripts/web/build.sh && node scripts/web/smoke.mjs` — booted (note: the smoke script expects a server already listening; an unrelated service on :8080 was the cause of a red herring here)
- Browser request capture against the built bundle with a raster basemap deep-linked: every `basemaps.cartocdn.com` tile arrives as `/proxy/basemaps.cartocdn.com/dark_all/9/…`, 95 of 97 outbound requests proxied.
- Manual: satellite basemap at KTLX zoom 17 under Xvfb now renders (stretched z16 imagery) instead of blank. `curl` confirms the old behaviour was a hard 404 — `.../USGSImageryOnly/MapServer/tile/17/…` returns 404, 16 returns a 28 KB tile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)