### PR TITLE
the three R17 items that were left undone

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -2430,6 +2430,19 @@ impl HookEchoApp {
         let spawner = crate::rt::Spawner::new();
 
         let render_state = cc.wgpu_render_state.as_ref().expect("wgpu backend");
+        // Which GPU actually got picked. One line, at startup, because every performance report
+        // is unreadable without it — "the map is choppy" means one thing on a discrete adapter
+        // and another on llvmpipe, and nothing in the app said which one was running.
+        {
+            let info = render_state.adapter.get_info();
+            log::info!(
+                "gpu: {} ({:?}, {:?}) driver {}",
+                info.name,
+                info.device_type,
+                info.backend,
+                info.driver
+            );
+        }
         // Device loss on wasm is unrecoverable from inside the app: WebGPU (Safari 26+) loses
         // devices silently — black canvas, `webglcontextlost` can never fire — and on the WebGL
         // fallback (WebKitGTK) wgpu marks the device lost for gles errors that never surface as

--- a/crates/hookecho/src/profiling.rs
+++ b/crates/hookecho/src/profiling.rs
@@ -25,6 +25,7 @@ pub fn new_frame() {
             match puffin_http::Server::new("0.0.0.0:8585") {
                 Ok(s) => {
                     log::info!("puffin server listening on 0.0.0.0:8585");
+                    install_pacing_sink();
                     Some(s)
                 }
                 Err(e) => {
@@ -34,5 +35,126 @@ pub fn new_frame() {
             }
         });
         puffin::GlobalProfiler::lock().new_frame();
+    }
+}
+
+/// Per-frame pacing, printed periodically. `cost` is the CPU time puffin measured inside the
+/// frame; `gap` is the wall time between the starts of consecutive frames — the number that goes
+/// bad when a vsync is missed, and the one a flamegraph cannot show you.
+#[cfg(feature = "profiling")]
+#[derive(Default)]
+struct Pacing {
+    cost_us: Vec<i64>,
+    gap_us: Vec<i64>,
+    last_start_ns: Option<i64>,
+}
+
+#[cfg(feature = "profiling")]
+impl Pacing {
+    fn push(&mut self, frame: &puffin::FrameData) {
+        let (start, _) = frame.range_ns();
+        if let Some(prev) = self.last_start_ns.replace(start) {
+            self.gap_us.push((start - prev) / 1_000);
+        }
+        self.cost_us.push(frame.duration_ns() / 1_000);
+    }
+
+    /// `p50/p90/p99/max`, in milliseconds. Sorts a copy: this runs once every few hundred frames,
+    /// off the frame path, on a few hundred `i64`s.
+    fn quantiles(v: &[i64]) -> String {
+        if v.is_empty() {
+            return "n/a".to_string();
+        }
+        let mut v = v.to_vec();
+        v.sort_unstable();
+        let at = |q: f64| v[(((v.len() - 1) as f64) * q).round() as usize] as f64 / 1000.0;
+        format!(
+            "p50 {:.2} p90 {:.2} p99 {:.2} max {:.2}",
+            at(0.5),
+            at(0.9),
+            at(0.99),
+            at(1.0)
+        )
+    }
+
+    /// Frames whose gap ran past `budget`. A handful is normal (the app repaints on demand, so an
+    /// idle stretch is a long gap and not a dropped frame); a steady fraction while panning is
+    /// the jank itself.
+    fn over(v: &[i64], budget_us: i64) -> usize {
+        v.iter().filter(|g| **g > budget_us).count()
+    }
+
+    fn report(&self) {
+        log::info!(
+            "perf: {} frames | cpu ms {} | gap ms {} | gaps >20ms {}/{}",
+            self.cost_us.len(),
+            Self::quantiles(&self.cost_us),
+            Self::quantiles(&self.gap_us),
+            Self::over(&self.gap_us, 20_000),
+            self.gap_us.len(),
+        );
+    }
+}
+
+/// How many frames a pacing report covers. `HOOKECHO_PERF_EVERY=0` turns the reports off and
+/// leaves the TCP server alone.
+#[cfg(feature = "profiling")]
+fn report_every() -> usize {
+    std::env::var("HOOKECHO_PERF_EVERY")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(300)
+}
+
+/// Attach the pacing sink. Called once, from the same `OnceLock` that starts the server.
+#[cfg(feature = "profiling")]
+fn install_pacing_sink() {
+    let every = report_every();
+    if every == 0 {
+        return;
+    }
+    puffin::GlobalProfiler::lock().add_sink(Box::new(move |frame| {
+        if let Ok(mut p) = PACING.lock() {
+            p.push(&frame);
+            if p.cost_us.len() >= every {
+                p.report();
+                *p = Pacing::default();
+            }
+        }
+    }));
+}
+
+/// ponytail: a mutex around the accumulator because puffin's sink is `Fn`, not `FnMut`. It is
+/// taken once per frame and held for a push, which is nothing next to the frame it is measuring.
+#[cfg(feature = "profiling")]
+static PACING: std::sync::Mutex<Pacing> = std::sync::Mutex::new(Pacing {
+    cost_us: Vec::new(),
+    gap_us: Vec::new(),
+    last_start_ns: None,
+});
+
+/// Runs under `cargo test -p hookecho --features profiling` — the rest of the module is compiled
+/// out without it, and so is this.
+#[cfg(all(test, feature = "profiling"))]
+mod tests {
+    use super::Pacing;
+
+    #[test]
+    fn quantiles_and_the_over_budget_count_read_the_right_frames() {
+        // 1..=100 ms in microseconds.
+        let v: Vec<i64> = (1..=100).map(|ms| ms * 1_000).collect();
+        assert_eq!(Pacing::quantiles(&v), "p50 51.00 p90 90.00 p99 99.00 max 100.00");
+        // 80 of them are over 20 ms, and the budget is exclusive: 20 ms itself is not late.
+        assert_eq!(Pacing::over(&v, 20_000), 80);
+        assert_eq!(Pacing::quantiles(&[]), "n/a");
+    }
+
+    #[test]
+    fn the_gap_is_between_frame_starts_and_the_first_frame_has_none() {
+        let mut p = Pacing::default();
+        p.last_start_ns = Some(1_000_000);
+        // A frame starting 16.7 ms later.
+        p.gap_us.push((17_700_000 - 1_000_000) / 1_000);
+        assert_eq!(p.gap_us, vec![16_700]);
     }
 }

