### PR TITLE
rules: per-rule sound and snapshot, one level of AND/OR, archive backtest

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1916,6 +1916,9 @@ pub struct HookEchoApp {
     sounding_rx: Option<std::sync::mpsc::Receiver<Result<wxdata::sounding::Sounding, String>>>,
     /// The observed RAOB fetched alongside the HRRR profile, for the same click.
     raob_rx: Option<std::sync::mpsc::Receiver<Result<wxdata::sounding::Sounding, String>>>,
+    /// Detections seen recently, for compound rules to ask "and was there also…". Trimmed to the
+    /// compound window every pass, so it stays a handful of entries.
+    recent_hits: Vec<(crate::settings::RuleTrigger, crate::rules::Detection, Instant)>,
     /// Chase mode: follow a position, auto-switching the active pane to the nearest radar.
     chase_mode: bool,
     chase_pos: Option<(f64, f64)>,
@@ -2715,6 +2718,7 @@ impl HookEchoApp {
             sounding_rx: None,
             raob_rx: None,
             chase_mode: false,
+            recent_hits: Vec::new(),
             chase_pos: None,
             chase_track: crate::chaselog::Track::default(),
             climo_tracks: None,
@@ -3955,11 +3959,23 @@ impl HookEchoApp {
                             }),
                     };
                     if reaches {
-                        let place = crate::rules::place_label(&rule.place, &self.settings);
-                        let title = format!("\u{25c9} {}", rule.title());
-                        let body = format!("{} at {place}", a.event);
-                        self.notify_alert(&title, &body, rule.urgent);
-                        self.banner(title, body);
+                        // The warning's own centroid stands in for a detection, so a warning rule
+                        // can carry extra conditions like every other rule ("a tornado warning,
+                        // and also rotation within 20 km").
+                        let hit = f
+                            .rings
+                            .first()
+                            .filter(|r| !r.is_empty())
+                            .map(|ring| {
+                                let n = ring.len() as f64;
+                                let (x, y) =
+                                    ring.iter().fold((0.0, 0.0), |(x, y), p| (x + p[0], y + p[1]));
+                                crate::rules::Detection::at(x / n, y / n)
+                            })
+                            .unwrap_or(crate::rules::Detection::at(0.0, 0.0));
+                        if crate::rules::compound_ok(&rule, &hit, &self.recent_for_rules()) {
+                            self.fire_rule_named(&rule, &hit, Some(a.event.clone()));
+                        }
                     }
                 }
                 let zone_name = zone;
@@ -4084,6 +4100,13 @@ impl HookEchoApp {
                 _ => Vec::new(),
             }
         };
+        // Every scan detector's hits are remembered, not only the armed ones: a compound rule
+        // asks about a trigger no rule is armed on all the time ("rotation and also a TDS").
+        for t in [T::Tds, T::Tbss, T::ZdrColumn, T::Rotation] {
+            let h = hits(&t);
+            self.note_hits(&t, &h);
+        }
+        let recent = self.recent_for_rules();
         for rule in self.settings.alert_rules.clone() {
             if !rule.enabled || !rule.trigger.is_scan() {
                 continue;
@@ -4097,6 +4120,9 @@ impl HookEchoApp {
                     d(a).total_cmp(&d(b))
                 });
             let Some(hit) = hit else { continue };
+            if !crate::rules::compound_ok(&rule, &hit, &recent) {
+                continue;
+            }
             self.fire_rule(&rule, &hit);
         }
     }
@@ -4143,7 +4169,10 @@ impl HookEchoApp {
                         .total_cmp(&b.strength.unwrap_or(0.0))
                 });
             if let Some(hit) = best {
-                self.fire_rule(&rule, &hit);
+                self.note_hits(&crate::settings::RuleTrigger::GlmFed, &[hit]);
+                if crate::rules::compound_ok(&rule, &hit, &self.recent_for_rules()) {
+                    self.fire_rule(&rule, &hit);
+                }
             }
         }
     }
@@ -4183,7 +4212,10 @@ impl HookEchoApp {
                 })
                 .copied();
             if let Some(hit) = worst {
-                self.fire_rule(&rule, &hit);
+                self.note_hits(&crate::settings::RuleTrigger::ProbSevere, &[hit]);
+                if crate::rules::compound_ok(&rule, &hit, &self.recent_for_rules()) {
+                    self.fire_rule(&rule, &hit);
+                }
             }
         }
     }
