### PR TITLE
alerts: Android delivery stack — exact alarms, exemption, watchdog, health

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -38,6 +38,14 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <!-- Re-arms the WorkManager poll after a reboot; see BootReceiver. -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <!-- An exact alarm is the only schedule Doze honours on time, and a warning delivered on the
+         OS's deferred schedule is not a warning. The user-grantable permission, not USE_EXACT_ALARM
+         (reserved for alarm-clock and calendar apps); denied, we fall back to inexact and say so in
+         the delivery-health panel. See AlertAlarm. -->
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <!-- Prompts for the battery-optimisation exemption that decides whether overnight alerts
+         arrive on a Samsung. Play-policy-sensitive; see the note in AlertAlarm.requestExemption. -->
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
     <!-- The wgpu backend is Vulkan; require Vulkan 1.1 (0x00400003). -->
     <uses-feature
@@ -126,6 +134,12 @@
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
+
+        <!-- Exact-alarm poll: the leg that keeps working when the service is dead. Not exported;
+             only our own PendingIntent triggers it. -->
+        <receiver
+            android:name=".AlertAlarm"
+            android:exported="false" />
 
         <service
             android:name=".AlertService"

--- a/android/app/src/main/kotlin/zip/batman/hookecho/AlertAlarm.kt
+++ b/android/app/src/main/kotlin/zip/batman/hookecho/AlertAlarm.kt
@@ -1,0 +1,174 @@
+package zip.batman.hookecho
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.PowerManager
+
+/**
+ * The third leg under background alerting, and the only one the OS cannot defer.
+ *
+ * [AlertService] is a foreground service, which Samsung's app-sleep and deep Doze both kill.
+ * [AlertWorker] survives that, but WorkManager's periodic floor is 15 minutes and it is a floor,
+ * not a promise — a tornado warning that arrives 15 minutes late is not a warning. An exact alarm
+ * (`setExactAndAllowWhileIdle`) is the one schedule Doze honours, so a poll runs on time with the
+ * app closed, the service dead and the screen off.
+ *
+ * Exact alarms are permissioned from API 31. We ask for `SCHEDULE_EXACT_ALARM` (the
+ * user-grantable one, prompted through its settings screen) rather than `USE_EXACT_ALARM` (the
+ * one reserved for alarm-clock and calendar apps, which a weather app would not survive review
+ * claiming). When it is not granted we fall back to `setAndAllowWhileIdle`, which still wakes in
+ * Doze but on the OS's own schedule — better than nothing, and honestly reported in the health
+ * readout instead of quietly pretending.
+ *
+ * ponytail: one alarm at a fixed 5-minute cadence, re-armed by each pass. Cadence that tightens
+ * while a warning is active would mean cancelling and re-arming on every poll; the service
+ * already does the tightening when it is alive, and this is the path for when it isn't.
+ */
+class AlertAlarm : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (!AlertService.isEnabled(context)) return
+        AlertService.createChannels(context)
+        // The alarm wakes the CPU only long enough to deliver this broadcast; a poll is a network
+        // round trip, so it needs its own lock or the device sleeps mid-fetch.
+        val wl = context.getSystemService(PowerManager::class.java)
+            .newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "hookecho:alarm")
+        try {
+            wl.acquire(60_000L)
+            AlertService.pollOnce(context, AlertService.loadSeen(context))
+            AlertWidget.refresh(context)
+            markPolled(context)
+        } finally {
+            if (wl.isHeld) wl.release()
+            // Re-arm last and unconditionally: a poll that threw must not end the chain.
+            arm(context)
+        }
+    }
+
+    companion object {
+        /** How often the alarm polls. Matches the service's calm-weather cadence. */
+        private const val PERIOD_MS = 5 * 60 * 1000L
+        private const val PREFS = "alerts"
+        private const val KEY_LAST_POLL = "last_alarm_poll"
+        private const val KEY_NEXT = "next_alarm"
+
+        private fun prefs(context: Context) =
+            context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+        private fun intent(context: Context) = PendingIntent.getBroadcast(
+            context, 0, Intent(context, AlertAlarm::class.java),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        private fun alarms(context: Context) = context.getSystemService(AlarmManager::class.java)
+
+        /** Whether the OS will honour an exact alarm from us right now. */
+        @JvmStatic
+        fun canExact(context: Context): Boolean =
+            Build.VERSION.SDK_INT < 31 || alarms(context).canScheduleExactAlarms()
+
+        /** Whether we are exempt from battery optimisation (Doze's app-standby buckets). */
+        @JvmStatic
+        fun isExempt(context: Context): Boolean =
+            context.getSystemService(PowerManager::class.java)
+                .isIgnoringBatteryOptimizations(context.packageName)
+
+        /**
+         * Schedule the next poll. Exact where permitted, `setAndAllowWhileIdle` where not — both
+         * fire in Doze, only one fires on time.
+         */
+        @JvmStatic
+        fun arm(context: Context) {
+            if (!AlertService.isEnabled(context)) return
+            val at = System.currentTimeMillis() + PERIOD_MS
+            val pi = intent(context)
+            // A denied exact alarm throws rather than degrading, so the fallback is a catch too:
+            // the permission can be revoked between the check and the call.
+            runCatching {
+                if (canExact(context)) {
+                    alarms(context).setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, at, pi)
+                } else {
+                    alarms(context).setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, at, pi)
+                }
+            }.onFailure {
+                alarms(context).setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, at, pi)
+            }
+            prefs(context).edit().putLong(KEY_NEXT, at).apply()
+        }
+
+        @JvmStatic
+        fun cancel(context: Context) {
+            alarms(context).cancel(intent(context))
+            prefs(context).edit().remove(KEY_NEXT).apply()
+        }
+
+        /** Record that a poll actually happened, for the health readout. */
+        @JvmStatic
+        fun markPolled(context: Context) {
+            prefs(context).edit().putLong(KEY_LAST_POLL, System.currentTimeMillis()).apply()
+        }
+
+        /**
+         * Open the OS screen that grants exact alarms. No-op below API 31, where the permission
+         * does not exist and alarms are already exact.
+         */
+        @JvmStatic
+        fun requestExact(context: Context) {
+            if (Build.VERSION.SDK_INT < 31 || canExact(context)) return
+            runCatching {
+                context.startActivity(
+                    Intent(android.provider.Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM)
+                        .setData(Uri.parse("package:${context.packageName}"))
+                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                )
+            }
+        }
+
+        /**
+         * Ask to be exempt from battery optimisation. This is the dialog that actually decides
+         * whether alerts arrive overnight on a Samsung.
+         *
+         * `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` is Play-policy-sensitive — the store allows it
+         * for apps whose core function needs it and rejects it otherwise. This build is sideloaded
+         * from GitHub releases, where the prompt is fine; whether a Play submission keeps it is a
+         * decision for whoever files that submission, and it is one call to delete.
+         */
+        @JvmStatic
+        fun requestExemption(context: Context) {
+            if (isExempt(context)) return
+            runCatching {
+                context.startActivity(
+                    Intent(android.provider.Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
+                        .setData(Uri.parse("package:${context.packageName}"))
+                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                )
+            }
+        }
+
+        /**
+         * Delivery health, as a tab-separated line for the Rust settings panel to parse:
+         * `enabled \t exact \t exempt \t lastPollMsAgo \t nextAlarmInMs`. -1 means never/unknown.
+         *
+         * Deliberately one string over the existing bridge rather than five JNI calls or a second
+         * bridge: the panel reads it once a second at most.
+         */
+        @JvmStatic
+        fun health(context: Context): String {
+            val p = prefs(context)
+            val now = System.currentTimeMillis()
+            val last = p.getLong(KEY_LAST_POLL, 0L)
+            val next = p.getLong(KEY_NEXT, 0L)
+            return listOf(
+                AlertService.isEnabled(context),
+                canExact(context),
+                isExempt(context),
+                if (last > 0) now - last else -1L,
+                if (next > 0) next - now else -1L,
+            ).joinToString("\t")
+        }
+    }
+}

