### PR TITLE
profiling: scope the UI frame, and what it measured

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -6339,6 +6339,7 @@ impl HookEchoApp {
     /// windows — searchable) with the app's own commands below it. It replaces a wall of parallel
     /// entry points; the map keeps nothing but transient status.
     fn sidebar(&mut self, root: &mut egui::Ui, ctx: &egui::Context) {
+        crate::prof_scope!("sidebar");
         let accent = crate::theme::accent(self.settings.theme);
         let entries = self.palette_entries();
         let mut query = std::mem::take(&mut self.layers_query);
@@ -6559,6 +6560,7 @@ impl HookEchoApp {
     }
 
     fn timeline_bar(&mut self, root: &mut egui::Ui) {
+        crate::prof_scope!("timeline_bar");
         use egui_phosphor::regular as ph;
         let accent = crate::theme::accent(self.settings.theme);
         let tz = self.active_tz();
@@ -9339,6 +9341,7 @@ impl HookEchoApp {
     /// `(item, opacity, loaded-placefile index)`. Iterated in `settings.placefiles` order, which
     /// is the paint order the Layer Manager reorders.
     fn visible_placefile_items(&self) -> Vec<(&wxdata::placefile::PlaceItem, f32, usize)> {
+        crate::prof_scope!("visible_placefile_items");
         let range = self.view_range_nmi();
         let now = Utc::now();
         let mut out = Vec::new();
@@ -9385,6 +9388,7 @@ impl HookEchoApp {
     /// Owned labels/markers for the visible placefile items (drawn by the egui painter).
     /// Icons resolve their sheet cell here, so the painter just blits a quad.
     fn placefile_labels(&self) -> Vec<PlaceLabel> {
+        crate::prof_scope!("placefile_labels");
         use wxdata::placefile::PlaceKind;
         self.visible_placefile_items()
             .iter()
@@ -10608,6 +10612,7 @@ impl HookEchoApp {
         first: bool,
         placefile_labels: &[PlaceLabel],
     ) {
+        crate::prof_scope!("render_pane");
         use crate::tiles::BasemapStyle;
         let vp = (prect.width(), prect.height());
         let response = ui.interact(
@@ -12486,6 +12491,7 @@ impl HookEchoApp {
 
         // Surface obs (METAR station plots): fltCat-colored circle, wind barb, T/Td in °F.
         if self.show_metar && cam.zoom >= 6.0 {
+            crate::prof_scope!("metar_plots");
             let show_labels = cam.zoom >= 7.0;
             let flt_color = |c: &str| match c {
                 "VFR" => egui::Color32::from_rgb(60, 200, 90),
@@ -12605,6 +12611,7 @@ impl HookEchoApp {
                 FloodCat::NoFlooding => "no flooding",
                 FloodCat::Unknown => "no current reading",
             };
+            crate::prof_scope!("river_gauges");
             let mut placed: Vec<egui::Rect> = Vec::new();
             for g in &self.gauges {
                 let w = crate::render::mercator::lonlat_to_world(g.lon, g.lat);


### PR DESCRIPTION
R17 wave B, PR 4 of 14. Stacked on #50.

## The plan said "profile, then fix the top 3". I profiled. There is no top 3.

The only in-frame scopes were `ui`, `render prepare` and `render paint`, which is enough to say a frame costs 0.9 ms and nothing about where it goes. This PR adds scopes for what a pan actually exercises — sidebar, timeline bar, per-pane render, placefile label building, METAR plots, river gauges — all compiled out without `--features profiling`.

Then I measured, driving a real session under Xvfb (KTLX 2013-05-20 archive, storm-attribute table and radar-site layers on, 22 s of continuous drag-pan and zoom), collecting over the existing puffin TCP server:

```
frames: 528
frame ms  p50 0.63  p90 0.93  p99 1.17  max 1.30

scope                     total ms    calls   us/call
ui                           237.2      528     449.2
sidebar                      118.0      528     223.6
render_pane                   84.7      528     160.3
timeline_bar                  14.5      528      27.4
palette_entries               13.9      528      26.3
render prepare                11.6      528      21.9
render paint                   1.8      528       3.4
visible_placefile_items        0.3     1056       0.3
placefile_labels               0.1      528       0.3
```

**Whole-frame CPU is 0.6–1.3 ms against a 16.7 ms budget.** Nothing here is worth optimising: the biggest single item is `sidebar` at 224 µs, and halving it would buy 0.1 ms.

The plan's two named suspects are both wrong. `placefile_labels()` allocating a fresh `Vec` every frame costs **0.3 µs** — it is called with no placefiles configured, which is the normal case. `palette_entries` is already memoised and shows 26 µs.

## What this means for the reported desktop jank

It is not in the CPU frame path, at least not in a session I can reproduce here. That leaves the GPU/present path or repaint scheduling — and Xvfb runs software GL, so this machine cannot see either honestly. Chasing it needs a capture on the real KDE Wayland session against the RTX 4080.

So this PR lands the instrumentation and the measurement, and deliberately does **not** ship speculative optimisation. Re-running it there is one command:

```
cargo run --release --features profiling
puffin_viewer --url 127.0.0.1:8585
```

If the numbers there look like these, the jank is not where the plan assumed and PR 4's optimisation half should be rewritten around whatever the capture actually shows.

## Verification

- `cargo clippy --workspace --all-targets` — clean
- `cargo test --workspace` — pass
- `cargo check -p hookecho --features profiling` — pass (the feature is not in the default gate set)
- `RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check --target wasm32-unknown-unknown -p hookecho --lib` — pass
- `./scripts/shots/shoot.sh check` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)