### PR TITLE
alerts: a spoken script worth hearing, and a local neural voice

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1916,6 +1916,8 @@ pub struct HookEchoApp {
     sounding_rx: Option<std::sync::mpsc::Receiver<Result<wxdata::sounding::Sounding, String>>>,
     /// The observed RAOB fetched alongside the HRRR profile, for the same click.
     raob_rx: Option<std::sync::mpsc::Receiver<Result<wxdata::sounding::Sounding, String>>>,
+    /// Last spoken storm-position update: when, and the distance in whole miles it reported.
+    spoke_pos: Option<(Instant, i32)>,
     /// Chase mode: follow a position, auto-switching the active pane to the nearest radar.
     chase_mode: bool,
     chase_pos: Option<(f64, f64)>,
@@ -2719,6 +2721,7 @@ impl HookEchoApp {
             sounding_rx: None,
             raob_rx: None,
             chase_mode: false,
+            spoke_pos: None,
             chase_pos: None,
             chase_track: crate::chaselog::Track::default(),
             climo_tracks: None,
@@ -2983,6 +2986,9 @@ impl HookEchoApp {
             app.locate_by_ip(&cc.egui_ctx.clone());
         }
         crate::platform::set_background_alerts(app.settings.background_alerts);
+        // Point the speech path at Piper before anything can speak.
+        #[cfg(not(target_arch = "wasm32"))]
+        crate::speech::set_piper(&app.settings.piper_path, &app.settings.piper_voice);
         // Not on the web: this is a burst of six fetches, and on the one thread a browser gives
         // us they queue ahead of the radar the visitor actually came for. The periodic refresh in
         // `update` picks them up a moment later, once there is radar on screen.
@@ -4026,7 +4032,13 @@ impl HookEchoApp {
                         })
                         .unwrap_or_default();
                     if !self.settings.mute_alerts {
-                        crate::speech::speak(&format!("{} for {}{}", a.event, area, until));
+                        // Hazard, place and heading first — see `wxdata::spoken`. `until` here
+                        // still carries its leading " until ", which the script builder adds.
+                        crate::speech::speak(&wxdata::spoken::warning_script(
+                            a,
+                            &area,
+                            until.trim_start_matches(" until "),
+                        ));
                     }
                 }
                 if notify_ok && self.settings.ntfy_snapshot {
@@ -4779,6 +4791,72 @@ impl HookEchoApp {
                 .await;
             });
         }
+    }
+
+    /// Fetch the Piper voice model into the data directory.
+    ///
+    /// The model and the `.onnx.json` beside it are both required — Piper reads its sample rate
+    /// and phoneme table from the JSON — so a download that gets one and not the other is a
+    /// failure, not a half-success. Written to a `.part` file and renamed, so an interrupted
+    /// download cannot leave a truncated model that Piper would then crash on.
+    ///
+    // ponytail: no pinned hash. The download is https from Piper's own voice repository and both
+    // files are validated (the JSON parses, the model is the size of a model); pinning a digest
+    // means pinning a version, and I could not verify one offline to pin.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn download_voice(&self) {
+        let Some(path) = crate::speech::default_voice_path() else {
+            crate::speech::set_voice_status(false, "no data directory to download into");
+            return;
+        };
+        let http = self.http.clone();
+        self.spawner.spawn(async move {
+            let cfg_url = format!("{}.json", crate::speech::VOICE_URL);
+            let cfg_path = path.with_extension("onnx.json");
+            if let Some(dir) = path.parent() {
+                if let Err(e) = std::fs::create_dir_all(dir) {
+                    crate::speech::set_voice_status(false, format!("could not create {dir:?}: {e}"));
+                    return;
+                }
+            }
+            crate::speech::set_voice_status(true, "downloading voice (~60 MB)…");
+            let get = |url: String| {
+                let http = http.clone();
+                async move { http.get(url).send().await?.error_for_status()?.bytes().await }
+            };
+            let cfg = match get(cfg_url).await {
+                Ok(b) => b,
+                Err(e) => {
+                    crate::speech::set_voice_status(false, format!("voice config failed: {e}"));
+                    return;
+                }
+            };
+            if serde_json::from_slice::<serde_json::Value>(&cfg).is_err() {
+                crate::speech::set_voice_status(false, "voice config was not JSON; refusing it");
+                return;
+            }
+            let model = match get(crate::speech::VOICE_URL.to_string()).await {
+                Ok(b) => b,
+                Err(e) => {
+                    crate::speech::set_voice_status(false, format!("voice download failed: {e}"));
+                    return;
+                }
+            };
+            // A medium-quality Piper voice is tens of megabytes; anything tiny is an error page
+            // that happened to arrive with a 200.
+            if model.len() < 1_000_000 {
+                crate::speech::set_voice_status(false, "download was too small to be a voice");
+                return;
+            }
+            let part = path.with_extension("part");
+            let wrote = std::fs::write(&part, &model)
+                .and_then(|()| std::fs::rename(&part, &path))
+                .and_then(|()| std::fs::write(&cfg_path, &cfg));
+            match wrote {
+                Ok(()) => crate::speech::set_voice_status(false, "voice ready"),
+                Err(e) => crate::speech::set_voice_status(false, format!("writing the voice failed: {e}")),
+            }
+        });
     }
 
     /// Sub-hourly GOES scrub bar: shown when the active basemap is a GOES layer and its frame