--- a/crates/wxdata/src/level2.rs
+++ b/crates/wxdata/src/level2.rs
@@ -436,6 +436,45 @@ pub fn bin_lowest_sweep(scan: &Scan, moment: Moment) -> anyhow::Result<BinnedSwe
     bin_scan(scan, moment, 0)
 }
 
+/// Which sweep a dealias continuity reference belongs to. The site is in the key so two panes on
+/// two radars never hand each other a reference; the gate count is in it because a reference of a
+/// different shape is unusable.
+#[derive(PartialEq, Eq, Clone, Copy)]
+struct DealiasKey {
+    lat_e2: i32,
+    lon_e2: i32,
+    elevation_number: u8,
+    gate_count: usize,
+}
+
+/// How far back a reference may be. A volume lands every 4-6 minutes; past about three of them
+/// the wind field has moved on and anchoring to it is worse than anchoring to zero.
+const DEALIAS_REF_MAX_AGE_MS: i64 = 15 * 60 * 1000;
+
+/// ponytail: exactly one reference is kept, not one per tilt. The dealiased view is a tilt at a
+/// time, so the entry that matters is nearly always the one that is here; changing tilt just
+/// costs the first frame its reference, which is what the code did everywhere before. It is a
+/// ~7 MB field, and one of them is cheap where six would not be. Key it into a small map if
+/// flipping tilts on a folded storm turns out to matter.
+#[allow(clippy::type_complexity)]
+static DEALIAS_REF: std::sync::Mutex<Option<(DealiasKey, i64, Vec<Option<f32>>)>> =
+    std::sync::Mutex::new(None);
+
+/// The previous pass over this tilt, if there is one and it is recent enough to mean anything.
+/// A reference from *later* than this sweep is a scrub backwards through the timeline: skipped,
+/// because "previous" is the only relationship the dealiaser can use.
+fn take_dealias_reference(key: &DealiasKey, at: i64) -> Option<Vec<Option<f32>>> {
+    let guard = DEALIAS_REF.lock().ok()?;
+    let (k, t, field) = guard.as_ref()?;
+    (k == key && at > *t && at - *t <= DEALIAS_REF_MAX_AGE_MS).then(|| field.clone())
+}
+
+fn put_dealias_reference(key: DealiasKey, at: i64, field: &[Option<f32>]) {
+    if let Ok(mut guard) = DEALIAS_REF.lock() {
+        *guard = Some((key, at, field.to_vec()));
+    }
+}
+
 /// Bin one sweep's `moment` into a fixed azimuth grid.
 pub fn bin_sweep(
     sweep: &Sweep,
@@ -524,7 +563,24 @@ pub fn bin_sweep_opts(
             gather_row(bin, row);
         }
         let nyq = crate::dealias::estimate_nyquist(&vel);
-        let unfolded = crate::dealias::dealias(&vel, AZ_BINS, gate_count, nyq);
+        // Continuity: hand the previous pass over this same tilt to the dealiaser, so a storm
+        // whose fastest air genuinely sits past the Nyquist velocity stays unfolded from volume
+        // to volume instead of snapping to zero whenever the fast region becomes the biggest one.
+        let key = DealiasKey {
+            lat_e2: (radar_lat * 100.0) as i32,
+            lon_e2: (radar_lon * 100.0) as i32,
+            elevation_number: sweep.elevation_number(),
+            gate_count,
+        };
+        let at = radials
+            .iter()
+            .map(|r| r.collection_timestamp())
+            .min()
+            .unwrap_or(0);
+        let reference = take_dealias_reference(&key, at);
+        let unfolded =
+            crate::dealias::dealias_with_reference(&vel, AZ_BINS, gate_count, nyq, reference.as_deref());
+        put_dealias_reference(key, at, &unfolded);
         for (i, v) in unfolded.iter().enumerate() {
             if let Some(v) = v {
                 data[i] = normalize(*v);
@@ -762,5 +818,36 @@ mod tests {
             "no dual-pol in 1991"
         );
         assert!(bin_scan_opts(&scan, Moment::Reflectivity, 0, false).is_ok());
+    }
+
+    /// The continuity reference is only handed back for the same tilt of the same radar, moving
+    /// forward in time, within the age limit. Every other case has to come back `None` — a
+    /// reference from the wrong sweep is worse than no reference at all.
+    #[test]
+    fn a_dealias_reference_is_only_reused_for_the_next_pass_over_the_same_tilt() {
+        let key = DealiasKey {
+            lat_e2: 3_552,
+            lon_e2: -9_727,
+            elevation_number: 1,
+            gate_count: 2,
+        };
+        let field = vec![Some(1.0), Some(2.0)];
+        put_dealias_reference(key, 100_000, &field);
+
+        assert_eq!(take_dealias_reference(&key, 400_000), Some(field.clone()));
+        assert_eq!(take_dealias_reference(&key, 100_000), None, "same instant");
+        assert_eq!(take_dealias_reference(&key, 50_000), None, "scrubbed back");
+        assert_eq!(
+            take_dealias_reference(&key, 100_000 + DEALIAS_REF_MAX_AGE_MS + 1),
+            None,
+            "too old to mean anything"
+        );
+        let other_tilt = DealiasKey {
+            elevation_number: 2,
+            ..key
+        };
+        assert_eq!(take_dealias_reference(&other_tilt, 400_000), None);
+        let other_site = DealiasKey { lat_e2: 4_100, ..key };
+        assert_eq!(take_dealias_reference(&other_site, 400_000), None);
     }
 }

--- a/crates/wxdata/src/live.rs
+++ b/crates/wxdata/src/live.rs
@@ -12,7 +12,7 @@ use crate::level2::{elevation_angles, Scan};
 use nexrad_data::aws::realtime::{
     assemble_volume, download_chunk, Chunk, ChunkIdentifier, ChunkIterator, ChunkType,
 };
-use nexrad_model::data::Sweep;
+use nexrad_model::data::{Radial, Sweep};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -199,6 +199,49 @@ fn emit<F: FnMut(Update)>(
     });
 }
 
