### PR TITLE
basemap: hybrid satellite, more Esri, Auto, custom XYZ

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -5969,7 +5969,7 @@ impl HookEchoApp {
     /// deepest level instead of an empty range).
     fn chasepack_zoom(&self) -> (u8, u8) {
         use crate::tiles::BasemapStyle;
-        let style = self.views[self.active].basemap;
+        let style = self.views[self.active].basemap.resolve(true);
         let z_lo = (self.views[self.active].camera.zoom.floor() as i64).clamp(2, 18) as u8;
         let max_z = if style.is_raster() {
             self.tiles.max_pack_z(style)
@@ -5985,7 +5985,9 @@ impl HookEchoApp {
     /// Per-frame chase-pack estimate + progress [`map_rows`](Self::map_rows) renders.
     fn chasepack_ui(&self) -> ui::layer_options::ChasePackUi {
         use crate::tiles::BasemapStyle;
-        let style = self.views[self.active].basemap;
+        // Dark and Light pack the same vector tiles (the `.pbf` cache is palette-agnostic), so
+        // resolving `Auto` either way gives the same pack.
+        let style = self.views[self.active].basemap.resolve(true);
         let packable = if style.is_raster() {
             self.tiles.packable(style)
         } else if matches!(style, BasemapStyle::Dark | BasemapStyle::Light) {
@@ -6017,6 +6019,17 @@ impl HookEchoApp {
                     vz_hi,
                 );
             }
+            if !style.is_raster() && self.settings.pack_include_satellite {
+                let sz_hi = z_hi.min(self.tiles.max_pack_z(BasemapStyle::HybridSatellite));
+                n += crate::tiles::pack_tile_count(
+                    min_lon,
+                    min_lat,
+                    max_lon,
+                    max_lat,
+                    z_lo.min(sz_hi),
+                    sz_hi,
+                );
+            }
             n
         } else {
             0
@@ -6043,7 +6056,7 @@ impl HookEchoApp {
         if self.chasepack.is_some() {
             return;
         }
-        let style = self.views[self.active].basemap;
+        let style = self.views[self.active].basemap.resolve(true);
         let (z_lo, z_hi) = self.chasepack_zoom();
         let (min_lon, min_lat, max_lon, max_lat) = self.view_bounds();
         // The DEM resolution is a per-session choice; make sure the pack fetches what the sampler
@@ -6068,6 +6081,20 @@ impl HookEchoApp {
                 self.vtiles
                     .pack_jobs(min_lon, min_lat, max_lon, max_lat, vz_lo, vz_hi),
             );
+        }
+        // And imagery alongside the streets, for the packs that went the other way round.
+        if !style.is_raster() && self.settings.pack_include_satellite {
+            let sat = BasemapStyle::HybridSatellite;
+            let sz_hi = z_hi.min(self.tiles.max_pack_z(sat));
+            jobs.extend(self.tiles.pack_jobs(
+                sat,
+                min_lon,
+                min_lat,
+                max_lon,
+                max_lat,
+                z_lo.min(sz_hi),
+                sz_hi,
+            ));
         }
         // The DEM rides along with every pack, whatever the basemap: offline chase mode wants the
         // blockage overlay as much as it wants the map under it.
@@ -6163,6 +6190,7 @@ impl HookEchoApp {
             !self.settings.mapbox_key.is_empty(),
             !self.settings.maptiler_key.is_empty(),
         );
+        let cx_ok = crate::tiles::valid_xyz_template(&self.settings.custom_tile_url);
         // Split the borrow: the combo writes both the pane's style and the persisted default.
         let (view, settings) = (&mut self.views[self.active], &mut self.settings);
         egui::ComboBox::from_label("Background")
@@ -6171,7 +6199,7 @@ impl HookEchoApp {
                 // Only styles whose provider key is set are selectable.
                 for s in BasemapStyle::ALL
                     .into_iter()
-                    .filter(|s| s.available(mb_key, mt_key))
+                    .filter(|s| s.available(mb_key, mt_key, cx_ok))
                 {
                     if ui
                         .selectable_value(&mut view.basemap, s, s.label())
@@ -6257,6 +6285,11 @@ impl HookEchoApp {
                     .on_hover_text(
                         "Pack vector street tiles beside raster imagery, so road names still \
                          render offline",
+                    );
+                ui.checkbox(&mut settings.pack_include_satellite, "Include satellite")
+                    .on_hover_text(
+                        "Pack satellite imagery beside the vector streets, so terrain still \
+                         renders offline",
                     );
                 ui.checkbox(&mut settings.pack_hires_dem, "High-detail terrain")
                     .on_hover_text(
@@ -8067,7 +8100,11 @@ impl HookEchoApp {
                     !self.settings.mapbox_key.is_empty(),
                     !self.settings.maptiler_key.is_empty(),
                 );
-                let next = self.views[self.active].basemap.next(mb, mt);
+                let next = self.views[self.active].basemap.next(
+                    mb,
+                    mt,
+                    crate::tiles::valid_xyz_template(&self.settings.custom_tile_url),
+                );
                 self.set_basemap(next);
             }
             PaletteAction::ToggleMute => self.apply_action(BindableAction::ToggleMute, ctx),
@@ -10578,8 +10615,12 @@ impl HookEchoApp {
     ) {
         use crate::tiles::BasemapStyle;
         // This pane's own basemap: panes are independent, the tile caches are keyed by style.
-        let pane_style = self.views[idx].basemap;
-        let is_vector = matches!(pane_style, BasemapStyle::Dark | BasemapStyle::Light);
+        // `Auto` resolves here rather than where it is stored, so the stored choice keeps
+        // following the theme instead of being frozen the first time it is rendered.
+        let pane_style = self.views[idx].basemap.resolve(ui.visuals().dark_mode);
+        // Hybrid satellite is both: Esri imagery from the raster path, roads and boundaries from
+        // the vector one drawn on top of it.
+        let is_vector = pane_style.vector_palette().is_some();
         let is_raster = pane_style.is_raster();
         let vp = (prect.width(), prect.height());
         let response = ui.interact(
@@ -11198,6 +11239,7 @@ impl HookEchoApp {
             new_tiles,
             visible,
             basemap_key: pane_style.key(),
+            vector_over_raster: pane_style == BasemapStyle::HybridSatellite,
             radar_upload,
             draw_radar,
             overlay_upload: if first {
@@ -11299,14 +11341,16 @@ impl HookEchoApp {
         // --- Painter overlays (clipped to this pane) ---
         let painter = ui.painter_at(prect);
         let view = &self.views[idx];
-        let basemap = view.basemap;
+        let basemap = pane_style;
 
         // City/town labels, overlaid on every basemap. On raster (satellite) the baked-in labels
         // are faint over imagery + echoes, so we draw crisp white text with a solid black halo;
         // vector basemaps use their palette's label colors. Bigger fonts + an 8-way halo read well.
         if !vlabels.is_empty() {
             let (text_col, halo_col, big) = if is_vector {
-                let st = crate::basemap_style::style(basemap == BasemapStyle::Dark);
+                let st = crate::basemap_style::style(
+                    basemap.vector_palette().unwrap_or_default(),
+                );
                 (
                     egui::Color32::from_rgb(st.label[0], st.label[1], st.label[2]),
                     egui::Color32::from_rgb(st.label_halo[0], st.label_halo[1], st.label_halo[2]),
@@ -11371,12 +11415,18 @@ impl HookEchoApp {
         }
 
         // Raster basemap attribution (provider styles + USGS satellite).
-        if view.basemap.is_raster() {
+        if pane_style.is_raster() {
             let col = egui::Color32::from_gray(200).gamma_multiply(0.6);
             painter.text(
                 egui::pos2(prect.left() + 6.0, prect.bottom() - 4.0),
                 egui::Align2::LEFT_BOTTOM,
-                view.basemap.attribution(),
+                if pane_style == BasemapStyle::CustomXyz
+                    && !self.settings.custom_tile_attribution.is_empty()
+                {
+                    self.settings.custom_tile_attribution.as_str()
+                } else {
+                    pane_style.attribution()
+                },
                 egui::FontId::proportional(10.0),
                 col,
             );
@@ -16397,8 +16447,10 @@ impl eframe::App for HookEchoApp {
             // ponytail: one GOES cursor + one vector palette for all panes; split them when
             // someone actually wants two satellite times or two vector palettes side by side.
             use crate::tiles::BasemapStyle;
-            let style = self.views[self.active.min(n - 1)].basemap;
-            let is_vector = matches!(style, BasemapStyle::Dark | BasemapStyle::Light);
+            let style = self.views[self.active.min(n - 1)]
+                .basemap
+                .resolve(ctx.theme() == egui::Theme::Dark);
+            let is_vector = style.vector_palette().is_some();
             let raster_style = if style.is_raster() {
                 style
             } else {
@@ -16406,6 +16458,9 @@ impl eframe::App for HookEchoApp {
             };
             self.tiles
                 .set_keys(&self.settings.mapbox_key, &self.settings.maptiler_key);
+            self.tiles
+                .set_custom_template(&self.settings.custom_tile_url);
+            self.tiles.set_custom_max_z(self.settings.custom_tile_max_z);
             // Ask for `@2x` tiles where the provider serves them: same tile count, twice the
             // pixels, labels drawn for the density instead of magnified. Off on a metered link —
             // a double-resolution tile is roughly double the bytes.
@@ -16449,7 +16504,9 @@ impl eframe::App for HookEchoApp {
             }
             let mut clear_vector = false;
             if is_vector {
-                clear_vector |= self.vtiles.set_style(style == BasemapStyle::Dark);
+                clear_vector |= self
+                    .vtiles
+                    .set_style(style.vector_palette().unwrap_or_default());
                 clear_vector |= self
                     .vtiles
                     .note_zoom(self.views[self.active.min(n - 1)].camera.zoom);

--- a/crates/hookecho/src/app/mobile/mod.rs
+++ b/crates/hookecho/src/app/mobile/mod.rs
@@ -441,12 +441,13 @@ impl super::HookEchoApp {
             !self.settings.mapbox_key.is_empty(),
             !self.settings.maptiler_key.is_empty(),
         );
+        let cx = crate::tiles::valid_xyz_template(&self.settings.custom_tile_url);
         let cur = self.views[self.active].basemap;
         let mut pick = None;
         ui.label(egui::RichText::new("Basemap").size(crate::ui::m3::T_LABEL_LG));
         ui.horizontal_wrapped(|ui| {
             for s in BasemapStyle::COMMON {
-                if s.available(mb, mt)
+                if s.available(mb, mt, cx)
                     && crate::ui::m3::chip(ui, s.short_label(), s == cur).clicked()
                 {
                     pick = Some(s);
@@ -461,7 +462,7 @@ impl super::HookEchoApp {
             .show(ui, |ui| {
                 ui.horizontal_wrapped(|ui| {
                     for s in BasemapStyle::ALL {
-                        if BasemapStyle::COMMON.contains(&s) || !s.available(mb, mt) {
+                        if BasemapStyle::COMMON.contains(&s) || !s.available(mb, mt, cx) {
                             continue;
                         }
                         if crate::ui::m3::chip(ui, s.label(), s == cur).clicked() {

--- a/crates/hookecho/src/basemap_style.rs
+++ b/crates/hookecho/src/basemap_style.rs
@@ -1,4 +1,4 @@
-//! Color/width styling for the OpenMapTiles vector basemap (dark + light).
+//! Color/width styling for the OpenMapTiles vector basemap.
 //!
 //! Pure lookups keyed by MVT layer name + a per-layer "class" discriminator (the caller pulls
 //! the right property: `class` for transportation, `admin_level` for boundary, empty otherwise).
@@ -10,10 +10,33 @@ const fn rgb(hex: u32) -> [u8; 4] {
     [(hex >> 16) as u8, (hex >> 8) as u8, hex as u8, 255]
 }
 
+/// Which look the vector pipeline tessellates for.
+///
+/// This used to be a bare `dark: bool`. It is an enum because the hybrid satellite basemap needs
+/// a third look — roads and boundaries only, no land or water fills — drawn *over* raster imagery
+/// rather than instead of it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Palette {
+    #[default]
+    Dark,
+    Light,
+    /// Roads/boundaries over satellite imagery: no fills, no background, high-contrast strokes.
+    HybridOverlay,
+}
+
+impl Palette {
+    /// The two full basemap looks share every code path; the overlay is the odd one out, so most
+    /// lookups only need to know which of the two it leans on for contrast.
+    fn dark(self) -> bool {
+        !matches!(self, Palette::Light)
+    }
+}
+
 /// Whole-tile constants (drawn before per-feature geometry).
 pub struct VecStyle {
-    /// Land quad under everything.
-    pub background: [u8; 4],
+    /// Land quad under everything. `None` draws no quad at all — the overlay palette wants
+    /// whatever is underneath (satellite imagery) to show through.
+    pub background: Option<[u8; 4]>,
     /// City/town label text.
     pub label: [u8; 4],
     /// Label halo/outline for contrast.
@@ -21,26 +44,40 @@ pub struct VecStyle {
 }
 
 const DARK: VecStyle = VecStyle {
-    background: rgb(0x111318),
+    background: Some(rgb(0x111318)),
     label: rgb(0xc8d0da),
     label_halo: rgb(0x0b0d11),
 };
 const LIGHT: VecStyle = VecStyle {
-    background: rgb(0xf2efe9),
+    background: Some(rgb(0xf2efe9)),
     label: rgb(0x3a3a3a),
     label_halo: rgb(0xf7f5f0),
 };
+// Imagery is busy and mid-tone in both directions, so the overlay leans on contrast rather than
+// hue: near-white lines and text, near-black halo.
+// ponytail: one fixed overlay palette. Per-style overlay tuning if a second raster basemap ever
+// wants a different one.
+const HYBRID: VecStyle = VecStyle {
+    background: None,
+    label: rgb(0xffffff),
+    label_halo: rgb(0x000000),
+};
 
-pub fn style(dark: bool) -> &'static VecStyle {
-    if dark {
-        &DARK
-    } else {
-        &LIGHT
+pub fn style(p: Palette) -> &'static VecStyle {
+    match p {
+        Palette::Dark => &DARK,
+        Palette::Light => &LIGHT,
+        Palette::HybridOverlay => &HYBRID,
     }
 }
 
 /// Fill color for a polygon feature, or `None` to skip it.
-pub fn fill(dark: bool, layer: &str, class: &str) -> Option<[u8; 4]> {
+pub fn fill(p: Palette, layer: &str, class: &str) -> Option<[u8; 4]> {
+    // Nothing is filled over imagery — the imagery *is* the land cover.
+    if p == Palette::HybridOverlay {
+        return None;
+    }
+    let dark = p.dark();
     let (water, wood, park, residential) = if dark {
         (0x1b2733, 0x151c17, 0x152018, 0x16181d)
     } else {
@@ -67,7 +104,28 @@ pub fn fill(dark: bool, layer: &str, class: &str) -> Option<[u8; 4]> {
 }
 
 /// Stroke color + pixel width for a line feature, or `None` to skip it.
-pub fn stroke(dark: bool, layer: &str, class: &str) -> Option<([u8; 4], f32)> {
+pub fn stroke(p: Palette, layer: &str, class: &str) -> Option<([u8; 4], f32)> {
+    if p == Palette::HybridOverlay {
+        // Wider than the vector basemap's own roads: a 0.8 px hairline vanishes against imagery.
+        // Only the classes worth having over aerial photography — the minor-road mesh would turn
+        // a city into a white smear.
+        let (c, w) = match layer {
+            "transportation" => match class {
+                "motorway" | "trunk" => (0xffe9a8, 2.6),
+                "primary" => (0xfff4d2, 2.0),
+                "secondary" | "tertiary" => (0xf0f0f0, 1.4),
+                _ => return None,
+            },
+            "boundary" => match class {
+                "2" => (0xffd9d9, 1.6),
+                "3" | "4" => (0xe8c8c8, 1.0),
+                _ => return None,
+            },
+            _ => return None,
+        };
+        return Some((rgb(c), w));
+    }
+    let dark = p.dark();
     let (motorway, primary, secondary, minor, rail, water, admin2, admin4, county) = if dark {
         (
             0x3d4450, 0x353c47, 0x2c323b, 0x23282f, 0x2a2f36, 0x24333f, 0x5a6470, 0x3a424c,
@@ -110,23 +168,41 @@ mod tests {
 
     #[test]
     fn dark_and_light_differ_and_resolve() {
-        assert_ne!(style(true).background, style(false).background);
+        assert_ne!(style(Palette::Dark).background, style(Palette::Light).background);
         // Every documented class resolves in both themes.
-        for dark in [true, false] {
-            assert!(fill(dark, "water", "").is_some());
-            assert!(fill(dark, "landcover", "wood").is_some());
-            assert!(fill(dark, "landuse", "residential").is_some());
-            assert!(fill(dark, "park", "").is_some());
-            assert!(stroke(dark, "transportation", "motorway").is_some());
-            assert!(stroke(dark, "transportation", "minor").is_some());
-            assert!(stroke(dark, "waterway", "").is_some());
-            assert!(stroke(dark, "boundary", "2").is_some());
-            assert!(stroke(dark, "boundary", "4").is_some());
-            assert!(stroke(dark, "boundary", "6").is_some());
+        for p in [Palette::Dark, Palette::Light] {
+            assert!(fill(p, "water", "").is_some());
+            assert!(fill(p, "landcover", "wood").is_some());
+            assert!(fill(p, "landuse", "residential").is_some());
+            assert!(fill(p, "park", "").is_some());
+            assert!(stroke(p, "transportation", "motorway").is_some());
+            assert!(stroke(p, "boundary", "2").is_some());
+            assert!(stroke(p, "waterway", "").is_some());
+            // Unstyled input is skipped, not defaulted.
+            assert!(fill(p, "aeroway", "").is_none());
+            assert!(stroke(p, "transportation", "path").is_none());
         }
-        // Unstyled -> skipped.
-        assert!(fill(true, "building", "").is_none());
-        assert!(stroke(true, "transportation", "path").is_none());
-        assert!(stroke(true, "boundary", "8").is_none());
+    }
+
+    /// The hybrid overlay's whole job is to add lines to imagery without hiding it. If it ever
+    /// starts returning fills or a background quad, it paints over the satellite photo.
+    #[test]
+    fn hybrid_overlay_covers_nothing_it_should_not() {
+        let p = Palette::HybridOverlay;
+        assert!(style(p).background.is_none());
+        for (layer, class) in [
+            ("water", ""),
+            ("landcover", "wood"),
+            ("landuse", "residential"),
+            ("park", ""),
+        ] {
+            assert!(fill(p, layer, class).is_none(), "{layer}/{class} fills over imagery");
+        }
+        // It still draws the roads it exists for, and thicker than the vector basemap's.
+        let (_, hybrid_w) = stroke(p, "transportation", "motorway").unwrap();
+        let (_, dark_w) = stroke(Palette::Dark, "transportation", "motorway").unwrap();
+        assert!(hybrid_w > dark_w);
+        // No minor-road mesh over imagery.
+        assert!(stroke(p, "transportation", "minor").is_none());
     }
 }

--- a/crates/hookecho/src/headless.rs
+++ b/crates/hookecho/src/headless.rs
@@ -85,7 +85,13 @@ fn national_basemap(
     let tiles = rt.block_on(async {
         let template = crate::vector_tiles::fetch_tilejson(&client, None).await?;
         Some(
-            crate::vector_tiles::fetch_visible_vector(&client, &template, true, camera.zoom, &vis)
+            crate::vector_tiles::fetch_visible_vector(
+                &client,
+                &template,
+                crate::basemap_style::Palette::Dark,
+                camera.zoom,
+                &vis,
+            )
                 .await
                 .0,
         )
@@ -223,7 +229,15 @@ pub fn run(
             println!("tilejson template: {template}");
             Ok::<_, anyhow::Error>(
                 crate::vector_tiles::fetch_visible_vector(
-                    &client, &template, dark, tess_zoom, &vis,
+                    &client,
+                    &template,
+                    if dark {
+                        crate::basemap_style::Palette::Dark
+                    } else {
+                        crate::basemap_style::Palette::Light
+                    },
+                    tess_zoom,
+                    &vis,
                 )
                 .await,
             )
@@ -252,6 +266,7 @@ pub fn run(
         new_tiles,
         visible,
         basemap_key: basemap.key(),
+        vector_over_raster: false,
         radar_upload: Some(crate::app::to_upload(
             &sweep, &table, None, smooth, storm_uv,
         )),
@@ -303,6 +318,7 @@ pub fn run_multipane(site: &str, out_a: &str, out_b: &str) -> anyhow::Result<()>
             camera_center: center,
             camera_scale: scale,
             basemap_key: 0,
+            vector_over_raster: false,
             new_tiles: Vec::new(),
             visible: Vec::new(),
             radar_upload: Some(crate::app::to_upload(&sweep, &table, None, false, None)),
@@ -954,6 +970,7 @@ pub fn run_live(out_path: &str, site: &str, moment: Moment) -> anyhow::Result<()
         camera_center: center,
         camera_scale: scale,
         basemap_key: 0,
+        vector_over_raster: false,
         new_tiles: Vec::new(),
         visible: Vec::new(),
         radar_upload: Some(crate::app::to_upload(&sweep, &table, None, false, None)),
@@ -1034,6 +1051,7 @@ pub fn run_placefile(path: &str, out_path: &str) -> anyhow::Result<()> {
         camera_center: center,
         camera_scale: scale,
         basemap_key: 0,
+        vector_over_raster: false,
         new_tiles: Vec::new(),
         visible: Vec::new(),
         radar_upload: None,
@@ -1093,6 +1111,7 @@ pub fn run_overlay(out_path: &str) -> anyhow::Result<()> {
         camera_center: center,
         camera_scale: scale,
         basemap_key: 0,
+        vector_over_raster: false,
         new_tiles,
         visible,
         radar_upload: None,
@@ -1193,6 +1212,7 @@ pub fn run_mrms(out_path: &str) -> anyhow::Result<()> {
         camera_center: center,
         camera_scale: scale,
         basemap_key: 0,
+        vector_over_raster: false,
         new_tiles,
         visible,
         radar_upload: None,
@@ -1247,6 +1267,7 @@ pub fn run_lightning(out_path: &str) -> anyhow::Result<()> {
         camera_center: center,
         camera_scale: scale,
         basemap_key: 0,
+        vector_over_raster: false,
         new_tiles,
         visible,
         radar_upload: None,
@@ -1317,6 +1338,7 @@ pub fn run_field(slug: &str, out_path: &str) -> anyhow::Result<()> {
         camera_center: center,
         camera_scale: scale,
         basemap_key: 0,
+        vector_over_raster: false,
         new_tiles,
         visible,
         radar_upload: None,
@@ -1415,6 +1437,7 @@ pub fn run_global(model: &str, slug: &str, out_path: &str) -> anyhow::Result<()>
         camera_center: center,
         camera_scale: scale,
         basemap_key: 0,
+        vector_over_raster: false,
         new_tiles,
         visible,
         radar_upload: None,
@@ -1528,6 +1551,7 @@ pub fn run_diff(slug: &str, out_path: &str) -> anyhow::Result<()> {
         camera_center: center,
         camera_scale: scale,
         basemap_key: 0,
+        vector_over_raster: false,
         new_tiles,
         visible,
         radar_upload: None,
@@ -1846,6 +1870,7 @@ pub fn run_l3grid(kind: &str, site: &str, out_path: &str) -> anyhow::Result<()> 
         camera_center: center,
         camera_scale: scale,
         basemap_key: 0,
+        vector_over_raster: false,
         new_tiles,
         visible,
         radar_upload: None,
@@ -1918,6 +1943,7 @@ pub fn run_env(slug: &str, out_path: &str) -> anyhow::Result<()> {
         camera_center: center,
         camera_scale: scale,
         basemap_key: 0,
+        vector_over_raster: false,
         new_tiles,
         visible,
         radar_upload: None,
@@ -2099,6 +2125,7 @@ pub fn run_hrrr_layer(
         camera_center: center,
         camera_scale: scale,
         basemap_key: 0,
+        vector_over_raster: false,
         new_tiles,
         visible,
         radar_upload: None,
@@ -2134,6 +2161,7 @@ fn render_field_png(
         camera_center: center,
         camera_scale: scale,
         basemap_key: 0,
+        vector_over_raster: false,
         new_tiles,
         visible,
         radar_upload: None,
@@ -2858,6 +2886,7 @@ mod golden_tests {
             camera_center: center,
             camera_scale: scale,
             basemap_key: 0,
+            vector_over_raster: false,
             new_tiles: Vec::new(),
             visible: Vec::new(),
             radar_upload: Some(crate::app::to_upload(&sweep, &table, None, false, None)),

--- a/crates/hookecho/src/render/mod.rs
+++ b/crates/hookecho/src/render/mod.rs
@@ -289,6 +289,9 @@ pub struct MapCallback {
     pub visible: Vec<VisibleTile>,
     /// Which basemap style this pane draws ([`crate::tiles::BasemapStyle::key`]).
     pub basemap_key: u8,
+    /// Draw the vector basemap *after* the raster tiles instead of under them — the hybrid
+    /// satellite style, where the vector geometry is roads over imagery.
+    pub vector_over_raster: bool,
     pub radar_upload: Option<RadarUpload>,
     pub draw_radar: bool,
     /// `Some` only when the overlay geometry changed (else the last upload is reused).
@@ -377,6 +380,7 @@ struct PaneGpu {
     /// a missing tile is stood in for by resident children or an ancestor.
     frame_visible: Vec<TileKey>,
     frame_visible_vector: Vec<TileId>,
+    vector_over_raster: bool,
     frame_draw_radar: bool,
     frame_draw_overlay: bool,
 }
@@ -693,6 +697,7 @@ impl RenderResources {
                 radar: None,
                 frame_visible: Vec::new(),
                 frame_visible_vector: Vec::new(),
+                vector_over_raster: false,
                 frame_draw_radar: false,
                 frame_draw_overlay: false,
             }
@@ -1049,6 +1054,7 @@ impl RenderResources {
         }
         pane.frame_visible = visible;
         pane.frame_visible_vector = cb.visible_vector.clone();
+        pane.vector_over_raster = cb.vector_over_raster;
         pane.frame_draw_radar = cb.draw_radar && pane.radar.is_some();
         pane.frame_draw_overlay = cb.draw_overlay && overlay_present;
     }
@@ -1241,17 +1247,10 @@ impl RenderResources {
             return;
         };
         let cam = &pane.camera_bg;
-        // Vector basemap first (opaque, under everything).
-        if !pane.frame_visible_vector.is_empty() {
-            pass.set_pipeline(&self.overlay_pipeline);
-            pass.set_bind_group(0, cam, &[]);
-            for tid in &pane.frame_visible_vector {
-                if let Some(t) = self.vector_tiles.get(tid) {
-                    pass.set_vertex_buffer(0, t.vbuf.slice(..));
-                    pass.set_index_buffer(t.ibuf.slice(..), wgpu::IndexFormat::Uint32);
-                    pass.draw_indexed(0..t.index_count, 0, 0..1);
-                }
-            }
+        // Vector basemap first (opaque, under everything) — unless it is the hybrid overlay, in
+        // which case it is roads drawn *onto* the raster imagery and has to come after it.
+        if !pane.vector_over_raster {
+            self.draw_vector_basemap(pane, cam, pass);
         }
         pass.set_pipeline(&self.tile_pipeline);
         pass.set_bind_group(0, cam, &[]);
@@ -1262,6 +1261,9 @@ impl RenderResources {
                 let base = (i * 6) as u32;
                 pass.draw(base..base + 6, 0..1);
             }
+        }
+        if pane.vector_over_raster {
+            self.draw_vector_basemap(pane, cam, pass);
         }
         // Field layers under the radar (national mosaic context).
         self.draw_fields(cam, pass, true);
@@ -1294,6 +1296,28 @@ impl RenderResources {
     }
 
     /// Stage a pane's uploads (mirrors the egui `prepare` phase). Public for the headless harness.
+    /// Draw one pane's resident vector-basemap tiles. Extracted so the caller can put it either
+    /// side of the raster tiles (see [`MapCallback::vector_over_raster`]).
+    fn draw_vector_basemap(
+        &self,
+        pane: &PaneGpu,
+        cam: &wgpu::BindGroup,
+        pass: &mut wgpu::RenderPass<'_>,
+    ) {
+        if pane.frame_visible_vector.is_empty() {
+            return;
+        }
+        pass.set_pipeline(&self.overlay_pipeline);
+        pass.set_bind_group(0, cam, &[]);
+        for tid in &pane.frame_visible_vector {
+            if let Some(t) = self.vector_tiles.get(tid) {
+                pass.set_vertex_buffer(0, t.vbuf.slice(..));
+                pass.set_index_buffer(t.ibuf.slice(..), wgpu::IndexFormat::Uint32);
+                pass.draw_indexed(0..t.index_count, 0, 0..1);
+            }
+        }
+    }
+
     pub fn prepare_pane(&mut self, device: &wgpu::Device, queue: &wgpu::Queue, cb: &MapCallback) {
         self.upload_frame(device, queue, cb);
     }

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -111,6 +111,10 @@ impl AlertSound {
     }
 }
 
+fn default_custom_tile_max_z() -> u8 {
+    19
+}
+
 fn default_volume() -> f32 {
     0.2
 }
@@ -155,6 +159,16 @@ pub struct Settings {
     /// MapTiler API key (enables the MapTiler raster basemap styles). Held locally only.
     #[serde(default)]
     pub maptiler_key: String,
+    /// `{z}/{x}/{y}` tile URL template for the "Custom (XYZ URL)" basemap. Validated at the
+    /// settings boundary — see [`crate::tiles::valid_xyz_template`] — and desktop/Android only.
+    #[serde(default)]
+    pub custom_tile_url: String,
+    /// Max zoom the custom tile source serves. Deeper views stretch the deepest tile that loaded.
+    #[serde(default = "default_custom_tile_max_z")]
+    pub custom_tile_max_z: u8,
+    /// Attribution line to paint for the custom tile source.
+    #[serde(default)]
+    pub custom_tile_attribution: String,
     /// WeatherFlow Tempest personal access token — adds your Tempest stations to the live station
     /// cards. Held locally only, same as the basemap keys.
     #[serde(default)]
@@ -254,6 +268,11 @@ pub struct Settings {
     /// are what a chase pack is for; the raster imagery alone leaves you without road names.
     #[serde(default = "default_true")]
     pub pack_include_vector: bool,
+    /// Include satellite imagery in a chase pack even when the active basemap is vector. The
+    /// mirror of `pack_include_vector`: a road map offline is no help for spotting a wall cloud
+    /// against terrain you have never seen.
+    #[serde(default)]
+    pub pack_include_satellite: bool,
     /// User-drawn zones that alert when an NWS warning polygon intersects them. The Android
     /// background service reads this file too, so the name is load-bearing across the boundary.
     #[serde(default)]
@@ -880,6 +899,9 @@ impl Default for Settings {
             detectors: DetectorTuning::default(),
             alert_rules: Vec::new(),
             serve_token: String::new(),
+            custom_tile_url: String::new(),
+            custom_tile_max_z: default_custom_tile_max_z(),
+            custom_tile_attribution: String::new(),
             quiet_pending: Vec::new(),
             volume_cache_mb: 0,
             tile_disk_cache_mb: 0,
@@ -933,6 +955,7 @@ impl Default for Settings {
             background_alerts: false,
             pack_hires_dem: false,
             pack_include_vector: true,
+            pack_include_satellite: false,
             alert_polygons: Vec::new(),
             plugins: Vec::new(),
             close_to_tray: false,
@@ -1256,6 +1279,9 @@ mod tests {
     #[test]
     fn roundtrips() {
         let s = Settings {
+            custom_tile_url: String::new(),
+            custom_tile_max_z: default_custom_tile_max_z(),
+            custom_tile_attribution: String::new(),
             detectors: DetectorTuning::default(),
             alert_rules: Vec::new(),
             serve_token: String::new(),
@@ -1330,6 +1356,7 @@ mod tests {
             background_alerts: false,
             pack_hires_dem: false,
             pack_include_vector: true,
+            pack_include_satellite: false,
             alert_polygons: Vec::new(),
             plugins: Vec::new(),
             close_to_tray: true,

--- a/crates/hookecho/src/tiles.rs
+++ b/crates/hookecho/src/tiles.rs
@@ -82,11 +82,24 @@ pub enum BasemapStyle {
     UsgsImageryTopo,
     OsmHot,
     CyclOsm,
+    EsriDarkGray,
+    EsriLightGray,
+    EsriNatGeo,
+    EsriOcean,
+    /// Esri World Imagery with our own vector roads/boundaries/labels drawn over it. Keyless, and
+    /// the closest thing to the "hybrid" layer every commercial provider charges for.
+    HybridSatellite,
+    /// Follows the app theme: resolves to [`Self::Dark`] or [`Self::Light`]. Never rendered
+    /// directly — see [`Self::resolve`].
+    Auto,
+    /// User-supplied `{z}/{x}/{y}` URL template from settings. Desktop and Android only; the web
+    /// build's proxy is exact-host allowlisted, so an arbitrary host cannot be fetched there.
+    CustomXyz,
 }
 
 impl BasemapStyle {
     /// Cycle order for the `z` hotkey; provider styles trail the built-ins.
-    pub const ALL: [BasemapStyle; 40] = [
+    pub const ALL: [BasemapStyle; 47] = [
         BasemapStyle::Dark,
         BasemapStyle::Light,
         BasemapStyle::Satellite,
@@ -103,6 +116,13 @@ impl BasemapStyle {
         BasemapStyle::UsgsImageryTopo,
         BasemapStyle::OsmHot,
         BasemapStyle::CyclOsm,
+        BasemapStyle::HybridSatellite,
+        BasemapStyle::EsriDarkGray,
+        BasemapStyle::EsriLightGray,
+        BasemapStyle::EsriNatGeo,
+        BasemapStyle::EsriOcean,
+        BasemapStyle::Auto,
+        BasemapStyle::CustomXyz,
         BasemapStyle::GoesEast,
         BasemapStyle::GoesWest,
         BasemapStyle::GoesEastIR,
@@ -149,6 +169,12 @@ impl BasemapStyle {
         match self {
             BasemapStyle::Satellite => "USGS",
             BasemapStyle::EsriImagery => "Satellite",
+            BasemapStyle::HybridSatellite => "Hybrid",
+            BasemapStyle::EsriDarkGray => "Dark Gray",
+            BasemapStyle::EsriLightGray => "Light Gray",
+            BasemapStyle::EsriNatGeo => "NatGeo",
+            BasemapStyle::EsriOcean => "Ocean",
+            BasemapStyle::CustomXyz => "Custom",
             BasemapStyle::OsmStandard => "Streets",
             BasemapStyle::OpenTopoMap => "Topo",
             BasemapStyle::GoesEast => "GOES-East",
@@ -193,6 +219,13 @@ impl BasemapStyle {
             BasemapStyle::UsgsImageryTopo => "USGS Imagery Topo",
             BasemapStyle::OsmHot => "OSM Humanitarian",
             BasemapStyle::CyclOsm => "CyclOSM",
+            BasemapStyle::EsriDarkGray => "Esri Dark Gray Canvas",
+            BasemapStyle::EsriLightGray => "Esri Light Gray Canvas",
+            BasemapStyle::EsriNatGeo => "Esri National Geographic",
+            BasemapStyle::EsriOcean => "Esri Ocean",
+            BasemapStyle::HybridSatellite => "Hybrid Satellite",
+            BasemapStyle::Auto => "Auto (follow theme)",
+            BasemapStyle::CustomXyz => "Custom (XYZ URL)",
             BasemapStyle::MapTilerStreets => "MapTiler Streets",
             BasemapStyle::MapTilerSatellite => "MapTiler Satellite",
             BasemapStyle::MapTilerOutdoor => "MapTiler Outdoor",
@@ -239,6 +272,13 @@ impl BasemapStyle {
             BasemapStyle::UsgsImageryTopo => "usgs-imagery-topo",
             BasemapStyle::OsmHot => "osm-hot",
             BasemapStyle::CyclOsm => "cyclosm",
+            BasemapStyle::EsriDarkGray => "esri-dark-gray",
+            BasemapStyle::EsriLightGray => "esri-light-gray",
+            BasemapStyle::EsriNatGeo => "esri-natgeo",
+            BasemapStyle::EsriOcean => "esri-ocean",
+            BasemapStyle::HybridSatellite => "hybrid-satellite",
+            BasemapStyle::Auto => "auto",
+            BasemapStyle::CustomXyz => "custom",
             BasemapStyle::MapTilerStreets => "maptiler-streets",
             BasemapStyle::MapTilerSatellite => "maptiler-satellite",
             BasemapStyle::MapTilerOutdoor => "maptiler-outdoor",
@@ -293,8 +333,17 @@ impl BasemapStyle {
                 BasemapStyle::CartoPositron
                 | BasemapStyle::CartoDarkMatter
                 | BasemapStyle::CartoVoyager => "© CARTO © OpenStreetMap",
-                BasemapStyle::EsriImagery => "© Esri, Maxar, Earthstar Geographics",
+                BasemapStyle::EsriImagery | BasemapStyle::HybridSatellite => {
+                    "© Esri, Maxar, Earthstar Geographics"
+                }
                 BasemapStyle::EsriStreets | BasemapStyle::EsriTopo => "© Esri © OpenStreetMap",
+                BasemapStyle::EsriDarkGray | BasemapStyle::EsriLightGray => {
+                    "© Esri © OpenStreetMap, HERE, Garmin"
+                }
+                BasemapStyle::EsriNatGeo => "© Esri, National Geographic",
+                BasemapStyle::EsriOcean => "© Esri, GEBCO, NOAA",
+                // The template is the user's; we cannot know whose data it serves.
+                BasemapStyle::CustomXyz => "Custom tile source",
                 _ if self.goes_layer().is_some() => "NASA GIBS · NOAA GOES",
                 _ => "© OpenMapTiles © OpenStreetMap",
             },
@@ -324,7 +373,7 @@ impl BasemapStyle {
     pub fn is_raster(self) -> bool {
         !matches!(
             self,
-            BasemapStyle::Dark | BasemapStyle::Light | BasemapStyle::None
+            BasemapStyle::Dark | BasemapStyle::Light | BasemapStyle::None | BasemapStyle::Auto
         )
     }
 
@@ -344,6 +393,18 @@ impl BasemapStyle {
             // USGS ArcGIS services (imagery and topo alike) stop at 16.
             BasemapStyle::Satellite | BasemapStyle::UsgsTopo | BasemapStyle::UsgsImageryTopo => 16,
             BasemapStyle::OpenTopoMap => 17,
+            // Measured over Dallas: the Canvas and NatGeo services hand back a fixed 2521-byte
+            // placeholder from 17 up, and the ocean base does the same from 11.
+            BasemapStyle::EsriOcean => 10,
+            BasemapStyle::EsriDarkGray | BasemapStyle::EsriLightGray | BasemapStyle::EsriNatGeo => {
+                16
+            }
+            // World Imagery serves real tiles through 20 and placeholders at 21.
+            BasemapStyle::HybridSatellite => 20,
+            // We cannot probe the user's own server, so we trust the max zoom they configured;
+            // overzoom covers an overshoot by stretching the deepest tile that did load.
+            // ponytail: no validation of the user's max_z beyond the settings clamp.
+            BasemapStyle::CustomXyz => 22,
             BasemapStyle::OsmHot => 18,
             BasemapStyle::OsmStandard | BasemapStyle::CyclOsm => 19,
             BasemapStyle::CartoPositron | BasemapStyle::CartoDarkMatter | BasemapStyle::CartoVoyager => 20,
@@ -370,8 +431,15 @@ impl BasemapStyle {
         matches!(self.provider_kind(), Provider::Mapbox | Provider::MapTiler)
     }
 
-    /// Is this style selectable given which provider keys are set?
-    pub fn available(self, mapbox_key: bool, maptiler_key: bool) -> bool {
+    /// Is this style selectable given which provider keys are set and whether the user has
+    /// configured a custom tile template?
+    pub fn available(self, mapbox_key: bool, maptiler_key: bool, custom: bool) -> bool {
+        if self == BasemapStyle::CustomXyz {
+            // Nothing to fetch without a template, and the web build cannot fetch an arbitrary
+            // host at all: the proxy allowlist is exact-match, and a direct fetch is at the mercy
+            // of whatever CORS headers the user's server happens to send.
+            return custom && !cfg!(target_arch = "wasm32");
+        }
         match self.provider_kind() {
             Provider::Mapbox => mapbox_key,
             Provider::MapTiler => maptiler_key,
@@ -380,15 +448,39 @@ impl BasemapStyle {
     }
 
     /// Next *available* style in [`Self::ALL`] (wraps) — the `z`-cycle step.
-    pub fn next(self, mapbox_key: bool, maptiler_key: bool) -> BasemapStyle {
+    pub fn next(self, mapbox_key: bool, maptiler_key: bool, custom: bool) -> BasemapStyle {
         let i = Self::ALL.iter().position(|s| *s == self).unwrap_or(0);
         for step in 1..=Self::ALL.len() {
             let cand = Self::ALL[(i + step) % Self::ALL.len()];
-            if cand.available(mapbox_key, maptiler_key) {
+            if cand.available(mapbox_key, maptiler_key, custom) {
                 return cand;
             }
         }
         self
+    }
+
+    /// [`Self::Auto`] resolved against the current theme; every other style is itself.
+    ///
+    /// Call this at the point a style is about to be *rendered or fetched*, not where it is
+    /// stored — the stored value has to stay `Auto` or it would stop following the theme.
+    pub fn resolve(self, dark_theme: bool) -> BasemapStyle {
+        match self {
+            BasemapStyle::Auto if dark_theme => BasemapStyle::Dark,
+            BasemapStyle::Auto => BasemapStyle::Light,
+            other => other,
+        }
+    }
+
+    /// Which vector palette this style tessellates with, or `None` if it draws no vector geometry
+    /// (raster basemaps other than hybrid, and `None`). Labels are drawn over every basemap
+    /// regardless — this is about the roads/fills.
+    pub fn vector_palette(self) -> Option<crate::basemap_style::Palette> {
+        match self {
+            BasemapStyle::Dark => Some(crate::basemap_style::Palette::Dark),
+            BasemapStyle::Light => Some(crate::basemap_style::Palette::Light),
+            BasemapStyle::HybridSatellite => Some(crate::basemap_style::Palette::HybridOverlay),
+            _ => None,
+        }
     }
 
     /// Stable small id for this style, used to key the GPU/fetch caches so panes showing
@@ -398,7 +490,12 @@ impl BasemapStyle {
     }
 
     /// Per-style cache subdir so sources don't collide on disk. Keys never appear here.
-    fn provider(self, retina: bool) -> String {
+    fn provider(self, retina: bool, custom: &str) -> String {
+        // The user can repoint the custom slot at a different server; hashing the template keeps
+        // the old server's tiles from being served for the new one.
+        if self == BasemapStyle::CustomXyz {
+            return format!("custom-{:08x}", template_hash(custom));
+        }
         // 512-px tiles share the tile grid with the 256-px ones they replace, so a cache written
         // before the switch would keep serving blurry 256s from the same paths. Separate dir —
         // and `@2x` tiles get their own for the same reason.
@@ -442,6 +539,7 @@ impl BasemapStyle {
         retina: bool,
         mapbox_key: &str,
         maptiler_key: &str,
+        custom: &str,
     ) -> Option<String> {
         // `@2x` on the sources that serve it; empty everywhere else, so the URL is unchanged.
         let hi = if retina && self.has_2x() { "@2x" } else { "" };
@@ -466,6 +564,27 @@ impl BasemapStyle {
                 BasemapStyle::EsriTopo => Some(format!(
                     "https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}"
                 )),
+                // Hybrid is World Imagery underneath; the roads and labels on top come from the
+                // vector pipeline, not from a second raster fetch.
+                BasemapStyle::HybridSatellite => Some(format!(
+                    "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
+                )),
+                // The extra Esri services live on `services.` rather than `server.`; both hosts
+                // are already in the proxy allowlist.
+                BasemapStyle::EsriDarkGray => Some(format!(
+                    "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}"
+                )),
+                BasemapStyle::EsriLightGray => Some(format!(
+                    "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}"
+                )),
+                BasemapStyle::EsriNatGeo => Some(format!(
+                    "https://services.arcgisonline.com/ArcGIS/rest/services/NatGeo_World_Map/MapServer/tile/{z}/{y}/{x}"
+                )),
+                BasemapStyle::EsriOcean => Some(format!(
+                    "https://services.arcgisonline.com/ArcGIS/rest/services/Ocean/World_Ocean_Base/MapServer/tile/{z}/{y}/{x}"
+                )),
+                BasemapStyle::CustomXyz => valid_xyz_template(custom)
+                    .then(|| crate::vector_tiles::fill_template(custom, z, x, y)),
                 // Standard XYZ `{z}/{x}/{y}.png` slippy tiles. Single subdomain shard where the
                 // provider uses them (ponytail: rotate a-c only if throttled).
                 BasemapStyle::OsmStandard => {
@@ -511,6 +630,28 @@ impl BasemapStyle {
             }),
         }
     }
+}
+
+/// Is this a tile-URL template we are willing to fetch?
+///
+/// Trust boundary: the string comes from the user's settings file, and whatever it points at gets
+/// fetched with the app's HTTP client. `https` only — a plain-http template would silently
+/// downgrade every tile request — and it has to actually be a slippy template, or every tile
+/// would be the same URL hammered a screenful at a time.
+pub fn valid_xyz_template(t: &str) -> bool {
+    t.starts_with("https://") && t.contains("{z}") && t.contains("{x}") && t.contains("{y}")
+}
+
+/// Short stable hash of a custom template, for its cache directory name.
+fn template_hash(t: &str) -> u32 {
+    // ponytail: FNV-1a, not a crypto hash. This names a cache directory; a collision would serve
+    // one custom source's tiles for another, which is why it is 32 bits and not 8.
+    let mut h: u32 = 0x811c9dc5;
+    for b in t.as_bytes() {
+        h ^= *b as u32;
+        h = h.wrapping_mul(0x01000193);
+    }
+    h
 }
 
 /// Integer tile ids covering `cam`'s view (zoom clamped to `max_z`) with their world rects.
@@ -688,6 +829,10 @@ pub struct TileManager {
     goes_time: Option<chrono::DateTime<chrono::Utc>>,
     /// Ask sources that serve them for `@2x` tiles (high-DPI screen, unmetered link).
     retina: bool,
+    /// `{z}/{x}/{y}` template for [`BasemapStyle::CustomXyz`]. Empty until the user sets one.
+    custom_template: String,
+    /// Deepest zoom the custom source is configured to serve.
+    custom_max_z: u8,
 }
 
 impl TileManager {
@@ -713,6 +858,8 @@ impl TileManager {
             uploaded: LruCache::new(NonZeroUsize::new(RASTER_TILE_CACHE).unwrap()),
             evicted: Vec::new(),
             frame_visible: 0,
+            custom_template: String::new(),
+            custom_max_z: 19,
             cache_root,
             mapbox_key: String::new(),
             maptiler_key: String::new(),
@@ -762,6 +909,22 @@ impl TileManager {
         }
     }
 
+    /// Point the custom-XYZ slot at a template. Clears the caches on change, like the key setter
+    /// above: the same `(z, x, y)` now means a different server's imagery.
+    pub fn set_custom_max_z(&mut self, z: u8) {
+        // Clamped rather than trusted: `tile_cover` builds a grid of `4^z` tiles, and a typo in
+        // the settings file should not turn into an unbounded fetch loop.
+        self.custom_max_z = z.clamp(1, 22);
+    }
+
+    pub fn set_custom_template(&mut self, template: &str) {
+        if self.custom_template != template {
+            self.custom_template = template.to_string();
+            self.requested.clear();
+            self.uploaded.clear();
+        }
+    }
+
     /// Integer tile ids covering the current view, and their world-space rects. `zoom_bias`
     /// pulls sharper tiles on high-DPI displays (see [`tile_cover`]).
     pub fn visible(
@@ -771,7 +934,17 @@ impl TileManager {
         viewport_px: (f32, f32),
         zoom_bias: f64,
     ) -> Vec<VisibleTile> {
-        tile_cover(cam, viewport_px, style.max_raster_z(), zoom_bias)
+        tile_cover(cam, viewport_px, self.max_z(style), zoom_bias)
+    }
+
+    /// Deepest zoom to fetch for `style` — the measured provider cap, except for the custom slot
+    /// where only the user knows.
+    fn max_z(&self, style: BasemapStyle) -> u8 {
+        if style == BasemapStyle::CustomXyz {
+            self.custom_max_z
+        } else {
+            style.max_raster_z()
+        }
     }
 
     /// Kick off fetches for any visible tiles not yet requested.
@@ -795,7 +968,7 @@ impl TileManager {
             }
             let (z, x, y) = v.id;
             let Some(mut url) =
-                style.url(z, x, y, self.retina, &self.mapbox_key, &self.maptiler_key)
+                style.url(z, x, y, self.retina, &self.mapbox_key, &self.maptiler_key, &self.custom_template)
             else {
                 continue;
             };
@@ -814,7 +987,7 @@ impl TileManager {
             };
             self.requested.insert((skey, v.id));
             let path = self.cache_root.as_ref().map(|d| {
-                d.join(style.provider(self.retina))
+                d.join(style.provider(self.retina, &self.custom_template))
                     .join(&time_tag)
                     .join(format!("{z}/{x}/{y}"))
             });
@@ -855,7 +1028,7 @@ impl TileManager {
 
     /// Max zoom `style` serves (for the chase-pack depth cap).
     pub fn max_pack_z(&self, style: BasemapStyle) -> u8 {
-        style.max_raster_z()
+        self.max_z(style)
     }
 
     /// Whether `style` produces raster tiles a chase pack can pre-download (has a URL, isn't a
@@ -864,7 +1037,7 @@ impl TileManager {
     pub fn packable(&self, style: BasemapStyle) -> bool {
         style.goes_layer().is_none()
             && style
-                .url(0, 0, 0, false, &self.mapbox_key, &self.maptiler_key)
+                .url(0, 0, 0, false, &self.mapbox_key, &self.maptiler_key, &self.custom_template)
                 .is_some()
     }
 
@@ -888,13 +1061,13 @@ impl TileManager {
         if style.goes_layer().is_some() {
             return Vec::new();
         }
-        let z_hi = z_hi.min(style.max_raster_z());
+        let z_hi = z_hi.min(self.max_z(style));
         // Packs are always 1x: a pack is written once and read on whatever device opens it later.
-        let dir = root.join(style.provider(false)).join("default");
+        let dir = root.join(style.provider(false, &self.custom_template)).join("default");
         pack_tile_ids(min_lon, min_lat, max_lon, max_lat, z_lo, z_hi)
             .into_iter()
             .filter_map(|(z, x, y)| {
-                let url = style.url(z, x, y, false, &self.mapbox_key, &self.maptiler_key)?;
+                let url = style.url(z, x, y, false, &self.mapbox_key, &self.maptiler_key, &self.custom_template)?;
                 Some((url, dir.join(format!("{z}/{x}/{y}"))))
             })
             .collect()
@@ -1020,7 +1193,7 @@ pub async fn fetch_visible(
     let mut out = Vec::new();
     for v in visible {
         let (z, x, y) = v.id;
-        let Some(url) = style.url(z, x, y, false, mapbox_key, maptiler_key) else {
+        let Some(url) = style.url(z, x, y, false, mapbox_key, maptiler_key, "") else {
             continue;
         };
         match load_tile_bytes(client, &url, None).await {
@@ -1410,23 +1583,28 @@ mod tests {
             BasemapStyle::UsgsImageryTopo,
             BasemapStyle::OsmHot,
             BasemapStyle::CyclOsm,
+            BasemapStyle::EsriDarkGray,
+            BasemapStyle::EsriLightGray,
+            BasemapStyle::EsriNatGeo,
+            BasemapStyle::EsriOcean,
+            BasemapStyle::HybridSatellite,
         ];
         for s in keyless {
             assert!(s.is_raster(), "{s:?} should be raster");
             assert!(
-                s.url(6, 15, 25, false, "", "").is_some(),
+                s.url(6, 15, 25, false, "", "", "").is_some(),
                 "{s:?} should have a keyless URL"
             );
         }
         // ArcGIS services use {z}/{y}/{x}: y before x in the path.
-        let esri = BasemapStyle::EsriImagery.url(6, 15, 25, false, "", "").unwrap();
+        let esri = BasemapStyle::EsriImagery.url(6, 15, 25, false, "", "", "").unwrap();
         assert!(esri.ends_with("/6/25/15"), "Esri y/x order: {esri}");
         // Standard slippy tiles use {z}/{x}/{y}.
-        let osm = BasemapStyle::OsmStandard.url(6, 15, 25, false, "", "").unwrap();
+        let osm = BasemapStyle::OsmStandard.url(6, 15, 25, false, "", "", "").unwrap();
         assert!(osm.ends_with("/6/15/25.png"), "OSM x/y order: {osm}");
         // Mapbox nav styles stay key-gated.
-        assert!(BasemapStyle::MapboxNavDay.url(6, 15, 25, false, "", "").is_none());
-        assert!(BasemapStyle::MapboxNavDay.url(6, 15, 25, false, "k", "").is_some());
+        assert!(BasemapStyle::MapboxNavDay.url(6, 15, 25, false, "", "", "").is_none());
+        assert!(BasemapStyle::MapboxNavDay.url(6, 15, 25, false, "k", "", "").is_some());
     }
 
     /// Retina asks for the `@2x` tile only where the provider serves one, and those tiles get
@@ -1434,13 +1612,13 @@ mod tests {
     #[test]
     fn retina_only_changes_the_sources_that_serve_2x() {
         let carto = BasemapStyle::CartoDarkMatter;
-        assert!(carto.url(6, 15, 25, true, "", "").unwrap().ends_with("@2x.png"));
-        assert!(carto.url(6, 15, 25, false, "", "").unwrap().ends_with("/25.png"));
-        assert_ne!(carto.provider(true), carto.provider(false));
+        assert!(carto.url(6, 15, 25, true, "", "", "").unwrap().ends_with("@2x.png"));
+        assert!(carto.url(6, 15, 25, false, "", "", "").unwrap().ends_with("/25.png"));
+        assert_ne!(carto.provider(true, ""), carto.provider(false, ""));
         // No `@2x` upstream: the URL and the cache path are identical either way.
         let osm = BasemapStyle::OsmStandard;
-        assert_eq!(osm.url(6, 15, 25, true, "", ""), osm.url(6, 15, 25, false, "", ""));
-        assert_eq!(osm.provider(true), osm.provider(false));
+        assert_eq!(osm.url(6, 15, 25, true, "", "", ""), osm.url(6, 15, 25, false, "", "", ""));
+        assert_eq!(osm.provider(true, ""), osm.provider(false, ""));
     }
 
     /// The USGS satellite basemap serves nothing past zoom 16; asking for 17 got a 404 and left a
@@ -1458,3 +1636,62 @@ mod tests {
         );
     }
 }
+
+    /// `Auto` is a marker, not something the tile layer should ever be asked to fetch.
+    #[test]
+    fn auto_resolves_to_a_real_style_and_nothing_else_moves() {
+        assert_eq!(BasemapStyle::Auto.resolve(true), BasemapStyle::Dark);
+        assert_eq!(BasemapStyle::Auto.resolve(false), BasemapStyle::Light);
+        assert!(!BasemapStyle::Auto.is_raster());
+        for s in BasemapStyle::ALL {
+            if s != BasemapStyle::Auto {
+                assert_eq!(s.resolve(true), s, "{s:?} should not follow the theme");
+                assert_eq!(s.resolve(false), s, "{s:?} should not follow the theme");
+            }
+        }
+    }
+
+    /// Hybrid satellite is the one style that is raster *and* draws vector geometry.
+    #[test]
+    fn only_hybrid_is_both_raster_and_vector() {
+        for s in BasemapStyle::ALL {
+            let both = s.is_raster() && s.vector_palette().is_some();
+            assert_eq!(
+                both,
+                s == BasemapStyle::HybridSatellite,
+                "{s:?} raster+vector should only be hybrid"
+            );
+        }
+        assert_eq!(
+            BasemapStyle::HybridSatellite.vector_palette(),
+            Some(crate::basemap_style::Palette::HybridOverlay)
+        );
+    }
+
+    /// The custom template comes out of the settings file, so it is a trust boundary: anything
+    /// that is not an https slippy template must not be fetched at all.
+    #[test]
+    fn custom_template_is_validated_and_keyed_by_content() {
+        assert!(valid_xyz_template("https://t.example/{z}/{x}/{y}.png"));
+        assert!(!valid_xyz_template("http://t.example/{z}/{x}/{y}.png"));
+        assert!(!valid_xyz_template("https://t.example/tiles.png"));
+        assert!(!valid_xyz_template(""));
+        assert!(!valid_xyz_template("file:///etc/{z}/{x}/{y}"));
+
+        let good = "https://t.example/{z}/{x}/{y}.png";
+        assert_eq!(
+            BasemapStyle::CustomXyz.url(6, 15, 25, false, "", "", good),
+            Some("https://t.example/6/15/25.png".to_string())
+        );
+        // An invalid template produces no URL rather than a request to something unexpected.
+        assert!(BasemapStyle::CustomXyz
+            .url(6, 15, 25, false, "", "", "http://t.example/{z}/{x}/{y}")
+            .is_none());
+        // Repointing the slot must not read the previous server's tiles out of the cache.
+        assert_ne!(
+            BasemapStyle::CustomXyz.provider(false, good),
+            BasemapStyle::CustomXyz.provider(false, "https://other.example/{z}/{x}/{y}.png")
+        );
+        // And it is only selectable once a template exists.
+        assert!(!BasemapStyle::CustomXyz.available(true, true, false));
+    }

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -512,6 +512,50 @@ fn units_tab(ui: &mut egui::Ui, settings: &mut Settings) {
     ui.weak("Reflectivity stays dBZ; internal data is unchanged (display-only).");
 }
 
+/// The "Custom (XYZ URL)" basemap's template, zoom cap and attribution.
+///
+/// Hidden on web: the tile proxy is an exact-host allowlist, so an arbitrary host cannot be
+/// fetched there at all (see `BasemapStyle::available`).
+fn custom_tile_source(ui: &mut egui::Ui, settings: &mut Settings) {
+    if cfg!(target_arch = "wasm32") {
+        return;
+    }
+    ui.separator();
+    ui.label("Custom tile source");
+    ui.weak("An XYZ template adds a \"Custom\" entry to the basemap list. Desktop and Android only.");
+    ui.add_space(6.0);
+    ui.horizontal(|ui| {
+        ui.label("URL template");
+        ui.add(
+            egui::TextEdit::singleline(&mut settings.custom_tile_url)
+                .hint_text("https://tiles.example.com/{z}/{x}/{y}.png")
+                .desired_width(340.0),
+        );
+    });
+    if !settings.custom_tile_url.is_empty()
+        && !crate::tiles::valid_xyz_template(&settings.custom_tile_url)
+    {
+        // Says why rather than silently dropping the entry from the list.
+        ui.colored_label(
+            egui::Color32::from_rgb(220, 120, 100),
+            "Needs to be an https URL containing {z}, {x} and {y}.",
+        );
+    }
+    ui.horizontal(|ui| {
+        ui.label("Max zoom");
+        ui.add(egui::DragValue::new(&mut settings.custom_tile_max_z).range(1..=22))
+            .on_hover_text("Deeper views stretch the deepest tile that loaded rather than blanking");
+    });
+    ui.horizontal(|ui| {
+        ui.label("Attribution");
+        ui.add(
+            egui::TextEdit::singleline(&mut settings.custom_tile_attribution)
+                .hint_text("© Your data source")
+                .desired_width(340.0),
+        );
+    });
+}
+
 fn basemaps_tab(ui: &mut egui::Ui, settings: &mut Settings) {
     ui.label("Provider API keys unlock additional raster basemap styles.");
     ui.add_space(6.0);
@@ -520,6 +564,8 @@ fn basemaps_tab(ui: &mut egui::Ui, settings: &mut Settings) {
     key_field(ui, "MapTiler API key", &mut settings.maptiler_key);
     ui.add_space(6.0);
     ui.weak("Keys are stored locally in settings.json and sent only to the provider's tile API.");
+    ui.add_space(12.0);
+    custom_tile_source(ui, settings);
     ui.add_space(12.0);
     ui.separator();
     ui.label("Live station cards");

--- a/crates/hookecho/src/ui/wizard.rs
+++ b/crates/hookecho/src/ui/wizard.rs
@@ -143,13 +143,14 @@ fn card_map(ui: &mut egui::Ui, settings: &mut Settings, basemap: &mut BasemapSty
     // Basemap picker, filtered by whichever keys are set this frame (typing a key unlocks styles).
     let mb = !settings.mapbox_key.is_empty();
     let mt = !settings.maptiler_key.is_empty();
+    let cx = crate::tiles::valid_xyz_template(&settings.custom_tile_url);
     ui.horizontal(|ui| {
         ui.label("Basemap");
         egui::ComboBox::from_id_salt("wiz_basemap")
             .selected_text(basemap.label())
             .show_ui(ui, |ui| {
                 for s in BasemapStyle::ALL {
-                    if s.available(mb, mt)
+                    if s.available(mb, mt, cx)
                         && ui.selectable_label(*basemap == s, s.label()).clicked()
                     {
                         *basemap = s;

--- a/crates/hookecho/src/vector_tiles.rs
+++ b/crates/hookecho/src/vector_tiles.rs
@@ -141,7 +141,7 @@ fn maybe_gunzip(bytes: &[u8]) -> Vec<u8> {
 pub fn build_tile(
     bytes: &[u8],
     id: TileId,
-    dark: bool,
+    palette: basemap_style::Palette,
     tess_zoom: f64,
 ) -> (Vec<OverlayVertex>, Vec<u32>, Vec<PlaceLabel>) {
     let (z, tx, ty) = id;
@@ -151,30 +151,33 @@ pub fn build_tile(
     let mut verts: Vec<OverlayVertex> = Vec::new();
     let mut indices: Vec<u32> = Vec::new();
 
-    // Background land quad covering the whole tile.
-    let bg = color(basemap_style::style(dark).background);
-    let (x0, y0) = (txf / n, tyf / n);
-    let (x1, y1) = ((txf + 1.0) / n, (tyf + 1.0) / n);
-    let base = verts.len() as u32;
-    verts.extend_from_slice(&[
-        OverlayVertex {
-            world: [x0 as f32, y0 as f32],
-            color: bg,
-        },
-        OverlayVertex {
-            world: [x1 as f32, y0 as f32],
-            color: bg,
-        },
-        OverlayVertex {
-            world: [x1 as f32, y1 as f32],
-            color: bg,
-        },
-        OverlayVertex {
-            world: [x0 as f32, y1 as f32],
-            color: bg,
-        },
-    ]);
-    indices.extend_from_slice(&[base, base + 1, base + 2, base, base + 2, base + 3]);
+    // Background land quad covering the whole tile — skipped entirely by the overlay palette,
+    // which draws on top of raster imagery and must not hide it.
+    if let Some(bg) = basemap_style::style(palette).background {
+        let bg = color(bg);
+        let (x0, y0) = (txf / n, tyf / n);
+        let (x1, y1) = ((txf + 1.0) / n, (tyf + 1.0) / n);
+        let base = verts.len() as u32;
+        verts.extend_from_slice(&[
+            OverlayVertex {
+                world: [x0 as f32, y0 as f32],
+                color: bg,
+            },
+            OverlayVertex {
+                world: [x1 as f32, y0 as f32],
+                color: bg,
+            },
+            OverlayVertex {
+                world: [x1 as f32, y1 as f32],
+                color: bg,
+            },
+            OverlayVertex {
+                world: [x0 as f32, y1 as f32],
+                color: bg,
+            },
+        ]);
+        indices.extend_from_slice(&[base, base + 1, base + 2, base, base + 2, base + 3]);
+    }
 
     let data = maybe_gunzip(bytes);
     let Ok(reader) = Reader::new(data) else {
@@ -197,7 +200,7 @@ pub fn build_tile(
         let feats = reader.get_features(i).unwrap_or_default();
         for f in &feats {
             let cls = prop(&f.properties, key);
-            let Some(c) = basemap_style::fill(dark, layer, &cls) else {
+            let Some(c) = basemap_style::fill(palette, layer, &cls) else {
                 continue;
             };
             let mut b = Path::builder();
@@ -256,7 +259,7 @@ pub fn build_tile(
             if *layer == "boundary" && cls == "6" && z < 7 {
                 continue;
             }
-            let Some((c, wpx)) = basemap_style::stroke(dark, layer, &cls) else {
+            let Some((c, wpx)) = basemap_style::stroke(palette, layer, &cls) else {
                 continue;
             };
             let w = (wpx as f64 * px_to_world) as f32;
@@ -359,7 +362,7 @@ fn extract_labels(
     out
 }
 
-fn fill_template(template: &str, z: u8, x: u32, y: u32) -> String {
+pub(crate) fn fill_template(template: &str, z: u8, x: u32, y: u32) -> String {
     template
         .replace("{z}", &z.to_string())
         .replace("{x}", &x.to_string())
@@ -413,7 +416,7 @@ pub async fn fetch_tilejson(
 pub async fn fetch_visible_vector(
     client: &reqwest::Client,
     template: &str,
-    dark: bool,
+    palette: basemap_style::Palette,
     tess_zoom: f64,
     visible: &[VisibleTile],
 ) -> (Vec<PendingVectorTile>, Vec<PlaceLabel>) {
@@ -424,7 +427,7 @@ pub async fn fetch_visible_vector(
         let url = fill_template(template, z, x, y);
         match load_tile_bytes(client, &url, None).await {
             Ok(bytes) => {
-                let (verts, indices, lbls) = build_tile(&bytes, v.id, dark, tess_zoom);
+                let (verts, indices, lbls) = build_tile(&bytes, v.id, palette, tess_zoom);
                 labels.extend(lbls);
                 out.push(PendingVectorTile {
                     id: v.id,
@@ -462,7 +465,7 @@ pub struct VectorTileManager {
     labels: HashMap<TileId, Vec<PlaceLabel>>,
     /// Bumped on every change to `labels` (see [`Self::label_generation`]).
     label_gen: u64,
-    dark: bool,
+    palette: basemap_style::Palette,
     tess_zoom: i32,
     /// Candidate new tessellation zoom and when it was first seen — see [`Self::note_zoom`].
     zoom_settled: Option<(i32, wxdata::clock::Instant)>,
@@ -497,7 +500,7 @@ impl VectorTileManager {
             vevicted: Vec::new(),
             labels: HashMap::new(),
             label_gen: 0,
-            dark: true,
+            palette: basemap_style::Palette::Dark,
             tess_zoom: 7,
             zoom_settled: None,
             cache_root,
@@ -513,12 +516,16 @@ impl VectorTileManager {
         self.ctx = Some(ctx);
     }
 
-    /// Switch dark/light. Returns true if changed (caller should clear the GPU vector cache).
-    pub fn set_style(&mut self, dark: bool) -> bool {
-        if self.dark == dark {
+    /// Switch palette. Returns true if changed (caller should clear the GPU vector cache).
+    ///
+    /// Colors are baked in at tessellation, so a palette change has to re-tessellate everything —
+    /// the same cost the dark/light switch always paid. ponytail: draw-time color indirection if
+    /// palette switching ever stops being a rare user action.
+    pub fn set_style(&mut self, palette: basemap_style::Palette) -> bool {
+        if self.palette == palette {
             return false;
         }
-        self.dark = dark;
+        self.palette = palette;
         self.requested.clear();
         self.uploaded.clear();
         self.labels.clear();
@@ -595,7 +602,7 @@ impl VectorTileManager {
         let Some(template) = self.template.clone() else {
             return;
         };
-        let dark = self.dark;
+        let palette = self.palette;
         let tess_zoom = self.tess_zoom as f64;
         for v in visible {
             if !self.requested.insert(v.id) {
@@ -617,7 +624,7 @@ impl VectorTileManager {
                     // gunzip + lyon tessellation is the heaviest CPU in the app after the volume
                     // decode; running it on the async worker starves every other fetch.
                     blocking.spawn_blocking(move || {
-                        let (vertices, indices, labels) = build_tile(&bytes, id, dark, tess_zoom);
+                        let (vertices, indices, labels) = build_tile(&bytes, id, palette, tess_zoom);
                         let _ = tx.send(FetchedVector {
                             id,
                             vertices,
@@ -739,10 +746,21 @@ mod tests {
     #[test]
     fn empty_bytes_yield_background_quad_only() {
         // Not a valid tile: build_tile still emits the background land quad (2 triangles).
-        let (verts, indices, labels) = build_tile(b"", (7, 30, 49), true, 7.0);
+        let (verts, indices, labels) =
+            build_tile(b"", (7, 30, 49), basemap_style::Palette::Dark, 7.0);
         assert_eq!(verts.len(), 4);
         assert_eq!(indices.len(), 6);
         assert!(labels.is_empty());
+    }
+
+    /// The hybrid overlay draws no background, so it must emit nothing at all for a tile with no
+    /// features — otherwise every hybrid tile would be a solid quad over the satellite imagery.
+    #[test]
+    fn overlay_palette_emits_no_background_quad() {
+        let (verts, indices, _) =
+            build_tile(b"", (7, 30, 49), basemap_style::Palette::HybridOverlay, 7.0);
+        assert!(verts.is_empty());
+        assert!(indices.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Seven new basemap entries and the plumbing three of them needed. Stacked on #49.

## Hybrid Satellite (the headline)

Esri World Imagery with our own vector roads, boundaries and labels drawn over it. Keyless. Every commercial provider charges for a hybrid layer; this one was almost free, because the vector label pipeline already ran over every raster basemap — the geometry was just being discarded.

Two things had to change:

- `basemap_style` gained a `Palette` enum in place of the `dark: bool` threaded through the tessellator, so there is somewhere to put a look with no fills and no background quad.
- The renderer learned to draw the vector basemap *after* the raster tiles for this one style (`MapCallback::vector_over_raster`). It was unconditionally drawn underneath, which would have buried it.

## The rest

| Style | Notes |
|---|---|
| Esri Dark Gray / Light Gray Canvas | max z16 — **measured** |
| Esri National Geographic | max z16 — measured |
| Esri Ocean | max z10 — measured |
| Auto (follow theme) | resolves at render/fetch time, never where stored |
| Custom (XYZ URL) | desktop + Android only |

Zoom caps are measured, not guessed: the canvases and NatGeo hand back a fixed 2521-byte placeholder from z17 up, the ocean base from z11. Same discipline as #49, for the same reason.

`Auto` resolves to Dark or Light at the point a style is about to be rendered or fetched. Storing the resolved value would freeze it at whatever the theme was the first time it drew, which is exactly what "follow theme" must not do.

## Custom XYZ is a trust boundary

The template comes out of the settings file and whatever it names gets fetched with the app's HTTP client. So: **https only** (a plain-http template would silently downgrade every tile request), and it must contain `{z}`, `{x}` and `{y}` or no URL is built at all. Its cache directory is keyed by a 32-bit hash of the template, so repointing the slot cannot serve the previous server's tiles. Max zoom is clamped to 22 — a typo in the settings file should not become an unbounded fetch loop.

**Not available on web.** The tile proxy is an exact-host allowlist, which an arbitrary host cannot pass, and a direct fetch would be at the mercy of whatever CORS headers the user's server happens to send. `available()` returns false under `wasm32` and the settings row is cfg'd out.

## Chase packs

Gained the mirror of the existing "include streets" option: pack satellite imagery beside the vector basemap. A road map with no terrain is half an offline chase kit.

## NAIP is deliberately absent

The plan listed it. USGS ImageryOnly caps at z16; Esri World Imagery serves real tiles through z20. A separate NAIP style would be strictly worse than imagery already in the list, so it is dropped rather than shipped.

## Verification

`clippy` · `cargo test --workspace` (468 passed) · wasm check · `shoot.sh check` — all clean. Every new tile URL curled before merge.

Hybrid confirmed against a live Xvfb session at KTLX: Esri imagery underneath, `© Esri, Maxar, Earthstar Geographics` attribution, nothing painted over the photo.

One thing this surfaced but does **not** fix: vector road strokes are tessellated with whatever `tess_zoom` was current when the tile was built, and a tile is only re-tessellated on overzoom. Jump straight to z12 and the roads come out roughly 30× too wide. It is pre-existing — the Dark basemap shows it identically, screenshotted both ways to confirm — and it belongs to the vector cartography PR that follows this one.

New tests: `auto_resolves_to_a_real_style_and_nothing_else_moves`, `only_hybrid_is_both_raster_and_vector`, `custom_template_is_validated_and_keyed_by_content`, `hybrid_overlay_covers_nothing_it_should_not`, `overlay_palette_emits_no_background_quad`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)