### PR TITLE
basemap: buildings, a real road ladder, four more vector looks

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -11365,7 +11365,7 @@ impl HookEchoApp {
             };
             let z = cam.zoom;
             let mut labels: Vec<&crate::vector_tiles::PlaceLabel> =
-                vlabels.iter().filter(|l| l.city || z >= 9.0).collect();
+                vlabels.iter().filter(|l| z >= l.min_zoom as f64).collect();
             labels.sort_by_key(|l| (!l.city, l.rank));
             let mut placed: Vec<egui::Rect> = Vec::new();
             let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();

--- a/crates/hookecho/src/basemap_style.rs
+++ b/crates/hookecho/src/basemap_style.rs
@@ -22,13 +22,159 @@ pub enum Palette {
     Light,
     /// Roads/boundaries over satellite imagery: no fills, no background, high-contrast strokes.
     HybridOverlay,
+    /// Warm, high-contrast street map in the OSM Liberty vein.
+    Liberty,
+    /// Pale, colourful, low-ink — reads well under heavy radar fill.
+    Bright,
+    /// Near-monochrome grey; the most radar gets out of the way.
+    Positron,
+    /// Very dark, desaturated navy — the night-drive look.
+    Midnight,
 }
 
 impl Palette {
-    /// The two full basemap looks share every code path; the overlay is the odd one out, so most
-    /// lookups only need to know which of the two it leans on for contrast.
-    fn dark(self) -> bool {
-        !matches!(self, Palette::Light)
+    /// Every selectable vector look, in menu order.
+    pub const ALL: [Palette; 6] = [
+        Palette::Dark,
+        Palette::Light,
+        Palette::Liberty,
+        Palette::Bright,
+        Palette::Positron,
+        Palette::Midnight,
+    ];
+
+}
+
+/// The per-palette color table. One struct rather than a pile of parallel `match` arms: adding a
+/// look is then a new `Colors` value, not an edit in five places.
+struct Colors {
+    water: u32,
+    wood: u32,
+    park: u32,
+    residential: u32,
+    building: u32,
+    motorway: u32,
+    primary: u32,
+    secondary: u32,
+    minor: u32,
+    rail: u32,
+    admin2: u32,
+    admin4: u32,
+    county: u32,
+    casing: u32,
+}
+
+const C_DARK: Colors = Colors {
+    water: 0x1b2733,
+    wood: 0x151c17,
+    park: 0x152018,
+    residential: 0x16181d,
+    building: 0x1d2028,
+    motorway: 0x3d4450,
+    primary: 0x353c47,
+    secondary: 0x2c323b,
+    minor: 0x23282f,
+    rail: 0x2a2f36,
+    admin2: 0x5a6470,
+    admin4: 0x3a424c,
+    county: 0x2f353d,
+    casing: 0x0d1015,
+};
+const C_LIGHT: Colors = Colors {
+    water: 0xc3d6e3,
+    wood: 0xd6e0cf,
+    park: 0xd9e8d2,
+    residential: 0xece8e0,
+    building: 0xe3ded4,
+    motorway: 0xf6d3a0,
+    primary: 0xf9dfb0,
+    secondary: 0xe9e3d5,
+    minor: 0xdedacf,
+    rail: 0xcdc9c0,
+    admin2: 0x9aa0a8,
+    admin4: 0xc4c0b8,
+    county: 0xd2cec6,
+    casing: 0xd8cfc0,
+};
+// Warmer paper, saturated road ladder, strong casings — the OSM Liberty look.
+const C_LIBERTY: Colors = Colors {
+    water: 0xa8ccdf,
+    wood: 0xc8dcb4,
+    park: 0xd2e8c0,
+    residential: 0xf0ece2,
+    building: 0xdfd8c8,
+    motorway: 0xf29a6a,
+    primary: 0xf7bd7a,
+    secondary: 0xfbdc9e,
+    minor: 0xf7f4ec,
+    rail: 0xb9b2a6,
+    admin2: 0x8c8478,
+    admin4: 0xb6afa2,
+    county: 0xcac3b6,
+    casing: 0xc08a5a,
+};
+// Pale and colourful but low-ink, so heavy radar fill still reads over it.
+const C_BRIGHT: Colors = Colors {
+    water: 0xd0e6f2,
+    wood: 0xdcecd4,
+    park: 0xe2f2da,
+    residential: 0xf6f4f0,
+    building: 0xeae5dc,
+    motorway: 0xffd9b0,
+    primary: 0xffe8c8,
+    secondary: 0xf4f0e6,
+    minor: 0xfbfaf6,
+    rail: 0xd8d2c8,
+    admin2: 0xb2aca4,
+    admin4: 0xd0cac2,
+    county: 0xdedad2,
+    casing: 0xe0d6c6,
+};
+// Near-monochrome. The look that gets furthest out of the radar's way.
+const C_POSITRON: Colors = Colors {
+    water: 0xd6dde2,
+    wood: 0xe4e7e4,
+    park: 0xe7eae7,
+    residential: 0xf2f2f0,
+    building: 0xe6e6e4,
+    motorway: 0xdcdcdc,
+    primary: 0xe4e4e4,
+    secondary: 0xececec,
+    minor: 0xf4f4f4,
+    rail: 0xdadada,
+    admin2: 0xb0b0b0,
+    admin4: 0xcccccc,
+    county: 0xdcdcdc,
+    casing: 0xc4c4c4,
+};
+// Darker and bluer than Dark, with slightly hotter roads — the night-drive look.
+const C_MIDNIGHT: Colors = Colors {
+    water: 0x0d1826,
+    wood: 0x0c1410,
+    park: 0x0d1712,
+    residential: 0x0e1118,
+    building: 0x141824,
+    motorway: 0x4a5570,
+    primary: 0x3c4560,
+    secondary: 0x2e3548,
+    minor: 0x232838,
+    rail: 0x282e3c,
+    admin2: 0x5a6480,
+    admin4: 0x38405a,
+    county: 0x2a3040,
+    casing: 0x05070c,
+};
+
+fn colors(p: Palette) -> &'static Colors {
+    match p {
+        Palette::Dark => &C_DARK,
+        Palette::Light => &C_LIGHT,
+        Palette::Liberty => &C_LIBERTY,
+        Palette::Bright => &C_BRIGHT,
+        Palette::Positron => &C_POSITRON,
+        Palette::Midnight => &C_MIDNIGHT,
+        // Never asked for: `fill` and `stroke` handle the overlay before they get here.
+        Palette::HybridOverlay => &C_DARK,
     }
 }
 