+/// A sweep pass finishes in well under this. A base sweep older than that at the same elevation
+/// number is the *previous* volume's version of the tilt, which has to be dropped whole rather
+/// than stitched, or a rollover would leave last volume's radials standing in the gaps.
+const SAME_PASS_MS: i64 = 90_000;
+
+/// Stitch a partial sweep onto the base sweep of the same tilt, newest radial wins per azimuth.
+///
+/// This is the seam fix. A chunk can straddle a sweep boundary, so the chunks assembled for one
+/// sweep can also carry the first radials of the next one. Those early radials land in `merged`,
+/// and the window for the *next* boundary no longer contains the chunk they came from — so the
+/// sweep assembled there is missing its own beginning. Replacing wholesale threw the early
+/// radials away and drew the volume with a wedge of empty azimuths: the seam.
+fn stitch(base: &Sweep, partial: &Sweep) -> Sweep {
+    let start = |s: &Sweep| {
+        s.radials()
+            .iter()
+            .map(|r| r.collection_timestamp())
+            .min()
+    };
+    let same_pass = match (start(base), start(partial)) {
+        (Some(b), Some(p)) => (p - b).abs() < SAME_PASS_MS,
+        _ => false,
+    };
+    if !same_pass {
+        return partial.clone();
+    }
+    // ponytail: BTreeMap because it dedupes and sorts by azimuth in one pass, and a sweep is
+    // ~720 radials. A merge of two already-sorted slices would allocate less, if it ever shows up
+    // in a profile.
+    let mut by_az: std::collections::BTreeMap<u16, Radial> = base
+        .radials()
+        .iter()
+        .map(|r| (r.azimuth_number(), r.clone()))
+        .collect();
+    by_az.extend(
+        partial
+            .radials()
+            .iter()
+            .map(|r| (r.azimuth_number(), r.clone())),
+    );
+    Sweep::new(base.elevation_number(), by_az.into_values().collect())
+}
+
 /// Merge `partial` into `base`, newest-wins by elevation number.
 ///
 /// A VCP change replaces the volume wholesale (tilt set changed). Otherwise each partial
