### PR TITLE
basemap: a thumbnail grid instead of a fifty-one-entry list

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -6184,31 +6184,29 @@ impl HookEchoApp {
     /// per-map state is edited.
     fn map_rows(&mut self, ui: &mut egui::Ui, actions: &mut ui::layer_options::UiActions) {
         use crate::settings::StartView;
-        use crate::tiles::BasemapStyle;
         let chasepack = self.chasepack_ui();
         let (mb_key, mt_key) = (
             !self.settings.mapbox_key.is_empty(),
             !self.settings.maptiler_key.is_empty(),
         );
-        let cx_ok = crate::tiles::valid_xyz_template(&self.settings.custom_tile_url);
-        // Split the borrow: the combo writes both the pane's style and the persisted default.
-        let (view, settings) = (&mut self.views[self.active], &mut self.settings);
-        egui::ComboBox::from_label("Background")
-            .selected_text(view.basemap.label())
-            .show_ui(ui, |ui| {
-                // Only styles whose provider key is set are selectable.
-                for s in BasemapStyle::ALL
-                    .into_iter()
-                    .filter(|s| s.available(mb_key, mt_key, cx_ok))
-                {
-                    if ui
-                        .selectable_value(&mut view.basemap, s, s.label())
-                        .clicked()
-                    {
-                        settings.basemap = s.slug().to_string(); // persist across restarts
-                    }
-                }
+        let current = self.views[self.active].basemap;
+        // A named button that opens the grid, rather than the grid inline: the drawer column is
+        // narrow, and fifty cards in it would push everything else off the panel.
+        let mut picked = None;
+        ui.menu_button(format!("Background: {}", current.label()), |ui| {
+            ui.set_min_width(460.0);
+            egui::ScrollArea::vertical().max_height(460.0).show(ui, |ui| {
+                picked = ui::basemap_picker::grid(ui, &mut self.tiles, current, &self.settings);
             });
+            if picked.is_some() {
+                ui.close();
+            }
+        });
+        if let Some(s) = picked {
+            self.views[self.active].basemap = s;
+            self.settings.basemap = s.slug().to_string(); // persist across restarts
+        }
+        let (view, settings) = (&mut self.views[self.active], &mut self.settings);
         ui.weak(if mb_key && mt_key {
             "Z cycles backgrounds"
         } else {
@@ -15761,6 +15759,7 @@ impl eframe::App for HookEchoApp {
             &mut self.settings,
             &mut self.views[active].basemap,
             &self.marker_icon_tex,
+            &mut self.tiles,
         ) {
             self.settings.setup_done = true;
             self.settings.save();

--- a/crates/hookecho/src/app/mobile/mod.rs
+++ b/crates/hookecho/src/app/mobile/mod.rs
@@ -445,6 +445,8 @@ impl super::HookEchoApp {
         let cur = self.views[self.active].basemap;
         let mut pick = None;
         ui.label(egui::RichText::new("Basemap").size(crate::ui::m3::T_LABEL_LG));
+        // The common styles stay a chip row: one tap, no scrolling, thumb-reachable. It is the
+        // *other* forty-odd that needed the grid.
         ui.horizontal_wrapped(|ui| {
             for s in BasemapStyle::COMMON {
                 if s.available(mb, mt, cx)
@@ -454,22 +456,15 @@ impl super::HookEchoApp {
                 }
             }
         });
-        // Everything COMMON leaves out — the other GOES products, the provider styles a key
-        // unlocks — behind one disclosure rather than in the chip row.
         egui::CollapsingHeader::new("All basemaps")
             .id_salt("m_basemap_all")
             .default_open(!BasemapStyle::COMMON.contains(&cur))
             .show(ui, |ui| {
-                ui.horizontal_wrapped(|ui| {
-                    for s in BasemapStyle::ALL {
-                        if BasemapStyle::COMMON.contains(&s) || !s.available(mb, mt, cx) {
-                            continue;
-                        }
-                        if crate::ui::m3::chip(ui, s.label(), s == cur).clicked() {
-                            pick = Some(s);
-                        }
-                    }
-                });
+                if let Some(s) =
+                    crate::ui::basemap_picker::grid(ui, &mut self.tiles, cur, &self.settings)
+                {
+                    pick = Some(s);
+                }
             });
         if let Some(s) = pick {
             self.set_basemap(s);

--- a/crates/hookecho/src/tiles.rs
+++ b/crates/hookecho/src/tiles.rs
@@ -28,6 +28,37 @@ pub enum Provider {
     MapTiler,
 }
 
+/// Picker grouping for a [`BasemapStyle`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Category {
+    Vector,
+    Streets,
+    Satellite,
+    Topo,
+    Other,
+}
+
+impl Category {
+    /// Groups in picker order.
+    pub const ALL: [Category; 5] = [
+        Category::Vector,
+        Category::Streets,
+        Category::Satellite,
+        Category::Topo,
+        Category::Other,
+    ];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Category::Vector => "Vector",
+            Category::Streets => "Streets",
+            Category::Satellite => "Satellite",
+            Category::Topo => "Terrain",
+            Category::Other => "Other",
+        }
+    }
+}
+
 /// A selectable basemap under the radar. Dark/Light are the vector MVT basemap
 /// (see [`crate::vector_tiles`]); Satellite is raster USGS imagery. The Mapbox*/MapTiler* styles
 /// are provider raster tiles, available only when the matching Settings API key is set.
@@ -486,6 +517,44 @@ impl BasemapStyle {
         self
     }
 
+    /// Which group this style belongs to in the picker.
+    pub fn category(self) -> Category {
+        if self.goes_layer().is_some() {
+            return Category::Satellite;
+        }
+        match self {
+            BasemapStyle::None | BasemapStyle::Auto | BasemapStyle::CustomXyz => Category::Other,
+            BasemapStyle::Dark
+            | BasemapStyle::Light
+            | BasemapStyle::VectorLiberty
+            | BasemapStyle::VectorBright
+            | BasemapStyle::VectorPositron
+            | BasemapStyle::VectorMidnight => Category::Vector,
+            BasemapStyle::Satellite
+            | BasemapStyle::EsriImagery
+            | BasemapStyle::HybridSatellite
+            | BasemapStyle::MapboxSatellite
+            | BasemapStyle::MapboxSatelliteStreets
+            | BasemapStyle::MapTilerSatellite => Category::Satellite,
+            BasemapStyle::OpenTopoMap
+            | BasemapStyle::UsgsTopo
+            | BasemapStyle::UsgsImageryTopo
+            | BasemapStyle::EsriTopo
+            | BasemapStyle::MapboxOutdoors
+            | BasemapStyle::MapTilerOutdoor
+            | BasemapStyle::MapTilerTopo
+            | BasemapStyle::EsriOcean => Category::Topo,
+            _ => Category::Streets,
+        }
+    }
+
+    /// URL of the one tile used as this style's picker thumbnail: z6 over the middle of CONUS,
+    /// which is the view the app opens on. Fetched through the same per-style disk cache as any
+    /// other tile, so opening the picker twice costs nothing.
+    pub(crate) fn thumb_url(self, mapbox: &str, maptiler: &str, custom: &str) -> Option<String> {
+        self.url(6, 14, 24, false, mapbox, maptiler, custom)
+    }
+
     /// [`Self::Auto`] resolved against the current theme; every other style is itself.
     ///
     /// Call this at the point a style is about to be *rendered or fetched*, not where it is
@@ -820,6 +889,13 @@ struct FetchedTile {
     height: u32,
 }
 
+/// A picker thumbnail's state.
+enum Thumb {
+    Loading,
+    Ready(egui::TextureHandle),
+    Failed,
+}
+
 /// A finished fetch, or the id of one that failed (so it can leave `requested` and be retried).
 type TileResult = Result<FetchedTile, crate::render::TileKey>;
 
@@ -864,11 +940,16 @@ pub struct TileManager {
     custom_template: String,
     /// Deepest zoom the custom source is configured to serve.
     custom_max_z: u8,
+    /// Picker thumbnails, keyed by [`BasemapStyle::key`].
+    thumbs: std::collections::HashMap<u8, Thumb>,
+    thumb_tx: Sender<(u8, Option<FetchedTile>)>,
+    thumb_rx: Receiver<(u8, Option<FetchedTile>)>,
 }
 
 impl TileManager {
     pub fn new(spawner: crate::rt::Spawner) -> Self {
         let (tx, rx) = std::sync::mpsc::channel();
+        let (thumb_tx, thumb_rx) = std::sync::mpsc::channel();
         let client =
             crate::platform::http_timeouts(reqwest::Client::builder().user_agent(USER_AGENT))
                 .build()
@@ -891,6 +972,9 @@ impl TileManager {
             frame_visible: 0,
             custom_template: String::new(),
             custom_max_z: 19,
+            thumbs: std::collections::HashMap::new(),
+            thumb_tx,
+            thumb_rx,
             cache_root,
             mapbox_key: String::new(),
             maptiler_key: String::new(),
@@ -938,6 +1022,85 @@ impl TileManager {
             self.requested.clear();
             self.uploaded.clear();
         }
+    }
+
+    /// This style's picker thumbnail, fetching it the first time it is asked for.
+    ///
+    /// One z6 tile over the middle of CONUS per style, through the same disk cache as any other
+    /// tile. Returns `None` while it is in flight, if it failed, or if the style has no raster
+    /// URL — the picker paints a palette swatch in all of those cases, so nothing ever waits on
+    /// a network round trip to draw.
+    pub fn thumb(&mut self, style: BasemapStyle, ctx: &egui::Context) -> Option<egui::TextureHandle> {
+        while let Ok((key, fetched)) = self.thumb_rx.try_recv() {
+            let state = match fetched {
+                Some(f) => {
+                    let img = egui::ColorImage::from_rgba_unmultiplied(
+                        [f.width as usize, f.height as usize],
+                        &f.rgba,
+                    );
+                    Thumb::Ready(ctx.load_texture(
+                        format!("basemap-thumb-{key}"),
+                        img,
+                        egui::TextureOptions::LINEAR,
+                    ))
+                }
+                None => Thumb::Failed,
+            };
+            self.thumbs.insert(key, state);
+        }
+        let key = style.key();
+        match self.thumbs.get(&key) {
+            Some(Thumb::Ready(t)) => return Some(t.clone()),
+            Some(_) => return None,
+            None => {}
+        }
+        // A cellular link should not spend a screenful of tiles on decoration.
+        if crate::platform::is_metered() {
+            return None;
+        }
+        // Small separate budget: the picker opening must not stall the map's own tile fetches.
+        // ponytail: flat 4, independent of MAX_INFLIGHT.
+        if self
+            .thumbs
+            .values()
+            .filter(|t| matches!(t, Thumb::Loading))
+            .count()
+            >= 4
+        {
+            return None;
+        }
+        let url = style.thumb_url(&self.mapbox_key, &self.maptiler_key, &self.custom_template)?;
+        let path = self.cache_root.as_ref().map(|d| {
+            d.join(style.provider(false, &self.custom_template))
+                .join("default")
+                .join("6/14/24")
+        });
+        self.thumbs.insert(key, Thumb::Loading);
+        let client = self.client.clone();
+        let tx = self.thumb_tx.clone();
+        let ctx2 = self.ctx.clone();
+        let blocking = self.spawner.clone();
+        self.spawner.spawn(async move {
+            let bytes = load_tile_bytes(&client, &url, path.as_deref()).await;
+            blocking.spawn_blocking(move || {
+                let decoded = bytes.ok().and_then(|b| image::load_from_memory(&b).ok()).map(|img| {
+                    let rgba = img.to_rgba8();
+                    let (w, h) = rgba.dimensions();
+                    FetchedTile {
+                        id: (6, 14, 24),
+                        style: key,
+                        rgba: rgba.into_raw(),
+                        width: w,
+                        height: h,
+                    }
+                });
+                let _ = tx.send((key, decoded));
+                if let Some(ctx) = ctx2 {
+                    ctx.request_repaint();
+                }
+            });
+        });
+        None
     }
 
     /// Point the custom-XYZ slot at a template. Clears the caches on change, like the key setter
@@ -1736,6 +1899,36 @@ mod tests {
                     .any(|s| s.vector_palette() == Some(pal)),
                 "{pal:?} is not reachable from the basemap list"
             );
+        }
+    }
+
+    /// The picker draws one section per category. A style in no section is invisible, and a
+    /// section with nothing in it is a stray heading.
+    #[test]
+    fn categories_partition_the_style_list() {
+        let mut seen = 0;
+        for cat in Category::ALL {
+            let n = BasemapStyle::ALL
+                .iter()
+                .filter(|s| s.category() == cat)
+                .count();
+            assert!(n > 0, "{cat:?} has no styles");
+            seen += n;
+        }
+        assert_eq!(seen, BasemapStyle::ALL.len());
+        // The three that are not a map of anywhere belong together, away from the imagery.
+        for s in [
+            BasemapStyle::None,
+            BasemapStyle::Auto,
+            BasemapStyle::CustomXyz,
+        ] {
+            assert_eq!(s.category(), Category::Other, "{s:?}");
+        }
+        // Every GOES product lands under Satellite whatever else the match says.
+        for s in BasemapStyle::ALL {
+            if s.goes_layer().is_some() {
+                assert_eq!(s.category(), Category::Satellite, "{s:?}");
+            }
         }
     }
 }

--- a/crates/hookecho/src/ui/basemap_picker.rs
+++ b/crates/hookecho/src/ui/basemap_picker.rs
@@ -1,0 +1,186 @@
+//! The basemap chooser: a thumbnail grid, grouped by category.
+//!
+//! Replaces a fifty-one-entry combo box on desktop and an eight-chip row plus a disclosure on the
+//! phone. The complaint that started this was "basemaps very lacking" — there were forty of them,
+//! but a flat alphabetical-ish list of names is not a way to choose a *look*.
+//!
+//! Raster styles show one real tile (z6 over the middle of CONUS, fetched through the normal
+//! per-style disk cache). Vector styles show a painted swatch of their own palette rather than a
+//! rasterised MVT tile: the swatch is honest about the colors, which is what the choice is
+//! actually between, and it needs no fetch at all.
+//!
+//! ponytail: painted swatches, not rendered MVT; one fixed thumbnail tile per style.
+
+use crate::settings::Settings;
+use crate::tiles::{BasemapStyle, Category, TileManager};
+
+/// Card size. Wide enough for a 256-px tile to read at a glance without the grid needing a
+/// scrollbar on a phone.
+const CARD_W: f32 = 104.0;
+const CARD_H: f32 = 72.0;
+
+/// Paint the swatch a vector style gets instead of a fetched tile: its background with a band of
+/// its own road and water colors, so the cards differ the way the maps do.
+fn swatch(painter: &egui::Painter, rect: egui::Rect, style: BasemapStyle) {
+    let Some(pal) = style.vector_palette() else {
+        painter.rect_filled(rect, 4.0, egui::Color32::from_gray(40));
+        return;
+    };
+    let c = |v: [u8; 4]| egui::Color32::from_rgb(v[0], v[1], v[2]);
+    let vs = crate::basemap_style::style(pal);
+    let bg = vs.background.map(c).unwrap_or(egui::Color32::from_gray(60));
+    painter.rect_filled(rect, 4.0, bg);
+    // A road, a casing under it, and a river: the three things the palettes differ most in.
+    if let Some((road, w)) = crate::basemap_style::stroke(pal, "transportation", "motorway") {
+        if let Some((case, cw)) = crate::basemap_style::casing(pal, "transportation", "motorway") {
+            painter.line_segment(
+                [
+                    egui::pos2(rect.left() + 6.0, rect.bottom() - 22.0),
+                    egui::pos2(rect.right() - 6.0, rect.top() + 20.0),
+                ],
+                egui::Stroke::new(cw * 2.2, c(case)),
+            );
+        }
+        painter.line_segment(
+            [
+                egui::pos2(rect.left() + 6.0, rect.bottom() - 22.0),
+                egui::pos2(rect.right() - 6.0, rect.top() + 20.0),
+            ],
+            egui::Stroke::new(w * 2.2, c(road)),
+        );
+    }
+    if let Some(water) = crate::basemap_style::fill(pal, "water", "") {
+        painter.rect_filled(
+            egui::Rect::from_min_size(
+                egui::pos2(rect.left(), rect.bottom() - 14.0),
+                egui::vec2(rect.width(), 14.0),
+            ),
+            0.0,
+            c(water),
+        );
+    }
+}
+
+/// The `Auto` card: half the Dark swatch, half the Light one, because that is what it does.
+fn auto_swatch(painter: &egui::Painter, rect: egui::Rect) {
+    let (l, r) = rect.split_left_right_at_fraction(0.5);
+    swatch(painter, l, BasemapStyle::Dark);
+    swatch(painter, r, BasemapStyle::Light);
+}
+
+/// One card. Returns its click response.
+fn card(
+    ui: &mut egui::Ui,
+    tiles: &mut TileManager,
+    style: BasemapStyle,
+    selected: bool,
+    enabled: bool,
+) -> egui::Response {
+    let (rect, response) = ui.allocate_exact_size(
+        egui::vec2(CARD_W, CARD_H + 16.0),
+        if enabled {
+            egui::Sense::click()
+        } else {
+            egui::Sense::hover()
+        },
+    );
+    if !ui.is_rect_visible(rect) {
+        return response;
+    }
+    let img_rect = egui::Rect::from_min_size(rect.min, egui::vec2(CARD_W, CARD_H));
+    let painter = ui.painter_at(rect);
+    // Only ask for a thumbnail once the card is on screen, so opening the picker does not fire
+    // fifty fetches for cards nobody scrolled to.
+    let thumb = if style.is_raster() {
+        tiles.thumb(style, ui.ctx())
+    } else {
+        None
+    };
+    match thumb {
+        Some(tex) => {
+            egui::Image::new(&tex)
+                .corner_radius(4.0)
+                .paint_at(ui, img_rect);
+        }
+        None if style == BasemapStyle::Auto => auto_swatch(&painter, img_rect),
+        None => swatch(&painter, img_rect, style),
+    }
+    if !enabled {
+        painter.rect_filled(
+            img_rect,
+            4.0,
+            egui::Color32::from_black_alpha(150),
+        );
+        painter.text(
+            img_rect.center(),
+            egui::Align2::CENTER_CENTER,
+            "🔒",
+            egui::FontId::proportional(18.0),
+            egui::Color32::from_gray(210),
+        );
+    }
+    let border = if selected {
+        egui::Stroke::new(2.0, ui.visuals().selection.bg_fill)
+    } else if response.hovered() {
+        egui::Stroke::new(1.0, ui.visuals().widgets.hovered.bg_stroke.color)
+    } else {
+        egui::Stroke::new(1.0, ui.visuals().widgets.inactive.bg_stroke.color)
+    };
+    painter.rect_stroke(img_rect, 4.0, border, egui::StrokeKind::Inside);
+    painter.text(
+        egui::pos2(rect.center().x, img_rect.bottom() + 2.0),
+        egui::Align2::CENTER_TOP,
+        style.short_label(),
+        egui::FontId::proportional(11.0),
+        ui.visuals().text_color(),
+    );
+    response
+}
+
+/// The whole grid. Returns the style the user picked, if any.
+///
+/// Takes `Settings` rather than three loose flags because availability depends on two API keys
+/// and the custom template, and passing those separately is how they get out of step.
+pub fn grid(
+    ui: &mut egui::Ui,
+    tiles: &mut TileManager,
+    current: BasemapStyle,
+    settings: &Settings,
+) -> Option<BasemapStyle> {
+    let mb = !settings.mapbox_key.is_empty();
+    let mt = !settings.maptiler_key.is_empty();
+    let cx = crate::tiles::valid_xyz_template(&settings.custom_tile_url);
+    let mut picked = None;
+    for cat in Category::ALL {
+        let styles: Vec<BasemapStyle> = BasemapStyle::ALL
+            .into_iter()
+            .filter(|s| s.category() == cat)
+            // A style whose key is missing is still shown, locked — that is how anyone finds out
+            // the key would unlock it. A custom slot with no template is not, because there is
+            // nothing to say about it that the settings row does not already say.
+            .filter(|s| *s != BasemapStyle::CustomXyz || cx)
+            .collect();
+        if styles.is_empty() {
+            continue;
+        }
+        ui.label(egui::RichText::new(cat.label()).strong());
+        ui.horizontal_wrapped(|ui| {
+            for s in styles {
+                let enabled = s.available(mb, mt, cx);
+                let r = card(ui, tiles, s, s == current, enabled);
+                if r.clicked() {
+                    picked = Some(s);
+                }
+                if !enabled {
+                    r.on_hover_text(match s.provider_kind() {
+                        crate::tiles::Provider::Mapbox => "Needs a Mapbox access token (Settings)",
+                        crate::tiles::Provider::MapTiler => "Needs a MapTiler API key (Settings)",
+                        crate::tiles::Provider::Builtin => "Not available in this build",
+                    });
+                }
+            }
+        });
+        ui.add_space(6.0);
+    }
+    picked
+}

--- a/crates/hookecho/src/ui/mod.rs
+++ b/crates/hookecho/src/ui/mod.rs
@@ -73,6 +73,7 @@ pub(crate) fn csv_buttons(
 pub mod about_window;
 pub mod afd_window;
 pub mod alert_panel;
+pub mod basemap_picker;
 pub mod cappi_window;
 pub mod cell_window;
 pub mod cells_window;

--- a/crates/hookecho/src/ui/wizard.rs
+++ b/crates/hookecho/src/ui/wizard.rs
@@ -49,6 +49,7 @@ pub fn show(
     settings: &mut Settings,
     basemap: &mut BasemapStyle,
     icon_tex: &IconTextures,
+    tiles: &mut crate::tiles::TileManager,
 ) -> Option<Finish> {
     if !wiz.open {
         return None;
@@ -65,7 +66,7 @@ pub fn show(
             ui.set_width(420.0_f32.min(ctx.content_rect().width() - 40.0));
             match wiz.step {
                 0 => card_site(ui, wiz, settings),
-                1 => card_map(ui, settings, basemap),
+                1 => card_map(ui, settings, basemap, tiles),
                 2 => card_alerts(ui, settings, icon_tex),
                 _ => {
                     if let Some(take_tour) = card_done(ui, settings, *basemap) {
@@ -127,7 +128,12 @@ fn card_site(ui: &mut egui::Ui, wiz: &mut Wizard, settings: &mut Settings) {
         });
 }
 
-fn card_map(ui: &mut egui::Ui, settings: &mut Settings, basemap: &mut BasemapStyle) {
+fn card_map(
+    ui: &mut egui::Ui,
+    settings: &mut Settings,
+    basemap: &mut BasemapStyle,
+    tiles: &mut crate::tiles::TileManager,
+) {
     heading(ui, 1);
     ui.small(
         "Plenty of basemaps work with no key at all. Free keys from mapbox.com and maptiler.com \
@@ -140,24 +146,13 @@ fn card_map(ui: &mut egui::Ui, settings: &mut Settings, basemap: &mut BasemapSty
     ui.add_space(4.0);
     super::settings_window::key_field(ui, "MapTiler key", &mut settings.maptiler_key);
     ui.add_space(6.0);
-    // Basemap picker, filtered by whichever keys are set this frame (typing a key unlocks styles).
-    let mb = !settings.mapbox_key.is_empty();
-    let mt = !settings.maptiler_key.is_empty();
-    let cx = crate::tiles::valid_xyz_template(&settings.custom_tile_url);
-    ui.horizontal(|ui| {
-        ui.label("Basemap");
-        egui::ComboBox::from_id_salt("wiz_basemap")
-            .selected_text(basemap.label())
-            .show_ui(ui, |ui| {
-                for s in BasemapStyle::ALL {
-                    if s.available(mb, mt, cx)
-                        && ui.selectable_label(*basemap == s, s.label()).clicked()
-                    {
-                        *basemap = s;
-                        settings.basemap = s.slug().to_string();
-                    }
-                }
-            });
+    // Same grid the drawer and the phone sheet use: the first thing a new user picks should look
+    // like the thing they will use to change it later. It re-filters as keys are typed above.
+    egui::ScrollArea::vertical().max_height(300.0).show(ui, |ui| {
+        if let Some(s) = crate::ui::basemap_picker::grid(ui, tiles, *basemap, settings) {
+            *basemap = s;
+            settings.basemap = s.slug().to_string();
+        }
     });
     ui.add_space(8.0);
     ui.label("Theme");


### PR DESCRIPTION
Closes out Wave C. Stacked on #53.

The complaint that started the basemap work was "basemaps very lacking". There were forty of them. The problem was never the count — a flat list of names is not a way to choose a *look*, and by the end of this release there are **51** names in it.

## What it is

A grid of thumbnails grouped into Vector / Streets / Satellite / Terrain / Other. One widget (`ui/basemap_picker.rs`), three call sites:

- **Drawer → Map** — behind a `Background: <name>` button, because fifty cards inline would push the panel apart
- **Phone sheet → All basemaps** — replaces the chip wall
- **First-run wizard** — the first basemap you pick should look like the thing you will use to change it later

The phone **keeps** its chip row for the eight common styles: one tap, no scrolling, thumb-reachable. It was the other forty-odd that needed this.

## Thumbnails

Raster styles show a real tile — z6 over the middle of CONUS, one per style, through the same per-style disk cache as any other tile. Opening the picker twice costs nothing. Fetches are lazy (only cards actually on screen ask), capped at **4 in flight** so the picker cannot starve the map's own tile fetches, and skipped entirely on a metered link.

Vector styles get a **painted swatch** of their own palette rather than a rasterised MVT tile. The swatch is honest about the colors, which is what the choice is actually between, and it needs no fetch at all. `Auto` gets a split swatch, half Dark half Light, because that is what it does.

Styles whose provider key is missing are shown **locked, not hidden** — that is how anyone finds out a key would unlock them. Hover says which key.

## Verification

`clippy` · `cargo test --workspace` (472) · wasm check · `shoot.sh check` — clean.

Driven under Xvfb: drawer → Map → Background, grid opens, six vector swatches visibly different from one another, Streets thumbnails arriving as real imagery, selection outlined, scrolls.

New test: `categories_partition_the_style_list` — every style lands in exactly one section and no section is empty, so a style added later cannot go invisible.

---

**Wave C is now complete**: #52 (sources) → #53 (cartography) → #54 (picker), stacked on Wave A's #48 → #49. That is six unmerged PRs in one chain. Worth a review pass before I start Wave D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)