--- a/android/app/src/main/kotlin/zip/batman/hookecho/AlertService.kt
+++ b/android/app/src/main/kotlin/zip/batman/hookecho/AlertService.kt
@@ -25,10 +25,9 @@ import android.os.PowerManager
  * [AlertWorker] is the safety net underneath it, not a replacement — both run the same
  * [pollOnce].
  *
- * ponytail: deep-Doze worst case is ~15 min via WorkManager once the OS kills this service;
- * setExactAndAllowWhileIdle escalation while a warning is active is the upgrade path if field
- * reports show FGS deaths. REQUEST_IGNORE_BATTERY_OPTIMIZATIONS is deliberately not requested
- * (Play-policy-sensitive).
+ * [AlertAlarm] is the third leg: an exact alarm is the one schedule Doze honours on time, so a
+ * poll still lands when this service has been killed and WorkManager's 15-minute floor is too
+ * slow to be a warning.
  */
 class AlertService : Service() {
     @Volatile private var running = false
@@ -65,6 +64,7 @@ class AlertService : Service() {
             // The widget's own 30-minute clock is a floor; while the service runs it stays as
             // fresh as the poll it just did.
             AlertWidget.refresh(this)
+            AlertAlarm.markPolled(this)
             // Tighten the cadence while something is actually warned at a watched point.
             val waitMs = if (hot) 60_000L else 300_000L
             var slept = 0L
@@ -215,9 +215,11 @@ class AlertService : Service() {
                 }
                 context.startForegroundService(intent)
                 AlertWorker.enqueue(context)
+                AlertAlarm.arm(context)
             } else {
                 context.stopService(intent)
                 AlertWorker.cancel(context)
+                AlertAlarm.cancel(context)
             }
         }
     }