@@ -6986,6 +7064,29 @@ impl HookEchoApp {
         let (close_km, close_min) =
             crate::geo::closest_approach([c.lon, c.lat], dir, kt, me, 120.0);
         let escape = crate::geo::escape_bearing([c.lon, c.lat], dir, me);
+        // Spoken position updates: only while chasing, only when the picture has actually
+        // changed, and never more than once a minute — a voice that repeats itself is a voice the
+        // user turns off. Reported in whole miles, so a storm parked in place says nothing.
+        if self.settings.speak_position && !self.settings.mute_alerts {
+            let miles = (km * 0.621_371).round() as i32;
+            let fresh = self
+                .spoke_pos
+                .is_none_or(|(t, m)| m != miles && t.elapsed() >= std::time::Duration::from_secs(60));
+            if fresh {
+                self.spoke_pos = Some((Instant::now(), miles));
+                crate::speech::speak(&wxdata::spoken::position_script(
+                    // "Cell O7", not the bare id — a synthesizer reading "O7" alone is a noise.
+                    &if c.id.is_empty() {
+                        c.title.clone()
+                    } else {
+                        format!("Cell {}", c.id)
+                    },
+                    bearing as f32,
+                    km,
+                    c.mvt_deg,
+                ));
+            }
+        }
         let mi = |km: f64| km * 0.621_371;
         // Urgent when the storm will be on top of you soon.
         let urgent = mi(close_km) < 5.0 && close_min < 20.0;
@@ -14997,6 +15098,12 @@ impl eframe::App for HookEchoApp {
         {
             self.goto_poll = Some(Instant::now());
             self.drain_goto_file();
+        }
+        // The settings window has no HTTP client or runtime, so the voice-download button raises
+        // a flag and the work happens here, on the same spawner everything else fetches on.
+        #[cfg(not(target_arch = "wasm32"))]
+        if crate::speech::take_voice_request() {
+            self.download_voice();
         }
         // A file the user picked, from any of the import buttons. Routed here rather than at the
         // button, because on Android the picker is an activity result that lands long after the

--- a/crates/hookecho/src/audio.rs
+++ b/crates/hookecho/src/audio.rs
@@ -51,6 +51,29 @@ pub fn play(sound: &AlertSound, volume: f32) {
     });
 }
 