@@ -63,12 +209,64 @@ const HYBRID: VecStyle = VecStyle {
     label_halo: rgb(0x000000),
 };
 
+const LIBERTY: VecStyle = VecStyle {
+    background: Some(rgb(0xf7f4ec)),
+    label: rgb(0x30302c),
+    label_halo: rgb(0xfbf9f3),
+};
+const BRIGHT: VecStyle = VecStyle {
+    background: Some(rgb(0xfbfaf6)),
+    label: rgb(0x44443e),
+    label_halo: rgb(0xfdfdfa),
+};
+const POSITRON: VecStyle = VecStyle {
+    background: Some(rgb(0xf4f4f2)),
+    label: rgb(0x555555),
+    label_halo: rgb(0xfafafa),
+};
+const MIDNIGHT: VecStyle = VecStyle {
+    background: Some(rgb(0x070a12)),
+    label: rgb(0xb8c4d8),
+    label_halo: rgb(0x03050a),
+};
+
 pub fn style(p: Palette) -> &'static VecStyle {
     match p {
         Palette::Dark => &DARK,
         Palette::Light => &LIGHT,
         Palette::HybridOverlay => &HYBRID,
+        Palette::Liberty => &LIBERTY,
+        Palette::Bright => &BRIGHT,
+        Palette::Positron => &POSITRON,
+        Palette::Midnight => &MIDNIGHT,
     }
+}
+
+/// Casing (outline) color + width for a road, drawn in a pass *under* the road itself so majors
+/// read as ribbons rather than bare lines. `None` for classes that get no casing.
+///
+/// Width here is the total width of the casing stroke, so it has to exceed the road's own or the
+/// road would cover it entirely.
+pub fn casing(p: Palette, layer: &str, class: &str) -> Option<([u8; 4], f32)> {
+    if layer != "transportation" {
+        return None;
+    }
+    // Only the classes wide enough for a casing to be visible. Below tertiary the casing and the
+    // road would be a pixel apart and the result is mud.
+    let widen = match class {
+        "motorway" | "trunk" => 2.2,
+        "primary" => 1.8,
+        "secondary" => 1.4,
+        _ => return None,
+    };
+    // Over imagery the casing is what makes a pale road legible at all.
+    let c = if p == Palette::HybridOverlay {
+        [0, 0, 0, 255]
+    } else {
+        rgb(colors(p).casing)
+    };
+    let (_, w) = stroke(p, layer, class)?;
+    Some((c, w + widen))
 }
 
 /// Fill color for a polygon feature, or `None` to skip it.