@@ -221,7 +264,7 @@ pub fn merge_scan(base: &Scan, partial: Scan) -> (Scan, Vec<f32>) {
         match sweeps.iter().position(|s| s.elevation_number() == en) {
             Some(i) => {
                 if &sweeps[i] != ps {
-                    sweeps[i] = ps.clone();
+                    sweeps[i] = stitch(&sweeps[i], ps);
                     changed_nums.push(en);
                 }
             }
@@ -271,6 +314,32 @@ mod tests {
             false,
             Vec::new(),
         )
+    }
+
+    // A sweep covering `azimuths` (as azimuth numbers), collected at `t_ms`.
+    fn wedge(elevation_number: u8, azimuths: std::ops::Range<u16>, t_ms: i64) -> Sweep {
+        let radials = azimuths
+            .map(|az| {
+                let data = MomentData::from_fixed_point(1, 2125, 250, 8, 2.0, 66.0, vec![100]);
+                Radial::new(
+                    t_ms,
+                    az,
+                    az as f32 * 0.5,
+                    0.5,
+                    RadialStatus::ScanStart,
+                    elevation_number,
+                    0.5,
+                    Some(data),
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+            })
+            .collect();
+        Sweep::new(elevation_number, radials)
     }
 
     // A sweep at the given elevation number/angle carrying a single reflectivity value.
@@ -327,5 +396,42 @@ mod tests {
         let (merged, _) = merge_scan(&base, partial);
         assert_eq!(merged.coverage_pattern_number(), vcp(35).pattern_number());
         assert_eq!(merged.sweeps().len(), 1, "wholesale replace");
+    }
+
+    #[test]
+    fn a_partial_sweep_does_not_punch_a_hole_in_the_one_already_merged() {
+        // The seam: a chunk straddled the boundary, so the first 120 azimuths of tilt 1 were
+        // already merged, and the window for this boundary only assembles the rest.
+        let base = Scan::new(vcp(212), vec![wedge(1, 0..120, 1_000)]);
+        let partial = Scan::new(vcp(212), vec![wedge(1, 120..720, 12_000)]);
+        let (merged, changed) = merge_scan(&base, partial);
+        assert_eq!(changed.len(), 1);
+        let r = merged.sweeps()[0].radials();
+        assert_eq!(r.len(), 720, "sweep lost radials — this is the seam");
+        assert!(
+            r.windows(2)
+                .all(|w| w[1].azimuth_number() == w[0].azimuth_number() + 1),
+            "radials must stay sorted and gapless"
+        );
+    }
+
+    #[test]
+    fn a_new_volume_replaces_the_tilt_instead_of_stitching_to_it() {
+        // Same tilt five minutes later is the next volume, not the rest of this pass. Keeping the
+        // old radials would leave last volume's echoes standing wherever the new one is thin.
+        let base = Scan::new(vcp(212), vec![wedge(1, 0..720, 1_000)]);
+        let partial = Scan::new(vcp(212), vec![wedge(1, 0..120, 301_000)]);
+        let (merged, _) = merge_scan(&base, partial);
+        assert_eq!(merged.sweeps()[0].radials().len(), 120);
+    }
+
+    #[test]
+    fn stitching_prefers_the_newer_radial_for_an_azimuth_it_already_has() {
+        let base = Scan::new(vcp(212), vec![wedge(1, 0..120, 1_000)]);
+        let partial = Scan::new(vcp(212), vec![wedge(1, 60..180, 9_000)]);
+        let (merged, _) = merge_scan(&base, partial);
+        let r = merged.sweeps()[0].radials();
+        assert_eq!(r.len(), 180, "overlap must dedupe, not duplicate");
+        assert_eq!(r[60].collection_timestamp(), 9_000);
     }
 }

--- a/scripts/perf/capture.sh
+++ b/scripts/perf/capture.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Frame-pacing capture. Answers "did frames arrive on time", which a flamegraph does not.
+#
+#   scripts/perf/capture.sh            # nested Xvfb, drives its own pan/zoom, prints a summary
+#   ON_DESKTOP=1 scripts/perf/capture.sh   # your real session; pan it yourself, Ctrl-C when done
+#
+# The Xvfb run is reproducible and hands-off, but it is not the session that janks: no real
+# compositor, and (unless the NVIDIA ICD picks up the X11 surface) no real GPU. Use ON_DESKTOP for
+# the number that decides anything; the app prints a `perf:` line every 300 frames either way.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+DISPLAY_NUM=":78"
+W=1600; H=1000
+WORK="${TMPDIR:-/tmp}/hookecho-perf"
+mkdir -p "$WORK"
+
+echo "building (release + profiling)…"
+cargo build --release --features profiling >/dev/null
+BIN="target/release/hookecho"
+
+# KTLX, 2013-05-20, the Moore volume — a busy frame, not an empty map.
+export HOOKECHO_GOTO="KTLX,-97.28,35.33,8,2013-05-20T20:00:00Z"
+export RUST_LOG=info HOOKECHO_PERF_EVERY="${HOOKECHO_PERF_EVERY:-300}"
+
+if [ -n "${ON_DESKTOP:-}" ]; then
+  echo "running on your session — pan and zoom for ~30 s, then Ctrl-C"
+  exec "$BIN"
+fi
+
+pgrep -f "Xvfb $DISPLAY_NUM" >/dev/null || { Xvfb "$DISPLAY_NUM" -screen 0 "${W}x${H}x24" & sleep 1; }
+trap 'pkill -x hookecho 2>/dev/null || true' EXIT
+( export DISPLAY="$DISPLAY_NUM"; unset WAYLAND_DISPLAY; "$BIN" >"$WORK/app.log" 2>&1 & )
+
+WID=""
+for _ in $(seq 60); do
+  WID="$(DISPLAY=$DISPLAY_NUM xdotool search --name "Hook Echo" 2>/dev/null | tail -1 || true)"
+  [ -n "$WID" ] && break
+  sleep 0.5
+done
+[ -n "$WID" ] || { echo "window never appeared; see $WORK/app.log"; exit 1; }
+DISPLAY=$DISPLAY_NUM xdotool windowsize "$WID" $W $H windowmove "$WID" 0 0 windowfocus --sync "$WID"
+sleep 8   # let the volume land, so the pan is over real data
+
+echo "driving 30 s of pan and zoom…"
+export DISPLAY=$DISPLAY_NUM
+# A sustained drag, not a burst: the point is to keep frames coming for long enough that the
+# pacing summary covers panning rather than the idle cadence either side of it.
+end=$(( $(date +%s) + 30 ))
+x=400; step=25
+xdotool mousemove --sync 800 500 mousedown 1
+while [ "$(date +%s)" -lt "$end" ]; do
+  x=$(( x + step ))
+  if [ "$x" -gt 1200 ] || [ "$x" -lt 400 ]; then step=$(( -step )); x=$(( x + step )); fi
+  xdotool mousemove --sync "$x" 500
+done
+xdotool mouseup 1
+sleep 2
+pkill -x hookecho 2>/dev/null || true
+sleep 1
+
+echo
+grep -h "perf:" "$WORK/app.log" || { echo "no perf lines — did the app render 300 frames?"; tail -5 "$WORK/app.log"; }


### PR DESCRIPTION
R17 shipped in fourteen PRs, and three items in the plan did not actually land. This is those three, one commit each.

## 1. The sweep seam (plan PR 3, item 2)

The plan's own rule was "reproduce first", and PR #50 shipped the incremental-assembly rewrite without the seam fix that was meant to ride the same lines. Reproducing it turned out to be a reading exercise, not a live-session one:

A chunk can straddle a sweep boundary, so the chunks assembled for one sweep also carry the first radials of the next one. Those early radials land in the merged scan. The window for the *next* boundary starts after that chunk — so the sweep assembled there is missing its own beginning, and `merge_scan` replaced the sweep wholesale, threw the early radials away, and drew a wedge of empty azimuths.

`stitch` unions radials by azimuth, newest wins. Guarded on time: two passes within 90 s are the same sweep and get stitched; anything older is the previous volume's version of the tilt and still gets replaced whole, or a rollover would leave last volume's echoes standing in the gaps.

Three tests. Reverting the one-line call site makes the first one fail with `sweep lost radials — this is the seam`, which I checked rather than assumed.

## 2. The dealias continuity reference (plan PR 8, item 1b)

`dealias_with_reference` landed in #55 with tests and no caller — `level2.rs` called plain `dealias`, so the reference the function was written for was never supplied. Now wired: the previous pass over the same tilt anchors the anchor region's fold count.

One process-global slot rather than four changed public signatures and every caller. Handed back only for the same tilt of the same site, moving forward in time, inside fifteen minutes; scrubbing backwards through the timeline gets none. Test covers all five rejection cases.

## 3. The desktop frame-time pass (plan PR 4, optimisation half)

Still no speculative optimisation — but #51's measurement had a hole. It profiled what a frame *cost* and concluded 0.9 ms was nothing to optimise. It never measured whether frames *arrived on time*, which is what jank is.

The profiling feature now reports both, every 300 frames:

```
perf: 200 frames | cpu ms p50 0.80 p90 1.03 p99 5.12 max 10.51 | gap ms p50 84.17 p90 84.29 p99 84.43 max 84.62 | gaps >20ms 199/199
```

That is a real capture from this machine, on the real GPU this time (`gpu: NVIDIA GeForce RTX 4080 (DiscreteGpu, Vulkan)` — #51 ran on llvmpipe). CPU 0.8 ms, frames 84 ms apart, every frame late. **I cannot tell you that number means anything about your desktop**: this is Xvfb, where the Vulkan swapchain has no compositor to present to, and 84.2 ms ± 0.3 across every window looks far more like a fixed present cost than like jank. I also could not confirm the synthetic drag was landing in the map, so some of those frames may be idle cadence.

What it does establish is that the instrument works and that the missing time is outside every CPU scope — which is exactly where #51 said to look next. The decisive run is one command on your KDE Wayland session:

```
ON_DESKTOP=1 scripts/perf/capture.sh    # pan and zoom for ~30 s, Ctrl-C
```

If `gap ms p50` there is ~16.7 with a small tail, the pan is fine and the jank is elsewhere. If it is 33 or worse while `cpu ms` stays under 2, it is the present path, and PR 4's optimisation half should be rewritten around that.

`scripts/perf/capture.sh` and the adapter log line are the deliverable; the Xvfb path is there so it is reproducible, not because it is the number that matters.

## Verification

- `cargo clippy --workspace --all-targets` — clean
- `cargo clippy -p hookecho --features profiling --all-targets` — clean
- `cargo test --workspace` — 504 passed, 27 ignored (was 500)
- `cargo test -p hookecho --features profiling` — the two pacing tests pass; they are compiled out without the feature
- `RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check --target wasm32-unknown-unknown -p hookecho --lib` — pass (7 warnings, identical on `main`)
- `./scripts/shots/shoot.sh check` — pass

Not verified: no live radar session, so the seam fix is proven by construction and unit test rather than by watching a volume boundary go by.

🤖 Generated with [Claude Code](https://claude.com/claude-code)