+/// Play WAV bytes that some other part of the app just produced (today: Piper's stdout).
+/// Non-blocking, same detached-thread shape as [`play`].
+#[cfg(not(target_arch = "wasm32"))]
+pub fn play_wav(bytes: Vec<u8>) {
+    std::thread::spawn(move || {
+        let Ok((_stream, handle)) = rodio::OutputStream::try_default() else {
+            log::warn!("no audio output for speech");
+            return;
+        };
+        let Ok(sink) = Sink::try_new(&handle) else {
+            return;
+        };
+        match rodio::Decoder::new(std::io::Cursor::new(bytes)) {
+            Ok(src) => sink.append(src),
+            Err(e) => {
+                log::warn!("speech audio decode failed: {e}");
+                return;
+            }
+        }
+        sink.sleep_until_end();
+    });
+}
+
 /// Try to queue a user audio file (wav/mp3/ogg/flac). Returns false (logged) on any failure.
 #[cfg(not(target_arch = "wasm32"))]
 fn append_file(sink: &Sink, path: &str) -> bool {

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -289,6 +289,17 @@ pub struct Settings {
     /// Read new warnings aloud (system speech engine). Off by default — speech is intrusive.
     #[serde(default)]
     pub speak_warnings: bool,
+    /// Path to a Piper binary, or blank to look on `PATH`. Piper is a local neural voice; when it
+    /// and a voice model are both present, spoken warnings go through it instead of espeak.
+    #[serde(default)]
+    pub piper_path: String,
+    /// Path to a Piper `.onnx` voice model. Blank turns Piper off — an engine with no model has
+    /// nothing to say. Never committed: it is a ~60 MB download or a file the user already has.
+    #[serde(default)]
+    pub piper_voice: String,
+    /// While chase mode is on, speak the nearest storm's bearing and distance as it changes.
+    #[serde(default)]
+    pub speak_position: bool,
     /// Alert when radar echo is heading for a saved location.
     #[serde(default)]
     pub rain_alerts: bool,
@@ -953,6 +964,9 @@ impl Default for Settings {
             anthropic_key: String::new(),
             lightning_alarm: false,
             speak_warnings: false,
+            piper_path: String::new(),
+            piper_voice: String::new(),
+            speak_position: false,
             rain_alerts: false,
             rain_sound: AlertSound::default(),
             setup_done: false,
@@ -1359,6 +1373,9 @@ mod tests {
             anthropic_key: "sk-test".to_string(),
             lightning_alarm: true,
             speak_warnings: true,
+            piper_path: String::new(),
+            piper_voice: String::new(),
+            speak_position: false,
             rain_alerts: true,
             rain_sound: AlertSound::Ding,
             setup_done: true,

--- a/crates/hookecho/src/speech.rs
+++ b/crates/hookecho/src/speech.rs
@@ -1,8 +1,91 @@
 //! Speaking warnings out loud.
 //!
+//! Two layers. The words come from [`wxdata::spoken`] — hazard, place and heading first, NWS
+//! shorthand expanded. The voice is whatever the machine has: a local neural engine (Piper) when
+//! one is configured, otherwise the platform's own synthesizer.
+//!
 //! Chasing is an eyes-on-the-road activity: a warning you have to read is a warning you read at
 //! the wrong moment. Every call is fire-and-forget on a background thread and every failure is
 //! logged and dropped — a machine with no speech engine is a normal machine, not a broken one.
+
+/// Piper binary and voice model, as configured. Empty binary means "look on PATH"; empty voice
+/// means Piper is off, since a neural engine with no model has nothing to say.
+///
+/// A global rather than a threaded-through parameter: `speak` is called from a dozen places that
+/// have no reason to know about settings, and this is one string pair that changes when the user
+/// edits it.
+#[cfg(not(target_arch = "wasm32"))]
+static PIPER: std::sync::RwLock<(String, String)> = std::sync::RwLock::new((String::new(), String::new()));
+
+/// Point the speech path at a Piper binary and voice model. Called at startup and whenever the
+/// user edits either field.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn set_piper(bin: &str, voice: &str) {
+    if let Ok(mut g) = PIPER.write() {
+        *g = (bin.trim().to_string(), voice.trim().to_string());
+    }
+}
+
+/// Where a downloaded voice lands. One slot: a second voice is a preference, not a capability.
+// ponytail: one voice slot; a picker if anyone actually wants two.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn default_voice_path() -> Option<std::path::PathBuf> {
+    crate::paths::data_dir().map(|d| d.join("voices").join(VOICE_FILE))
+}
+
+/// The voice the download button fetches — a mid-quality US English model, the smallest one that
+/// does not sound worse than espeak.
+#[cfg(not(target_arch = "wasm32"))]
+pub const VOICE_FILE: &str = "en_US-lessac-medium.onnx";
+
+/// Upstream for that model. Piper's own voice repository; the `.onnx.json` beside it is required,
+/// since Piper reads its sample rate and phoneme table from there.
+#[cfg(not(target_arch = "wasm32"))]
+pub const VOICE_URL: &str = "https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/lessac/medium/en_US-lessac-medium.onnx";
+
+/// What the settings row shows about the voice download.
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone, Default)]
+pub struct VoiceStatus {
+    /// A download is in flight, so the button hides rather than starting a second one.
+    pub busy: bool,
+    /// Progress or outcome, already phrased for the user. Empty means nothing to say.
+    pub text: String,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+static VOICE: std::sync::RwLock<Option<VoiceStatus>> = std::sync::RwLock::new(None);
+#[cfg(not(target_arch = "wasm32"))]
+static WANT_VOICE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn voice_status() -> VoiceStatus {
+    VOICE.read().ok().and_then(|g| g.clone()).unwrap_or_default()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn set_voice_status(busy: bool, text: impl Into<String>) {
+    if let Ok(mut g) = VOICE.write() {
+        *g = Some(VoiceStatus {
+            busy,
+            text: text.into(),
+        });
+    }
+}
+
+/// Ask for the voice download. The settings window has no HTTP client or runtime of its own, so
+/// it raises this flag and the app's frame loop does the work on the shared spawner.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn request_voice_download() {
+    WANT_VOICE.store(true, std::sync::atomic::Ordering::Relaxed);
+    set_voice_status(true, "starting…");
+}
+
+/// Drained once per frame by the app.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn take_voice_request() -> bool {
+    WANT_VOICE.swap(false, std::sync::atomic::Ordering::Relaxed)
+}
 
 /// Speak `text` aloud, if the platform can. Returns immediately.
 #[cfg(not(target_arch = "wasm32"))]
