### PR TITLE
labels: one collision pass for every layer that draws on the map

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1690,6 +1690,8 @@ pub struct HookEchoApp {
     spawner: crate::rt::Spawner,
     tiles: TileManager,
     vtiles: crate::vector_tiles::VectorTileManager,
+    /// One shared label-occupancy pass for the whole frame — see [`crate::labelplace`].
+    labels: crate::labelplace::Placer,
     settings: Settings,
     saved: Settings,
     views: Vec<MapView>,
@@ -2567,6 +2569,7 @@ impl HookEchoApp {
 
         let mut app = Self {
             vtiles,
+            labels: crate::labelplace::Placer::default(),
             spawner,
             #[cfg(not(target_arch = "wasm32"))]
             _rt: rt,
@@ -11298,6 +11301,50 @@ impl HookEchoApp {
         let view = &self.views[idx];
         let basemap = view.basemap;
 
+        // Storm-cell ids reserve their space first — they are the top tier, and the cell markers
+        // themselves are drawn much further down with the rest of the cell layer. Reserving here
+        // and drawing there is the whole reason the placer separates the two: a warning label
+        // must not lose its slot to a town name that merely happened to be painted earlier.
+        let cell_labels_shown: std::collections::HashSet<String> =
+            if self.filters.show_cells && self.cells_site.as_deref() == view.site.as_deref() {
+                let ids: Vec<(String, egui::Pos2)> = self
+                    .active_storm_cells()
+                    .iter()
+                    .filter(|c| c.kind == CellKind::Storm && !c.id.is_empty())
+                    .map(|c| {
+                        let w = crate::render::mercator::lonlat_to_world(c.lon, c.lat);
+                        let (sx, sy) = cam.world_to_screen(w, vp);
+                        (
+                            c.id.clone(),
+                            egui::pos2(prect.left() + sx, prect.top() + sy),
+                        )
+                    })
+                    .collect();
+                ids.into_iter()
+                    .filter(|(_, p)| prect.contains(*p))
+                    .filter(|(id, p)| {
+                        // Matches the draw below: 11 pt text, left-bottom anchored, up and right
+                        // of the marker.
+                        let anchor = *p + egui::vec2(8.0, -8.0);
+                        let size = egui::vec2(id.len() as f32 * 6.5, 13.0);
+                        let rect = egui::Rect::from_min_size(
+                            egui::pos2(anchor.x, anchor.y - size.y),
+                            size,
+                        )
+                        .expand(2.0);
+                        self.labels.place(
+                            crate::labelplace::key(id),
+                            rect,
+                            crate::labelplace::Priority::Warning,
+                        )
+                    })
+                    .map(|(id, _)| id)
+                    .collect()
+            } else {
+                std::collections::HashSet::new()
+            };
+        let view = &self.views[idx];
+
         // City/town labels, overlaid on every basemap. On raster (satellite) the baked-in labels
         // are faint over imagery + echoes, so we draw crisp white text with a solid black halo;
         // vector basemaps use their palette's label colors. Bigger fonts + an 8-way halo read well.
@@ -11319,8 +11366,16 @@ impl HookEchoApp {
             let z = cam.zoom;
             let mut labels: Vec<&crate::vector_tiles::PlaceLabel> =
                 vlabels.iter().filter(|l| l.city || z >= 9.0).collect();
-            labels.sort_by_key(|l| (!l.city, l.rank));
-            let mut placed: Vec<egui::Rect> = Vec::new();
+            // Labels already on screen are offered their slot before newcomers of the same
+            // importance; without that a name at the edge of a collision wins and loses on
+            // alternate frames, which is exactly the flicker you see while panning.
+            labels.sort_by_key(|l| {
+                (
+                    !self.labels.was_shown(crate::labelplace::key(&l.name)),
+                    !l.city,
+                    l.rank,
+                )
+            });
             let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
             // 8-way halo (cardinals + diagonals) for a solid, readable outline.
             const HALO: [egui::Vec2; 8] = [
@@ -11345,10 +11400,13 @@ impl HookEchoApp {
                 let font = egui::FontId::proportional(if l.city { big } else { big - 2.5 });
                 let galley = painter.layout_no_wrap(l.name.clone(), font, text_col);
                 let r = egui::Rect::from_min_size(p, galley.size()).expand(4.0);
-                if placed.iter().any(|q| q.intersects(r)) {
+                if !self.labels.place(
+                    crate::labelplace::key(&l.name),
+                    r,
+                    crate::labelplace::Priority::Place,
+                ) {
                     continue;
                 }
-                placed.push(r);
                 // One layout per label, reused for all nine draws. `painter.text` would lay the
                 // string out again every time, which at eight halo offsets meant ten text
                 // layouts per visible place name, every frame.
@@ -11832,7 +11890,7 @@ impl HookEchoApp {
                 let color = egui::Color32::from_rgba_unmultiplied(col[0], col[1], col[2], 255);
                 painter.circle_stroke(p, 6.0, egui::Stroke::new(2.0, color));
                 painter.circle_filled(p, 2.0, color);
-                if c.kind == CellKind::Storm && !c.id.is_empty() {
+                if c.kind == CellKind::Storm && cell_labels_shown.contains(&c.id) {
                     painter.text(
                         p + egui::vec2(8.0, -8.0),
                         egui::Align2::LEFT_BOTTOM,
@@ -12475,7 +12533,9 @@ impl HookEchoApp {
                     .unwrap_or(std::cmp::Ordering::Equal)
             });
             let temp_unit = self.settings.temp_unit;
-            let mut placed: Vec<egui::Rect> = Vec::new();
+            // Same stickiness rule as the place names: a station already plotted keeps its cell
+            // ahead of a windier one that has only just come into view.
+            obs.sort_by_key(|ob| !self.labels.was_shown(crate::labelplace::key(&ob.icao)));
             for ob in obs {
                 let w = crate::render::mercator::lonlat_to_world(ob.lon, ob.lat);
                 let (sx, sy) = cam.world_to_screen(w, vp);
@@ -12483,12 +12543,15 @@ impl HookEchoApp {
                 if !prect.contains(p) {
                     continue;
                 }
-                // Greedy declutter: skip stations whose plot cell overlaps one already drawn.
+                // Shared declutter: this also sees the place names drawn above it.
                 let cell = egui::Rect::from_center_size(p, egui::vec2(44.0, 34.0));
-                if placed.iter().any(|r| r.intersects(cell)) {
+                if !self.labels.place(
+                    crate::labelplace::key(&ob.icao),
+                    cell,
+                    crate::labelplace::Priority::Station,
+                ) {
                     continue;
                 }
-                placed.push(cell);
                 let col = flt_color(&ob.flt_cat);
                 painter.circle_stroke(p, 3.0, egui::Stroke::new(1.5, col));
                 // Wind barb, rotated so the shaft points toward the wind source (FROM bearing).
@@ -12578,7 +12641,6 @@ impl HookEchoApp {
                 FloodCat::NoFlooding => "no flooding",
                 FloodCat::Unknown => "no current reading",
             };
-            let mut placed: Vec<egui::Rect> = Vec::new();
             for g in &self.gauges {
                 let w = crate::render::mercator::lonlat_to_world(g.lon, g.lat);
                 let (sx, sy) = cam.world_to_screen(w, vp);
@@ -12586,12 +12648,15 @@ impl HookEchoApp {
                 if !prect.contains(p) {
                     continue;
                 }
-                // Greedy declutter: skip droplets that would overlap one already placed.
+                // Shared declutter: gauges are the lowest tier, so they fill what is left.
                 let cell = egui::Rect::from_center_size(p, egui::vec2(15.0, 15.0));
-                if placed.iter().any(|r| r.intersects(cell)) {
+                if !self.labels.place(
+                    crate::labelplace::key(&g.lid),
+                    cell,
+                    crate::labelplace::Priority::Minor,
+                ) {
                     continue;
                 }
-                placed.push(cell);
                 let s = 6.0;
                 painter.add(egui::Shape::convex_polygon(
                     vec![
@@ -12877,7 +12942,21 @@ impl HookEchoApp {
                 let r = if is_current { 5.0 } else { 3.5 };
                 painter.circle_stroke(p, r, egui::Stroke::new(1.5, col));
                 painter.circle_filled(p, 1.5, col);
-                if show_labels {
+                // The dot always draws — it is the click target, and it is small enough not to
+                // matter. Only the four-letter id competes for space, and it loses to city names:
+                // "TDAL" sitting across "Grapevine" is the exact overlap this pass exists for.
+                let id_rect = egui::Rect::from_min_size(
+                    p + egui::vec2(6.0, -6.0),
+                    egui::vec2(s.id.len() as f32 * 6.5, 12.0),
+                )
+                .expand(1.0);
+                if show_labels
+                    && self.labels.place(
+                        crate::labelplace::key(s.id),
+                        id_rect,
+                        crate::labelplace::Priority::Minor,
+                    )
+                {
                     painter.text(
                         p + egui::vec2(6.0, 0.0),
                         egui::Align2::LEFT_CENTER,
@@ -16375,6 +16454,10 @@ impl eframe::App for HookEchoApp {
         }
 
         let placefile_labels = self.placefile_labels();
+        // One occupancy set for the whole frame, across every pane and every label layer. Panes
+        // occupy disjoint screen rects, so sharing it between them costs nothing and saves
+        // resetting it per pane.
+        self.labels.begin();
         egui::CentralPanel::default().show(root, |ui| {
             let full = ui.available_rect_before_wrap();
             let n = self.views.len();

--- a/crates/hookecho/src/labelplace.rs
+++ b/crates/hookecho/src/labelplace.rs
@@ -1,0 +1,158 @@
+//! One frame-level label placer, shared by every layer that draws text or a symbol on the map.
+//!
+//! Each layer used to keep its own `Vec<Rect>` and greedily skip anything that overlapped
+//! something *it* had already drawn. Three of those existed, so a METAR plot could sit on top of
+//! a city name and a river gauge on top of both: each declutter was correct and the map still
+//! came out overlapped.
+//!
+//! This is the same greedy algorithm with two things added. The occupancy is shared, so a layer
+//! sees what every earlier layer took. And a label that was drawn last frame is offered its slot
+//! before any newcomer in its tier, which is what stops names flickering in and out while you pan
+//! — without stickiness a label at the edge of a collision wins and loses on alternate frames.
+//!
+//! ponytail: greedy by priority, no annealing and no nudging labels off their anchors. A label
+//! either fits where it belongs or it is not drawn.
+
+use std::collections::HashSet;
+
+/// Draw priority. Higher-priority layers reserve first, so a warning label can never be squeezed
+/// out by a river gauge that happened to be drawn earlier.
+///
+/// The order here *is* the order layers must call [`Placer::place`] in; [`Placer::place`] asserts
+/// it in debug builds, so getting the draw order wrong is a test failure rather than a subtle
+/// visual regression.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Priority {
+    /// Warnings and storm cells — the things the app exists to show.
+    Warning,
+    /// City and town names from the vector basemap.
+    Place,
+    /// Surface observations.
+    Station,
+    /// User placefile text.
+    Placefile,
+    /// River gauges, points of interest: useful, never at the expense of the above.
+    Minor,
+}
+
+/// A stable identity for one label across frames. Anything hashable that names the *object*, not
+/// its position — the position is what moves.
+pub type LabelKey = u64;
+
+/// Hash a string id into a [`LabelKey`].
+pub fn key(s: &str) -> LabelKey {
+    // ponytail: FNV-1a. This only has to separate labels within one frame's occupancy set.
+    let mut h: u64 = 0xcbf29ce484222325;
+    for b in s.as_bytes() {
+        h ^= *b as u64;
+        h = h.wrapping_mul(0x100000001b3);
+    }
+    h
+}
+
+#[derive(Default)]
+pub struct Placer {
+    taken: Vec<egui::Rect>,
+    /// Keys that were drawn on the previous frame.
+    shown_last: HashSet<LabelKey>,
+    /// Keys drawn so far this frame; becomes `shown_last` at the next [`Self::begin`].
+    shown_now: HashSet<LabelKey>,
+    /// Highest priority seen this frame, to catch a layer reserving out of order.
+    last_priority: Option<Priority>,
+}
+
+impl Placer {
+    /// Start a frame. Call once, before any layer places anything.
+    pub fn begin(&mut self) {
+        self.taken.clear();
+        std::mem::swap(&mut self.shown_last, &mut self.shown_now);
+        self.shown_now.clear();
+        self.last_priority = None;
+    }
+
+    /// Was this label drawn on the previous frame? Layers sort their candidates by this first, so
+    /// a label that is already on screen gets its slot back before a newcomer takes it.
+    pub fn was_shown(&self, key: LabelKey) -> bool {
+        self.shown_last.contains(&key)
+    }
+
+    /// Reserve `rect` for `key`. Returns false if it collides with something already reserved, in
+    /// which case the caller draws nothing.
+    pub fn place(&mut self, key: LabelKey, rect: egui::Rect, priority: Priority) -> bool {
+        debug_assert!(
+            self.last_priority.is_none_or(|p| p <= priority),
+            "label layers must reserve in priority order: {priority:?} after {:?}",
+            self.last_priority
+        );
+        self.last_priority = Some(priority);
+        if self.taken.iter().any(|r| r.intersects(rect)) {
+            return false;
+        }
+        self.taken.push(rect);
+        self.shown_now.insert(key);
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn r(x: f32, y: f32) -> egui::Rect {
+        egui::Rect::from_min_size(egui::pos2(x, y), egui::vec2(10.0, 10.0))
+    }
+
+    #[test]
+    fn overlapping_labels_lose_and_disjoint_ones_do_not() {
+        let mut p = Placer::default();
+        p.begin();
+        assert!(p.place(key("a"), r(0.0, 0.0), Priority::Place));
+        assert!(!p.place(key("b"), r(5.0, 5.0), Priority::Place));
+        assert!(p.place(key("c"), r(50.0, 50.0), Priority::Place));
+    }
+
+    /// The whole point of sharing one placer: a later layer must see what an earlier one took.
+    #[test]
+    fn occupancy_is_shared_across_layers() {
+        let mut p = Placer::default();
+        p.begin();
+        assert!(p.place(key("city"), r(0.0, 0.0), Priority::Place));
+        assert!(!p.place(key("metar"), r(4.0, 4.0), Priority::Station));
+        assert!(!p.place(key("gauge"), r(2.0, 2.0), Priority::Minor));
+    }
+
+    /// Stickiness: the caller asks about the previous frame and offers returning labels first,
+    /// which is what keeps a contested label from alternating frame to frame.
+    #[test]
+    fn a_label_drawn_last_frame_is_known_next_frame() {
+        let mut p = Placer::default();
+        p.begin();
+        assert!(!p.was_shown(key("a")));
+        p.place(key("a"), r(0.0, 0.0), Priority::Place);
+        // Still the same frame: `was_shown` is about the previous one.
+        assert!(!p.was_shown(key("a")));
+        p.begin();
+        assert!(p.was_shown(key("a")));
+        // Dropped for a frame, and it is no longer sticky.
+        p.begin();
+        assert!(!p.was_shown(key("a")));
+    }
+
+    #[test]
+    fn a_frame_starts_empty() {
+        let mut p = Placer::default();
+        p.begin();
+        assert!(p.place(key("a"), r(0.0, 0.0), Priority::Place));
+        p.begin();
+        assert!(p.place(key("b"), r(0.0, 0.0), Priority::Place));
+    }
+
+    #[test]
+    #[should_panic(expected = "priority order")]
+    fn reserving_out_of_priority_order_is_a_bug() {
+        let mut p = Placer::default();
+        p.begin();
+        p.place(key("gauge"), r(0.0, 0.0), Priority::Minor);
+        p.place(key("city"), r(50.0, 50.0), Priority::Place);
+    }
+}

--- a/crates/hookecho/src/lib.rs
+++ b/crates/hookecho/src/lib.rs
@@ -31,6 +31,7 @@ pub mod gps;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod headless;
 pub mod hotkeys;
+pub mod labelplace;
 pub mod icon;
 pub mod loopexport;
 pub mod notify;


### PR DESCRIPTION
Wave D, part two. Branches off `main`, independent of the basemap stack and of #55.

## The problem

Four layers each kept their own `Vec<Rect>` and greedily skipped anything overlapping something *they* had already drawn. Every one of those declutters was correct in isolation. The map still came out overlapped, because none of them could see the others: a METAR plot on a city name, a river gauge on both, `TDAL` written across `Grapevine`.

## What changed

One `labelplace::Placer` per frame, shared by every layer, reserved in priority order:

```
Warning  storm cell ids
Place    city and town names
Station  surface observations
Minor    river gauges, radar site ids
```

That order is not a comment. `Placer::place` debug-asserts that reservations arrive in non-decreasing priority, so drawing a layer in the wrong order fails a test instead of quietly regressing.

**Storm cell ids reserve somewhere other than where they draw.** The cell layer is painted well below the basemap labels, and "a warning label loses its slot to a town name that happened to be painted first" is the exact failure this exists to prevent. So the ids reserve at the top of the pane and the accepted set is consulted at the draw site.

**Stickiness.** A label drawn last frame is offered its slot before any newcomer in the same tier. Without it a label right at the edge of a collision wins and loses on alternate frames — the flicker you get panning slowly across a metro.

## Deliberately excluded

**Placefile labels.** They carry a user-specified anchor and pixel offset. The author said exactly where they want that text; silently dropping it because a town name got there first is the wrong answer, so they draw unconditionally as before.

## Note on the plan

This PR was specced to build on the placement cache from PR 4. That cache was never built, because #51's profiling showed label placement isn't hot — `placefile_labels()` costs 0.3 µs against a 16.7 ms budget. So this is the collision work on its own, with no caching layer under it, and nothing in it is measurably expensive.

## Verification

`clippy` · `cargo test --workspace` (464) · wasm check · `shoot.sh check` — clean.

Confirmed over the DFW metro under Xvfb, the densest label field in the country. Before: `TDAL` across `Grapevine`, `TDFW` across `Lewisville`. After: the site dots remain (they are the click target) and their ids yield to the city names.

New tests: `overlapping_labels_lose_and_disjoint_ones_do_not`, `occupancy_is_shared_across_layers`, `a_label_drawn_last_frame_is_known_next_frame`, `a_frame_starts_empty`, `reserving_out_of_priority_order_is_a_bug`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)