@@ -4200,10 +4232,64 @@ impl HookEchoApp {
         crate::geo::great_circle([site.longitude as f64, site.latitude as f64], [lon, lat]).0
     }
 
+    /// Kick off a backtest of one rule against an archive day, on the shared runtime.
+    ///
+    /// The site is whichever radar the active pane is on: a rule about a place is only replayable
+    /// against a radar that can see it, and the pane the user is looking at is the best guess
+    /// anyone can make without asking.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn start_backtest(&mut self, rule_idx: usize, day: chrono::NaiveDate) {
+        let Some(rule) = self.settings.alert_rules.get(rule_idx).cloned() else {
+            return;
+        };
+        let Some(site) = self.views[self.active].site.clone() else {
+            return;
+        };
+        let shared: crate::backtest::Shared = Default::default();
+        self.rules_window.backtest = Some(shared.clone());
+        let settings = self.settings.clone();
+        self.spawner.spawn(crate::backtest::run(
+            site, day, rule, settings, shared,
+        ));
+    }
+
+    /// Remember detections so a compound rule can ask about them next pass, and forget anything
+    /// older than the compound window.
+    fn note_hits(&mut self, trigger: &crate::settings::RuleTrigger, hits: &[crate::rules::Detection]) {
+        let window = std::time::Duration::from_secs_f64(crate::rules::COMPOUND_WINDOW_MIN * 60.0);
+        self.recent_hits.retain(|(_, _, t)| t.elapsed() < window);
+        for h in hits {
+            self.recent_hits.push((trigger.clone(), *h, Instant::now()));
+        }
+    }
+
+    /// The recent detections in the shape `rules::compound_ok` wants.
+    fn recent_for_rules(&self) -> Vec<crate::rules::RecentHit> {
+        self.recent_hits
+            .iter()
+            .map(|(trigger, hit, t)| crate::rules::RecentHit {
+                trigger: trigger.clone(),
+                hit: *hit,
+                age_min: t.elapsed().as_secs_f64() / 60.0,
+            })
+            .collect()
+    }
+
     /// Deliver a rule's alert, unless its cooldown for this place is still running.
     ///
     /// Keyed by rule *and* place, so a rule watching two zones can speak about each of them.
     fn fire_rule(&mut self, rule: &crate::settings::AlertRule, hit: &crate::rules::Detection) {
+        self.fire_rule_named(rule, hit, None);
+    }
+
+    /// [`Self::fire_rule`], with the body spelled out. Warning rules name the event they matched,
+    /// which the trigger label alone does not carry.
+    fn fire_rule_named(
+        &mut self,
+        rule: &crate::settings::AlertRule,
+        hit: &crate::rules::Detection,
+        detail: Option<String>,
+    ) {
         let place = crate::rules::place_label(&rule.place, &self.settings);
         let key = format!("{}:{place}", rule.id);
         let cooldown = std::time::Duration::from_secs(u64::from(rule.cooldown_min) * 60);
@@ -4216,13 +4302,21 @@ impl HookEchoApp {
         }
         self.rules_fired.insert(key, Instant::now());
         let title = format!("\u{25c9} {}", rule.title());
-        let body = match hit.strength {
-            Some(v) => format!("{} \u{2014} {v:.0} at {place}", rule.trigger.label()),
-            None => format!("{} at {place}", rule.trigger.label()),
+        let body = match (detail, hit.strength) {
+            (Some(d), _) => format!("{d} at {place}"),
+            (None, Some(v)) => format!("{} \u{2014} {v:.0} at {place}", rule.trigger.label()),
+            (None, None) => format!("{} at {place}", rule.trigger.label()),
         };
-        // ponytail: no snapshot attachment (see `snapshot_push`) and no per-rule sound; the
-        // delivery fan-out in `notify_alert` is the place to add either.
+        if rule.snapshot {
+            // Same one-picture-per-pass rule the warning snapshot follows: newest wins.
+            self.snapshot_push = Some(format!("{title} — {place}"));
+        }
         self.notify_alert(&title, &body, rule.urgent);
+        if let Some(sound) = rule.sound.clone() {
+            if self.settings.alert_sound && !self.settings.mute_alerts {
+                self.play_alert(&sound);
+            }
+        }
         self.banner(title, body);
     }
 
@@ -16097,6 +16191,10 @@ impl eframe::App for HookEchoApp {
             }
         }
 
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some((i, day)) = self.rules_window.backtest_request.take() {
+            self.start_backtest(i, day);
+        }
         if let Some(detail) = &self.detail {
             let tex = detail
                 .image

--- a/crates/hookecho/src/backtest.rs
+++ b/crates/hookecho/src/backtest.rs
@@ -1,0 +1,152 @@
+//! Running one rule against an archive day, so the user can see whether it would have fired.
+//!
+//! A rule is a guess until something tests it. "Rotation over 45 knots near home" sounds right
+//! and fires nine times a season or never, and the only honest way to find out which is to run it
+//! over a day that already happened.
+//!
+//! Sequential and capped: this downloads and decodes real volumes, and twenty-four of them is
+//! already a couple of hundred megabytes and a minute of CPU. Parallelising it would finish
+//! sooner and make the progress readout a lie about what is downloading.
+//!
+//! ponytail: capped at 24 volumes and one rule at a time. Both are one constant and one loop away
+//! if anyone actually wants a whole outbreak day scored at once.
+
+use crate::rules::Detection;
+use crate::settings::{AlertRule, RuleTrigger as T, Settings};
+use std::sync::{Arc, Mutex};
+use wxdata::level2::{self, Moment};
+
+/// Most volumes one backtest will pull. About two hours at a severe-weather VCP.
+pub const MAX_VOLUMES: usize = 24;
+
+/// Shared with the UI thread: what the run is doing and what it found.
+#[derive(Default)]
+pub struct Progress {
+    /// Volumes examined so far, and how many there are.
+    pub done: usize,
+    pub total: usize,
+    /// Volume times at which the rule would have fired.
+    pub fired: Vec<chrono::DateTime<chrono::Utc>>,
+    /// Set when the run ends, successfully or not.
+    pub finished: Option<String>,
+}
+
+/// A run in flight.
+pub type Shared = Arc<Mutex<Progress>>;
+
+/// Score `rule` against up to [`MAX_VOLUMES`] volumes from `site` on `day`.
+///
+/// Only scan triggers can be replayed: ProbSevere, lightning density and warnings are feeds, not
+/// something a decoded volume carries, and pretending otherwise would produce a confident empty
+/// result. Compound conditions are not evaluated either — they ask "was there also, recently",
+/// which needs the running history the live path keeps.
+pub async fn run(
+    site: String,
+    day: chrono::NaiveDate,
+    rule: AlertRule,
+    settings: Settings,
+    out: Shared,
+) {
+    let finish = |out: &Shared, msg: &str| {
+        if let Ok(mut p) = out.lock() {
+            p.finished = Some(msg.to_string());
+        }
+    };
+    if !rule.trigger.is_scan() {
+        finish(&out, "only scan triggers can be replayed from the archive");
+        return;
+    }
+    let ids = match level2::list_volumes(&site, day).await {
+        Ok(v) => v,
+        Err(e) => return finish(&out, &format!("listing {site} for {day} failed: {e}")),
+    };
+    // The end of the day is where the weather usually is, and the cap has to fall somewhere.
+    let ids: Vec<_> = ids
+        .into_iter()
+        .rev()
+        .take(MAX_VOLUMES)
+        .rev()
+        .collect();
+    if let Ok(mut p) = out.lock() {
+        p.total = ids.len();
+    }
+    if ids.is_empty() {
+        return finish(&out, "no volumes archived for that site and day");
+    }
+    let cache = crate::paths::cache_dir();
+    for id in ids {
+        let at = id.date_time();
+        match level2::download_scan(id, cache.clone()).await {
+            Ok(scan) => {
+                if let Some(hit) = first_hit(&scan, &rule, &settings) {
+                    let _ = hit;
+                    if let (Ok(mut p), Some(at)) = (out.lock(), at) {
+                        p.fired.push(at);
+                    }
+                }
+            }
+            // One bad volume is not a failed backtest; the archive has truncated objects in it.
+            Err(e) => log::warn!("backtest: skipping a volume: {e}"),
+        }
+        if let Ok(mut p) = out.lock() {
+            p.done += 1;
+        }
+    }
+    let n = out.lock().map(|p| p.fired.len()).unwrap_or(0);
+    finish(&out, &format!("done — would have fired {n} times"));
+}
+
+/// The first detection in this volume that the rule accepts, if any. Same detectors and the same
+/// thresholds the live path uses, so a backtest verdict means what the app would have done.
+fn first_hit(scan: &level2::Scan, rule: &AlertRule, settings: &Settings) -> Option<Detection> {
+    let d = &settings.detectors;
+    let hits: Vec<Detection> = match rule.trigger {
+        T::Tds => {
+            let z = level2::bin_scan(scan, Moment::Reflectivity, 0).ok()?;
+            let cc = level2::bin_scan(scan, Moment::CorrelationCoefficient, 0).ok()?;
+            wxdata::tds::detect(&z, &cc, 0.80, 40.0, 150.0, 4)
+                .iter()
+                .map(|h| Detection::at(h.lon, h.lat))
+                .collect()
+        }
+        T::Tbss => {
+            let z = level2::bin_scan(scan, Moment::Reflectivity, 0).ok()?;
+            let cc = level2::bin_scan(scan, Moment::CorrelationCoefficient, 0).ok()?;
+            wxdata::dualpol::tbss(&z, &cc, d.tbss_core_dbz, 20.0, 0.8, 4.0, 150.0)
+                .iter()
+                .map(|h| Detection::at(h.lon, h.lat))
+                .collect()
+        }
+        T::ZdrColumn => {
+            let n = level2::elevation_angles(scan).len();
+            let take = |m: Moment| -> Vec<level2::BinnedSweep> {
+                (0..n)
+                    .filter_map(|t| level2::bin_scan(scan, m, t).ok())
+                    .collect()
+            };
+            // No model freezing level in a backtest; 4 km ARL is the warm-season figure the
+            // headless dual-pol pass uses too.
+            wxdata::dualpol::zdr_columns(
+                &take(Moment::DifferentialReflectivity),
+                &take(Moment::Reflectivity),
+                4.0,
+                d.zdr_min_db,
+                d.zdr_min_depth_km,
+                40.0,
+                100.0,
+            )
+            .iter()
+            .map(|h| Detection::at(h.lon, h.lat))
+            .collect()
+        }
+        _ => {
+            let vel = level2::bin_scan_opts(scan, Moment::Velocity, 0, true).ok()?;
+            wxdata::rotation::detect(&vel, 25.0, 15.0, 150.0, 3)
+                .iter()
+                .map(|h| Detection::with_strength(h.lon, h.lat, h.vrot_ms as f64 * 1.943_844))
+                .collect()
+        }
+    };
+    hits.into_iter()
+        .find(|h| crate::rules::matches(rule, h, settings))
+}

--- a/crates/hookecho/src/lib.rs
+++ b/crates/hookecho/src/lib.rs
@@ -9,6 +9,8 @@ pub mod alert_snapshot;
 pub mod app;
 pub mod astro;
 pub mod audio;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod backtest;
 pub mod basemap_style;
 /// Live camera video (desktop only — Android cannot spawn an ffmpeg child).
 #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]

--- a/crates/hookecho/src/rules.rs
+++ b/crates/hookecho/src/rules.rs
@@ -9,7 +9,7 @@
 //! why. The cooldown, the notification and the layer plumbing live in `app.rs` — this file is
 //! the part that can be tested without a GPU.
 
-use crate::settings::{AlertRule, RulePlace, RuleTrigger, Settings};
+use crate::settings::{AlertRule, RuleCombinator, RulePlace, RuleTrigger, Settings};
 
 /// One thing a rule could fire on: where it is, and how strong it is in the trigger's own units.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -78,6 +78,55 @@ pub fn place_contains(place: &RulePlace, hit: &Detection, settings: &Settings) -
             .iter()
             .find(|z| &z.name == name)
             .is_some_and(|z| wxdata::overlay::point_in_ring(&z.ring, hit.lon, hit.lat)),
+    }
+}
+
+/// Something that fired recently, kept so a compound rule can ask "and was there also…".
+#[derive(Debug, Clone, PartialEq)]
+pub struct RecentHit {
+    pub trigger: RuleTrigger2,
+    pub hit: Detection,
+    /// Minutes since it was seen.
+    pub age_min: f64,
+}
+
+/// Compound conditions are matched on trigger *kind*, not on the warning text a `Warning` trigger
+/// carries — a rule saying "rotation and also a warning" means any warning, and writing the text
+/// twice would be a second place to get it wrong.
+pub type RuleTrigger2 = RuleTrigger;
+
+/// How recently an extra condition must have been satisfied to count. A storm does not do two
+/// things in the same second, and it does not stay the same storm for an hour.
+pub const COMPOUND_WINDOW_MIN: f64 = 15.0;
+
+/// How close to the primary detection an extra condition must be. Two signatures 100 km apart are
+/// two storms, and a rule about one of them should not fire on the other.
+pub const COMPOUND_NEAR_KM: f64 = 20.0;
+
+/// Do the rule's extra conditions hold around `hit`?
+///
+/// The rule's own trigger is not re-checked here — it is what started the evaluation. A rule with
+/// no extra conditions is unchanged from before this existed, which is what makes every rule in
+/// every existing settings file keep working.
+pub fn compound_ok(rule: &AlertRule, hit: &Detection, recent: &[RecentHit]) -> bool {
+    if rule.conditions.is_empty() {
+        return true;
+    }
+    let holds = |c: &crate::settings::RuleCondition| {
+        recent.iter().any(|r| {
+            r.trigger == c.trigger
+                && r.age_min <= COMPOUND_WINDOW_MIN
+                && crate::geo::great_circle([hit.lon, hit.lat], [r.hit.lon, r.hit.lat]).0
+                    <= COMPOUND_NEAR_KM
+                && match c.threshold {
+                    Some(min) => r.hit.strength.is_some_and(|v| v >= min),
+                    None => true,
+                }
+        })
+    };
+    match rule.combine {
+        RuleCombinator::And => rule.conditions.iter().all(holds),
+        RuleCombinator::Or => rule.conditions.iter().any(holds),
     }
 }
 
