### PR TITLE
alerts: dedupe by VTEC event, outbreak rollup, delivery retry

### DIFF
--- a/crates/hookecho/src/alert_rollup.rs
+++ b/crates/hookecho/src/alert_rollup.rs
@@ -1,0 +1,160 @@
+//! Outbreak mode: when alerts arrive faster than anyone can read them, stop delivering one push
+//! per warning and deliver one rolling summary instead.
+//!
+//! On a big day a single office can issue a dozen warnings in ten minutes, and every one of them
+//! is a phone buzz. Past a threshold the buzzes stop carrying information — you already know it
+//! is a bad day, and the individual pushes are what makes people mute the app during exactly the
+//! event they installed it for.
+//!
+//! This is only about *delivery*. Banners, the alert list, sounds and the map are untouched; so
+//! is the escalated tier, which always pushes on its own.
+
+use std::collections::VecDeque;
+use std::time::Duration;
+use wxdata::clock::Instant;
+
+/// What the caller should do with an alert it was about to push.
+#[derive(Debug, PartialEq)]
+pub enum Decision {
+    /// Push it as itself.
+    Send,
+    /// Hold it and push this summary instead (already includes everything rolled up so far).
+    Rollup(String),
+    /// Hold it and push nothing — the summary is already current for this minute.
+    Hold,
+}
+
+/// Rolling window of recently pushed alert titles.
+pub struct Rollup {
+    /// (arrival, short title) within the window, oldest first.
+    recent: VecDeque<(Instant, String)>,
+    /// Everything folded into the current summary, in arrival order.
+    folded: Vec<String>,
+    /// When the summary last went out, so it updates at most once a minute.
+    last_summary: Option<Instant>,
+}
+
+/// Don't re-push the summary more often than this, however fast the alerts land.
+const SUMMARY_EVERY: Duration = Duration::from_secs(60);
+
+impl Default for Rollup {
+    fn default() -> Self {
+        Self {
+            recent: VecDeque::new(),
+            folded: Vec::new(),
+            last_summary: None,
+        }
+    }
+}
+
+impl Rollup {
+    /// Offer an alert. `threshold` alerts inside `window` turns rollup on; it turns off by itself
+    /// when the window drains back below the threshold.
+    pub fn offer(
+        &mut self,
+        now: Instant,
+        title: &str,
+        threshold: usize,
+        window: Duration,
+    ) -> Decision {
+        while self
+            .recent
+            .front()
+            .is_some_and(|(t, _)| now.duration_since(*t) > window)
+        {
+            self.recent.pop_front();
+        }
+        self.recent.push_back((now, title.to_string()));
+        if self.recent.len() < threshold.max(2) {
+            // Out of outbreak mode: the next one starts a fresh summary.
+            self.folded.clear();
+            self.last_summary = None;
+            return Decision::Send;
+        }
+        self.folded.push(title.to_string());
+        let due = self
+            .last_summary
+            .is_none_or(|t| now.duration_since(t) >= SUMMARY_EVERY);
+        if !due {
+            return Decision::Hold;
+        }
+        self.last_summary = Some(now);
+        Decision::Rollup(self.summary(window))
+    }
+
+    /// One line per alert, newest first, capped — a notification nobody scrolls.
+    fn summary(&self, window: Duration) -> String {
+        const MAX_LINES: usize = 8;
+        let mins = window.as_secs().div_ceil(60);
+        let mut s = format!(
+            "{} alerts in the last {mins} min:\n",
+            self.recent.len().max(self.folded.len())
+        );
+        for t in self.folded.iter().rev().take(MAX_LINES) {
+            s.push_str("• ");
+            s.push_str(t);
+            s.push('\n');
+        }
+        if self.folded.len() > MAX_LINES {
+            s.push_str(&format!("…and {} more", self.folded.len() - MAX_LINES));
+        }
+        s.trim_end().to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn win() -> Duration {
+        Duration::from_secs(600)
+    }
+
+    #[test]
+    fn under_the_threshold_everything_sends_itself() {
+        let mut r = Rollup::default();
+        let t0 = Instant::now();
+        for i in 0..4 {
+            let d = r.offer(t0 + Duration::from_secs(i * 10), "Severe Thunderstorm", 5, win());
+            assert_eq!(d, Decision::Send, "alert {i}");
+        }
+    }
+
+    #[test]
+    fn the_fifth_alert_rolls_up_and_the_sixth_is_held() {
+        let mut r = Rollup::default();
+        let t0 = Instant::now();
+        for i in 0..4 {
+            r.offer(t0 + Duration::from_secs(i * 10), "Severe Thunderstorm", 5, win());
+        }
+        let Decision::Rollup(text) = r.offer(t0 + Duration::from_secs(50), "Tornado Warning", 5, win())
+        else {
+            panic!("fifth alert inside the window should roll up");
+        };
+        assert!(text.starts_with("5 alerts in the last 10 min:"), "{text}");
+        assert!(text.contains("Tornado Warning"));
+        // Same minute: the summary is current, so nothing goes out.
+        assert_eq!(
+            r.offer(t0 + Duration::from_secs(60), "Flash Flood Warning", 5, win()),
+            Decision::Hold
+        );
+        // A minute later it refreshes, now carrying the held one too.
+        let Decision::Rollup(text) = r.offer(t0 + Duration::from_secs(120), "Special Marine", 5, win())
+        else {
+            panic!("summary should refresh after a minute");
+        };
+        assert!(text.contains("Flash Flood Warning"), "{text}");
+    }
+
+    #[test]
+    fn the_window_drains_and_normal_pushes_resume() {
+        let mut r = Rollup::default();
+        let t0 = Instant::now();
+        for i in 0..5 {
+            r.offer(t0 + Duration::from_secs(i * 10), "Severe Thunderstorm", 5, win());
+        }
+        // Eleven minutes later the window holds only this one.
+        let d = r.offer(t0 + Duration::from_secs(11 * 60), "Tornado Warning", 5, win());
+        assert_eq!(d, Decision::Send);
+    }
+}

--- a/crates/hookecho/src/alert_rollup.rs
+++ b/crates/hookecho/src/alert_rollup.rs
@@ -25,6 +25,7 @@ pub enum Decision {
 }
 
 /// Rolling window of recently pushed alert titles.
+#[derive(Default)]
 pub struct Rollup {
     /// (arrival, short title) within the window, oldest first.
     recent: VecDeque<(Instant, String)>,
@@ -36,16 +37,6 @@ pub struct Rollup {
 
 /// Don't re-push the summary more often than this, however fast the alerts land.
 const SUMMARY_EVERY: Duration = Duration::from_secs(60);
-
-impl Default for Rollup {
-    fn default() -> Self {
-        Self {
-            recent: VecDeque::new(),
-            folded: Vec::new(),
-            last_summary: None,
-        }
-    }
-}
 
 impl Rollup {
     /// Offer an alert. `threshold` alerts inside `window` turns rollup on; it turns off by itself

--- a/crates/hookecho/src/alert_snapshot.rs
+++ b/crates/hookecho/src/alert_snapshot.rs
@@ -85,6 +85,7 @@ mod tests {
                 tornado_detection: None,
                 damage_threat: None,
                 source: None,
+                vtec: None,
                 motion: None,
             }),
         }

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1916,6 +1916,8 @@ pub struct HookEchoApp {
     sounding_rx: Option<std::sync::mpsc::Receiver<Result<wxdata::sounding::Sounding, String>>>,
     /// The observed RAOB fetched alongside the HRRR profile, for the same click.
     raob_rx: Option<std::sync::mpsc::Receiver<Result<wxdata::sounding::Sounding, String>>>,
+    /// Last spoken storm-position update: when, and the distance in whole miles it reported.
+    spoke_pos: Option<(Instant, i32)>,
     /// Chase mode: follow a position, auto-switching the active pane to the nearest radar.
     chase_mode: bool,
     chase_pos: Option<(f64, f64)>,
@@ -2719,6 +2721,7 @@ impl HookEchoApp {
             sounding_rx: None,
             raob_rx: None,
             chase_mode: false,
+            spoke_pos: None,
             chase_pos: None,
             chase_track: crate::chaselog::Track::default(),
             climo_tracks: None,
@@ -2983,6 +2986,9 @@ impl HookEchoApp {
             app.locate_by_ip(&cc.egui_ctx.clone());
         }
         crate::platform::set_background_alerts(app.settings.background_alerts);
+        // Point the speech path at Piper before anything can speak.
+        #[cfg(not(target_arch = "wasm32"))]
+        crate::speech::set_piper(&app.settings.piper_path, &app.settings.piper_voice);
         // Not on the web: this is a burst of six fetches, and on the one thread a browser gives
         // us they queue ahead of the radar the visitor actually came for. The periodic refresh in
         // `update` picks them up a moment later, once there is radar on screen.
@@ -4026,7 +4032,13 @@ impl HookEchoApp {
                         })
                         .unwrap_or_default();
                     if !self.settings.mute_alerts {
-                        crate::speech::speak(&format!("{} for {}{}", a.event, area, until));
+                        // Hazard, place and heading first — see `wxdata::spoken`. `until` here
+                        // still carries its leading " until ", which the script builder adds.
+                        crate::speech::speak(&wxdata::spoken::warning_script(
+                            a,
+                            &area,
+                            until.trim_start_matches(" until "),
+                        ));
                     }
                 }
                 if notify_ok && self.settings.ntfy_snapshot {
@@ -4779,6 +4791,72 @@ impl HookEchoApp {
                 .await;
             });
         }
+    }
+
+    /// Fetch the Piper voice model into the data directory.
+    ///
+    /// The model and the `.onnx.json` beside it are both required — Piper reads its sample rate
+    /// and phoneme table from the JSON — so a download that gets one and not the other is a
+    /// failure, not a half-success. Written to a `.part` file and renamed, so an interrupted
+    /// download cannot leave a truncated model that Piper would then crash on.
+    ///
+    // ponytail: no pinned hash. The download is https from Piper's own voice repository and both
+    // files are validated (the JSON parses, the model is the size of a model); pinning a digest
+    // means pinning a version, and I could not verify one offline to pin.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn download_voice(&self) {
+        let Some(path) = crate::speech::default_voice_path() else {
+            crate::speech::set_voice_status(false, "no data directory to download into");
+            return;
+        };
+        let http = self.http.clone();
+        self.spawner.spawn(async move {
+            let cfg_url = format!("{}.json", crate::speech::VOICE_URL);
+            let cfg_path = path.with_extension("onnx.json");
+            if let Some(dir) = path.parent() {
+                if let Err(e) = std::fs::create_dir_all(dir) {
+                    crate::speech::set_voice_status(false, format!("could not create {dir:?}: {e}"));
+                    return;
+                }
+            }
+            crate::speech::set_voice_status(true, "downloading voice (~60 MB)…");
+            let get = |url: String| {
+                let http = http.clone();
+                async move { http.get(url).send().await?.error_for_status()?.bytes().await }
+            };
+            let cfg = match get(cfg_url).await {
+                Ok(b) => b,
+                Err(e) => {
+                    crate::speech::set_voice_status(false, format!("voice config failed: {e}"));
+                    return;
+                }
+            };
+            if serde_json::from_slice::<serde_json::Value>(&cfg).is_err() {
+                crate::speech::set_voice_status(false, "voice config was not JSON; refusing it");
+                return;
+            }
+            let model = match get(crate::speech::VOICE_URL.to_string()).await {
+                Ok(b) => b,
+                Err(e) => {
+                    crate::speech::set_voice_status(false, format!("voice download failed: {e}"));
+                    return;
+                }
+            };
+            // A medium-quality Piper voice is tens of megabytes; anything tiny is an error page
+            // that happened to arrive with a 200.
+            if model.len() < 1_000_000 {
+                crate::speech::set_voice_status(false, "download was too small to be a voice");
+                return;
+            }
+            let part = path.with_extension("part");
+            let wrote = std::fs::write(&part, &model)
+                .and_then(|()| std::fs::rename(&part, &path))
+                .and_then(|()| std::fs::write(&cfg_path, &cfg));
+            match wrote {
+                Ok(()) => crate::speech::set_voice_status(false, "voice ready"),
+                Err(e) => crate::speech::set_voice_status(false, format!("writing the voice failed: {e}")),
+            }
+        });
     }
 
     /// Sub-hourly GOES scrub bar: shown when the active basemap is a GOES layer and its frame
