### PR TITLE
chrome audit: one bad settings value no longer discards the whole file

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -7693,7 +7693,13 @@ impl HookEchoApp {
                 T::MiniLoop,
                 "Reference",
                 "Mini loop window",
-                "A small always-on-top window showing the active pane",
+                // Honest about the caveat rather than promising something the compositor will
+                // not do — see `mini_loop_viewport`.
+                if cfg!(unix) && std::env::var_os("WAYLAND_DISPLAY").is_some() {
+                    "A small window showing the active pane (Wayland cannot keep it on top)"
+                } else {
+                    "A small always-on-top window showing the active pane"
+                },
                 false,
             ),
         ] {
@@ -10482,7 +10488,13 @@ impl HookEchoApp {
             .with_title("Hook Echo-WX — mini loop")
             .with_inner_size([340.0, 260.0])
             .with_decorations(false)
-            // ponytail: GNOME's Wayland compositor ignores this by policy; X11 and KDE honour it.
+            // Honoured on X11 only. The comment here used to blame GNOME's policy and say KDE
+            // was fine — it is not a policy question: winit's Wayland backend implements
+            // `set_window_level` as an empty function (winit 0.30, `platform_impl/linux/wayland/
+            // window/mod.rs`), so no Wayland compositor is ever asked. Nothing to fix here
+            // without going around winit to `xdg-foreign`/layer-shell, which is not worth it for
+            // one optional window. The tool's own description says so under Wayland rather than
+            // leaving the user to wonder why their window keeps disappearing behind the browser.
             .with_always_on_top();
         let mut close = false;
         ctx.show_viewport_immediate(

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -1039,12 +1039,46 @@ impl Settings {
     }
 
     /// Load saved settings, falling back to defaults on any error (nothing saved, parse failure).
+    /// Parse a settings file, keeping every field that reads and defaulting only the ones that
+    /// do not.
+    ///
+    /// This used to be a plain `serde_json::from_str().unwrap_or_default()`. Every field carries
+    /// `#[serde(default)]`, so a *missing* key was always fine — but one bad *value* anywhere in
+    /// the file failed the whole struct, and the whole file was thrown away: every marker, every
+    /// alert rule, every API key, replaced by defaults, and then written back over the file by the
+    /// next `save()`. A settings file whose `theme` said `"light"` instead of `"Light"` is enough
+    /// to do it, which is how this was found.
+    ///
+    /// The repair is per-key: rebuild the object one key at a time and drop any key that stops it
+    /// parsing. That is one full deserialize per key, but only on a file that already failed, and
+    /// only at startup.
+    ///
+    /// ponytail: quadratic in the number of keys on the error path. It runs once, on a file that
+    /// is already broken.
+    fn from_json_lossy(text: &str) -> Self {
+        match serde_json::from_str::<Self>(text) {
+            Ok(v) => return v,
+            Err(e) => log::warn!("settings parse failed ({e}); salvaging what reads"),
+        }
+        let Ok(serde_json::Value::Object(map)) = serde_json::from_str::<serde_json::Value>(text)
+        else {
+            log::warn!("settings file is not a JSON object; using defaults");
+            return Self::default();
+        };
+        let mut good = serde_json::Map::new();
+        for (k, v) in map {
+            good.insert(k.clone(), v);
+            if serde_json::from_value::<Self>(serde_json::Value::Object(good.clone())).is_err() {
+                good.remove(&k);
+                log::warn!("settings: ignoring unreadable value for `{k}`");
+            }
+        }
+        serde_json::from_value(serde_json::Value::Object(good)).unwrap_or_default()
+    }
+
     pub fn load() -> Self {
         let mut loaded = match Self::read_saved() {
-            Some(s) => serde_json::from_str(&s).unwrap_or_else(|e| {
-                log::warn!("settings parse failed ({e}); using defaults");
-                Self::default()
-            }),
+            Some(s) => Self::from_json_lossy(&s),
             None => Self::default(),
         };
         // One-shot repair: early Android builds persisted ui_scale 1.3 as the default, which
@@ -1502,5 +1536,47 @@ mod tests {
             serde_json::json!(-97.0),
             "Nws.kt reads ring vertices as [lon, lat]"
         );
+    }
+
+    /// The bug this was written for: one bad enum value used to discard the entire settings file.
+    #[test]
+    fn one_unreadable_value_does_not_discard_the_whole_file() {
+        // `theme` serialises as "Light"; lowercase is not a valid variant. Everything else here
+        // is perfectly good and must survive.
+        let text = r#"{
+            "theme": "light",
+            "mapbox_key": "kept",
+            "ui_scale": 1.25,
+            "smooth_radar": true
+        }"#;
+        let s = Settings::from_json_lossy(text);
+        assert_eq!(s.mapbox_key, "kept", "a good key was thrown away");
+        assert!((s.ui_scale - 1.25).abs() < 1e-6);
+        assert!(s.smooth_radar);
+        // Only the unreadable field falls back.
+        assert_eq!(s.theme, Theme::default());
+    }
+
+    #[test]
+    fn a_good_file_is_unchanged_and_a_broken_one_still_loads() {
+        let mut original = Settings::default();
+        original.mapbox_key = "abc".to_string();
+        original.ui_scale = 1.1;
+        let text = serde_json::to_string(&original).unwrap();
+        let round = Settings::from_json_lossy(&text);
+        assert_eq!(round.mapbox_key, "abc");
+        assert!((round.ui_scale - 1.1).abs() < 1e-6);
+
+        // Not an object at all, and not even JSON: defaults, no panic.
+        assert_eq!(Settings::from_json_lossy("[1,2,3]").mapbox_key, "");
+        assert_eq!(Settings::from_json_lossy("not json").mapbox_key, "");
+    }
+
+    /// Unknown keys were already tolerated and must stay that way — a settings file written by a
+    /// newer build has to open in an older one.
+    #[test]
+    fn unknown_keys_are_still_ignored() {
+        let s = Settings::from_json_lossy(r#"{"mapbox_key":"x","a_field_from_the_future":42}"#);
+        assert_eq!(s.mapbox_key, "x");
     }
 }


### PR DESCRIPTION
Wave D, part three. Reproduce-first, as specced: nothing here is fixed without a written repro, and everything that did **not** reproduce is written up below rather than patched on suspicion.

## Fixed — settings loading threw away the whole file

Found by accident while screenshotting the light theme for this audit. I wrote `"theme": "light"` into a test settings file. The app came up with the **first-run wizard** and no settings at all.

`Theme` serialises as `"Light"`. Lowercase is not a valid variant, so `serde_json::from_str::<Settings>` failed — and the handler was `.unwrap_or_default()`. Every field carries `#[serde(default)]`, so a *missing* key was always fine, but one bad *value* anywhere in the file fails the whole struct. Result: every marker, every alert rule, every API key, the site list, the workspace — replaced by defaults, and then written straight back over the file by the next `save()`.

One character of the wrong case, and the user's configuration is gone.

Loading is now per-key: on a parse failure the object is rebuilt a key at a time and only the keys that stop it parsing are dropped. Quadratic in key count, on the error path, once, on a file that is already broken — which is the right place to spend it.

This is not really a chrome bug. It was found by a chrome check, and it is the most valuable thing in this PR, so it ships here rather than waiting for a tidier home.

## Fixed — the mini loop promised something Wayland will never do

The mini loop asked for always-on-top with this comment:

> `// ponytail: GNOME's Wayland compositor ignores this by policy; X11 and KDE honour it.`

That is wrong, and not a policy question. winit 0.30's Wayland backend implements it as an empty function:

```rust
// platform_impl/linux/wayland/window/mod.rs:430
pub fn set_window_level(&self, _level: WindowLevel) {}
```

No Wayland compositor is ever asked — KDE included, which is what you're running. Going around winit to layer-shell for one optional window is not worth it, so the tool's description now says so under Wayland rather than promising a behaviour that will not happen. Comment corrected too.

## Did not reproduce

**Resize torture.** Five resizes between 1900×1150 and 420×300, then down to 480×340 and back to 1600×1000, under Xvfb. No panic, no error in the log beyond the usual Xvfb `DRI3`/`XSETTINGS` noise, layout degrades gracefully (sidebar narrows, legend stays readable) and restores exactly. Screenshots at both extremes. Nothing to fix.

**Hardcoded colours outside the theme lookup.** 160 `Color32::from_rgb` call sites across the UI. Sampling them, the overwhelming majority are *data* colours — reflectivity bands, flight categories, warning polygons, flood stages — which are supposed to be fixed and would be wrong to theme. I found no chrome element that failed to follow the theme in the screenshots I took. Converting them on suspicion would be a large diff with no repro behind it, so I did not.

## Could not test here

Honestly flagged rather than silently skipped — this machine has no KDE Wayland session and no phone attached:

- KDE Wayland fractional scaling at 125% / 150%
- Window decorations under KDE specifically
- Android bottom sheet, insets, keyboard, rotation

Those are yours to walk. If any of them reproduces, send me the repro and it becomes a `fix(chrome):` commit on this branch.

## Verification

`clippy` · `cargo test --workspace` (462) · wasm check · `shoot.sh check` — clean.

New tests: `one_unreadable_value_does_not_discard_the_whole_file`, `a_good_file_is_unchanged_and_a_broken_one_still_loads`, `unknown_keys_are_still_ignored`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)