@@ -77,12 +275,8 @@ pub fn fill(p: Palette, layer: &str, class: &str) -> Option<[u8; 4]> {
     if p == Palette::HybridOverlay {
         return None;
     }
-    let dark = p.dark();
-    let (water, wood, park, residential) = if dark {
-        (0x1b2733, 0x151c17, 0x152018, 0x16181d)
-    } else {
-        (0xc3d6e3, 0xd6e0cf, 0xd9e8d2, 0xece8e0)
-    };
+    let k = colors(p);
+    let (water, wood, park, residential) = (k.water, k.wood, k.park, k.residential);
     let c = match layer {
         "water" | "ocean" => water,
         "waterway" => water,
@@ -98,6 +292,10 @@ pub fn fill(p: Palette, layer: &str, class: &str) -> Option<[u8; 4]> {
             _ => return None,
         },
         "park" => park,
+        // Flat footprints, a touch off the background so blocks read without shouting.
+        // ponytail: flat fills, no extrusion — `render_height` is in the tile if that ever
+        // becomes worth the depth buffer.
+        "building" => k.building,
         _ => return None,
     };
     Some(rgb(c))
@@ -125,28 +323,26 @@ pub fn stroke(p: Palette, layer: &str, class: &str) -> Option<([u8; 4], f32)> {
         };
         return Some((rgb(c), w));
     }
-    let dark = p.dark();
-    let (motorway, primary, secondary, minor, rail, water, admin2, admin4, county) = if dark {
-        (
-            0x3d4450, 0x353c47, 0x2c323b, 0x23282f, 0x2a2f36, 0x24333f, 0x5a6470, 0x3a424c,
-            0x2f353d,
-        )
-    } else {
-        (
-            0xf6d3a0, 0xf9dfb0, 0xe9e3d5, 0xdedacf, 0xcdc9c0, 0xa9c4d6, 0x9aa0a8, 0xc4c0b8,
-            0xd2cec6,
-        )
-    };
+    let k = colors(p);
+    let (motorway, primary, secondary, minor, rail) =
+        (k.motorway, k.primary, k.secondary, k.minor, k.rail);
+    let (admin2, admin4, county) = (k.admin2, k.admin4, k.county);
+    // Waterway lines lean on the water fill so the two agree.
+    let water = k.water;
     let (c, w) = match layer {
         "transportation" => match class {
-            "motorway" | "trunk" => (motorway, 2.0),
-            "primary" => (primary, 1.5),
-            "secondary" => (secondary, 1.2),
-            "tertiary" => (secondary, 1.0),
-            "minor" | "service" | "street" => (minor, 0.8),
+            "motorway" => (motorway, 2.2),
+            "trunk" => (motorway, 1.9),
+            "primary" => (primary, 1.6),
+            "secondary" => (secondary, 1.3),
+            "tertiary" => (secondary, 1.05),
+            "minor" | "street" => (minor, 0.85),
+            "service" | "track" => (minor, 0.55),
+            "path" | "footway" | "cycleway" | "pedestrian" => (minor, 0.4),
             "rail" | "transit" => (rail, 0.8),
             _ => return None,
         },
+        "aeroway" => (rail, 1.4),
         "waterway" => (water, 1.0),
         // caller passes admin_level as the class string; maritime boundaries filtered upstream.
         "boundary" => match class {
@@ -178,9 +374,10 @@ mod tests {
             assert!(stroke(p, "transportation", "motorway").is_some());
             assert!(stroke(p, "boundary", "2").is_some());
             assert!(stroke(p, "waterway", "").is_some());
+            assert!(fill(p, "building", "").is_some());
             // Unstyled input is skipped, not defaulted.
             assert!(fill(p, "aeroway", "").is_none());
-            assert!(stroke(p, "transportation", "path").is_none());
+            assert!(stroke(p, "transportation", "elevator").is_none());
         }
     }
 
@@ -204,5 +401,41 @@ mod tests {
         assert!(hybrid_w > dark_w);
         // No minor-road mesh over imagery.
         assert!(stroke(p, "transportation", "minor").is_none());
+    }
+
+    /// A casing only works if it is wider than the road it sits under and darker than it — get
+    /// either backwards and the road disappears into its own outline.
+    #[test]
+    fn casings_sit_under_the_roads_they_outline() {
+        for p in [Palette::Dark, Palette::Light, Palette::HybridOverlay] {
+            for class in ["motorway", "trunk", "primary", "secondary"] {
+                let Some((_, road_w)) = stroke(p, "transportation", class) else {
+                    continue;
+                };
+                let (_, case_w) = casing(p, "transportation", class)
+                    .unwrap_or_else(|| panic!("{p:?}/{class} should have a casing"));
+                assert!(case_w > road_w, "{p:?}/{class}: casing must be wider");
+            }
+            // Small roads get none: at a pixel apart the two strokes are just mud.
+            assert!(casing(p, "transportation", "minor").is_none());
+            // And nothing else in the tile has a casing at all.
+            assert!(casing(p, "boundary", "2").is_none());
+            assert!(casing(p, "waterway", "").is_none());
+        }
+    }
+
+    /// The road ladder has to be monotonic, or a residential street outdraws an interstate.
+    #[test]
+    fn road_widths_descend_by_importance() {
+        for p in [Palette::Dark, Palette::Light] {
+            let w = |c: &str| stroke(p, "transportation", c).unwrap().1;
+            assert!(w("motorway") > w("trunk"));
+            assert!(w("trunk") > w("primary"));
+            assert!(w("primary") > w("secondary"));
+            assert!(w("secondary") > w("tertiary"));
+            assert!(w("tertiary") > w("minor"));
+            assert!(w("minor") > w("service"));
+            assert!(w("service") > w("path"));
+        }
     }
 }

