### PR TITLE
radar accuracy: beam geometry, dealiasing, smoothing

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -3224,8 +3224,9 @@ impl HookEchoApp {
         let beam = crate::elevation::BeamSite {
             lon: site.longitude as f64,
             lat: site.latitude as f64,
-            // The site registry is the elevation source; `elevation::TOWER_M` adds the antenna.
+            // The site registry is the elevation source; the tower table adds the antenna.
             ground_m: site.elevation_meters as f64,
+            tower_m: wxdata::towers::tower_m(site.id),
             tilt_deg: tilt_deg as f64,
         };
         self.blockage_pending = Some((key.clone(), Instant::now()));

--- a/crates/hookecho/src/elevation.rs
+++ b/crates/hookecho/src/elevation.rs
@@ -191,14 +191,17 @@ pub struct BeamSite {
     pub lat: f64,
     /// Ground elevation MSL from the site registry, in metres.
     pub ground_m: f64,
+    /// Antenna height above `ground_m`, from [`wxdata::towers::tower_m`].
+    pub tower_m: f64,
     /// Elevation angle of the tilt being displayed, in degrees.
     pub tilt_deg: f64,
 }
 
-/// Antenna height above the site's registry ground elevation. The registry carries the ground, not
-/// the feedhorn, and WSR-88D towers are all in this neighbourhood.
-/// ponytail: one constant for every site; per-site tower heights if a shading check needs them.
-pub const TOWER_M: f64 = 20.0;
+/// Antenna height above the site's registry ground elevation, for a site we have no measurement
+/// for. Real per-site heights live in [`wxdata::towers`] — they run from 10 m to 55 m, so the flat
+/// 20 m this used to be was wrong by up to 35 m, about a fifth of a degree of beam elevation at
+/// 10 km.
+pub const TOWER_M: f64 = wxdata::towers::DEFAULT_TOWER_M;
 
 /// Beam is only useful out to about the unambiguous range; past it there is nothing to shade.
 const MAX_RANGE_KM: f64 = 250.0;
@@ -250,7 +253,7 @@ pub async fn blockage_image(
     site: BeamSite,
     world: [f64; 4],
 ) -> egui::ColorImage {
-    let radar_msl = site.ground_m + TOWER_M;
+    let radar_msl = site.ground_m + site.tower_m;
     let polar = occultation(client, site, radar_msl).await;
     let mut px = vec![egui::Color32::TRANSPARENT; RASTER_N * RASTER_N];
     let (wx0, wy0, wx1, wy1) = (world[0], world[1], world[2], world[3]);
@@ -387,6 +390,7 @@ mod tests {
             lon: -122.717,
             lat: 42.081,
             ground_m: summit as f64,
+            tower_m: wxdata::towers::tower_m("KMAX"),
             tilt_deg: 0.5,
         };
         let (cx, cy) = crate::render::mercator::lonlat_to_world(site.lon, site.lat);

--- a/crates/hookecho/src/shaders/radar.wgsl
+++ b/crates/hookecho/src/shaders/radar.wgsl
@@ -47,6 +47,14 @@ fn vs_main(in: VsIn) -> VsOut {
     return out;
 }
 
+// Width of the blend band as a fraction of a cell. 1.0 is plain bilinear; 0.0 is nearest.
+// ponytail: one fixed constant. It becomes a slider if anyone actually wants to tune it.
+const SHARPEN_W: f32 = 0.55;
+
+fn sharpen(t: f32) -> f32 {
+    return smoothstep(0.5 - SHARPEN_W * 0.5, 0.5 + SHARPEN_W * 0.5, t);
+}
+
 fn world_to_lonlat(w: vec2<f32>) -> vec2<f32> {
     let lon = w.x * 360.0 - 180.0;
     let n = PI * (1.0 - 2.0 * w.y);
@@ -93,8 +101,13 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
         let af = az_bin - 0.5;
         let g0 = i32(floor(gf));
         let a0 = i32(floor(af));
-        let tg = gf - floor(gf);
-        let ta = af - floor(af);
+        // Sharpened bilinear. Plain bilinear ramps linearly all the way across a gate, which
+        // smears every edge in the field by a full gate — a hail core's boundary and the far side
+        // of a hook both go soft, and the smoothing setting stops being usable for interrogation.
+        // Squeezing the ramp into a band around the cell boundary keeps the interior of each gate
+        // at its own value (crisp edges) while removing the staircase between them.
+        let tg = sharpen(gf - floor(gf));
+        let ta = sharpen(af - floor(af));
         var acc = 0.0;
         var wsum = 0.0;
         for (var i = 0; i < 2; i++) {

--- a/crates/wxdata/src/dealias.rs
+++ b/crates/wxdata/src/dealias.rs
@@ -12,6 +12,26 @@
 //! global edge-cost optimization, and no second (sequential) pass. Sound and deterministic
 //! for typical single-fold storms; upgrade to the graph optimizer if multi-fold cases
 //! (very high-shear tornadic couplets past 2·V_ny) show seams.
+//!
+//! Two things it does do beyond the simplest version of that idea. Region folds are chosen by a
+//! *vote* over the gate pairs along a boundary rather than by averaging them: one stray pair on a
+//! long boundary used to be able to drag the mean across the rounding line and fold a whole
+//! region wrongly. And the anchor region can be tied to a reference field — the previous sweep's
+//! already-dealiased velocity — instead of being assumed unfolded, which is what keeps a storm
+//! that is genuinely moving faster than the Nyquist velocity from snapping back to zero folds the
+//! moment it becomes the largest region in the sweep.
+//!
+//! ponytail: one previous sweep of continuity, not a 4D UNRAVEL-style solve.
+
+/// The fold with the most votes. Ties break toward the smaller unfold: with no evidence either
+/// way, the answer that moves the data least is the safer one.
+fn winning_fold(votes: std::collections::HashMap<i32, u32>) -> i32 {
+    votes
+        .into_iter()
+        .max_by_key(|&(fold, n)| (n, -fold.abs()))
+        .map(|(fold, _)| fold)
+        .unwrap_or(0)
+}
 
 /// Estimate the Nyquist velocity from a folded field as the largest observed |v|.
 /// Folded data saturates at ±V_ny, so this is a robust practical proxy when the model
@@ -30,6 +50,24 @@ pub fn dealias(
     az_bins: usize,
     gate_count: usize,
     nyquist: f32,
+) -> Vec<Option<f32>> {
+    dealias_with_reference(vel, az_bins, gate_count, nyquist, None)
+}
+
+/// As [`dealias`], with an optional continuity reference on the same grid — normally the previous
+/// sweep's dealiased output.
+///
+/// The reference does one job: it decides how many folds the *anchor* region carries, instead of
+/// the anchor being assumed unfolded. Everything else is unchanged, because every other region is
+/// already solved relative to the anchor. A sweep whose fastest air is genuinely past the Nyquist
+/// velocity is stable across volumes this way rather than snapping to zero whenever the fast
+/// region happens to become the biggest one.
+pub fn dealias_with_reference(
+    vel: &[Option<f32>],
+    az_bins: usize,
+    gate_count: usize,
+    nyquist: f32,
+    reference: Option<&[Option<f32>]>,
 ) -> Vec<Option<f32>> {
     let n = az_bins * gate_count;
     debug_assert_eq!(vel.len(), n);
@@ -127,6 +165,25 @@ pub fn dealias(
     let Some(anchor) = (0..region_count).max_by_key(|&r| sizes[r]) else {
         return vel.to_vec();
     };
+    // Anchor fold: zero unless a reference field says otherwise. Same vote, against the previous
+    // sweep's value at each of the anchor's own gates.
+    unfold[anchor] = reference
+        .filter(|r| r.len() == n)
+        .map(|refv| {
+            let mut votes: std::collections::HashMap<i32, u32> = std::collections::HashMap::new();
+            for i in 0..n {
+                if labels[i] != anchor {
+                    continue;
+                }
+                let (Some(v), Some(rv)) = (vel[i], refv[i]) else {
+                    continue;
+                };
+                let fold = ((rv as f64 - v as f64) / interval as f64).round() as i32;
+                *votes.entry(fold).or_insert(0) += 1;
+            }
+            winning_fold(votes)
+        })
+        .unwrap_or(0);
     solved[anchor] = true;
     let mut queue = std::collections::VecDeque::new();
     for &(nb, _, _) in &edges[anchor] {
@@ -138,24 +195,29 @@ pub fn dealias(
         if solved[r] {
             continue;
         }
-        // Fold count that best aligns this region with its already-solved neighbors:
-        // per boundary edge the ideal fold is round(((v_nb + f_nb·interval) - v_self)/interval);
-        // average over all such edges, then round to an integer number of folds.
-        let mut sum = 0.0f64;
-        let mut count = 0u32;
+        // Fold count that best aligns this region with its already-solved neighbours. Each
+        // boundary gate pair votes for the integer fold that would make it continuous, and the
+        // fold with the most votes wins.
+        //
+        // This used to average the per-pair ideal folds and round the mean. On a long boundary
+        // that is fragile: the pairs cluster tightly around the right integer, but a handful of
+        // pairs sitting on a genuine shear line contribute values half a fold away, and a mean
+        // near x.5 rounds the whole region the wrong way. A vote cannot be dragged like that —
+        // the outliers have to outnumber the rest, not merely outweigh them.
+        let mut votes: std::collections::HashMap<i32, u32> = std::collections::HashMap::new();
         for &(nb, v_self, v_nb) in &edges[r] {
             if solved[nb] {
                 let target = v_nb as f64 + unfold[nb] as f64 * interval as f64;
-                sum += (target - v_self as f64) / interval as f64;
-                count += 1;
+                let fold = ((target - v_self as f64) / interval as f64).round() as i32;
+                *votes.entry(fold).or_insert(0) += 1;
             }
         }
-        if count == 0 {
+        if votes.is_empty() {
             // Not yet reachable from the solved set; requeue later.
             queue.push_back(r);
             continue;
         }
-        unfold[r] = (sum / count as f64).round() as i32;
+        unfold[r] = winning_fold(votes);
         solved[r] = true;
         for &(nb, _, _) in &edges[r] {
             if !solved[nb] {
@@ -230,5 +292,130 @@ mod tests {
     fn passthrough_when_no_nyquist() {
         let f = vec![Some(3.0f32), None, Some(-7.0)];
         assert_eq!(dealias(&f, 1, 3, 0.0), f);
+    }
+
+    /// Build a folded sweep from a truth field: `v_folded = ((v + nyq) mod 2nyq) - nyq`.
+    fn fold(truth: &[f32], nyq: f32) -> Vec<Option<f32>> {
+        truth
+            .iter()
+            .map(|&v| Some(((v + nyq).rem_euclid(2.0 * nyq)) - nyq))
+            .collect()
+    }
+
+    /// Compare two fields up to one whole-field constant fold, which is all an unreferenced
+    /// dealias can ever recover.
+    fn matches_up_to_a_constant_fold(got: &[Option<f32>], truth: &[f32], nyq: f32) -> bool {
+        let interval = 2.0 * nyq;
+        let Some(offset) = got.first().and_then(|g| *g).map(|g| truth[0] - g) else {
+            return false;
+        };
+        let offset = (offset / interval).round() * interval;
+        got.iter()
+            .zip(truth)
+            .all(|(g, t)| g.is_none_or(|g| (g + offset - t).abs() < 0.5))
+    }
+
+    /// A tornadic couplet: inbound and outbound maxima either side of a shear line, both past the
+    /// Nyquist velocity so both fold. The shear line itself is a real discontinuity — the point of
+    /// the fixture is that the dealiaser must not treat it as a fold.
+    #[test]
+    fn unfolds_an_aliased_couplet_across_a_shear_line() {
+        let nyq = 25.0f32;
+        let (az_bins, gates) = (36, 20);
+        let mut truth = vec![0.0f32; az_bins * gates];
+        for az in 0..az_bins {
+            for g in 0..gates {
+                // Inbound on one side of the couplet, outbound on the other, peaking at 40 m/s —
+                // well past the 25 m/s Nyquist, so the field folds on both sides.
+                let across = if az < az_bins / 2 { -1.0 } else { 1.0 };
+                let ramp = (g as f32 / (gates - 1) as f32) * 40.0;
+                truth[az * gates + g] = across * ramp;
+            }
+        }
+        let folded = fold(&truth, nyq);
+        assert!(
+            folded.iter().enumerate().any(|(i, v)| {
+                (v.unwrap() - truth[i]).abs() > 1.0
+            }),
+            "fixture should actually fold"
+        );
+        let out = dealias(&folded, az_bins, gates, nyq);
+        // Every gate recovered, up to the one constant fold the anchor choice leaves free.
+        assert!(
+            matches_up_to_a_constant_fold(&out, &truth, nyq),
+            "couplet not recovered"
+        );
+    }
+
+    /// The failure the vote exists to prevent: a long boundary whose gate pairs mostly agree on
+    /// one fold, plus a minority sitting on a shear line that pull the *mean* over the rounding
+    /// line. Averaging folds the region the wrong way; voting does not.
+    #[test]
+    fn a_minority_of_shear_pairs_cannot_outweigh_the_boundary() {
+        // Nine boundary gate pairs agree on fold 1; three sit on a shear line and ask for 3.
+        // The mean of those is 1.5 and rounds away to 2, which is what the old code did. The vote
+        // holds, because the outliers have to outnumber the majority, not merely outweigh it.
+        let ideal = [1.0_f64; 9]
+            .into_iter()
+            .chain([3.0_f64; 3])
+            .collect::<Vec<_>>();
+        let mean = ideal.iter().sum::<f64>() / ideal.len() as f64;
+        assert_eq!(mean.round() as i32, 2, "the mean really is dragged across");
+
+        let mut votes = std::collections::HashMap::new();
+        for v in &ideal {
+            *votes.entry(v.round() as i32).or_insert(0) += 1;
+        }
+        assert_eq!(winning_fold(votes), 1);
+    }
+
+    #[test]
+    fn an_empty_or_tied_vote_moves_the_data_least() {
+        assert_eq!(winning_fold(std::collections::HashMap::new()), 0);
+        let tied = std::collections::HashMap::from([(0, 4), (3, 4)]);
+        assert_eq!(winning_fold(tied), 0);
+        let tied_both_folded = std::collections::HashMap::from([(-1, 2), (4, 2)]);
+        assert_eq!(winning_fold(tied_both_folded), -1);
+    }
+
+    /// Continuity: a field whose *whole* content is past the Nyquist velocity has no internal
+    /// evidence of how many folds it carries, so an unreferenced dealias anchors it at zero. Given
+    /// the previous sweep it should keep the folds instead of snapping back.
+    #[test]
+    fn a_reference_sweep_anchors_folds_the_field_cannot_infer() {
+        let nyq = 25.0f32;
+        let (az_bins, gates) = (4, 8);
+        // Uniformly 60 m/s outbound: one region, folds once, and nothing inside the sweep says so.
+        let truth = vec![60.0f32; az_bins * gates];
+        let folded = fold(&truth, nyq);
+        let bare = dealias(&folded, az_bins, gates, nyq);
+        assert!(
+            (bare[0].unwrap() - 60.0).abs() > 1.0,
+            "without a reference there is nothing to anchor to"
+        );
+        // The previous sweep had the same air, correctly unfolded.
+        let reference: Vec<Option<f32>> = truth.iter().map(|v| Some(*v)).collect();
+        let out = dealias_with_reference(&folded, az_bins, gates, nyq, Some(&reference));
+        for v in out.iter().flatten() {
+            assert!((v - 60.0).abs() < 0.5, "expected 60 m/s, got {v}");
+        }
+    }
+
+    /// A reference of the wrong shape, or one full of holes, must be ignored rather than trusted.
+    #[test]
+    fn a_useless_reference_changes_nothing() {
+        let nyq = 25.0f32;
+        let folded = fold(&[10.0, 20.0, 30.0, 40.0], nyq);
+        let bare = dealias(&folded, 1, 4, nyq);
+        let wrong_size = vec![Some(60.0f32); 99];
+        assert_eq!(
+            dealias_with_reference(&folded, 1, 4, nyq, Some(&wrong_size)),
+            bare
+        );
+        let all_holes = vec![None; 4];
+        assert_eq!(
+            dealias_with_reference(&folded, 1, 4, nyq, Some(&all_holes)),
+            bare
+        );
     }
 }

--- a/crates/wxdata/src/lib.rs
+++ b/crates/wxdata/src/lib.rs
@@ -50,6 +50,7 @@ pub mod task;
 pub mod tds;
 pub mod tdwr;
 pub mod torclimo;
+pub mod towers;
 pub mod tropical;
 pub mod tz;
 pub mod verify;

--- a/crates/wxdata/src/towers.rs
+++ b/crates/wxdata/src/towers.rs
@@ -1,0 +1,207 @@
+//! Per-site WSR-88D antenna height above the ground elevation the site registry carries.
+//!
+//! The beam-height model used one flat 20 m for every site, with a `ponytail:` note saying the
+//! towers were "all in this neighbourhood". They are not: across the 152 sites below they run
+//! from 9.8 m to 54.8 m, a spread of 45.0 m. At 10 km that is about a fifth of a
+//! degree of beam elevation, which is the difference between a ridge clearing the beam and
+//! blocking it.
+//!
+//! Derived, not transcribed: NCEI's `nexrad-stations.txt` publishes each site's elevation in feet
+//! measured at the feedhorn, and the site registry publishes the ground elevation in metres. The
+//! tower is the difference. Both sources round (whole feet, whole metres), so each value here is
+//! good to about half a metre — far better than the 10 m error the flat constant carried.
+//!
+//! ponytail: WSR-88D only. TDWR and every other radar falls back to [`DEFAULT_TOWER_M`].
+
+/// Median of the table, used for any site not in it.
+pub const DEFAULT_TOWER_M: f64 = 29.8;
+
+/// `(ICAO, tower height in metres)`, sorted by id.
+const TOWERS: &[(&str, f64)] = &[
+    ("KABR", 24.5),
+    ("KABX", 24.9),
+    ("KAKQ", 43.7),
+    ("KAMA", 35.7),
+    ("KAMX", 29.8),
+    ("KAPX", 29.8),
+    ("KARX", 24.6),
+    ("KATX", 44.7),
+    ("KBBX", 14.4),
+    ("KBGM", 29.1),
+    ("KBIS", 29.9),
+    ("KBLX", 31.7),
+    ("KBMX", 34.3),
+    ("KBOX", 34.7),
+    ("KBRO", 19.8),
+    ("KBUF", 29.8),
+    ("KBYX", 24.1),
+    ("KCAE", 35.2),
+    ("KCBW", 35.1),
+    ("KCBX", 33.8),
+    ("KCCX", 24.7),
+    ("KCLE", 29.1),
+    ("KCLX", 39.8),
+    ("KCRP", 29.3),
+    ("KCXX", 34.4),
+    ("KCYS", 19.6),
+    ("KDAX", 34.9),
+    ("KDDC", 24.1),
+    ("KDFX", 19.5),
+    ("KDGX", 36.6),
+    ("KDIX", 25.1),
+    ("KDLH", 35.0),
+    ("KDMX", 34.8),
+    ("KDTX", 43.6),
+    ("KDVN", 29.4),
+    ("KDYX", 19.2),
+    ("KEAX", 29.8),
+    ("KEMX", 35.2),
+    ("KENX", 32.8),
+    ("KEOX", 31.7),
+    ("KEPZ", 34.6),
+    ("KESX", 25.2),
+    ("KEVX", 24.4),
+    ("KEWX", 40.8),
+    ("KEYX", 35.7),
+    ("KFCX", 29.7),
+    ("KFDR", 14.8),
+    ("KFDX", 15.0),
+    ("KFFC", 34.3),
+    ("KFSD", 19.7),
+    ("KFSX", 29.3),
+    ("KFTG", 35.2),
+    ("KFWS", 28.8),
+    ("KGGW", 32.6),
+    ("KGJX", 33.8),
+    ("KGLD", 19.6),
+    ("KGRB", 42.9),
+    ("KGRK", 19.8),
+    ("KGRR", 29.7),
+    ("KGSP", 29.8),
+    ("KGWX", 34.8),
+    ("KGYX", 19.5),
+    ("KHDX", 14.5),
+    ("KHGX", 30.1),
+    ("KHNX", 29.6),
+    ("KHPX", 9.8),
+    ("KHTX", 30.6),
+    ("KICT", 19.7),
+    ("KICX", 47.7),
+    ("KILN", 34.6),
+    ("KILX", 45.8),
+    ("KIND", 29.4),
+    ("KINX", 24.3),
+    ("KIWA", 21.6),
+    ("KIWX", 28.9),
+    ("KJAX", 38.8),
+    ("KJGX", 29.4),
+    ("KJKL", 30.3),
+    ("KLBB", 36.6),
+    ("KLCH", 37.8),
+    ("KLIX", 47.6),
+    ("KLNX", 42.8),
+    ("KLOT", 29.6),
+    ("KLRX", 45.6),
+    ("KLSX", 35.1),
+    ("KLTX", 25.2),
+    ("KLVX", 34.9),
+    ("KLWX", 40.1),
+    ("KLZK", 24.8),
+    ("KMAF", 28.8),
+    ("KMAX", 14.6),
+    ("KMBX", 29.6),
+    ("KMHX", 35.2),
+    ("KMKX", 19.8),
+    ("KMLB", 34.4),
+    ("KMOB", 25.1),
+    ("KMPX", 47.6),
+    ("KMQT", 34.8),
+    ("KMRX", 29.1),
+    ("KMSX", 37.7),
+    ("KMTX", 40.9),
+    ("KMUX", 25.0),
+    ("KMVX", 29.1),
+    ("KMXX", 48.7),
+    ("KNKX", 29.6),
+    ("KNQA", 46.6),
+    ("KOAX", 34.7),
+    ("KOHX", 30.0),
+    ("KOKX", 34.7),
+    ("KOTX", 18.5),
+    ("KPAH", 35.2),
+    ("KPBZ", 24.9),
+    ("KPDT", 19.6),
+    ("KPOE", 20.2),
+    ("KPUX", 34.6),
+    ("KRAX", 34.8),
+    ("KRGX", 29.1),
+    ("KRIW", 19.9),
+    ("KRLX", 40.7),
+    ("KRTX", 47.7),
+    ("KSFX", 19.5),
+    ("KSGF", 29.1),
+    ("KSHV", 35.0),
+    ("KSJT", 34.8),
+    ("KSOX", 23.7),
+    ("KSRX", 29.6),
+    ("KTBW", 24.2),
+    ("KTFX", 27.8),
+    ("KTLH", 34.9),
+    ("KTLX", 19.5),
+    ("KTWX", 14.3),
+    ("KTYX", 35.4),
+    ("KUDX", 54.8),
+    ("KUEX", 25.0),
+    ("KVAX", 46.6),
+    ("KVBX", 39.7),
+    ("KVNX", 14.4),
+    ("KVTX", 24.6),
+    ("KVWX", 35.5),
+    ("KYUX", 19.8),
+    ("PABC", 10.8),
+    ("PACG", 19.9),
+    ("PAEC", 11.4),
+    ("PAHG", 34.5),
+    ("PAIH", 20.2),
+    ("PAKC", 24.9),
+    ("PGUA", 39.7),
+    ("PHKI", 48.6),
+    ("PHKM", 47.8),
+    ("PHMO", 24.1),
+    ("PHWA", 24.3),
+    ("TJUA", 34.6),
+];
+
+/// Antenna height above ground for `id`, or [`DEFAULT_TOWER_M`] if the site is not a WSR-88D we
+/// have a measurement for.
+pub fn tower_m(id: &str) -> f64 {
+    TOWERS
+        .binary_search_by(|(k, _)| k.cmp(&id))
+        .map(|i| TOWERS[i].1)
+        .unwrap_or(DEFAULT_TOWER_M)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_table_is_sorted_and_plausible() {
+        assert!(TOWERS.windows(2).all(|w| w[0].0 < w[1].0), "binary_search needs sorted ids");
+        for (id, h) in TOWERS {
+            assert!(*h > 5.0 && *h < 80.0, "{id}: {h} m is not a radar tower");
+        }
+    }
+
+    #[test]
+    fn known_sites_resolve_and_unknown_ones_fall_back() {
+        // KTLX's tower is a shade under 20 m; KMXX's is nearly 50. The flat constant was right
+        // for one of them.
+        assert!((tower_m("KTLX") - 19.5).abs() < 0.05);
+        assert!((tower_m("KMXX") - 48.7).abs() < 0.05);
+        assert!(tower_m("KMXX") > tower_m("KTLX") + 20.0);
+        // TDWR ids and nonsense both fall back rather than panicking.
+        assert_eq!(tower_m("TOKC"), DEFAULT_TOWER_M);
+        assert_eq!(tower_m(""), DEFAULT_TOWER_M);
+    }
+}

--- a/crates/wxdata/src/xsection.rs
+++ b/crates/wxdata/src/xsection.rs
@@ -58,6 +58,38 @@ pub fn beam_height_km(slant_km: f64, elev_deg: f64) -> f64 {
         - R_EFF_KM
 }
 
+/// Slant range (km) to the point where the `elev_deg` beam passes over a ground range of
+/// `ground_km`, under the same 4/3-earth model as [`beam_height_km`].
+///
+/// This replaces `ground_km / cos(elev)`, which is the flat-earth answer. Under the 4/3-earth
+/// model the ground arc subtends an angle at the earth's centre, and the beam climbs away from
+/// the surface as it goes; the closed form falls out of the plane triangle formed by the earth's
+/// centre, the radar and the target:
+///
+/// ```text
+///     theta = ground_km / R_eff              (angle subtended at the centre)
+///     slant = R_eff * sin(theta) / cos(elev + theta)
+/// ```
+///
+/// As `R_eff` grows the angle vanishes and this collapses back to `ground_km / cos(elev)`, which
+/// is why the old approximation was good close in and drifted with range.
+pub fn slant_from_ground_km(ground_km: f64, elev_deg: f64) -> f64 {
+    let theta = ground_km / R_EFF_KM;
+    let denom = (elev_deg.to_radians() + theta).cos();
+    if denom.abs() < 1e-9 {
+        return ground_km;
+    }
+    R_EFF_KM * theta.sin() / denom
+}
+
+/// Ground range (km) under the beam at slant range `slant_km` — the inverse of
+/// [`slant_from_ground_km`], used to check it.
+pub fn ground_from_slant_km(slant_km: f64, elev_deg: f64) -> f64 {
+    let h = beam_height_km(slant_km, elev_deg);
+    let e = elev_deg.to_radians();
+    R_EFF_KM * (slant_km * e.cos() / (R_EFF_KM + h)).clamp(-1.0, 1.0).asin()
+}
+
 /// Great-circle distance (km) and initial bearing (deg from north) from `(lon0,lat0)` to `(lon,lat)`.
 pub(crate) fn dist_bearing(lon0: f64, lat0: f64, lon: f64, lat: f64) -> (f64, f64) {
     let (p0, p1) = (lat0.to_radians(), lat.to_radians());
@@ -84,9 +116,7 @@ pub(crate) fn column_samples(
     out.clear();
     for s in sweeps {
         let e = s.elevation_deg as f64;
-        // ponytail: flat-fan slant approximation (ground/cos elev); exact inversion of the
-        // 4/3-earth ground-range formula only matters past ~200 km — fine for interrogation.
-        let slant = ground_km / e.to_radians().cos();
+        let slant = slant_from_ground_km(ground_km, e);
         let gate = ((slant - s.first_gate_km as f64) / s.gate_interval_km.max(f32::EPSILON) as f64)
             .round();
         if gate < 0.0 || gate as usize >= s.gate_count {
@@ -211,5 +241,39 @@ mod tests {
         assert_eq!(sample_profile(&s, 2.0), Some(30.0)); // midpoint
         assert_eq!(sample_profile(&s, 1.0), Some(20.0));
         assert_eq!(sample_profile(&s, 10.0), None); // far above top beam
+    }
+
+    /// The slant/ground conversion has to round-trip, or the cross-section is sampling the wrong
+    /// gate and drawing it at the wrong height.
+    #[test]
+    fn slant_and_ground_range_are_inverses() {
+        for elev in [0.5_f64, 1.5, 4.3, 10.0, 19.5] {
+            for ground in [1.0_f64, 10.0, 50.0, 100.0, 200.0, 300.0] {
+                let slant = slant_from_ground_km(ground, elev);
+                let back = ground_from_slant_km(slant, elev);
+                assert!(
+                    (back - ground).abs() < 0.01,
+                    "elev {elev} ground {ground}: round-tripped to {back}"
+                );
+                // The beam never gets closer than the ground range it covers.
+                assert!(slant >= ground - 1e-6, "elev {elev} ground {ground}");
+            }
+        }
+    }
+
+    /// What the flat-earth approximation this replaced actually cost. Close in it was right to
+    /// centimetres; at long range it put the sample in the wrong gate.
+    #[test]
+    fn the_flat_earth_approximation_drifts_with_range() {
+        let flat = |g: f64, e: f64| g / e.to_radians().cos();
+        assert!((slant_from_ground_km(10.0, 0.5) - flat(10.0, 0.5)).abs() < 0.01);
+        // A quarter-kilometre gate is 250 m wide. The error grows with both range and tilt: at
+        // 0.5° it stays inside a gate all the way out, but the upper tilts of a VCP walk clear of
+        // one — at 4.3° and 230 km the old formula was two gates out, so the cross-section read
+        // the wrong gate *and* drew it at the wrong height.
+        let err = (slant_from_ground_km(230.0, 4.3) - flat(230.0, 4.3)).abs();
+        assert!(err > 0.5, "expected a multi-gate error at long range, got {err} km");
+        // And still under a gate where most interrogation happens.
+        assert!((slant_from_ground_km(100.0, 0.5) - flat(100.0, 0.5)).abs() < 0.25);
     }
 }


### PR DESCRIPTION
Wave D, part one. Three bounded commits, independent of the basemap stack — this branches off `main`, not the Wave A/C chain.

## Beam geometry (`6c9bccc`)

Two approximations that each carried a `ponytail:` note saying "good enough close in". Both were wrong further out.

**Antenna height** was one flat 20 m for every site, with a comment claiming WSR-88D towers are "all in this neighbourhood". Across the 152 sites in the registry they run **10 m to 55 m**. At 10 km that spread is about a fifth of a degree of beam elevation — the difference between a ridge clearing the beam and blocking it, which is the one question beam blockage exists to answer.

The table is derived, not transcribed. NCEI's `nexrad-stations.txt` publishes each site's elevation measured *at the feedhorn*; the site registry publishes the *ground* elevation. The tower is the difference. (Checked against KTLX: 1278 ft = 389.5 m feedhorn, 370 m ground, 19.5 m tower — which is why the flat 20 happened to look right to whoever picked it.) Both sources round, so each value is good to about half a metre. Unknown sites fall back to the table's median, 29.8 m, rather than the old 20.

**Cross-section slant range** was `ground_km / cos(elev)` — the flat-earth answer — while the *height* of that same sample was computed with the 4/3-earth model. The 4/3-earth inversion has a closed form, so there was nothing to approximate:

```
theta = ground_km / R_eff
slant = R_eff * sin(theta) / cos(elev + theta)
```

At 0.5° the old formula stayed inside a gate all the way out. On the upper tilts it did not: at 4.3° and 230 km it was **two gates** out, so the cross-section read the wrong gate and then drew it at that gate's height.

## Dealiasing (`3e608b3`)

**Fold selection is now a vote, not a mean.** Averaging the ideal fold over every gate pair along a boundary is fragile: the pairs cluster tightly around the right integer, but the handful on a genuine shear line sit half a fold away, and a mean near x.5 rounds the whole region wrongly. Nine pairs asking for 1 and three asking for 3 average to exactly 1.5. A vote can't be dragged like that — outliers have to outnumber the majority, not outweigh it. Ties break toward the smaller unfold.

**The anchor can be tied to a reference field.** A sweep whose air is genuinely faster than Nyquist carries no internal evidence of how many folds it has, so it snaps to zero the moment the fast region becomes the largest one. Given the previous sweep's dealiased velocity it stays put. `dealias` keeps its signature and delegates.

⚠️ **The reference is not wired into the decode path yet.** `bin_sweep_opts` bins one sweep with no access to the previous volume, so wiring it needs a per-(site, tilt) cache of the last dealiased field held in the app and threaded through the crate boundary — a change with its own review surface, and one that touches the wasm worker path. I've landed the capability with its tests and stopped there rather than bundling it in. Say the word and it's the next commit.

## Smoothing (`3e608b3`)

Plain bilinear ramps linearly all the way across a gate, so it smears every edge in the field by a full gate — a hail core's boundary and the far side of a hook both go soft, which is what made the setting unusable for interrogation. The blend now runs through a smoothstep band around the cell boundary (`SHARPEN_W = 0.55`): gate interiors keep their own value so edges stay crisp, and the staircase between them still goes away.

## Verification

`clippy` · `cargo test --workspace` (468) · wasm check · `shoot.sh check` — clean.

New tests: `slant_and_ground_range_are_inverses`, `the_flat_earth_approximation_drifts_with_range`, `the_table_is_sorted_and_plausible`, `known_sites_resolve_and_unknown_ones_fall_back`, `unfolds_an_aliased_couplet_across_a_shear_line`, `a_minority_of_shear_pairs_cannot_outweigh_the_boundary`, `an_empty_or_tied_vote_moves_the_data_least`, `a_reference_sweep_anchors_folds_the_field_cannot_infer`, `a_useless_reference_changes_nothing`.

Smoothing confirmed under Xvfb against the KTLX 2013-05-20 archive: gate interiors flat, transitions short, no full-gate smear. There are no radar-render goldens in-tree to diff against, so that is an eyeball check and I'd rather say so than imply otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)