--- a/android/app/src/main/kotlin/zip/batman/hookecho/AlertWorker.kt
+++ b/android/app/src/main/kotlin/zip/batman/hookecho/AlertWorker.kt
@@ -36,6 +36,11 @@ class AlertWorker(context: Context, params: WorkerParameters) : Worker(context, 
         }
         AlertService.pollOnce(context, AlertService.loadSeen(context))
         AlertWidget.refresh(context)
+        AlertAlarm.markPolled(context)
+        // Watchdog half: an exact alarm is a one-shot that re-arms itself, so anything that eats
+        // one — a force-stop, a reboot before BootReceiver, the OS cancelling on package replace
+        // — ends the chain silently. Re-arming here every 15 minutes is what restarts it.
+        AlertAlarm.arm(context)
         return Result.success()
     }
 

--- a/android/app/src/main/kotlin/zip/batman/hookecho/BootReceiver.kt
+++ b/android/app/src/main/kotlin/zip/batman/hookecho/BootReceiver.kt
@@ -14,6 +14,9 @@ import android.content.Intent
 class BootReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action != Intent.ACTION_BOOT_COMPLETED) return
-        if (AlertService.isEnabled(context)) AlertWorker.enqueue(context)
+        if (!AlertService.isEnabled(context)) return
+        AlertWorker.enqueue(context)
+        // Alarms do not survive a reboot; this is the only thing that re-arms them.
+        AlertAlarm.arm(context)
     }
 }

--- a/crates/hookecho/src/platform.rs
+++ b/crates/hookecho/src/platform.rs
@@ -86,6 +86,69 @@ pub fn set_background_alerts(_enabled: bool) {
     android_alerts::set_enabled(_enabled);
 }
 
+/// Delivery health from the Android alert stack, parsed from `AlertAlarm.health`. `None`
+/// everywhere else — on desktop the window being open *is* the delivery mechanism.
+pub fn alert_health() -> Option<AlertHealth> {
+    #[cfg(target_os = "android")]
+    {
+        android_alerts::health().and_then(|s| AlertHealth::parse(&s))
+    }
+    #[cfg(not(target_os = "android"))]
+    {
+        None
+    }
+}
+
+/// What the Android alert stack reports about itself.
+#[derive(Debug, PartialEq)]
+pub struct AlertHealth {
+    /// The user's background-alerts switch.
+    pub enabled: bool,
+    /// Whether the OS will honour an exact alarm. False means polls arrive on Doze's schedule.
+    pub exact: bool,
+    /// Whether we are exempt from battery optimisation.
+    pub exempt: bool,
+    /// Since the last poll actually ran. `None` if it never has.
+    pub since_poll: Option<std::time::Duration>,
+    /// Until the next scheduled alarm. `None` if none is armed.
+    pub until_next: Option<std::time::Duration>,
+}
+
+impl AlertHealth {
+    /// `enabled \t exact \t exempt \t sincePollMs \t untilNextMs`, -1 for never/unknown.
+    pub fn parse(line: &str) -> Option<Self> {
+        let f: Vec<&str> = line.split('\t').collect();
+        if f.len() != 5 {
+            return None;
+        }
+        let ms = |s: &str| {
+            s.parse::<i64>()
+                .ok()
+                .filter(|v| *v >= 0)
+                .map(|v| std::time::Duration::from_millis(v as u64))
+        };
+        Some(Self {
+            enabled: f[0] == "true",
+            exact: f[1] == "true",
+            exempt: f[2] == "true",
+            since_poll: ms(f[3]),
+            until_next: ms(f[4]),
+        })
+    }
+}
+
+/// Open the OS screen that grants exact alarms (Android 12+). No-op elsewhere.
+pub fn request_exact_alarms() {
+    #[cfg(target_os = "android")]
+    android_alerts::call_void("requestExact");
+}
+
+/// Prompt for the battery-optimisation exemption. No-op elsewhere.
+pub fn request_battery_exemption() {
+    #[cfg(target_os = "android")]
+    android_alerts::call_void("requestExemption");
+}
+
 /// Open `url` in the system browser. Used by the Google sign-in, which has to hand the user off
 /// to a real browser and get them back. Desktop shells out to the platform opener; Android goes
 /// through an `ACTION_VIEW` intent.