@@ -221,6 +270,79 @@ mod tests {
         let mut tds = rule(RuleTrigger::Tds, RulePlace::Anywhere);
         tds.threshold = Some(99.0);
         assert!(matches(&tds, &Detection::at(-97.5, 35.3), &s));
+    }
+
+    #[test]
+    fn compound_conditions_need_the_same_storm_and_a_recent_one() {
+        let mut r = rule(RuleTrigger::Rotation, RulePlace::Anywhere);
+        r.conditions = vec![crate::settings::RuleCondition {
+            trigger: RuleTrigger::Tds,
+            threshold: None,
+        }];
+        let hit = Detection::with_strength(-97.5, 35.3, 50.0);
+        let near = |age_min: f64, lon: f64| RecentHit {
+            trigger: RuleTrigger::Tds,
+            hit: Detection::at(lon, 35.3),
+            age_min,
+        };
+        // Same storm, two minutes ago.
+        assert!(compound_ok(&r, &hit, &[near(2.0, -97.45)]));
+        // Same place, but an hour ago — a different storm by now.
+        assert!(!compound_ok(&r, &hit, &[near(60.0, -97.45)]));
+        // Recent, but 200 km away.
+        assert!(!compound_ok(&r, &hit, &[near(2.0, -95.3)]));
+        // Nothing at all.
+        assert!(!compound_ok(&r, &hit, &[]));
+    }
+
+    #[test]
+    fn and_needs_both_conditions_and_or_needs_one() {
+        let mut r = rule(RuleTrigger::Rotation, RulePlace::Anywhere);
+        r.conditions = vec![
+            crate::settings::RuleCondition {
+                trigger: RuleTrigger::Tds,
+                threshold: None,
+            },
+            crate::settings::RuleCondition {
+                trigger: RuleTrigger::ProbSevere,
+                threshold: Some(70.0),
+            },
+        ];
+        let hit = Detection::with_strength(-97.5, 35.3, 50.0);
+        let tds = RecentHit {
+            trigger: RuleTrigger::Tds,
+            hit: Detection::at(-97.5, 35.3),
+            age_min: 1.0,
+        };
+        let weak_ps = RecentHit {
+            trigger: RuleTrigger::ProbSevere,
+            hit: Detection::with_strength(-97.5, 35.3, 40.0),
+            age_min: 1.0,
+        };
+        let strong_ps = RecentHit {
+            trigger: RuleTrigger::ProbSevere,
+            hit: Detection::with_strength(-97.5, 35.3, 85.0),
+            age_min: 1.0,
+        };
+        r.combine = RuleCombinator::And;
+        assert!(!compound_ok(&r, &hit, std::slice::from_ref(&tds)));
+        assert!(!compound_ok(&r, &hit, &[tds.clone(), weak_ps.clone()]));
+        assert!(compound_ok(&r, &hit, &[tds.clone(), strong_ps]));
+        r.combine = RuleCombinator::Or;
+        assert!(compound_ok(&r, &hit, &[tds]));
+        assert!(!compound_ok(&r, &hit, &[weak_ps]));
+    }
+
+    #[test]
+    fn an_old_rule_deserializes_with_no_conditions_and_behaves_as_before() {
+        // The shape a settings file written before compound rules existed carries.
+        let json = r#"{"id":"abc","trigger":"Tds","place":"Anywhere","cooldown_min":10,
+                       "enabled":true}"#;
+        let r: AlertRule = serde_json::from_str(json).expect("old rules must still read");
+        assert!(r.conditions.is_empty());
+        assert_eq!(r.combine, RuleCombinator::And);
+        assert!(r.sound.is_none() && !r.snapshot);
+        assert!(compound_ok(&r, &Detection::at(-97.5, 35.3), &[]));
     }
 
     #[test]

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -701,6 +701,54 @@ pub struct AlertRule {
     /// Rules are created switched off, and armed deliberately.
     #[serde(default)]
     pub enabled: bool,
+    /// Play this sound when the rule fires, instead of nothing. `None` keeps the old behaviour:
+    /// the rule banners and pushes but makes no noise of its own.
+    #[serde(default)]
+    pub sound: Option<AlertSound>,
+    /// Attach a picture of the map to the rule's push (desktop only, same path the warning
+    /// snapshot uses).
+    #[serde(default)]
+    pub snapshot: bool,
+    /// Extra conditions on top of the trigger. Empty is the old single-condition rule, and an old
+    /// rule deserializes into exactly that.
+    #[serde(default)]
+    pub conditions: Vec<RuleCondition>,
+    /// How the extra conditions combine among themselves. The rule's own trigger is always
+    /// required — it is what starts the evaluation.
+    #[serde(default)]
+    pub combine: RuleCombinator,
+}
+
+/// One extra thing that must (or may) also be true for a rule to fire.
+///
+/// Deliberately a trigger and a threshold, not an expression: one level, no nesting. A rule
+/// nobody can read at 3am is a rule nobody trusts.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct RuleCondition {
+    pub trigger: RuleTrigger,
+    #[serde(default)]
+    pub threshold: Option<f64>,
+}
+
+/// How a rule's extra conditions combine.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum RuleCombinator {
+    /// Every extra condition must also hold.
+    #[default]
+    And,
+    /// At least one of them must.
+    Or,
+}
+
+impl RuleCombinator {
+    pub const ALL: [RuleCombinator; 2] = [RuleCombinator::And, RuleCombinator::Or];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            RuleCombinator::And => "and also",
+            RuleCombinator::Or => "and either",
+        }
+    }
 }
 
 /// Ten minutes, matching the built-in proximity alerts' own cooldown.