@@ -49,6 +132,14 @@ mod imp {
     /// Linux, PowerShell's System.Speech on Windows, `say` on macOS. No new dependency, and on a
     /// box with none of them installed this is a no-op rather than a failed build.
     pub fn speak_blocking(text: &str) -> Result<(), String> {
+        // Piper first when it is configured and present: a neural voice is the difference between
+        // a warning you listen to and one you turn off. Anything wrong with it — missing binary,
+        // missing model, a crash — falls through to the platform engine rather than going silent.
+        match piper(text) {
+            Ok(true) => return Ok(()),
+            Ok(false) => {}
+            Err(e) => log::warn!("piper failed, falling back: {e}"),
+        }
         #[cfg(target_os = "linux")]
         let candidates: Vec<(&str, Vec<String>)> = vec![
             ("spd-say", vec!["-w".into(), text.to_string()]),
@@ -88,6 +179,52 @@ mod imp {
             }
         }
         Err("no speech engine found (tried spd-say / espeak)".into())
+    }
+
+    /// Synthesize through Piper and play the result. `Ok(false)` means Piper is not configured,
+    /// which is not an error — it is the default state of every machine.
+    ///
+    // ponytail: subprocess, not in-process ONNX. `ort` would put a C++ runtime and a licence
+    // question into a build that currently cross-compiles to four targets without one; the
+    // process boundary costs a fork per warning, which is nothing against a network fetch.
+    fn piper(text: &str) -> Result<bool, String> {
+        use std::io::Write;
+        let (bin, voice) = super::PIPER
+            .read()
+            .map(|g| g.clone())
+            .map_err(|_| "piper config poisoned")?;
+        if voice.is_empty() || !std::path::Path::new(&voice).exists() {
+            return Ok(false);
+        }
+        let bin = if bin.is_empty() { "piper".to_string() } else { bin };
+        let mut cmd = Command::new(&bin);
+        crate::platform::no_window(&mut cmd);
+        // `--output_file -` gives a WAV on stdout, which rodio decodes directly. Writing to a
+        // temp file would mean choosing a directory and cleaning it up for no gain.
+        let mut child = match cmd
+            .args(["--model", &voice, "--output_file", "-"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+        {
+            Ok(c) => c,
+            // Not installed is the common case, and it is not a failure worth a warning.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(e) => return Err(format!("spawn {bin}: {e}")),
+        };
+        child
+            .stdin
+            .take()
+            .ok_or("no stdin")?
+            .write_all(text.as_bytes())
+            .map_err(|e| e.to_string())?;
+        let out = child.wait_with_output().map_err(|e| e.to_string())?;
+        if !out.status.success() || out.stdout.is_empty() {
+            return Err(format!("piper exited {}", out.status));
+        }
+        crate::audio::play_wav(out.stdout);
+        Ok(true)
     }
 }
 

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -1046,6 +1046,10 @@ fn alerts_tab(ui: &mut egui::Ui, settings: &mut Settings) {
              your eyes are on the road",
         );
     ui.weak("Linux needs spd-say or espeak installed; Android uses its built-in voice.");
+    #[cfg(not(target_arch = "wasm32"))]
+    if !cfg!(target_os = "android") {
+        piper_row(ui, settings);
+    }
 
     ui.add_space(8.0);
     ui.separator();
@@ -1060,4 +1064,60 @@ fn alerts_tab(ui: &mut egui::Ui, settings: &mut Settings) {
     );
     ui.checkbox(&mut settings.lightning_alarm, "Lightning within ~15 km of a saved location")
         .on_hover_text("Chime + push when CG lightning strikes near a marker. Requires the Lightning layer (National) to be on.");
+}
+
+/// Piper: the local neural voice, and the one download this app ever offers.
+///
+/// Nothing here is bundled. The binary is whatever the user installed (most distros package it),
+/// and the voice model is a ~60 MB file that would be absurd to commit — so the button fetches it
+/// into the data directory on request, and until then espeak keeps working.
+#[cfg(not(target_arch = "wasm32"))]
+fn piper_row(ui: &mut egui::Ui, settings: &mut Settings) {
+    ui.add_space(4.0);
+    let mut edited = false;
+    ui.horizontal(|ui| {
+        ui.label("Piper binary:");
+        edited |= ui
+            .add(
+                egui::TextEdit::singleline(&mut settings.piper_path)
+                    .hint_text("blank = find `piper` on PATH"),
+            )
+            .changed();
+    });
+    ui.horizontal(|ui| {
+        ui.label("Voice model:");
+        edited |= ui
+            .add(
+                egui::TextEdit::singleline(&mut settings.piper_voice)
+                    .hint_text("path to a .onnx voice"),
+            )
+            .changed();
+    });
+    if edited {
+        crate::speech::set_piper(&settings.piper_path, &settings.piper_voice);
+    }
+    ui.horizontal(|ui| {
+        let status = crate::speech::voice_status();
+        if settings.piper_voice.is_empty()
+            && !status.busy
+            && ui.button("Download a voice").clicked()
+        {
+            crate::speech::request_voice_download();
+        }
+        if !status.text.is_empty() {
+            ui.weak(&status.text);
+        }
+    });
+    // The download writes the model to a known path, so filling the field in for the user is the
+    // whole handoff — there is nothing else to configure.
+    if settings.piper_voice.is_empty() {
+        if let Some(p) = crate::speech::default_voice_path().filter(|p| p.exists()) {
+            settings.piper_voice = p.to_string_lossy().into_owned();
+            crate::speech::set_piper(&settings.piper_path, &settings.piper_voice);
+        }
+    }
+    ui.checkbox(
+        &mut settings.speak_position,
+        "Speak the nearest storm's bearing while chasing",
+    );
 }

--- a/crates/wxdata/src/lib.rs
+++ b/crates/wxdata/src/lib.rs
@@ -44,6 +44,7 @@ pub mod rotation;
 pub mod severe;
 pub mod sounding;
 pub mod spc;
+pub mod spoken;
 pub mod spotters;
 pub mod stations;
 pub mod task;

--- a/crates/wxdata/src/spoken.rs
+++ b/crates/wxdata/src/spoken.rs
@@ -1,0 +1,260 @@
+//! Turning an alert into something worth hearing.
+//!
+//! The old spoken line was `"{event} for {area} until {time}"`, which starts with the four words
+//! the listener already guessed and buries the two that matter: what it is going to do, and
+//! whether it is coming at you. Driving, you get one sentence before your attention goes back to
+//! the road, so the hazard, the place and the direction go in that sentence.
+//!
+//! It also read raw NWS text, which is written to be *seen*: "60 MPH", "SW of", "1.75 IN".
+//! A synthesizer says "sixty em pee aitch". [`expand`] fixes that.
+//!
+//! Pure string work, no engine and no platform: desktop, Android and the browser all speak
+//! whatever this returns.
+
+use crate::overlay::AlertInfo;
+
+/// 16-point compass bearing, spoken in full.
+fn spoken_compass(deg: f32) -> &'static str {
+    const D: [&str; 16] = [
+        "north",
+        "north northeast",
+        "northeast",
+        "east northeast",
+        "east",
+        "east southeast",
+        "southeast",
+        "south southeast",
+        "south",
+        "south southwest",
+        "southwest",
+        "west southwest",
+        "west",
+        "west northwest",
+        "northwest",
+        "north northwest",
+    ];
+    D[((deg / 22.5).round() as usize) % 16]
+}
+
+/// Abbreviations as issued, and how to say them. Matched on whole words, longest first, so `MPH`
+/// wins before `PH` could and `NNE` before `N`.
+const ABBREV: &[(&str, &str)] = &[
+    ("MPH", "miles per hour"),
+    ("KTS", "knots"),
+    ("KT", "knots"),
+    ("TSTM", "thunderstorm"),
+    ("TSTMS", "thunderstorms"),
+    ("PDS", "particularly dangerous situation"),
+    ("NWS", "National Weather Service"),
+    ("EMER", "emergency"),
+    ("SVR", "severe"),
+    ("TOR", "tornado"),
+    ("FFW", "flash flood warning"),
+    ("CO", "county"),
+    ("CNTY", "county"),
+    ("MI", "miles"),
+    ("NM", "nautical miles"),
+    ("IN", "inch"),
+    ("FT", "feet"),
+    ("AM", "A M"),
+    ("PM", "P M"),
+    ("CDT", "central time"),
+    ("CST", "central time"),
+    ("EDT", "eastern time"),
+    ("EST", "eastern time"),
+    ("MDT", "mountain time"),
+    ("MST", "mountain time"),
+    ("PDT", "pacific time"),
+    ("PST", "pacific time"),
+    ("N", "north"),
+    ("S", "south"),
+    ("E", "east"),
+    ("W", "west"),
+    ("NE", "northeast"),
+    ("NW", "northwest"),
+    ("SE", "southeast"),
+    ("SW", "southwest"),
+    ("NNE", "north northeast"),
+    ("ENE", "east northeast"),
+    ("ESE", "east southeast"),
+    ("SSE", "south southeast"),
+    ("SSW", "south southwest"),
+    ("WSW", "west southwest"),
+    ("WNW", "west northwest"),
+    ("NNW", "north northwest"),
+];
+
+/// Expand NWS shorthand into words a synthesizer can say.
+///
+/// Only whole all-caps words are touched: a place called Independence keeps its `IN`, and lower
+/// case prose is left exactly as written. Anything not in the table is passed through, because a
+/// wrong expansion is worse than an unexpanded one — "N" heard as "north" in the wrong place is a
+/// direction the listener acts on.
+pub fn expand(text: &str) -> String {
+    let mut out = String::with_capacity(text.len() + 16);
+    let mut word = String::new();
+    let flush = |word: &mut String, out: &mut String| {
+        if !word.is_empty() {
+            let hit = word
+                .chars()
+                .all(|c| c.is_ascii_uppercase())
+                .then(|| ABBREV.iter().find(|(a, _)| *a == word).map(|(_, b)| *b))
+                .flatten();
+            match hit {
+                Some(rep) => out.push_str(rep),
+                None => out.push_str(word),
+            }
+            word.clear();
+        }
+    };
+    for c in text.chars() {
+        if c.is_ascii_alphabetic() {
+            word.push(c);
+        } else {
+            flush(&mut word, &mut out);
+            out.push(c);
+        }
+    }
+    flush(&mut word, &mut out);
+    out
+}
+
+/// The sentence spoken when a warning arrives: hazard, place, motion, then the expiry.
+///
+/// `place` is the watched location the warning hit, or the alert's own area when it hit none.
+/// `until` is the already-formatted clock time, or empty.
+pub fn warning_script(a: &AlertInfo, place: &str, until: &str) -> String {
+    let mut s = String::new();
+    // Lead with the escalated wording when there is any — "Tornado emergency" first, not fourth.
+    let lead = a
+        .damage_threat
+        .as_deref()
+        .filter(|t| t.eq_ignore_ascii_case("DESTRUCTIVE") || t.eq_ignore_ascii_case("CATASTROPHIC"))
+        .map(|t| format!("{} {}", expand(t).to_lowercase(), a.event.to_lowercase()))
+        .unwrap_or_else(|| a.event.to_lowercase());
+    s.push_str(&capitalize(&lead));
+    if !place.is_empty() {
+        s.push_str(" for ");
+        s.push_str(&expand(place));
+    }
+    if let Some(m) = &a.motion {
+        // `deg` is the FROM bearing as issued; the heading it travels toward is the other way,
+        // and the heading is the only half a listener can act on.
+        s.push_str(&format!(
+            ", moving {} at {} miles per hour",
+            spoken_compass((m.deg + 180.0) % 360.0),
+            (m.kt * 1.15078).round() as i32
+        ));
+    }
+    if let Some(h) = a.max_hail_in {
+        s.push_str(&format!(", hail to {h} inch"));
+    }
+    if let Some(w) = &a.max_wind {
+        s.push_str(&format!(", winds {}", expand(w)));
+    }
+    if !until.is_empty() {
+        s.push_str(", until ");
+        s.push_str(until);
+    }
+    s.push('.');
+    s
+}
+
+/// The optional chase update: where the nearest storm is relative to you, spoken.
+///
+/// `bearing_deg` is the direction from the listener to the storm, `km` the distance, and
+/// `moving_toward_deg` the heading the storm travels *toward* — which is what storm-cell tables
+/// carry, unlike an alert's motion field. Nothing is flipped here.
+pub fn position_script(
+    name: &str,
+    bearing_deg: f32,
+    km: f64,
+    moving_toward_deg: Option<f32>,
+) -> String {
+    let miles = (km * 0.621_371).round() as i32;
+    let mut s = format!(
+        "{name} is {miles} miles to your {}",
+        spoken_compass(bearing_deg)
+    );
+    if let Some(d) = moving_toward_deg {
+        s.push_str(&format!(", moving {}", spoken_compass(d)));
+    }
+    s.push('.');
+    s
+}
+
+fn capitalize(s: &str) -> String {
+    let mut c = s.chars();
+    match c.next() {
+        Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+        None => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::overlay::StormMotion;
+
+    fn tor() -> AlertInfo {
+        AlertInfo {
+            id: "urn:x".into(),
+            event: "Tornado Warning".into(),
+            headline: String::new(),
+            area: "Cleveland County".into(),
+            description: String::new(),
+            instruction: String::new(),
+            expires: None,
+            max_hail_in: None,
+            max_wind: None,
+            tornado_detection: Some("OBSERVED".into()),
+            damage_threat: Some("CATASTROPHIC".into()),
+            source: None,
+            motion: Some(StormMotion {
+                deg: 225.0, // from the southwest, so travelling northeast
+                kt: 40.0,
+                points: vec![],
+            }),
+            vtec: None,
+        }
+    }
+
+    #[test]
+    fn the_hazard_place_and_heading_come_first() {
+        let s = warning_script(&tor(), "Home", "7 15 PM");
+        assert!(
+            s.starts_with("Catastrophic tornado warning for Home, moving northeast at 46 miles"),
+            "{s}"
+        );
+        assert!(s.ends_with("until 7 15 PM."), "{s}");
+    }
+
+    #[test]
+    fn abbreviations_expand_only_as_whole_capital_words() {
+        assert_eq!(expand("60 MPH winds"), "60 miles per hour winds");
+        assert_eq!(expand("2 MI SW of Norman"), "2 miles southwest of Norman");
+        // Lower case prose and mixed-case place names are left alone — a wrong expansion is
+        // worse than none, since a listener acts on a direction.
+        assert_eq!(expand("Independence, Indiana"), "Independence, Indiana");
+        assert_eq!(expand("in the county"), "in the county");
+    }
+
+    #[test]
+    fn a_plain_warning_still_reads_cleanly() {
+        let mut a = tor();
+        a.damage_threat = None;
+        a.motion = None;
+        a.max_hail_in = Some(1.75);
+        assert_eq!(
+            warning_script(&a, "", ""),
+            "Tornado warning, hail to 1.75 inch."
+        );
+    }
+
+    #[test]
+    fn a_position_update_names_the_side_it_is_on() {
+        // 225 here is a heading, not a from-bearing: cell tables give direction of travel.
+        let s = position_script("The storm", 90.0, 32.2, Some(225.0));
+        assert_eq!(s, "The storm is 20 miles to your east, moving southwest.");
+    }
+}


### PR DESCRIPTION
Wave E, PR 13. Stacked on #58 (it uses `AlertInfo`, which #58 adds a field to).

## The words — `wxdata::spoken`

The spoken line was `"{event} for {area} until {time}"`: it opens with the four words the listener already guessed and buries the two that matter. Driving, you get one sentence before your attention goes back to the road.

Now: hazard first, with the escalated wording folded in ("Catastrophic tornado warning", not "Tornado warning" with the threat lost), then the watched place, then the heading. An alert's motion field is the direction the storm comes *from*; the heading is the only half a listener can act on, so it is flipped. Hail and wind follow, expiry last.

It also read raw NWS text, which is written to be *seen*: "60 MPH", "2 MI SW of", "1.75 IN". A synthesizer says "sixty em pee aitch". `expand` fixes that, touching only whole all-caps words — Independence, Indiana keeps its "IN", because a wrong expansion is worse than none when the listener acts on a direction.

Pure string work, no engine and no platform: desktop, Android and the browser all speak whatever it returns.

Optional spoken storm-position updates while chasing ride on the existing nearest-cell sensor: whole miles, at most once a minute, silent when the number has not changed. Storm-cell tables give the heading the cell travels *toward* (unlike an alert's motion), so nothing is flipped there — that asymmetry is why `position_script` and `warning_script` are separate functions and both are tested.

## The voice — Piper

Piper when a binary and a voice model are both present; anything wrong with it (missing binary, missing model, a crash, an empty stdout) falls through to the existing platform engine rather than going silent.

**Subprocess, not in-process ONNX.** `ort` would put a C++ runtime and a licence question into a build that currently cross-compiles to four targets without one. A fork per warning is nothing against the network fetch that produced the warning. Piper's WAV comes back on stdout and goes straight to rodio via a new `audio::play_wav`.

**No model is committed** — it is ~60 MB. The settings row downloads one into the data directory on request and fills the path in; until then espeak keeps working. The `.onnx.json` is fetched too and required (Piper reads its sample rate and phoneme table from it), the model is written through a `.part` file so an interrupt cannot leave a truncated model Piper would crash on, and both files are validated before they are kept.

The settings window has no HTTP client or runtime of its own, so the button raises a flag the app's frame loop drains onto the shared spawner — the same pattern as the file-picker handover.

## Ponytails

- One voice slot. A picker if anyone wants two.
- Subprocess over in-process, above.
- **No pinned hash on the download.** It is https from Piper's own voice repository and both files are validated, but pinning a digest means pinning a version, and I could not verify one offline to pin. Stated in the code, not hidden.

## Verification

`cargo clippy --workspace --all-targets` clean · `cargo test --workspace` 477 passed · wasm `cargo check` clean · `shoot.sh check` passed.

New tests: hazard/place/heading ordering with the from-bearing flip; abbreviation expansion including the two negatives (mixed case and lower case left alone); a plain warning with no motion; the position update and its opposite motion convention.

Verified by hand, since piper happens to be installed here: downloaded `en_US-lessac-medium` from the URL this PR uses (config 4885 bytes and parses, model 63,201,294 bytes) and confirmed `piper --model … --output_file -` writes a `RIFF` WAV to stdout — the exact invocation, and the exact assumption the fallback logic rests on.

Not verified: audible playback (no audio device here), and the download path end to end inside the app — the URL and the shape of the response are what I checked, with curl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)