@@ -396,7 +459,7 @@ mod android_ime {
 /// knows nothing about the APK's classes.
 #[cfg(target_os = "android")]
 mod android_alerts {
-    use jni::objects::{JClass, JObject, JValue};
+    use jni::objects::{JClass, JObject, JString, JValue};
 
     pub(super) fn set_enabled(enabled: bool) {
         if let Err(e) = try_set(enabled) {
@@ -404,9 +467,61 @@ mod android_alerts {
         }
     }
 
-    fn try_set(enabled: bool) -> jni::errors::Result<()> {
+    /// Call a `(Context)V` static on `AlertAlarm` — the two permission prompts share this shape.
+    pub(super) fn call_void(method: &str) {
+        if let Err(e) = try_call_alarm(method) {
+            log::warn!("AlertAlarm.{method} failed: {e:?}");
+        }
+    }
+
+    fn try_call_alarm(method: &str) -> jni::errors::Result<()> {
+        with_class("zip.batman.hookecho.AlertAlarm", |env, class, activity| {
+            let res = env.call_static_method(
+                class,
+                method,
+                "(Landroid/content/Context;)V",
+                &[JValue::Object(activity)],
+            );
+            if res.is_err() {
+                let _ = env.exception_clear();
+            }
+            res.map(|_| ())
+        })
+    }
+
+    /// `AlertAlarm.health(Context)` as its raw tab-separated line.
+    pub(super) fn health() -> Option<String> {
+        let out = with_class("zip.batman.hookecho.AlertAlarm", |env, class, activity| {
+            let s = env
+                .call_static_method(
+                    class,
+                    "health",
+                    "(Landroid/content/Context;)Ljava/lang/String;",
+                    &[JValue::Object(activity)],
+                )?
+                .l()?;
+            Ok(env.get_string(&JString::from(s))?.into())
+        });
+        match out {
+            Ok(s) => Some(s),
+            Err(e) => {
+                log::warn!("AlertAlarm.health failed: {e:?}");
+                None
+            }
+        }
+    }
+
+    /// Load a class through the activity's loader and hand it to `f` with the activity.
+    ///
+    /// The app's own classes are not on the JNI thread's default loader — `FindClass` from a
+    /// thread the JVM did not create only sees the system loader — so every call into our Kotlin
+    /// goes through `getClassLoader().loadClass()`.
+    fn with_class<T>(
+        name: &str,
+        f: impl FnOnce(&mut jni::JNIEnv, &JClass, &JObject) -> jni::errors::Result<T>,
+    ) -> jni::errors::Result<T> {
         let Some(app) = super::android::app() else {
-            return Ok(());
+            return Err(jni::errors::Error::NullPtr("no android app"));
         };
         let vm = unsafe { jni::JavaVM::from_raw(app.vm_as_ptr() as *mut jni::sys::JavaVM) }?;
         let mut env = vm.attach_current_thread()?;
@@ -419,26 +534,31 @@ mod android_alerts {
                 &[],
             )?
             .l()?;
-        let name = env.new_string("zip.batman.hookecho.AlertService")?;
+        let jname = env.new_string(name)?;
         let class = env
             .call_method(
                 &loader,
                 "loadClass",
                 "(Ljava/lang/String;)Ljava/lang/Class;",
-                &[(&name).into()],
+                &[(&jname).into()],
             )?
             .l()?;
-        let class = JClass::from(class);
-        let res = env.call_static_method(
-            &class,
-            "setEnabled",
-            "(Landroid/content/Context;Z)V",
-            &[JValue::Object(&activity), JValue::Bool(enabled as u8)],
-        );
-        if res.is_err() {
-            let _ = env.exception_clear();
-        }
-        res.map(|_| ())
+        f(&mut env, &JClass::from(class), &activity)
+    }
+
+    fn try_set(enabled: bool) -> jni::errors::Result<()> {
+        with_class("zip.batman.hookecho.AlertService", |env, class, activity| {
+            let res = env.call_static_method(
+                class,
+                "setEnabled",
+                "(Landroid/content/Context;Z)V",
+                &[JValue::Object(activity), JValue::Bool(enabled as u8)],
+            );
+            if res.is_err() {
+                let _ = env.exception_clear();
+            }
+            res.map(|_| ())
+        })
     }
 }
 
@@ -1034,4 +1154,19 @@ pub fn http_timeouts(b: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
         .timeout(std::time::Duration::from_secs(30))
         .connect_timeout(std::time::Duration::from_secs(10));
     b
+}
+
+#[cfg(test)]
+mod health_tests {
+    use super::AlertHealth;
+
+    #[test]
+    fn health_line_parses_and_never_ran_is_none() {
+        let h = AlertHealth::parse("true\tfalse\ttrue\t-1\t42000").unwrap();
+        assert!(h.enabled && !h.exact && h.exempt);
+        assert_eq!(h.since_poll, None);
+        assert_eq!(h.until_next, Some(std::time::Duration::from_secs(42)));
+        // A short line is a Kotlin-side change we haven't followed; report nothing, not garbage.
+        assert_eq!(AlertHealth::parse("true\tfalse"), None);
+    }
 }

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -979,10 +979,7 @@ fn alerts_tab(ui: &mut egui::Ui, settings: &mut Settings) {
         {
             crate::platform::set_background_alerts(settings.background_alerts);
         }
-        ui.weak(
-            "Some phones kill background services aggressively — if alerts stop arriving, \
-                 exempt Hook Echo-WX from battery optimisation in system settings.",
-        );
+        alert_health(ui);
     }
 
     ui.add_space(8.0);
@@ -1043,4 +1040,57 @@ fn alerts_tab(ui: &mut egui::Ui, settings: &mut Settings) {
     );
     ui.checkbox(&mut settings.lightning_alarm, "Lightning within ~15 km of a saved location")
         .on_hover_text("Chime + push when CG lightning strikes near a marker. Requires the Lightning layer (National) to be on.");
+}
+
+/// Delivery health for the Android alert stack: what the OS is currently letting us do, and the
+/// two prompts that change it.
+///
+/// Worth its own panel because every honest answer to "why didn't I get that warning" is here,
+/// and none of it is visible anywhere else on the phone. The Samsung line is not an excuse — it
+/// is the truth, and a user who knows to check One UI's app-sleep list is better off than one
+/// who thinks the app is broken.
+fn alert_health(ui: &mut egui::Ui) {
+    let Some(h) = crate::platform::alert_health() else {
+        return;
+    };
+    let ago = |d: Option<std::time::Duration>| match d {
+        Some(d) if d.as_secs() < 90 => format!("{} s", d.as_secs()),
+        Some(d) => format!("{} min", d.as_secs() / 60),
+        None => "never".to_string(),
+    };
+    ui.add_space(4.0);
+    ui.horizontal(|ui| {
+        ui.label("Last check:");
+        ui.strong(ago(h.since_poll));
+        ui.label("· next in");
+        ui.strong(match h.until_next {
+            Some(d) => format!("{} min", d.as_secs() / 60),
+            None => "not scheduled".to_string(),
+        });
+    });
+    if !h.exact {
+        ui.horizontal(|ui| {
+            ui.colored_label(egui::Color32::from_rgb(230, 160, 60), "\u{26a0} Inexact alarms");
+            if ui.button("Allow exact alarms").clicked() {
+                crate::platform::request_exact_alarms();
+            }
+        });
+        ui.weak("Without this, checks arrive on Android's own schedule — minutes late, or later.");
+    }
+    if !h.exempt {
+        ui.horizontal(|ui| {
+            ui.colored_label(egui::Color32::from_rgb(230, 160, 60), "\u{26a0} Battery optimised");
+            if ui.button("Exempt from battery optimisation").clicked() {
+                crate::platform::request_battery_exemption();
+            }
+        });
+        ui.weak("This is the one that decides whether overnight warnings arrive.");
+    }
+    if h.exact && h.exempt {
+        ui.weak(
+            "Exact alarms and battery exemption are both granted. Samsung's One UI can still put \
+             the app to sleep on its own — that switch lives in Settings \u{2192} Battery \u{2192} \
+             Background usage limits, and is outside what any app can set for you.",
+        );
+    }
 }


### PR DESCRIPTION
Wave E, PR 12. The Android half of alert reliability: the complaint was late and missed warnings on the phone.

## What was wrong

Two legs, both bend. `AlertService` is a foreground service — Samsung's app-sleep and deep Doze both kill it. `AlertWorker` survives that, but WorkManager's periodic floor is 15 minutes and it is a floor, not a promise. A tornado warning 15 minutes late is not a warning.

## The third leg

`AlertAlarm` — an exact alarm is the one schedule Doze honours on time, so a poll runs with the app closed, the service dead and the screen off. It is a one-shot that re-arms itself from its own receiver, on a 5-minute cadence matching the service's calm-weather poll. All three legs share `AlertService.pollOnce`, so there is still exactly one poll path.

**Watchdog:** the worker re-arms the alarm every pass. Anything that eats an alarm — force-stop, reboot before BootReceiver, package replace — otherwise ends the chain silently, and nothing would notice. BootReceiver arms it too; alarms do not survive a reboot.

**Permission shape:** `SCHEDULE_EXACT_ALARM` (user-grantable, prompted through its settings screen), *not* `USE_EXACT_ALARM` — that one is reserved for alarm-clock and calendar apps, and a weather app would not survive review claiming it. Denied, we fall back to `setAndAllowWhileIdle`: still wakes in Doze, on the OS's schedule. The fallback is also a `catch`, since the permission can be revoked between the check and the call.

**Battery exemption:** `ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`, prompted from the health panel. This is the one that actually decides whether overnight warnings arrive. Play-policy-sensitive — fine for a sideloaded GitHub-release build, and commented as one call to delete if a store submission ever needs it gone. Store push is R18-fenced anyway.

**Health readout:** `AlertAlarm.health()` returns a tab-separated line over the existing MainActivity class-loader bridge — no second bridge — parsed into `platform::AlertHealth`. Settings → Alerts now shows last check, next check, and a prompt button for whichever of exact-alarms / battery-exemption is missing. When both are granted it says plainly that One UI's own app-sleep list is outside what any app can set for you, because that is the truth and a user who knows to check it is better off than one who thinks the app is broken.

The JNI class-loading dance (our classes are not on a JNI thread's default loader) was duplicated per call site; it is now one `with_class` helper that the existing `setEnabled` call also goes through.

## Ponytails

- One alarm at a fixed 5-minute cadence. Tightening it while a warning is active means cancel-and-re-arm on every poll; the service already tightens when it is alive, and this is the path for when it isn't.
- The watchdog runs at WorkManager's 15-minute minimum, which is the floor, not a choice.

## Verification

`cargo clippy --workspace --all-targets` clean · `cargo test --workspace` 460 passed · wasm `cargo check` clean · `shoot.sh check` passed. New test: the health line parses, and a short line (a Kotlin-side change we haven't followed) reports nothing rather than garbage.

**Not verified here, and I want this on the record:** this sandbox has no JDK, no Android SDK and no NDK, so the Kotlin was not compiled and the `#[cfg(target_os = "android")]` Rust was not type-checked. Every claim below is a manual check on the S24 Ultra, none of which I can run:

- `adb shell dumpsys deviceidle force-idle` → the alarm still fires in Doze
- force-stop → the worker revives it within 15 min
- reboot → BootReceiver re-arms
- the health panel reflects each of granted / denied / never-polled
- both permission buttons land on the right OS screen

Please build and run those before merging — the design is checkable by reading, the Kotlin is not, and I did not compile it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)