### PR TITLE
show the mesoscale discussion, not a link to it

### DIFF
--- a/crates/hookecho/src/ui/detail_window.rs
+++ b/crates/hookecho/src/ui/detail_window.rs
@@ -19,7 +19,9 @@ pub fn show(ctx: &egui::Context, detail: &Detail, image: Option<&egui::TextureHa
     let mut open = true;
     crate::ui::phone_surface(ctx, egui::Window::new("Feature Details"))
         .open(&mut open)
-        .default_size([380.0, 320.0])
+        // Wide enough for a 69-column fixed-width product (SPC bulletins, L3 attribute
+        // tables) to land on its own line breaks instead of the wrap point.
+        .default_size([560.0, 420.0])
         .show(ctx, |ui| {
             ui.horizontal(|ui| {
                 let c = detail.color;

--- a/crates/wxdata/src/spc.rs
+++ b/crates/wxdata/src/spc.rs
@@ -183,8 +183,34 @@ fn push_polys(
     }
 }
 
-/// Parse an SPC Mesoscale Discussion GeoJSON payload.
-pub fn parse_md(json: &str) -> anyhow::Result<Vec<GeoFeature>> {
+/// The plain-text bulletin URL for an MCD whose `popupinfo` is `page`.
+///
+/// SPC serves every discussion twice: `md2032.html` for a browser and `md2032.txt` for the raw
+/// product. The map service only ever hands out the HTML one, so the readout has to be derived.
+fn md_text_url(page: &str) -> Option<String> {
+    let page = page.trim();
+    let rest = page
+        .strip_prefix("https://")
+        .or_else(|| page.strip_prefix("http://"))?;
+    // Upgraded to https on the way out: the service still advertises these links as plain http.
+    Some(format!("https://{}.txt", rest.strip_suffix(".html")?))
+}
+
+/// Strip the WMO routing header off a raw SPC product, leaving the discussion itself.
+///
+/// The first four lines are `ZCZC`, the AWIPS/WMO ids and the UGC zone line — machine routing
+/// nobody clicked a polygon to read. Anything unrecognized is returned whole rather than
+/// truncated on a guess.
+fn strip_wmo_header(text: &str) -> &str {
+    match text.find("\nMesoscale Discussion") {
+        Some(i) => text[i + 1..].trim_end(),
+        None => text.trim_end(),
+    }
+}
+
+/// Parse an SPC Mesoscale Discussion GeoJSON payload into features paired with the URL of each
+/// one's bulletin text, which the payload itself does not carry.
+pub fn parse_md(json: &str) -> anyhow::Result<Vec<(GeoFeature, Option<String>)>> {
     let mut out = Vec::new();
     for_each_feature(json, |geom, props| {
         let str_of = |k: &str| props.get(k).and_then(|v| v.as_str()).unwrap_or("");
@@ -194,21 +220,22 @@ pub fn parse_md(json: &str) -> anyhow::Result<Vec<GeoFeature>> {
         } else {
             format!("Mesoscale Discussion {name}")
         };
-        let detail = format!(
-            "{title}\n\n{}\n{}",
-            str_of("popupinfo"),
-            str_of("folderpath")
-        );
+        let page = str_of("popupinfo");
+        let detail = format!("{}\n\n{page}", str_of("folderpath"));
+        let text_url = md_text_url(page);
         for poly in polygons_of(geom) {
-            out.push(GeoFeature {
-                rings: poly,
-                fill: [255, 120, 0, 30],
-                stroke: [255, 140, 0, 235],
-                kind: FeatureKind::MesoDiscussion,
-                title: title.clone(),
-                detail: detail.clone(),
-                alert: None,
-            });
+            out.push((
+                GeoFeature {
+                    rings: poly,
+                    fill: [255, 120, 0, 30],
+                    stroke: [255, 140, 0, 235],
+                    kind: FeatureKind::MesoDiscussion,
+                    title: title.clone(),
+                    detail: detail.clone(),
+                    alert: None,
+                },
+                text_url.clone(),
+            ));
         }
     })?;
     Ok(out)
@@ -242,7 +269,28 @@ pub async fn fetch_outlook_kind(
     parse_outlook_kind(&body, day, kind)
 }
 
-/// Fetch active Mesoscale Discussions.
+/// Fetch one MCD's bulletin text. `None` on any failure: a discussion whose text will not load
+/// still has a polygon worth drawing, and the URL stays in the detail either way.
+async fn fetch_md_text(client: &reqwest::Client, url: &str) -> Option<String> {
+    let body = client
+        .get(crate::net::fetch_url(url))
+        .header("User-Agent", USER_AGENT)
+        .send()
+        .await
+        .ok()?
+        .error_for_status()
+        .ok()?
+        .text()
+        .await
+        .ok()?;
+    Some(strip_wmo_header(&body).to_string())
+}
+
+/// Fetch active Mesoscale Discussions, each with its full bulletin text.
+///
+/// The GeoJSON carries a link and nothing else, so clicking a discussion used to show a URL. The
+/// text is a second request per discussion, done here rather than on click so the popup opens
+/// with the readout already in it.
 pub async fn fetch_mesoscale_discussions(
     client: &reqwest::Client,
 ) -> anyhow::Result<Vec<GeoFeature>> {
@@ -254,7 +302,25 @@ pub async fn fetch_mesoscale_discussions(
         .error_for_status()?
         .text()
         .await?;
-    parse_md(&body)
+    // ponytail: sequential, and cached per URL because one MultiPolygon MD yields several
+    // features sharing a bulletin. A handful are active at once even on an outbreak day; reach
+    // for join_all only if that stops being true.
+    let mut texts: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    let mut out = Vec::new();
+    for (mut feature, url) in parse_md(&body)? {
+        if let Some(url) = url {
+            if !texts.contains_key(&url) {
+                if let Some(text) = fetch_md_text(client, &url).await {
+                    texts.insert(url.clone(), text);
+                }
+            }
+            if let Some(text) = texts.get(&url) {
+                feature.detail = format!("{text}\n\n{}", feature.detail);
+            }
+        }
+        out.push(feature);
+    }
+    Ok(out)
 }
 
 /// Kind of a local storm report (drives the marker color/label).
@@ -302,6 +368,67 @@ pub struct StormReport {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Live check against SPC, run by hand: `cargo test -p wxdata live_mcd -- --ignored`.
+    /// Quiet when no discussion is active — there is nothing to fetch on a calm day.
+    #[tokio::test]
+    #[ignore = "network"]
+    async fn live_mcd_text_arrives_with_the_polygon() {
+        let client = reqwest::Client::new();
+        let features = fetch_mesoscale_discussions(&client).await.unwrap();
+        for f in &features {
+            assert!(
+                f.detail.starts_with("Mesoscale Discussion"),
+                "no readout, only a link: {}",
+                f.detail
+            );
+        }
+    }
+
+    #[test]
+    fn a_discussion_link_becomes_its_bulletin_url() {
+        // What the map service actually hands out, plain http and all.
+        assert_eq!(
+            md_text_url("http://www.spc.noaa.gov/products/md/md2032.html").as_deref(),
+            Some("https://www.spc.noaa.gov/products/md/md2032.txt")
+        );
+        assert_eq!(md_text_url(""), None);
+        assert_eq!(md_text_url("www.spc.noaa.gov/products/md/md2032.html"), None);
+        assert_eq!(
+            md_text_url("https://www.spc.noaa.gov/products/md/md2032"),
+            None
+        );
+    }
+
+    #[test]
+    fn the_readout_starts_at_the_discussion_not_the_routing_header() {
+        let raw = "ZCZC SPCSWOMCD ALL\nACUS11 KWNS 190154 \nSPC MCD 190154 \nSDZ000-190330-\n\n\
+                   Mesoscale Discussion 2032\nNWS Storm Prediction Center Norman OK\n\nSUMMARY...\
+                   hail\n";
+        let out = strip_wmo_header(raw);
+        assert!(out.starts_with("Mesoscale Discussion 2032"), "{out}");
+        assert!(out.ends_with("hail"), "{out}");
+        // A product that doesn't look like an MCD comes back whole rather than half-eaten.
+        assert_eq!(strip_wmo_header("something else\n"), "something else");
+    }
+
+    #[test]
+    fn parsing_a_discussion_yields_the_url_the_text_fetch_needs() {
+        let json = r##"{"type":"FeatureCollection","features":[
+            {"type":"Feature",
+             "properties":{"name":"MD 2032","folderpath":"MD 2032 Active Till 0330 UTC",
+                           "popupinfo":"http://www.spc.noaa.gov/products/md/md2032.html"},
+             "geometry":{"type":"Polygon","coordinates":[[[-98.0,35.0],[-97.0,35.0],[-97.0,36.0],[-98.0,35.0]]]}}
+        ]}"##;
+        let out = parse_md(json).unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].0.title, "Mesoscale Discussion MD 2032");
+        assert_eq!(out[0].0.kind, FeatureKind::MesoDiscussion);
+        assert_eq!(
+            out[0].1.as_deref(),
+            Some("https://www.spc.noaa.gov/products/md/md2032.txt")
+        );
+    }
 
     #[test]
     fn parses_outlook_with_own_color() {


### PR DESCRIPTION
Clicking an MD polygon showed a popup whose entire body was `http://www.spc.noaa.gov/products/md/md2032.html`. That is genuinely all the map service gives us — the GeoJSON's `popupinfo` field is the link and nothing more:

```
'name'       = 'MD 2032'
'folderpath' = 'MD 2032 Active Till 0330 UTC'
'popupinfo'  = 'http://www.spc.noaa.gov/products/md/md2032.html'
```

The text is a second request. SPC serves every discussion twice, so `md_text_url` derives the `.txt` sibling from the HTML link (upgrading to https, which the service does not do itself), and `fetch_mesoscale_discussions` fetches it right after the GeoJSON. Doing it there rather than on click means the popup opens with the readout in it, with no loading state and no per-click request path to add.

The WMO routing header comes off — `ZCZC SPCSWOMCD ALL`, the AWIPS ids, the UGC zone line. Nobody clicked a polygon to read those. Anything that doesn't look like an MCD is passed through whole rather than truncated on a guess. The link stays as the last line.

`parse_md` now returns `Vec<(GeoFeature, Option<String>)>` — the `GeoFeature` it builds has nowhere to carry a URL, and adding a field to it would touch 21 struct literals across nine files for one caller's benefit.

`www.spc.noaa.gov` was already in `ALLOWED_HOSTS`, so the browser build gets this through the existing proxy. No allowlist change, no new host, no new dependency.

A failed text fetch returns `None` and costs the discussion its readout only; the polygon and the link survive.

The detail window went from 380 to 560 wide. These are 69-column fixed-width products and the old wrap point landed mid-sentence. L3 attribute tables get the same benefit.

## Verification

Full bar green: `cargo clippy --workspace --all-targets` (one pre-existing `settings.rs:1649` warning, untouched file) · `cargo test --workspace` **507 passed, 27 ignored** (was 504) · wasm check, 7 warnings identical to `main` · `./scripts/shots/shoot.sh check`.

Three unit tests cover the URL derivation, the header strip, and the parse pairing. Plus one live test, run against SPC while two discussions were active:

```
cargo test -p wxdata live_mcd -- --ignored
1 passed
```

It asserts every returned feature's detail starts with `Mesoscale Discussion` — i.e. a real bulletin, not a link. It is `#[ignore]`d as network, and is a no-op on a calm day when nothing is active.

Not verified by me: how it looks on screen. The render path is the existing detail window with a wider default and no other change, but you are the one who will see whether 560 is right for a 69-column product on your display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)