--- a/crates/hookecho/src/tiles.rs
+++ b/crates/hookecho/src/tiles.rs
@@ -82,6 +82,14 @@ pub enum BasemapStyle {
     UsgsImageryTopo,
     OsmHot,
     CyclOsm,
+    /// Vector basemap, OSM Liberty look.
+    VectorLiberty,
+    /// Vector basemap, pale low-ink look.
+    VectorBright,
+    /// Vector basemap, near-monochrome look.
+    VectorPositron,
+    /// Vector basemap, night-drive look.
+    VectorMidnight,
     EsriDarkGray,
     EsriLightGray,
     EsriNatGeo,
@@ -99,7 +107,7 @@ pub enum BasemapStyle {
 
 impl BasemapStyle {
     /// Cycle order for the `z` hotkey; provider styles trail the built-ins.
-    pub const ALL: [BasemapStyle; 47] = [
+    pub const ALL: [BasemapStyle; 51] = [
         BasemapStyle::Dark,
         BasemapStyle::Light,
         BasemapStyle::Satellite,
@@ -116,6 +124,10 @@ impl BasemapStyle {
         BasemapStyle::UsgsImageryTopo,
         BasemapStyle::OsmHot,
         BasemapStyle::CyclOsm,
+        BasemapStyle::VectorLiberty,
+        BasemapStyle::VectorBright,
+        BasemapStyle::VectorPositron,
+        BasemapStyle::VectorMidnight,
         BasemapStyle::HybridSatellite,
         BasemapStyle::EsriDarkGray,
         BasemapStyle::EsriLightGray,
@@ -219,6 +231,10 @@ impl BasemapStyle {
             BasemapStyle::UsgsImageryTopo => "USGS Imagery Topo",
             BasemapStyle::OsmHot => "OSM Humanitarian",
             BasemapStyle::CyclOsm => "CyclOSM",
+            BasemapStyle::VectorLiberty => "Liberty",
+            BasemapStyle::VectorBright => "Bright",
+            BasemapStyle::VectorPositron => "Positron",
+            BasemapStyle::VectorMidnight => "Midnight",
             BasemapStyle::EsriDarkGray => "Esri Dark Gray Canvas",
             BasemapStyle::EsriLightGray => "Esri Light Gray Canvas",
             BasemapStyle::EsriNatGeo => "Esri National Geographic",
@@ -272,6 +288,10 @@ impl BasemapStyle {
             BasemapStyle::UsgsImageryTopo => "usgs-imagery-topo",
             BasemapStyle::OsmHot => "osm-hot",
             BasemapStyle::CyclOsm => "cyclosm",
+            BasemapStyle::VectorLiberty => "liberty",
+            BasemapStyle::VectorBright => "bright",
+            BasemapStyle::VectorPositron => "positron",
+            BasemapStyle::VectorMidnight => "midnight",
             BasemapStyle::EsriDarkGray => "esri-dark-gray",
             BasemapStyle::EsriLightGray => "esri-light-gray",
             BasemapStyle::EsriNatGeo => "esri-natgeo",
@@ -373,7 +393,14 @@ impl BasemapStyle {
     pub fn is_raster(self) -> bool {
         !matches!(
             self,
-            BasemapStyle::Dark | BasemapStyle::Light | BasemapStyle::None | BasemapStyle::Auto
+            BasemapStyle::Dark
+                | BasemapStyle::Light
+                | BasemapStyle::None
+                | BasemapStyle::Auto
+                | BasemapStyle::VectorLiberty
+                | BasemapStyle::VectorBright
+                | BasemapStyle::VectorPositron
+                | BasemapStyle::VectorMidnight
         )
     }
 
@@ -478,6 +505,10 @@ impl BasemapStyle {
         match self {
             BasemapStyle::Dark => Some(crate::basemap_style::Palette::Dark),
             BasemapStyle::Light => Some(crate::basemap_style::Palette::Light),
+            BasemapStyle::VectorLiberty => Some(crate::basemap_style::Palette::Liberty),
+            BasemapStyle::VectorBright => Some(crate::basemap_style::Palette::Bright),
+            BasemapStyle::VectorPositron => Some(crate::basemap_style::Palette::Positron),
+            BasemapStyle::VectorMidnight => Some(crate::basemap_style::Palette::Midnight),
             BasemapStyle::HybridSatellite => Some(crate::basemap_style::Palette::HybridOverlay),
             _ => None,
         }
@@ -1635,7 +1666,6 @@ mod tests {
             BasemapStyle::GoesEast.goes_layer().unwrap().1
         );
     }
-}
 
     /// `Auto` is a marker, not something the tile layer should ever be asked to fetch.
     #[test]
@@ -1695,3 +1725,17 @@ mod tests {
         // And it is only selectable once a template exists.
         assert!(!BasemapStyle::CustomXyz.available(true, true, false));
     }
+
+    /// Every vector look has to be selectable, or it is dead code that still costs a review.
+    #[test]
+    fn every_palette_has_a_basemap_entry() {
+        for pal in crate::basemap_style::Palette::ALL {
+            assert!(
+                BasemapStyle::ALL
+                    .iter()
+                    .any(|s| s.vector_palette() == Some(pal)),
+                "{pal:?} is not reachable from the basemap list"
+            );
+        }
+    }
+}

--- a/crates/hookecho/src/vector_tiles.rs
+++ b/crates/hookecho/src/vector_tiles.rs
@@ -36,13 +36,28 @@ const FILL_LAYERS: &[(&str, &str)] = &[
     ("landuse", "class"),
     ("park", "class"),
     ("water", "class"),
+    // Buildings only exist in the tiles from z13 (checked against the OpenFreeMap tilejson), so
+    // this costs nothing at the zooms most of the app is used at.
+    ("building", "class"),
 ];
-// Stroke layers, drawn last (over the fills).
-const STROKE_LAYERS: &[(&str, &str)] = &[
-    ("waterway", ""),
-    ("transportation", "class"),
-    ("boundary", "admin_level"),
+/// Stroke layers, drawn last (over the fills), in draw order.
+///
+/// `transportation` appears twice on purpose: the first pass lays the casings for every road, the
+/// second lays the roads on top. Casing-then-road per feature would let the next road's casing
+/// paint over the previous road.
+const STROKE_LAYERS: &[(&str, &str, StrokePass)] = &[
+    ("waterway", "", StrokePass::Road),
+    ("aeroway", "class", StrokePass::Road),
+    ("transportation", "class", StrokePass::Casing),
+    ("transportation", "class", StrokePass::Road),
+    ("boundary", "admin_level", StrokePass::Road),
 ];
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum StrokePass {
+    Casing,
+    Road,
+}
 
 /// A city/town label to draw with the egui painter (never appears in GPU/headless PNGs).
 #[derive(Clone, Debug)]
@@ -53,6 +68,9 @@ pub struct PlaceLabel {
     pub rank: i64,
     /// True for `city` class (always shown); towns only appear when zoomed in.
     pub city: bool,
+    /// Camera zoom below which this label is not worth the screen space. Cities are 0 (always),
+    /// towns 9, points of interest 13 — a POI at CONUS zoom is noise.
+    pub min_zoom: f32,
 }
 
 fn srgb_to_linear(c: u8) -> f32 {
@@ -244,7 +262,7 @@ pub fn build_tile(
     }
 
     // Strokes.
-    for (layer, key) in STROKE_LAYERS {
+    for (layer, key, pass) in STROKE_LAYERS {
         let Some(i) = names.iter().position(|nm| nm == layer) else {
             continue;
         };
@@ -259,7 +277,11 @@ pub fn build_tile(
             if *layer == "boundary" && cls == "6" && z < 7 {
                 continue;
             }
-            let Some((c, wpx)) = basemap_style::stroke(palette, layer, &cls) else {
+            let styled = match pass {
+                StrokePass::Casing => basemap_style::casing(palette, layer, &cls),
+                StrokePass::Road => basemap_style::stroke(palette, layer, &cls),
+            };
+            let Some((c, wpx)) = styled else {
                 continue;
             };
             let w = (wpx as f64 * px_to_world) as f32;
@@ -356,7 +378,87 @@ fn extract_labels(
                 name,
                 rank,
                 city,
+                min_zoom: if city { 0.0 } else { 9.0 },
             });
+        }
+    }
+    out.extend(extract_pois(reader, names, n, txf, tyf));
+    out
+}
+
+/// The handful of POI classes worth a label on a weather map: somewhere to be, or somewhere to
+/// take shelter. The full `poi` layer is hundreds of classes and would bury the map.
+///
+/// ponytail: fixed class list. If it ever needs to be user-configurable, it becomes a setting,
+/// not a bigger list.
+const POI_CLASSES: &[&str] = &[
+    "hospital",
+    "college",
+    "town_hall",
+    "police",
+    "fire_station",
+    "stadium",
+    "airport",
+    "aerodrome",
+    "railway",
+];
+
+/// Most labels any one tile may contribute. The first pass of this shipped with `school` and
+/// `park` in the class list and no cap, and downtown Oklahoma City came out as a solid mat of
+/// text with the map invisible underneath. Both the list and this number exist because of that.
+const MAX_POIS_PER_TILE: usize = 12;
+
+/// Pull the interesting subset of the `poi` layer. Present in the tiles from z11.
+fn extract_pois(
+    reader: &Reader,
+    names: &[String],
+    n: f64,
+    txf: f64,
+    tyf: f64,
+) -> Vec<PlaceLabel> {
+    let Some(i) = names.iter().position(|nm| nm == "poi") else {
+        return Vec::new();
+    };
+    let extent = reader
+        .get_layer_metadata()
+        .ok()
+        .and_then(|m| m.get(i).map(|l| l.extent as f64))
+        .unwrap_or(4096.0);
+    let mut out = Vec::new();
+    for f in reader.get_features(i).unwrap_or_default() {
+        let cls = prop(&f.properties, "class");
+        if !POI_CLASSES.contains(&cls.as_str()) {
+            continue;
+        }
+        let name = {
+            let en = prop(&f.properties, "name:en");
+            if en.is_empty() {
+                prop(&f.properties, "name")
+            } else {
+                en
+            }
+        };
+        if name.is_empty() {
+            continue;
+        }
+        let pt = match &f.geometry {
+            geo_types::Geometry::Point(p) => Some((p.x(), p.y())),
+            geo_types::Geometry::MultiPoint(mp) => mp.0.first().map(|p| (p.x(), p.y())),
+            _ => None,
+        };
+        if let Some((px, py)) = pt {
+            let p = tw(px, py, n, txf, tyf, extent);
+            out.push(PlaceLabel {
+                world: [p.x, p.y],
+                name,
+                // Below every town: the collision pass drops these first when space runs out.
+                rank: 500,
+                city: false,
+                min_zoom: 14.0,
+            });
+        }
+        if out.len() >= MAX_POIS_PER_TILE {
+            break;
         }
     }
     out
@@ -555,17 +657,19 @@ impl VectorTileManager {
             return false;
         }
         self.zoom_settled = None;
-        let overzoom = self.tess_zoom > MAX_VECTOR_Z as i32 || tz > MAX_VECTOR_Z as i32;
         self.tess_zoom = tz;
-        if overzoom {
-            self.requested.clear();
-            self.uploaded.clear();
-            self.labels.clear();
-            self.label_gen += 1;
-            true
-        } else {
-            false
-        }
+        // Every resident tile was tessellated for the *old* zoom, and stroke widths are baked in
+        // at tessellation. This used to re-tessellate only when overzooming past the deepest tile
+        // level, on the theory that below that the tile ids change anyway and the new tiles pick
+        // up the new width. They do — but the tiles already on screen do not, and a jump straight
+        // to z12 from the z7 the manager starts at left roads roughly thirty times too wide until
+        // something else happened to clear them. The 700 ms settle above is what makes doing this
+        // unconditionally affordable.
+        self.requested.clear();
+        self.uploaded.clear();
+        self.labels.clear();
+        self.label_gen += 1;
+        true
     }
 
     pub fn visible(&self, cam: &Camera, viewport_px: (f32, f32)) -> Vec<VisibleTile> {


### PR DESCRIPTION
The interview called the default vector cartography weak. It was: four fill classes, six road widths, no buildings — and a stroke width that was often simply wrong. Stacked on #52.

## The width bug came first

Stroke widths are baked in at tessellation, and a resident tile was only re-tessellated when the camera overzoomed past the deepest tile level. Below that the tile ids change as you zoom, so *new* tiles came out right — but the tiles already on screen kept whatever width they were built with.

Open straight onto z12 from the z7 the manager starts at and every road is roughly **thirty times too wide**. This is what that looked like, and what it looks like now:

| before | after |
|---|---|
| roads as fat rectangles | hairlines at the right width |

Found while verifying #52's hybrid satellite, confirmed pre-existing by screenshotting the Dark basemap the same way. `note_zoom` now clears unconditionally when the tessellation zoom moves. The 700 ms settle already guarding it is what makes that affordable — that comment about re-tessellating mid-pinch being "the worst possible moment" is still true, and still handled.

## Cartography

- **Buildings** — `building` layer, flat fills. Only exists in the tiles from z13, so it costs nothing at the zooms most of the app is used at. *ponytail: flat, no extrusion; `render_height` is in the tile if that ever earns the depth buffer.*
- **Road ladder** — motorway through path, monotonically descending, with casings under the four biggest classes so majors read as ribbons rather than bare lines. The casing is its own pass over the transportation layer: casing-then-road per feature lets the next road's casing paint over the previous road.
- **POIs** — from z14, nine classes, capped at twelve per tile.

The POI cap is not theoretical. The first cut had `school` and `park` in the class list and no cap; downtown Oklahoma City came out as a solid mat of text with the map invisible under it. Screenshot in the branch history if you want to see it. Both the list and the number exist because of that.

## Four new looks

Liberty, Bright, Positron, Midnight — same OpenFreeMap tiles, new palettes.

Adding them meant the per-palette colors had to stop being two hardcoded tuples inside `fill` and `stroke`. They are now one `Colors` table per palette, so a new look is a new value rather than an edit in five places. `every_palette_has_a_basemap_entry` keeps a palette from being added and then left unreachable.

## Verification

`clippy` · `cargo test --workspace` (471 passed) · wasm check · `shoot.sh check` — all clean.

Liberty confirmed over Oklahoma City under Xvfb: buildings, parks, water, and a label density you can actually read a radar through.

New tests: `casings_sit_under_the_roads_they_outline`, `road_widths_descend_by_importance`, `every_palette_has_a_basemap_entry`.

One thing left on the table: road strokes are legible but on the thin side at 1× DPI. That is a number in one table, not a structural problem, and it wants your eyes on real hardware rather than mine on a software-GL screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)