@@ -6986,6 +7064,29 @@ impl HookEchoApp {
         let (close_km, close_min) =
             crate::geo::closest_approach([c.lon, c.lat], dir, kt, me, 120.0);
         let escape = crate::geo::escape_bearing([c.lon, c.lat], dir, me);
+        // Spoken position updates: only while chasing, only when the picture has actually
+        // changed, and never more than once a minute — a voice that repeats itself is a voice the
+        // user turns off. Reported in whole miles, so a storm parked in place says nothing.
+        if self.settings.speak_position && !self.settings.mute_alerts {
+            let miles = (km * 0.621_371).round() as i32;
+            let fresh = self
+                .spoke_pos
+                .is_none_or(|(t, m)| m != miles && t.elapsed() >= std::time::Duration::from_secs(60));
+            if fresh {
+                self.spoke_pos = Some((Instant::now(), miles));
+                crate::speech::speak(&wxdata::spoken::position_script(
+                    // "Cell O7", not the bare id — a synthesizer reading "O7" alone is a noise.
+                    &if c.id.is_empty() {
+                        c.title.clone()
+                    } else {
+                        format!("Cell {}", c.id)
+                    },
+                    bearing as f32,
+                    km,
+                    c.mvt_deg,
+                ));
+            }
+        }
         let mi = |km: f64| km * 0.621_371;
         // Urgent when the storm will be on top of you soon.
         let urgent = mi(close_km) < 5.0 && close_min < 20.0;
@@ -14997,6 +15098,12 @@ impl eframe::App for HookEchoApp {
         {
             self.goto_poll = Some(Instant::now());
             self.drain_goto_file();
+        }
+        // The settings window has no HTTP client or runtime, so the voice-download button raises
+        // a flag and the work happens here, on the same spawner everything else fetches on.
+        #[cfg(not(target_arch = "wasm32"))]
+        if crate::speech::take_voice_request() {
+            self.download_voice();
         }
         // A file the user picked, from any of the import buttons. Routed here rather than at the
         // button, because on Android the picker is an activity result that lands long after the

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -4661,7 +4661,6 @@ impl HookEchoApp {
     /// Deliver an alert to every configured channel: ntfy.sh push plus Discord / Slack / Matrix
     /// webhooks. Each is a no-op when its settings field is blank.
     /// Best-effort on the shared tokio runtime; failures are logged, never fatal.
-    // ponytail: fire-and-forget, no retry; add a bounded retry queue if users report drops.
     fn notify_alert(&self, title: &str, body: &str, urgent: bool) {
         // Quiet hours hold everything back except the escalated tier, which is the one worth
         // waking up for. Banners and the alert list are untouched — this gates what leaves the
@@ -4714,17 +4713,14 @@ impl HookEchoApp {
             let (http, title, body) = (http.clone(), title.clone(), body.clone());
             let priority = if urgent { "urgent" } else { "high" };
             self.spawner.spawn(async move {
-                let res = http
-                    .post(format!("https://ntfy.sh/{topic}"))
-                    .header("Title", title)
-                    .header("Priority", priority)
-                    .header("Tags", "warning,cloud_with_lightning")
-                    .body(body)
-                    .send()
-                    .await;
-                if let Err(e) = res {
-                    log::warn!("ntfy push failed: {e}");
-                }
+                crate::notify::send_retrying("ntfy push", || {
+                    http.post(format!("https://ntfy.sh/{topic}"))
+                        .header("Title", title.clone())
+                        .header("Priority", priority)
+                        .header("Tags", "warning,cloud_with_lightning")
+                        .body(body.clone())
+                })
+                .await;
             });
         }
 
@@ -4751,15 +4747,12 @@ impl HookEchoApp {
         for (what, url, payload, _) in posts {
             let http = http.clone();
             self.spawner.spawn(async move {
-                let res = http
-                    .post(url)
-                    .header("Content-Type", "application/json")
-                    .body(payload)
-                    .send()
-                    .await;
-                if let Err(e) = res {
-                    log::warn!("{what} webhook failed: {e}");
-                }
+                crate::notify::send_retrying(&format!("{what} webhook"), || {
+                    http.post(url.clone())
+                        .header("Content-Type", "application/json")
+                        .body(payload.clone())
+                })
+                .await;
             });
         }
 
@@ -4777,16 +4770,13 @@ impl HookEchoApp {
             let url = crate::notify::matrix_url(&hs, &room, txn);
             let payload = crate::notify::matrix_body(&title, &body);
             self.spawner.spawn(async move {
-                let res = http
-                    .put(url)
-                    .bearer_auth(token)
-                    .header("Content-Type", "application/json")
-                    .body(payload)
-                    .send()
-                    .await;
-                if let Err(e) = res {
-                    log::warn!("matrix webhook failed: {e}");
-                }
+                crate::notify::send_retrying("matrix webhook", || {
+                    http.put(url.clone())
+                        .bearer_auth(token.clone())
+                        .header("Content-Type", "application/json")
+                        .body(payload.clone())
+                })
+                .await;
             });
         }
     }

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1977,6 +1977,9 @@ pub struct HookEchoApp {
     /// Held across a restart through `Settings::quiet_pending`, written on exit: a quiet window
     /// that spans a relaunch still owes its catch-up.
     quiet_queue: std::sync::Mutex<Vec<(String, String)>>,
+    /// Outbreak rollup state. A `Mutex` for the same reason `quiet_queue` is one: `notify_alert`
+    /// takes `&self`.
+    rollup: std::sync::Mutex<crate::alert_rollup::Rollup>,
     /// Whether the last frame was inside quiet hours, so the end of the window is an edge.
     was_quiet: bool,
     /// Where a requested screenshot should go once the image event arrives.
@@ -2749,6 +2752,7 @@ impl HookEchoApp {
             rotation_alerted: std::collections::HashMap::new(),
             last_chime: None,
             quiet_queue: std::sync::Mutex::new(quiet_pending),
+            rollup: std::sync::Mutex::default(),
             was_quiet: false,
             screenshot_pending: None,
             share_card: None,
@@ -4672,7 +4676,34 @@ impl HookEchoApp {
             return;
         }
         let http = self.http.clone();
-        let (title, body) = (title.to_string(), body.to_string());
+        let (mut title, mut body) = (title.to_string(), body.to_string());
+
+        // Outbreak mode: past the threshold, one rolling summary goes out instead of one push per
+        // warning. Escalated alerts are exempt — those are the ones worth a buzz each.
+        // ponytail: the summary is a fresh notification each refresh, not an in-place replace;
+        // desktop replace-by-tag and the Android fixed notification id can land with the rest of
+        // the Android delivery stack.
+        if !urgent && self.settings.alert_rollup_threshold > 0 {
+            let window =
+                std::time::Duration::from_secs(self.settings.alert_rollup_window_min.max(1) * 60);
+            let decision = self.rollup.lock().map(|mut r| {
+                r.offer(
+                    Instant::now(),
+                    &title,
+                    self.settings.alert_rollup_threshold,
+                    window,
+                )
+            });
+            match decision {
+                Ok(crate::alert_rollup::Decision::Hold) => return,
+                Ok(crate::alert_rollup::Decision::Rollup(text)) => {
+                    title = "Multiple alerts".to_string();
+                    body = text;
+                }
+                _ => {}
+            }
+        }
+        let (title, body) = (title, body);
 
         if self.settings.desktop_notify {
             crate::notify::desktop(&title, &body);

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -2285,7 +2285,8 @@ pub struct HookEchoApp {
     obs_tour: bool,
     obs_tour_last: Option<Instant>,
     obs_tour_idx: usize,
-    /// Warning ids already seen, so a new warning is detected on arrival (not re-alerted).
+    /// Warning dedupe keys already seen (VTEC event keys), so a new warning is detected on
+    /// arrival and a continuation of one already announced is not.
     known_warning_ids: std::collections::HashSet<String>,
     /// False until the first alert fetch seeds `known_warning_ids` (avoids alerting on startup).
     warnings_seeded: bool,
@@ -2467,7 +2468,7 @@ impl HookEchoApp {
         let seeded_alerts = crate::alert_snapshot::load();
         let known_warning_ids: std::collections::HashSet<String> = seeded_alerts
             .iter()
-            .filter_map(|f| f.alert.as_ref().map(|a| a.id.clone()))
+            .filter_map(|f| f.alert.as_ref().map(|a| a.dedupe_key()))
             .collect();
         // Zone geometry (county and forecast-zone shapes) never changes, so it outlives the run.
         if let Some(dir) = crate::paths::cache_dir() {
@@ -3875,8 +3876,10 @@ impl HookEchoApp {
             }
             let Some(a) = &f.alert else { continue };
             // Mark every warning seen so it can't re-banner later, but only alert on genuinely new
-            // ones after the first (seeding) pass.
-            if self.known_warning_ids.insert(a.id.clone()) && self.warnings_seeded {
+            // ones after the first (seeding) pass. Keyed by VTEC event, not message id — an office
+            // re-issues a continuation of the same warning every few minutes with a fresh id, and
+            // deduping on that is why the same tornado warning announced itself over and over.
+            if self.known_warning_ids.insert(a.dedupe_key()) && self.warnings_seeded {
                 let esc = wxdata::alerts::escalation(a);
                 let urgent = esc >= 2;
                 // Severity floor: below the tier the user set, the warning still banners and

--- a/crates/hookecho/src/audio.rs
+++ b/crates/hookecho/src/audio.rs
@@ -51,6 +51,29 @@ pub fn play(sound: &AlertSound, volume: f32) {
     });
 }
 
+/// Play WAV bytes that some other part of the app just produced (today: Piper's stdout).
+/// Non-blocking, same detached-thread shape as [`play`].
+#[cfg(not(target_arch = "wasm32"))]
+pub fn play_wav(bytes: Vec<u8>) {
+    std::thread::spawn(move || {
+        let Ok((_stream, handle)) = rodio::OutputStream::try_default() else {
+            log::warn!("no audio output for speech");
+            return;
+        };
+        let Ok(sink) = Sink::try_new(&handle) else {
+            return;
+        };
+        match rodio::Decoder::new(std::io::Cursor::new(bytes)) {
+            Ok(src) => sink.append(src),
+            Err(e) => {
+                log::warn!("speech audio decode failed: {e}");
+                return;
+            }
+        }
+        sink.sleep_until_end();
+    });
+}
+
 /// Try to queue a user audio file (wav/mp3/ogg/flac). Returns false (logged) on any failure.
 #[cfg(not(target_arch = "wasm32"))]
 fn append_file(sink: &Sink, path: &str) -> bool {

--- a/crates/hookecho/src/lib.rs
+++ b/crates/hookecho/src/lib.rs
@@ -5,6 +5,7 @@
 //! `eframe::NativeOptions`, Android hands eframe the `AndroidApp` from the activity glue and points
 //! [`paths`] at the app-private data dir.
 
+pub mod alert_rollup;
 pub mod alert_snapshot;
 pub mod app;
 pub mod astro;

--- a/crates/hookecho/src/notify.rs
+++ b/crates/hookecho/src/notify.rs
@@ -86,9 +86,152 @@ pub fn desktop(title: &str, body: &str) {
 #[cfg(any(target_os = "android", target_arch = "wasm32"))]
 pub fn desktop(_title: &str, _body: &str) {}
 
+/// Waits before each retry. A webhook that fails is usually failing for seconds (a Discord blip,
+/// a laptop's wifi coming back after a lid open), so the first retry is quick and the last one is
+/// far enough out to outlast a short outage.
+const BACKOFF_SECS: [u64; 3] = [2, 8, 30];
+
+/// How many alert deliveries may be sitting in backoff at once. An outbreak plus a dead webhook
+/// should not accumulate tasks without bound.
+const MAX_RETRYING: usize = 32;
+
+static RETRYING: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// Is this worth trying again? A transport error or a 5xx/429 is; a 404 on a deleted webhook or a
+/// 401 on a stale token will fail identically forever, and retrying it only delays the log line.
+fn worth_retrying(res: &Result<reqwest::Response, reqwest::Error>) -> bool {
+    match res {
+        Err(_) => true,
+        Ok(r) => r.status().is_server_error() || r.status() == reqwest::StatusCode::TOO_MANY_REQUESTS,
+    }
+}
+
+/// Send a notification request, retrying a transient failure up to three times with backoff.
+///
+/// `make` builds the request fresh each attempt — `RequestBuilder` is consumed by `send`, and a
+/// body may not be cloneable. The queue is the spawned tasks themselves, bounded by a counter.
+///
+// ponytail: in memory, so a crash mid-backoff loses the delivery; persist the queue if anyone
+// reports losing alerts to a restart rather than to a dead webhook.
+pub async fn send_retrying(what: &str, make: impl Fn() -> reqwest::RequestBuilder) {
+    use std::sync::atomic::Ordering;
+    let first = make().send().await;
+    if log_outcome(what, "delivery", &first) {
+        return;
+    }
+    // On the web there is no timer and no runtime to wait on, so one attempt is the whole story.
+    if cfg!(target_arch = "wasm32") || !worth_retrying(&first) {
+        return;
+    }
+    // Taking a retry slot is what the cap counts; the first attempt is always free.
+    if RETRYING.fetch_add(1, Ordering::Relaxed) >= MAX_RETRYING {
+        RETRYING.fetch_sub(1, Ordering::Relaxed);
+        log::warn!("{what}: retry queue full, dropping");
+        return;
+    }
+    struct Slot;
+    impl Drop for Slot {
+        fn drop(&mut self) {
+            std::sync::atomic::AtomicUsize::fetch_sub(&RETRYING, 1, Ordering::Relaxed);
+        }
+    }
+    let _slot = Slot;
+    for secs in BACKOFF_SECS {
+        sleep_secs(secs).await;
+        let res = make().send().await;
+        if log_outcome(what, "retry", &res) {
+            log::info!("{what} delivery succeeded on retry");
+            return;
+        }
+        if !worth_retrying(&res) {
+            return;
+        }
+    }
+    log::warn!("{what}: giving up after {} retries", BACKOFF_SECS.len());
+}
+
+/// Log what happened; `true` means it landed and there is nothing more to do.
+fn log_outcome(what: &str, stage: &str, res: &Result<reqwest::Response, reqwest::Error>) -> bool {
+    match res {
+        Ok(r) if r.status().is_success() => true,
+        Ok(r) => {
+            log::warn!("{what} {stage} returned {}", r.status());
+            false
+        }
+        Err(e) => {
+            log::warn!("{what} {stage} failed: {e}");
+            false
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+async fn sleep_secs(secs: u64) {
+    tokio::time::sleep(std::time::Duration::from_secs(secs)).await;
+}
+
+/// No tokio in the browser, and no timer worth pulling a crate for: the web build gets the one
+/// attempt it had before.
+// ponytail: web sends once; wire a `gloo-timers` sleep here if web push ever matters.
+#[cfg(target_arch = "wasm32")]
+async fn sleep_secs(_secs: u64) {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Tiny HTTP server answering `codes` in order (then repeating the last), counting requests.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn mock_sink(codes: Vec<u16>) -> (String, std::sync::Arc<std::sync::atomic::AtomicUsize>) {
+        use std::io::{Read, Write};
+        use std::sync::atomic::Ordering;
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}/hook", listener.local_addr().unwrap());
+        let hits = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let n = hits.clone();
+        std::thread::spawn(move || {
+            for sock in listener.incoming() {
+                let Ok(mut sock) = sock else { break };
+                let i = n.fetch_add(1, Ordering::SeqCst);
+                let code = codes[i.min(codes.len() - 1)];
+                let mut buf = [0u8; 2048];
+                let _ = sock.read(&mut buf);
+                let _ = sock.write_all(
+                    format!("HTTP/1.1 {code} X\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+                        .as_bytes(),
+                );
+            }
+        });
+        (url, hits)
+    }
+
+    #[test]
+    #[cfg(not(target_arch = "wasm32"))]
+    fn a_transient_failure_is_retried_and_a_permanent_one_is_not() {
+        use std::sync::atomic::Ordering;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let http = reqwest::Client::new();
+
+        // 503 then 200: the second attempt lands, so the sink sees exactly two requests.
+        let (url, hits) = mock_sink(vec![503, 200]);
+        rt.block_on(send_retrying("test", || http.post(&url).body("x")));
+        assert_eq!(hits.load(Ordering::SeqCst), 2, "a 503 should be retried");
+
+        // 404 is a dead webhook — retrying it forever only delays the log line. `send_retrying`
+        // returns without ever sleeping, which is what makes this assertion immediate.
+        let (url, hits) = mock_sink(vec![404]);
+        rt.block_on(send_retrying("test", || http.post(&url).body("x")));
+        assert_eq!(hits.load(Ordering::SeqCst), 1, "a 404 should not be retried");
+    }
+
+    #[test]
+    fn backoff_grows_and_is_bounded() {
+        assert_eq!(BACKOFF_SECS, [2, 8, 30]);
+        assert!(BACKOFF_SECS.windows(2).all(|w| w[1] > w[0]));
+    }
 
     #[test]
     fn payloads_are_valid_json_and_escape() {

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -1370,6 +1370,8 @@ mod tests {
             quiet_start_hour: 22,
             quiet_end_hour: 7,
             alert_min_escalation: 0,
+            alert_rollup_threshold: default_alert_rollup_threshold(),
+            alert_rollup_window_min: default_alert_rollup_window_min(),
             scan_chime: false,
             scan_sound: AlertSound::Ding,
             warn_sound: AlertSound::Siren,

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -329,6 +329,13 @@ pub struct Settings {
     /// 0 lets everything through, which is the default.
     #[serde(default)]
     pub alert_min_escalation: u8,
+    /// Alerts inside `alert_rollup_window_min` before pushes collapse into one rolling summary.
+    /// 0 turns the rollup off. Escalated alerts always push as themselves.
+    #[serde(default = "default_alert_rollup_threshold")]
+    pub alert_rollup_threshold: usize,
+    /// Window the rollup threshold counts over, in minutes.
+    #[serde(default = "default_alert_rollup_window_min")]
+    pub alert_rollup_window_min: u64,
     /// Chime when a new radar volume lands on the live pane in view.
     #[serde(default)]
     pub scan_chime: bool,
@@ -496,6 +503,12 @@ fn default_quiet_start() -> u32 {
     22
 }
 
+pub fn default_alert_rollup_threshold() -> usize {
+    5
+}
+pub fn default_alert_rollup_window_min() -> u64 {
+    10
+}
 fn default_quiet_end() -> u32 {
     7
 }
@@ -951,6 +964,8 @@ impl Default for Settings {
             quiet_start_hour: default_quiet_start(),
             quiet_end_hour: default_quiet_end(),
             alert_min_escalation: 0,
+            alert_rollup_threshold: default_alert_rollup_threshold(),
+            alert_rollup_window_min: default_alert_rollup_window_min(),
             scan_chime: false,
             scan_sound: default_scan_sound(),
             warn_sound: AlertSound::default(),

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -289,6 +289,17 @@ pub struct Settings {
     /// Read new warnings aloud (system speech engine). Off by default — speech is intrusive.
     #[serde(default)]
     pub speak_warnings: bool,
+    /// Path to a Piper binary, or blank to look on `PATH`. Piper is a local neural voice; when it
+    /// and a voice model are both present, spoken warnings go through it instead of espeak.
+    #[serde(default)]
+    pub piper_path: String,
+    /// Path to a Piper `.onnx` voice model. Blank turns Piper off — an engine with no model has
+    /// nothing to say. Never committed: it is a ~60 MB download or a file the user already has.
+    #[serde(default)]
+    pub piper_voice: String,
+    /// While chase mode is on, speak the nearest storm's bearing and distance as it changes.
+    #[serde(default)]
+    pub speak_position: bool,
     /// Alert when radar echo is heading for a saved location.
     #[serde(default)]
     pub rain_alerts: bool,
@@ -953,6 +964,9 @@ impl Default for Settings {
             anthropic_key: String::new(),
             lightning_alarm: false,
             speak_warnings: false,
+            piper_path: String::new(),
+            piper_voice: String::new(),
+            speak_position: false,
             rain_alerts: false,
             rain_sound: AlertSound::default(),
             setup_done: false,
@@ -1359,6 +1373,9 @@ mod tests {
             anthropic_key: "sk-test".to_string(),
             lightning_alarm: true,
             speak_warnings: true,
+            piper_path: String::new(),
+            piper_voice: String::new(),
+            speak_position: false,
             rain_alerts: true,
             rain_sound: AlertSound::Ding,
             setup_done: true,

--- a/crates/hookecho/src/speech.rs
+++ b/crates/hookecho/src/speech.rs
@@ -1,8 +1,91 @@
 //! Speaking warnings out loud.
 //!
+//! Two layers. The words come from [`wxdata::spoken`] — hazard, place and heading first, NWS
+//! shorthand expanded. The voice is whatever the machine has: a local neural engine (Piper) when
+//! one is configured, otherwise the platform's own synthesizer.
+//!
 //! Chasing is an eyes-on-the-road activity: a warning you have to read is a warning you read at
 //! the wrong moment. Every call is fire-and-forget on a background thread and every failure is
 //! logged and dropped — a machine with no speech engine is a normal machine, not a broken one.
+
+/// Piper binary and voice model, as configured. Empty binary means "look on PATH"; empty voice
+/// means Piper is off, since a neural engine with no model has nothing to say.
+///
+/// A global rather than a threaded-through parameter: `speak` is called from a dozen places that
+/// have no reason to know about settings, and this is one string pair that changes when the user
+/// edits it.
+#[cfg(not(target_arch = "wasm32"))]
+static PIPER: std::sync::RwLock<(String, String)> = std::sync::RwLock::new((String::new(), String::new()));
+
+/// Point the speech path at a Piper binary and voice model. Called at startup and whenever the
+/// user edits either field.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn set_piper(bin: &str, voice: &str) {
+    if let Ok(mut g) = PIPER.write() {
+        *g = (bin.trim().to_string(), voice.trim().to_string());
+    }
+}
+
+/// Where a downloaded voice lands. One slot: a second voice is a preference, not a capability.
+// ponytail: one voice slot; a picker if anyone actually wants two.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn default_voice_path() -> Option<std::path::PathBuf> {
+    crate::paths::data_dir().map(|d| d.join("voices").join(VOICE_FILE))
+}
+
+/// The voice the download button fetches — a mid-quality US English model, the smallest one that
+/// does not sound worse than espeak.
+#[cfg(not(target_arch = "wasm32"))]
+pub const VOICE_FILE: &str = "en_US-lessac-medium.onnx";
+
+/// Upstream for that model. Piper's own voice repository; the `.onnx.json` beside it is required,
+/// since Piper reads its sample rate and phoneme table from there.
+#[cfg(not(target_arch = "wasm32"))]
+pub const VOICE_URL: &str = "https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/lessac/medium/en_US-lessac-medium.onnx";
+
+/// What the settings row shows about the voice download.
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone, Default)]
+pub struct VoiceStatus {
+    /// A download is in flight, so the button hides rather than starting a second one.
+    pub busy: bool,
+    /// Progress or outcome, already phrased for the user. Empty means nothing to say.
+    pub text: String,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+static VOICE: std::sync::RwLock<Option<VoiceStatus>> = std::sync::RwLock::new(None);
+#[cfg(not(target_arch = "wasm32"))]
+static WANT_VOICE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn voice_status() -> VoiceStatus {
+    VOICE.read().ok().and_then(|g| g.clone()).unwrap_or_default()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn set_voice_status(busy: bool, text: impl Into<String>) {
+    if let Ok(mut g) = VOICE.write() {
+        *g = Some(VoiceStatus {
+            busy,
+            text: text.into(),
+        });
+    }
+}
+
+/// Ask for the voice download. The settings window has no HTTP client or runtime of its own, so
+/// it raises this flag and the app's frame loop does the work on the shared spawner.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn request_voice_download() {
+    WANT_VOICE.store(true, std::sync::atomic::Ordering::Relaxed);
+    set_voice_status(true, "starting…");
+}
+
+/// Drained once per frame by the app.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn take_voice_request() -> bool {
+    WANT_VOICE.swap(false, std::sync::atomic::Ordering::Relaxed)
+}
 
 /// Speak `text` aloud, if the platform can. Returns immediately.
 #[cfg(not(target_arch = "wasm32"))]
@@ -49,6 +132,14 @@ mod imp {
     /// Linux, PowerShell's System.Speech on Windows, `say` on macOS. No new dependency, and on a
     /// box with none of them installed this is a no-op rather than a failed build.
     pub fn speak_blocking(text: &str) -> Result<(), String> {
+        // Piper first when it is configured and present: a neural voice is the difference between
+        // a warning you listen to and one you turn off. Anything wrong with it — missing binary,
+        // missing model, a crash — falls through to the platform engine rather than going silent.
+        match piper(text) {
+            Ok(true) => return Ok(()),
+            Ok(false) => {}
+            Err(e) => log::warn!("piper failed, falling back: {e}"),
+        }
         #[cfg(target_os = "linux")]
         let candidates: Vec<(&str, Vec<String>)> = vec![
             ("spd-say", vec!["-w".into(), text.to_string()]),
@@ -88,6 +179,52 @@ mod imp {
             }
         }
         Err("no speech engine found (tried spd-say / espeak)".into())
+    }
+
+    /// Synthesize through Piper and play the result. `Ok(false)` means Piper is not configured,
+    /// which is not an error — it is the default state of every machine.
+    ///
+    // ponytail: subprocess, not in-process ONNX. `ort` would put a C++ runtime and a licence
+    // question into a build that currently cross-compiles to four targets without one; the
+    // process boundary costs a fork per warning, which is nothing against a network fetch.
+    fn piper(text: &str) -> Result<bool, String> {
+        use std::io::Write;
+        let (bin, voice) = super::PIPER
+            .read()
+            .map(|g| g.clone())
+            .map_err(|_| "piper config poisoned")?;
+        if voice.is_empty() || !std::path::Path::new(&voice).exists() {
+            return Ok(false);
+        }
+        let bin = if bin.is_empty() { "piper".to_string() } else { bin };
+        let mut cmd = Command::new(&bin);
+        crate::platform::no_window(&mut cmd);
+        // `--output_file -` gives a WAV on stdout, which rodio decodes directly. Writing to a
+        // temp file would mean choosing a directory and cleaning it up for no gain.
+        let mut child = match cmd
+            .args(["--model", &voice, "--output_file", "-"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+        {
+            Ok(c) => c,
+            // Not installed is the common case, and it is not a failure worth a warning.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(e) => return Err(format!("spawn {bin}: {e}")),
+        };
+        child
+            .stdin
+            .take()
+            .ok_or("no stdin")?
+            .write_all(text.as_bytes())
+            .map_err(|e| e.to_string())?;
+        let out = child.wait_with_output().map_err(|e| e.to_string())?;
+        if !out.status.success() || out.stdout.is_empty() {
+            return Err(format!("piper exited {}", out.status));
+        }
+        crate::audio::play_wav(out.stdout);
+        Ok(true)
     }
 }
 

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -1046,6 +1046,10 @@ fn alerts_tab(ui: &mut egui::Ui, settings: &mut Settings) {
              your eyes are on the road",
         );
     ui.weak("Linux needs spd-say or espeak installed; Android uses its built-in voice.");
+    #[cfg(not(target_arch = "wasm32"))]
+    if !cfg!(target_os = "android") {
+        piper_row(ui, settings);
+    }
 
     ui.add_space(8.0);
     ui.separator();
@@ -1060,4 +1064,60 @@ fn alerts_tab(ui: &mut egui::Ui, settings: &mut Settings) {
     );
     ui.checkbox(&mut settings.lightning_alarm, "Lightning within ~15 km of a saved location")
         .on_hover_text("Chime + push when CG lightning strikes near a marker. Requires the Lightning layer (National) to be on.");
+}
+
+/// Piper: the local neural voice, and the one download this app ever offers.
+///
+/// Nothing here is bundled. The binary is whatever the user installed (most distros package it),
+/// and the voice model is a ~60 MB file that would be absurd to commit — so the button fetches it
+/// into the data directory on request, and until then espeak keeps working.
+#[cfg(not(target_arch = "wasm32"))]
+fn piper_row(ui: &mut egui::Ui, settings: &mut Settings) {
+    ui.add_space(4.0);
+    let mut edited = false;
+    ui.horizontal(|ui| {
+        ui.label("Piper binary:");
+        edited |= ui
+            .add(
+                egui::TextEdit::singleline(&mut settings.piper_path)
+                    .hint_text("blank = find `piper` on PATH"),
+            )
+            .changed();
+    });
+    ui.horizontal(|ui| {
+        ui.label("Voice model:");
+        edited |= ui
+            .add(
+                egui::TextEdit::singleline(&mut settings.piper_voice)
+                    .hint_text("path to a .onnx voice"),
+            )
+            .changed();
+    });
+    if edited {
+        crate::speech::set_piper(&settings.piper_path, &settings.piper_voice);
+    }
+    ui.horizontal(|ui| {
+        let status = crate::speech::voice_status();
+        if settings.piper_voice.is_empty()
+            && !status.busy
+            && ui.button("Download a voice").clicked()
+        {
+            crate::speech::request_voice_download();
+        }
+        if !status.text.is_empty() {
+            ui.weak(&status.text);
+        }
+    });
+    // The download writes the model to a known path, so filling the field in for the user is the
+    // whole handoff — there is nothing else to configure.
+    if settings.piper_voice.is_empty() {
+        if let Some(p) = crate::speech::default_voice_path().filter(|p| p.exists()) {
+            settings.piper_voice = p.to_string_lossy().into_owned();
+            crate::speech::set_piper(&settings.piper_path, &settings.piper_voice);
+        }
+    }
+    ui.checkbox(
+        &mut settings.speak_position,
+        "Speak the nearest storm's bearing while chasing",
+    );
 }

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -904,6 +904,23 @@ fn alerts_tab(ui: &mut egui::Ui, settings: &mut Settings) {
         }
     });
     ui.weak("Quieter warnings still banner and still show in the alert list.");
+    ui.horizontal(|ui| {
+        ui.label("Roll up after");
+        ui.add(
+            egui::DragValue::new(&mut settings.alert_rollup_threshold)
+                .range(0..=50)
+                .suffix(" alerts"),
+        );
+        ui.label("within");
+        ui.add(
+            egui::DragValue::new(&mut settings.alert_rollup_window_min)
+                .range(1..=120)
+                .suffix(" min"),
+        );
+    });
+    ui.weak(
+        "On an outbreak day, pushes past that rate collapse into one rolling summary instead of          one buzz per warning. 0 turns it off; escalated warnings always push as themselves.",
+    );
 
     ui.add_space(8.0);
     ui.separator();

--- a/crates/wxdata/src/alerts.rs
+++ b/crates/wxdata/src/alerts.rs
@@ -212,6 +212,7 @@ fn build_alert(
         tornado_detection: param(props, "tornadoDetection"),
         damage_threat: param(props, "thunderstormDamageThreat")
             .or_else(|| param(props, "tornadoDamageThreat")),
+        vtec: param(props, "VTEC"),
         source: param(props, "eventMotionDescription").or_else(|| Some("Radar indicated".into())),
         motion: param(props, "eventMotionDescription")
             .as_deref()
@@ -530,6 +531,7 @@ mod tests {
             tornado_detection: det.map(str::to_string),
             damage_threat: threat.map(str::to_string),
             source: None,
+            vtec: None,
             motion: None,
         };
         assert_eq!(escalation(&mk("plain warning", None, None)), 0);

--- a/crates/wxdata/src/archive_warnings.rs
+++ b/crates/wxdata/src/archive_warnings.rs
@@ -55,6 +55,7 @@ pub fn parse(json: &str) -> anyhow::Result<Vec<GeoFeature>> {
             get("expire"),
         );
         let alert = AlertInfo {
+            vtec: None,
             id,
             event: event.clone(),
             headline: event.clone(),

--- a/crates/wxdata/src/lib.rs
+++ b/crates/wxdata/src/lib.rs
@@ -44,6 +44,7 @@ pub mod rotation;
 pub mod severe;
 pub mod sounding;
 pub mod spc;
+pub mod spoken;
 pub mod spotters;
 pub mod stations;
 pub mod task;

--- a/crates/wxdata/src/lib.rs
+++ b/crates/wxdata/src/lib.rs
@@ -53,6 +53,7 @@ pub mod torclimo;
 pub mod tropical;
 pub mod tz;
 pub mod verify;
+pub mod vtec;
 pub mod volume3d;
 /// Off-main-thread Level 2 decode in the browser.
 #[cfg(target_arch = "wasm32")]

--- a/crates/wxdata/src/overlay.rs
+++ b/crates/wxdata/src/overlay.rs
@@ -75,6 +75,46 @@ pub struct AlertInfo {
     pub source: Option<String>,
     /// Parsed storm motion (direction/speed/track) from `eventMotionDescription`; not persisted.
     pub motion: Option<StormMotion>,
+    /// Raw P-VTEC string, when the product carries one. [`Self::event_key`] is what uses it.
+    #[serde(default)]
+    pub vtec: Option<String>,
+}
+
+impl AlertInfo {
+    /// Identity of the *event*, for a seen-set to key on.
+    ///
+    /// `id` identifies a *message*, not an event. Continuing a tornado warning issues a fresh
+    /// message with a fresh id and the same warning underneath, so an id-keyed seen-set
+    /// re-announces the same warning every few minutes. The VTEC event key does not move.
+    /// Products with no VTEC (most non-warning-tier alerts) fall back to the id, which is the
+    /// old behaviour.
+    pub fn event_key(&self) -> String {
+        self.vtec
+            .as_deref()
+            .and_then(crate::vtec::Vtec::parse)
+            .map(|v| v.event_key())
+            .unwrap_or_else(|| self.id.clone())
+    }
+
+    /// The string the app dedupes announcements on. Normally one entry per *event*, so a
+    /// continuation of a tornado warning is silent; an upgrade earns its own entry (keyed by
+    /// message id) so it announces once and only once.
+    pub fn dedupe_key(&self) -> String {
+        let k = self.event_key();
+        if self.is_upgrade() {
+            format!("{k}#{}", self.id)
+        } else {
+            k
+        }
+    }
+
+    /// Should this message re-announce an event we have already announced? Only an upgrade does.
+    pub fn is_upgrade(&self) -> bool {
+        self.vtec
+            .as_deref()
+            .and_then(crate::vtec::Vtec::parse)
+            .is_some_and(|v| v.action.is_newsworthy_repeat())
+    }
 }
 
 /// One renderable, clickable overlay polygon.
@@ -399,5 +439,52 @@ mod tests {
         assert!(rings_intersect(&base, &sq(1.0, 0.0, 1.0)));
         // Degenerate rings are never a match.
         assert!(!rings_intersect(&base, &[[0.5, 0.5], [0.6, 0.6]]));
+    }
+}
+
+#[cfg(test)]
+mod dedupe_tests {
+    use super::*;
+
+    fn alert(id: &str, vtec: &str) -> AlertInfo {
+        AlertInfo {
+            id: id.into(),
+            event: "Tornado Warning".into(),
+            headline: String::new(),
+            area: String::new(),
+            description: String::new(),
+            instruction: String::new(),
+            expires: None,
+            max_hail_in: None,
+            max_wind: None,
+            tornado_detection: None,
+            damage_threat: None,
+            source: None,
+            motion: None,
+            vtec: Some(vtec.into()),
+        }
+    }
+
+    #[test]
+    fn a_continuation_dedupes_against_the_new_warning() {
+        // Same event, two messages: the second must not announce.
+        let new = alert("urn:a", "/O.NEW.KOUN.TO.W.0071.130520T2012Z-130520T2045Z/");
+        let con = alert("urn:b", "/O.CON.KOUN.TO.W.0071.000000T0000Z-130520T2045Z/");
+        assert_eq!(new.dedupe_key(), con.dedupe_key());
+    }
+
+    #[test]
+    fn an_upgrade_announces_once_and_only_once() {
+        let new = alert("urn:a", "/O.NEW.KOUN.TO.W.0071.130520T2012Z-130520T2045Z/");
+        let upg = alert("urn:c", "/O.UPG.KOUN.TO.W.0071.000000T0000Z-130520T2045Z/");
+        assert_ne!(new.dedupe_key(), upg.dedupe_key());
+        assert_eq!(upg.dedupe_key(), upg.dedupe_key());
+    }
+
+    #[test]
+    fn no_vtec_falls_back_to_the_message_id() {
+        let mut a = alert("urn:z", "");
+        a.vtec = None;
+        assert_eq!(a.dedupe_key(), "urn:z");
     }
 }

--- a/crates/wxdata/src/spoken.rs
+++ b/crates/wxdata/src/spoken.rs
@@ -1,0 +1,260 @@
+//! Turning an alert into something worth hearing.
+//!
+//! The old spoken line was `"{event} for {area} until {time}"`, which starts with the four words
+//! the listener already guessed and buries the two that matter: what it is going to do, and
+//! whether it is coming at you. Driving, you get one sentence before your attention goes back to
+//! the road, so the hazard, the place and the direction go in that sentence.
+//!
+//! It also read raw NWS text, which is written to be *seen*: "60 MPH", "SW of", "1.75 IN".
+//! A synthesizer says "sixty em pee aitch". [`expand`] fixes that.
+//!
+//! Pure string work, no engine and no platform: desktop, Android and the browser all speak
+//! whatever this returns.
+
+use crate::overlay::AlertInfo;
+
+/// 16-point compass bearing, spoken in full.
+fn spoken_compass(deg: f32) -> &'static str {
+    const D: [&str; 16] = [
+        "north",
+        "north northeast",
+        "northeast",
+        "east northeast",
+        "east",
+        "east southeast",
+        "southeast",
+        "south southeast",
+        "south",
+        "south southwest",
+        "southwest",
+        "west southwest",
+        "west",
+        "west northwest",
+        "northwest",
+        "north northwest",
+    ];
+    D[((deg / 22.5).round() as usize) % 16]
+}
+
+/// Abbreviations as issued, and how to say them. Matched on whole words, longest first, so `MPH`
+/// wins before `PH` could and `NNE` before `N`.
+const ABBREV: &[(&str, &str)] = &[
+    ("MPH", "miles per hour"),
+    ("KTS", "knots"),
+    ("KT", "knots"),
+    ("TSTM", "thunderstorm"),
+    ("TSTMS", "thunderstorms"),
+    ("PDS", "particularly dangerous situation"),
+    ("NWS", "National Weather Service"),
+    ("EMER", "emergency"),
+    ("SVR", "severe"),
+    ("TOR", "tornado"),
+    ("FFW", "flash flood warning"),
+    ("CO", "county"),
+    ("CNTY", "county"),
+    ("MI", "miles"),
+    ("NM", "nautical miles"),
+    ("IN", "inch"),
+    ("FT", "feet"),
+    ("AM", "A M"),
+    ("PM", "P M"),
+    ("CDT", "central time"),
+    ("CST", "central time"),
+    ("EDT", "eastern time"),
+    ("EST", "eastern time"),
+    ("MDT", "mountain time"),
+    ("MST", "mountain time"),
+    ("PDT", "pacific time"),
+    ("PST", "pacific time"),
+    ("N", "north"),
+    ("S", "south"),
+    ("E", "east"),
+    ("W", "west"),
+    ("NE", "northeast"),
+    ("NW", "northwest"),
+    ("SE", "southeast"),
+    ("SW", "southwest"),
+    ("NNE", "north northeast"),
+    ("ENE", "east northeast"),
+    ("ESE", "east southeast"),
+    ("SSE", "south southeast"),
+    ("SSW", "south southwest"),
+    ("WSW", "west southwest"),
+    ("WNW", "west northwest"),
+    ("NNW", "north northwest"),
+];
+
+/// Expand NWS shorthand into words a synthesizer can say.
+///
+/// Only whole all-caps words are touched: a place called Independence keeps its `IN`, and lower
+/// case prose is left exactly as written. Anything not in the table is passed through, because a
+/// wrong expansion is worse than an unexpanded one — "N" heard as "north" in the wrong place is a
+/// direction the listener acts on.
+pub fn expand(text: &str) -> String {
+    let mut out = String::with_capacity(text.len() + 16);
+    let mut word = String::new();
+    let flush = |word: &mut String, out: &mut String| {
+        if !word.is_empty() {
+            let hit = word
+                .chars()
+                .all(|c| c.is_ascii_uppercase())
+                .then(|| ABBREV.iter().find(|(a, _)| *a == word).map(|(_, b)| *b))
+                .flatten();
+            match hit {
+                Some(rep) => out.push_str(rep),
+                None => out.push_str(word),
+            }
+            word.clear();
+        }
+    };
+    for c in text.chars() {
+        if c.is_ascii_alphabetic() {
+            word.push(c);
+        } else {
+            flush(&mut word, &mut out);
+            out.push(c);
+        }
+    }
+    flush(&mut word, &mut out);
+    out
+}
+
+/// The sentence spoken when a warning arrives: hazard, place, motion, then the expiry.
+///
+/// `place` is the watched location the warning hit, or the alert's own area when it hit none.
+/// `until` is the already-formatted clock time, or empty.
+pub fn warning_script(a: &AlertInfo, place: &str, until: &str) -> String {
+    let mut s = String::new();
+    // Lead with the escalated wording when there is any — "Tornado emergency" first, not fourth.
+    let lead = a
+        .damage_threat
+        .as_deref()
+        .filter(|t| t.eq_ignore_ascii_case("DESTRUCTIVE") || t.eq_ignore_ascii_case("CATASTROPHIC"))
+        .map(|t| format!("{} {}", expand(t).to_lowercase(), a.event.to_lowercase()))
+        .unwrap_or_else(|| a.event.to_lowercase());
+    s.push_str(&capitalize(&lead));
+    if !place.is_empty() {
+        s.push_str(" for ");
+        s.push_str(&expand(place));
+    }
+    if let Some(m) = &a.motion {
+        // `deg` is the FROM bearing as issued; the heading it travels toward is the other way,
+        // and the heading is the only half a listener can act on.
+        s.push_str(&format!(
+            ", moving {} at {} miles per hour",
+            spoken_compass((m.deg + 180.0) % 360.0),
+            (m.kt * 1.15078).round() as i32
+        ));
+    }
+    if let Some(h) = a.max_hail_in {
+        s.push_str(&format!(", hail to {h} inch"));
+    }
+    if let Some(w) = &a.max_wind {
+        s.push_str(&format!(", winds {}", expand(w)));
+    }
+    if !until.is_empty() {
+        s.push_str(", until ");
+        s.push_str(until);
+    }
+    s.push('.');
+    s
+}
+
+/// The optional chase update: where the nearest storm is relative to you, spoken.
+///
+/// `bearing_deg` is the direction from the listener to the storm, `km` the distance, and
+/// `moving_toward_deg` the heading the storm travels *toward* — which is what storm-cell tables
+/// carry, unlike an alert's motion field. Nothing is flipped here.
+pub fn position_script(
+    name: &str,
+    bearing_deg: f32,
+    km: f64,
+    moving_toward_deg: Option<f32>,
+) -> String {
+    let miles = (km * 0.621_371).round() as i32;
+    let mut s = format!(
+        "{name} is {miles} miles to your {}",
+        spoken_compass(bearing_deg)
+    );
+    if let Some(d) = moving_toward_deg {
+        s.push_str(&format!(", moving {}", spoken_compass(d)));
+    }
+    s.push('.');
+    s
+}
+
+fn capitalize(s: &str) -> String {
+    let mut c = s.chars();
+    match c.next() {
+        Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+        None => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::overlay::StormMotion;
+
+    fn tor() -> AlertInfo {
+        AlertInfo {
+            id: "urn:x".into(),
+            event: "Tornado Warning".into(),
+            headline: String::new(),
+            area: "Cleveland County".into(),
+            description: String::new(),
+            instruction: String::new(),
+            expires: None,
+            max_hail_in: None,
+            max_wind: None,
+            tornado_detection: Some("OBSERVED".into()),
+            damage_threat: Some("CATASTROPHIC".into()),
+            source: None,
+            motion: Some(StormMotion {
+                deg: 225.0, // from the southwest, so travelling northeast
+                kt: 40.0,
+                points: vec![],
+            }),
+            vtec: None,
+        }
+    }
+
+    #[test]
+    fn the_hazard_place_and_heading_come_first() {
+        let s = warning_script(&tor(), "Home", "7 15 PM");
+        assert!(
+            s.starts_with("Catastrophic tornado warning for Home, moving northeast at 46 miles"),
+            "{s}"
+        );
+        assert!(s.ends_with("until 7 15 PM."), "{s}");
+    }
+
+    #[test]
+    fn abbreviations_expand_only_as_whole_capital_words() {
+        assert_eq!(expand("60 MPH winds"), "60 miles per hour winds");
+        assert_eq!(expand("2 MI SW of Norman"), "2 miles southwest of Norman");
+        // Lower case prose and mixed-case place names are left alone — a wrong expansion is
+        // worse than none, since a listener acts on a direction.
+        assert_eq!(expand("Independence, Indiana"), "Independence, Indiana");
+        assert_eq!(expand("in the county"), "in the county");
+    }
+
+    #[test]
+    fn a_plain_warning_still_reads_cleanly() {
+        let mut a = tor();
+        a.damage_threat = None;
+        a.motion = None;
+        a.max_hail_in = Some(1.75);
+        assert_eq!(
+            warning_script(&a, "", ""),
+            "Tornado warning, hail to 1.75 inch."
+        );
+    }
+
+    #[test]
+    fn a_position_update_names_the_side_it_is_on() {
+        // 225 here is a heading, not a from-bearing: cell tables give direction of travel.
+        let s = position_script("The storm", 90.0, 32.2, Some(225.0));
+        assert_eq!(s, "The storm is 20 miles to your east, moving southwest.");
+    }
+}

--- a/crates/wxdata/src/vtec.rs
+++ b/crates/wxdata/src/vtec.rs
@@ -1,0 +1,199 @@
+//! Parsing for the NWS P-VTEC string that rides on every warning-tier alert.
+//!
+//! An alert's `id` is per *message*, not per *event*. When an office continues a tornado warning
+//! it issues a fresh message with a fresh id and the same warning underneath, which is why
+//! deduping on `id` re-announces the same warning every few minutes. The VTEC string names the
+//! event itself, and stays the same for the life of it:
+//!
+//! ```text
+//! /O.NEW.KOUN.TO.W.0071.130520T2012Z-130520T2045Z/
+//!  │ │   │    │  │ │
+//!  │ │   │    │  │ └─ event tracking number, unique per office/phenomenon/year
+//!  │ │   │    │  └─── significance: W arning, A dvisory, Y (advisory), S tatement
+//!  │ │   │    └────── phenomenon: TO rnado, SV severe thunderstorm, FF flash flood, …
+//!  │ │   └─────────── issuing office
+//!  │ └─────────────── action: NEW, CON, EXT, EXA, EXB, CAN, EXP, UPG, COR, ROU
+//!  └───────────────── product class: O perational, T est, E xperimental
+//! ```
+//!
+//! ponytail: P-VTEC only. The H-VTEC segment that follows it on hydrologic products carries flood
+//! severity and crest times, which nothing here needs yet.
+
+/// What an office is doing to the event with this message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Action {
+    /// A warning that did not exist before.
+    New,
+    /// Continued — the same warning, still in force. The common case, and the one that used to
+    /// re-announce.
+    Continued,
+    /// Extended in time or area.
+    Extended,
+    /// Cancelled, expired, or upgraded away.
+    Ended,
+    /// Upgraded to a more serious product (severe thunderstorm to tornado, say).
+    Upgraded,
+    /// Correction, routine, or anything else.
+    Other,
+}
+
+impl Action {
+    fn parse(s: &str) -> Action {
+        match s {
+            "NEW" => Action::New,
+            "CON" => Action::Continued,
+            "EXT" | "EXA" | "EXB" => Action::Extended,
+            "CAN" | "EXP" => Action::Ended,
+            "UPG" => Action::Upgraded,
+            _ => Action::Other,
+        }
+    }
+
+    /// Does this action deserve a fresh notification, given we have already announced the event?
+    ///
+    /// Only an upgrade does. A continuation is the same warning restated, and announcing it again
+    /// is the duplicate-notification bug.
+    pub fn is_newsworthy_repeat(self) -> bool {
+        matches!(self, Action::Upgraded)
+    }
+}
+
+/// The parts of a P-VTEC string that identify an event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Vtec {
+    pub action: Action,
+    pub office: String,
+    pub phenomenon: String,
+    pub significance: String,
+    pub etn: u16,
+    /// Two-digit year from the event's start time, which is what makes `etn` unique — offices
+    /// restart the numbering every January.
+    pub year: u16,
+}
+
+impl Vtec {
+    /// Identity of the *event*, stable across every message about it. This is what a seen-set
+    /// should key on.
+    pub fn event_key(&self) -> String {
+        format!(
+            "{}.{}.{}.{:04}.{}",
+            self.office, self.phenomenon, self.significance, self.etn, self.year
+        )
+    }
+
+    /// Parse the first P-VTEC line out of `s`, which may be a bare VTEC string or a block of text
+    /// containing one.
+    pub fn parse(s: &str) -> Option<Vtec> {
+        for line in s.lines() {
+            let line = line.trim();
+            // A P-VTEC string is slash-delimited with exactly six dot-separated fields before the
+            // time range.
+            let Some(inner) = line.strip_prefix('/') else {
+                continue;
+            };
+            let inner = inner.strip_suffix('/').unwrap_or(inner);
+            // class.action.office.phenomenon.significance.etn.start-end
+            let parts: Vec<&str> = inner.split('.').collect();
+            if parts.len() < 7 {
+                continue;
+            }
+            // parts[0] is the product class (O/T/E); a test product must never notify anyone.
+            if parts[0] != "O" {
+                continue;
+            }
+            let Ok(etn) = parts[5].parse::<u16>() else {
+                continue;
+            };
+            // The time range is "130520T2012Z-130520T2045Z"; the first two digits are the year.
+            // A continuation zeroes its start time, so fall back to the end time — the event does
+            // not span a new year between messages.
+            let Some(year) = parts[6]
+                .split('-')
+                .find(|t| !t.starts_with("000000"))
+                .and_then(|t| t.get(..2))
+                .and_then(|y| y.parse::<u16>().ok())
+                .map(|y| 2000 + y)
+            else {
+                continue;
+            };
+            return Some(Vtec {
+                action: Action::parse(parts[1]),
+                office: parts[2].to_string(),
+                phenomenon: parts[3].to_string(),
+                significance: parts[4].to_string(),
+                etn,
+                year,
+            });
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TOR: &str = "/O.NEW.KOUN.TO.W.0071.130520T2012Z-130520T2045Z/";
+    const TOR_CON: &str = "/O.CON.KOUN.TO.W.0071.000000T0000Z-130520T2045Z/";
+
+    #[test]
+    fn parses_a_tornado_warning() {
+        let v = Vtec::parse(TOR).unwrap();
+        assert_eq!(v.action, Action::New);
+        assert_eq!(v.office, "KOUN");
+        assert_eq!(v.phenomenon, "TO");
+        assert_eq!(v.significance, "W");
+        assert_eq!(v.etn, 71);
+        assert_eq!(v.year, 2013);
+    }
+
+    /// The whole point: a continuation is the *same event*, so it must produce the same key.
+    #[test]
+    fn a_continuation_shares_the_events_identity() {
+        let new = Vtec::parse(TOR).unwrap();
+        let con = Vtec::parse(TOR_CON).unwrap();
+        assert_eq!(new.event_key(), con.event_key());
+        assert_eq!(con.action, Action::Continued);
+        assert!(!con.action.is_newsworthy_repeat());
+    }
+
+    /// Different offices, phenomena, significances and years never collide, because event
+    /// tracking numbers are only unique within one of each.
+    #[test]
+    fn keys_separate_events_that_share_a_number() {
+        let k = |s: &str| Vtec::parse(s).unwrap().event_key();
+        let base = k("/O.NEW.KOUN.TO.W.0071.130520T2012Z-130520T2045Z/");
+        assert_ne!(base, k("/O.NEW.KFWD.TO.W.0071.130520T2012Z-130520T2045Z/"));
+        assert_ne!(base, k("/O.NEW.KOUN.SV.W.0071.130520T2012Z-130520T2045Z/"));
+        assert_ne!(base, k("/O.NEW.KOUN.TO.A.0071.130520T2012Z-130520T2045Z/"));
+        assert_ne!(base, k("/O.NEW.KOUN.TO.W.0071.140520T2012Z-140520T2045Z/"));
+    }
+
+    #[test]
+    fn an_upgrade_is_worth_announcing_and_a_continuation_is_not() {
+        let upg = Vtec::parse("/O.UPG.KOUN.SV.W.0142.130520T2012Z-130520T2045Z/").unwrap();
+        assert!(upg.action.is_newsworthy_repeat());
+        for a in ["CON", "EXT", "EXA", "COR", "ROU"] {
+            let s = format!("/O.{a}.KOUN.TO.W.0071.130520T2012Z-130520T2045Z/");
+            assert!(
+                !Vtec::parse(&s).unwrap().action.is_newsworthy_repeat(),
+                "{a} should not re-announce"
+            );
+        }
+    }
+
+    /// Test and experimental products carry the same shape and must never be treated as real.
+    #[test]
+    fn non_operational_products_are_not_events() {
+        assert!(Vtec::parse("/T.NEW.KOUN.TO.W.0071.130520T2012Z-130520T2045Z/").is_none());
+        assert!(Vtec::parse("/E.NEW.KOUN.TO.W.0071.130520T2012Z-130520T2045Z/").is_none());
+    }
+
+    #[test]
+    fn junk_is_rejected_rather_than_guessed_at() {
+        assert!(Vtec::parse("").is_none());
+        assert!(Vtec::parse("not a vtec string").is_none());
+        assert!(Vtec::parse("/O.NEW.KOUN/").is_none());
+        assert!(Vtec::parse("/O.NEW.KOUN.TO.W.XXXX.130520T2012Z-130520T2045Z/").is_none());
+    }
+}


### PR DESCRIPTION
Wave E of R17. Three bounded commits against the three alert complaints from the interview: duplicates, outbreak noise, and deliveries that vanish.

## 1. Duplicates — dedupe by VTEC event, not message id

Root cause: an alert's `id` identifies a *message*. When an office continues a tornado warning it issues a fresh message with a fresh id and the same warning underneath, so an id-keyed seen-set re-announced the same warning every few minutes.

New `wxdata::vtec` parses the P-VTEC string (`/O.NEW.KOUN.TO.W.0071.130520T2012Z-130520T2045Z/`) into class, action, office, phenomenon, significance, ETN and year. `AlertInfo::event_key()` is office+phenomenon+significance+ETN+year, which does not move across a continuation. `dedupe_key()` is that, except an upgrade (UPG/EXA/EXB) gets its own entry keyed by message id, so it announces once and only once. Products with no VTEC fall back to the id — the old behaviour.

The persisted seen-set the plan asked for turned out to already exist: it seeds from the on-disk alert snapshot, which drops expired alerts on load. A restart mid-event does not re-fire, and a snapshot from last week seeds nothing.

## 2. Outbreak rollup

`alert_rollup` is a rolling window over pushed alert titles. Past `alert_rollup_threshold` alerts inside `alert_rollup_window_min` (default 5 in 10 min; 0 disables), `notify_alert` stops delivering individual pushes and delivers one summary instead — newest first, eight lines, "…and N more" — refreshed at most once a minute. The window drains by itself, so normal pushes resume when the outbreak does. Escalated alerts (Tornado Emergency, PDS, destructive) are exempt and always push as themselves.

Delivery only: banners, the alert list, sounds and the map are untouched.

Named `alert_rollup` because `digest.rs` is taken (plain-language storm digest).

## 3. Delivery retry

`notify::send_retrying` is now the shared send path for ntfy, Discord, Slack and Matrix. Retries a transport error or a 5xx/429 three times at 2 s, 8 s, 30 s; a 4xx is not retried, because a deleted webhook or a stale token fails identically forever. Bounded at 32 deliveries in backoff at once. The Matrix retry reuses its transaction id, which is what that id is for.

## Ponytails

- The rollup summary is a fresh notification per refresh, not an in-place replace. Desktop replace-by-tag and the Android fixed notification id belong with the Android delivery stack (PR 12), which is where that plumbing lives.
- The retry queue is in memory: a crash mid-backoff loses the delivery. Persist it if anyone reports losing alerts to a restart rather than to a dead webhook.
- Web sends once — no tokio timer in the browser, and not worth a crate for it.

## Verification

`cargo clippy --workspace --all-targets` clean · `cargo test --workspace` 473 passed · wasm `cargo check` clean · `shoot.sh check` passed.

New tests: six VTEC parse cases; three dedupe cases (continuation dedupes, upgrade announces once, no-VTEC falls back to id); three rollup state-machine cases (under threshold sends, fifth rolls up and sixth holds, window drains and normal pushes resume); retry against a socket-level mock sink (503-then-200 served twice, 404 served once).

Not done here, stated plainly: no live outbreak replay — the rollup is covered by the state-machine tests, not by an archive run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)