@@ -721,6 +769,10 @@ impl AlertRule {
             urgent: false,
             cooldown_min: default_rule_cooldown(),
             enabled: false,
+            sound: None,
+            snapshot: false,
+            conditions: Vec::new(),
+            combine: RuleCombinator::default(),
         }
     }
 

--- a/crates/hookecho/src/ui/rules_window.rs
+++ b/crates/hookecho/src/ui/rules_window.rs
@@ -12,6 +12,16 @@ use crate::settings::{AlertRule, RulePlace, RuleTrigger, Settings};
 #[derive(Default)]
 pub struct RulesWindow {
     pub open: bool,
+    /// A backtest the user asked for, picked up by the app (which owns the runtime) on its next
+    /// frame: rule index, and the UTC day to replay.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub backtest_request: Option<(usize, chrono::NaiveDate)>,
+    /// The run in flight or the last one's result.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub backtest: Option<crate::backtest::Shared>,
+    /// The day the buttons replay, edited as text because a date picker is a dependency.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub backtest_day: String,
 }
 
 impl RulesWindow {
@@ -92,6 +102,14 @@ pub fn show(state: &mut RulesWindow, ctx: &egui::Context, settings: &mut Setting
                     });
                     ui.end_row();
 
+                    // Second row per rule: the parts that are usually left alone — extra
+                    // conditions, a sound, a snapshot. Below the rule rather than beside it, so
+                    // the grid stays readable for the common single-condition case.
+                    ui.label("");
+                    ui.label("");
+                    extra_row(ui, i, &mut settings.alert_rules[i], &mut changed);
+                    ui.end_row();
+
                     if dangling {
                         ui.label("");
                         ui.colored_label(
@@ -107,6 +125,9 @@ pub fn show(state: &mut RulesWindow, ctx: &egui::Context, settings: &mut Setting
             settings.alert_rules.remove(i);
             changed = true;
         }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        backtest_bar(ui, state, settings);
 
         ui.add_space(6.0);
         ui.horizontal(|ui| {
@@ -236,6 +257,173 @@ fn place_combo(
     changed
 }
 
+/// Replay one rule against an archive day, and say what it would have done.
+///
+/// The window has no tokio runtime and no HTTP client, so the button records a request the app
+/// picks up on its next frame — the same handover the voice download and the file picker use.
+#[cfg(not(target_arch = "wasm32"))]
+fn backtest_bar(ui: &mut egui::Ui, state: &mut RulesWindow, settings: &Settings) {
+    ui.add_space(6.0);
+    ui.separator();
+    if state.backtest_day.is_empty() {
+        state.backtest_day = chrono::Utc::now().date_naive().to_string();
+    }
+    let running = state
+        .backtest
+        .as_ref()
+        .and_then(|s| s.lock().ok().map(|p| p.finished.is_none()))
+        .unwrap_or(false);
+    ui.horizontal(|ui| {
+        ui.strong("Backtest");
+        ui.label("day (UTC):");
+        ui.add(
+            egui::TextEdit::singleline(&mut state.backtest_day)
+                .desired_width(96.0)
+                .hint_text("YYYY-MM-DD"),
+        );
+        let day = state.backtest_day.parse::<chrono::NaiveDate>().ok();
+        let armed: Vec<usize> = settings
+            .alert_rules
+            .iter()
+            .enumerate()
+            .filter(|(_, r)| r.trigger.is_scan())
+            .map(|(i, _)| i)
+            .collect();
+        ui.add_enabled_ui(day.is_some() && !running && !armed.is_empty(), |ui| {
+            egui::ComboBox::from_id_salt("backtest_rule")
+                .selected_text("Run a rule…")
+                .show_ui(ui, |ui| {
+                    for i in armed {
+                        if ui.button(settings.alert_rules[i].title()).clicked() {
+                            if let Some(d) = day {
+                                state.backtest_request = Some((i, d));
+                            }
+                        }
+                    }
+                });
+        });
+    });
+    ui.weak(format!(
+        "Replays up to {} volumes from the archive against one scan rule — the same detectors the \
+         live path runs. Feed triggers (warnings, ProbSevere, lightning) and extra conditions are \
+         not replayable.",
+        crate::backtest::MAX_VOLUMES
+    ));
+    let Some(shared) = &state.backtest else {
+        return;
+    };
+    let Ok(p) = shared.lock() else { return };
+    if let Some(msg) = &p.finished {
+        ui.label(msg);
+    } else {
+        ui.label(format!("checking volume {} of {}…", p.done, p.total.max(1)));
+    }
+    if !p.fired.is_empty() {
+        ui.label(
+            p.fired
+                .iter()
+                .map(|t| t.format("%H:%MZ").to_string())
+                .collect::<Vec<_>>()
+                .join("  "),
+        );
+    }
+}
+
+/// The per-rule extras: one level of AND/OR, a sound, and a snapshot attachment.
+///
+/// One level deliberately — a condition list with a combinator, not an expression tree. A rule
+/// nobody can read at 3am is a rule nobody trusts, and the second level is where that starts.
+fn extra_row(ui: &mut egui::Ui, i: usize, rule: &mut AlertRule, changed: &mut bool) {
+    ui.horizontal(|ui| {
+        egui::ComboBox::from_id_salt(("rule_combine", i))
+            .width(90.0)
+            .selected_text(rule.combine.label())
+            .show_ui(ui, |ui| {
+                for c in crate::settings::RuleCombinator::ALL {
+                    *changed |= ui
+                        .selectable_value(&mut rule.combine, c, c.label())
+                        .changed();
+                }
+            });
+        let mut drop: Option<usize> = None;
+        for (j, cond) in rule.conditions.iter_mut().enumerate() {
+            egui::ComboBox::from_id_salt(("rule_cond", i, j))
+                .width(130.0)
+                .selected_text(cond.trigger.label())
+                .show_ui(ui, |ui| {
+                    for t in RuleTrigger::ALL {
+                        let label = t.label();
+                        if ui
+                            .selectable_label(cond.trigger == t, label)
+                            .clicked()
+                        {
+                            cond.threshold = t.threshold_hint().map(|(_, d)| d);
+                            cond.trigger = t;
+                            *changed = true;
+                        }
+                    }
+                });
+            if let Some((unit, default)) = cond.trigger.threshold_hint() {
+                let mut v = cond.threshold.unwrap_or(default);
+                if ui
+                    .add(egui::DragValue::new(&mut v).suffix(format!(" {unit}")))
+                    .changed()
+                {
+                    cond.threshold = Some(v);
+                    *changed = true;
+                }
+            }
+            if ui.small_button("✕").clicked() {
+                drop = Some(j);
+            }
+        }
+        if let Some(j) = drop {
+            rule.conditions.remove(j);
+            *changed = true;
+        }
+        if ui
+            .button("➕ condition")
+            .on_hover_text(format!(
+                "Also require another signature within {:.0} km and {:.0} minutes",
+                crate::rules::COMPOUND_NEAR_KM,
+                crate::rules::COMPOUND_WINDOW_MIN,
+            ))
+            .clicked()
+        {
+            rule.conditions.push(crate::settings::RuleCondition {
+                trigger: RuleTrigger::Tds,
+                threshold: None,
+            });
+            *changed = true;
+        }
+    });
+    ui.horizontal(|ui| {
+        let mut on = rule.sound.is_some();
+        if ui
+            .checkbox(&mut on, "Sound")
+            .on_hover_text("Play a sound when this rule fires")
+            .changed()
+        {
+            rule.sound = on.then(crate::settings::AlertSound::default);
+            *changed = true;
+        }
+        if let Some(sound) = &mut rule.sound {
+            egui::ComboBox::from_id_salt(("rule_sound", i))
+                .width(110.0)
+                .selected_text(sound.label())
+                .show_ui(ui, |ui| {
+                    for s in crate::settings::AlertSound::BUILTINS {
+                        *changed |= ui.selectable_value(sound, s.clone(), s.label()).changed();
+                    }
+                });
+        }
+        *changed |= ui
+            .checkbox(&mut rule.snapshot, "Snapshot")
+            .on_hover_text("Attach a picture of the map to this rule's push (desktop only)")
+            .changed();
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -275,3 +463,4 @@ mod tests {
         );
     }
 }
+


### PR DESCRIPTION
Wave E, PR 14 — the last of the R17 plan. Independent of #58/#59/#60; based on `main`.

## Per-rule sound and snapshot

`fire_rule` carried a ponytail saying the delivery fan-out was the place to add either. It is, and now it does: a rule can play its own sound and attach a picture of the map to its push, through the same `snapshot_push` path the warning snapshot already uses.

Warning rules used to notify inline, bypassing `fire_rule` entirely — so they got no cooldown key, no sound and no snapshot. They now go through it, with the event name preserved in the body (the trigger label alone does not carry it).

## Compound triggers — one level

`AlertRule` gains a condition list and a combinator. One level of AND/OR, not an expression tree: a rule nobody can read at 3am is a rule nobody trusts, and the second level is where that starts.

The rule's own trigger is always required — it is what starts the evaluation. The extras ask *"was this also seen, recently, near here"*: within 20 km and 15 minutes, against a running list of detections the app now keeps for **every** scan detector rather than only the armed ones, since "rotation and also a TDS" needs TDS hits nobody armed a rule on.

Old rules deserialize to an empty condition list and behave exactly as before. There is a test that feeds in the JSON shape a pre-compound settings file carries and asserts it.

## Backtest

A rule is a guess until something tests it. "Rotation over 45 knots near home" sounds right and fires nine times a season or never.

The rules window can now replay one scan rule against an archive day: up to 24 volumes, sequential, on the shared runtime, using the same detectors and the same thresholds the live path runs — so the verdict means what the app would have done, not what a second implementation thinks. It reports the volume times it would have fired at, and progress while it works. The window has no runtime or HTTP client of its own, so the button records a request the app picks up next frame — the same handover the file picker uses.

Not replayable, and the UI says so rather than returning a confident empty result: feed triggers (warnings, ProbSevere, lightning), which a decoded volume does not carry, and compound conditions, which need the running history the live path keeps.

## Ponytails

- One level of AND/OR.
- Backtest capped at 24 volumes, one rule at a time, sequential. Parallelising would finish sooner and make the progress readout a lie about what is downloading.

## Verification

`cargo clippy --workspace --all-targets` clean · `cargo test --workspace` 462 passed · wasm `cargo check` clean · `shoot.sh check` passed.

New tests: compound conditions need the same storm *and* a recent one (four cases: near+recent, near+stale, recent+far, nothing); AND needs both while OR needs one, including a threshold that fails; a pre-compound rule JSON deserializes with no conditions and behaves as before.

Not verified here: no backtest was actually run against a live archive day — that needs the network and a site with weather on it. The detector calls it makes are the same ones `headless.rs` already runs, which is why they are reused rather than rewritten, but the end-to-end run is a manual check I did not do. Worth one before merge: pick a known outbreak date and a rotation rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)