### PR TITLE
make the update check actually find updates

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1726,8 +1726,8 @@ pub struct HookEchoApp {
     /// About window + the once-per-session release check.
     about_open: bool,
     update_state: ui::about_window::UpdateState,
-    update_tx: Sender<Option<String>>,
-    update_rx: Receiver<Option<String>>,
+    update_tx: Sender<ui::about_window::UpdateState>,
+    update_rx: Receiver<ui::about_window::UpdateState>,
     geocode_tx: Sender<Result<(String, f64, f64), String>>,
     geocode_rx: Receiver<Result<(String, f64, f64), String>>,
     /// `(lon, lat)` from the hosting edge's own geo-IP (browser build only), used once at boot to
@@ -3642,8 +3642,11 @@ impl HookEchoApp {
         Some((dir, (u * u + v * v).sqrt()))
     }
 
-    /// Ask GitHub for the newest tagged release, once per session. `/releases/latest` skips
-    /// prereleases, which is exactly right here: the rolling `latest` build is a prerelease.
+    /// Ask GitHub for the newest tagged release, once per session.
+    ///
+    /// The list endpoint, not `/releases/latest` — see [`ui::about_window::pick_latest_tag`] for
+    /// why. Thirty is more releases than this project has, and one page keeps it to one request
+    /// against the 60/hour unauthenticated budget.
     fn check_for_update(&mut self, ctx: &egui::Context) {
         if self.update_state != ui::about_window::UpdateState::Idle {
             return;
@@ -3653,23 +3656,33 @@ impl HookEchoApp {
         let tx = self.update_tx.clone();
         let ctx2 = ctx.clone();
         self.spawner.spawn(async move {
-            let url = "https://api.github.com/repos/d4vid87/hookecho/releases/latest";
+            let url = "https://api.github.com/repos/d4vid87/hookecho/releases?per_page=30";
             // GitHub rejects requests without a User-Agent.
-            let tag = async {
+            let body = async {
                 let text = http
                     .get(url)
                     .header("User-Agent", "hookecho")
                     .send()
                     .await
                     .ok()?
+                    .error_for_status()
+                    .ok()?
                     .text()
                     .await
                     .ok()?;
-                let body: serde_json::Value = serde_json::from_str(&text).ok()?;
-                body.get("tag_name")?.as_str().map(str::to_string)
+                Some(text)
             }
             .await;
-            let _ = tx.send(tag);
+            // `None` means the request itself failed; a body with no version tag in it is a
+            // different answer, and the two must not collapse into one message.
+            let state = match body {
+                Some(body) => match ui::about_window::pick_latest_tag(&body) {
+                    Some(tag) => ui::about_window::compare(&tag),
+                    None => ui::about_window::UpdateState::NoRelease,
+                },
+                None => ui::about_window::UpdateState::Failed,
+            };
+            let _ = tx.send(state);
             ctx2.request_repaint();
         });
     }
@@ -16036,11 +16049,8 @@ impl eframe::App for HookEchoApp {
         if ctx.input(|i| i.time) > 30.0 {
             self.check_for_update(ctx);
         }
-        while let Ok(tag) = self.update_rx.try_recv() {
-            self.update_state = match tag {
-                Some(tag) => ui::about_window::compare(&tag),
-                None => ui::about_window::UpdateState::Failed,
-            };
+        while let Ok(state) = self.update_rx.try_recv() {
+            self.update_state = state;
             if let ui::about_window::UpdateState::Newer(v) = self.update_state.clone() {
                 self.toast(ToastKind::Info, format!("Hook Echo-WX {v} is available"));
             }

--- a/crates/hookecho/src/ui/about_window.rs
+++ b/crates/hookecho/src/ui/about_window.rs
@@ -12,6 +12,10 @@ pub enum UpdateState {
     Checking,
     UpToDate,
     Newer(String),
+    /// The repo has no published versioned release to compare against. Distinct from `Failed`:
+    /// the request worked, there was simply nothing tagged. A repo whose releases are all still
+    /// drafts looks like this to everyone but its owner.
+    NoRelease,
     Failed,
 }
 
@@ -50,6 +54,9 @@ pub fn show(ctx: &egui::Context, open: &mut bool, update: &UpdateState, accent: 
                         ui.hyperlink_to("Download", format!("{REPO}/releases/latest"));
                     });
                 }
+                UpdateState::NoRelease => {
+                    ui.label(egui::RichText::new("No published release to compare against.").weak());
+                }
                 UpdateState::Failed => {
                     ui.label(egui::RichText::new("Couldn't check for updates.").weak());
                 }
@@ -83,6 +90,28 @@ pub fn compare(tag: &str) -> UpdateState {
     }
 }
 
+/// The newest version tag in a GitHub `/releases` response.
+///
+/// Not `/releases/latest`, which returns whatever was published most recently regardless of what
+/// it is called — here that is the rolling `latest` CI build, whose tag is not a version at all,
+/// so the check reported "couldn't check for updates" forever. Scanning the list and taking the
+/// highest tag that actually parses as a version ignores rolling and named builds by
+/// construction. Drafts and prereleases are skipped; the API omits drafts from unauthenticated
+/// callers anyway, which is every copy of this app.
+pub fn pick_latest_tag(json: &str) -> Option<String> {
+    let releases: Vec<serde_json::Value> = serde_json::from_str(json).ok()?;
+    releases
+        .iter()
+        .filter(|r| {
+            !r.get("draft").and_then(|v| v.as_bool()).unwrap_or(false)
+                && !r.get("prerelease").and_then(|v| v.as_bool()).unwrap_or(false)
+        })
+        .filter_map(|r| r.get("tag_name")?.as_str())
+        .filter_map(|tag| Some((parse_version(tag)?, tag.to_string())))
+        .max()
+        .map(|(_, tag)| tag)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -94,6 +123,34 @@ mod tests {
         assert_eq!(parse_version("v1.2.3-rc1"), Some((1, 2, 3)));
         assert_eq!(parse_version("nightly"), None);
         assert!(parse_version("v0.6.0") > parse_version("v0.5.9"));
+    }
+
+    #[test]
+    fn the_rolling_build_is_not_mistaken_for_a_release() {
+        // Shape of the real response as of 0.10.0: a rolling `latest` that is neither a draft nor
+        // a prerelease, sitting above the version tags. `/releases/latest` hands back this one.
+        let json = r##"[
+            {"tag_name":"latest","draft":false,"prerelease":false},
+            {"tag_name":"v0.9.0","draft":false,"prerelease":false},
+            {"tag_name":"v0.10.0","draft":false,"prerelease":false},
+            {"tag_name":"v0.11.0","draft":true,"prerelease":false},
+            {"tag_name":"v0.12.0","draft":false,"prerelease":true}
+        ]"##;
+        // Highest *version*, not the newest entry, and not the draft or prerelease above it.
+        assert_eq!(pick_latest_tag(json).as_deref(), Some("v0.10.0"));
+    }
+
+    #[test]
+    fn a_repo_with_nothing_published_yields_no_tag() {
+        assert_eq!(pick_latest_tag("[]"), None);
+        // Every version still a draft: this is what the repo looks like today to anyone but its
+        // owner, and it must not read as "you're on the latest release".
+        let drafts = r##"[
+            {"tag_name":"latest","draft":false,"prerelease":false},
+            {"tag_name":"v0.10.0","draft":true,"prerelease":false}
+        ]"##;
+        assert_eq!(pick_latest_tag(drafts), None);
+        assert_eq!(pick_latest_tag("not json"), None);
     }
 
     #[test]


### PR DESCRIPTION
You asked for a check-for-updates feature. One is already in the app — About window state, a once-per-session check 30 s after start, a toast when something newer exists. It has never worked, so this PR fixes it rather than adding a second one.

## Why it was broken

It asked `/releases/latest`, and the comment above it said that endpoint skips prereleases so the rolling build wouldn't match. It does skip prereleases — but the rolling CI build isn't marked as one:

```
$ gh api repos/d4vid87/hookecho/releases/latest
{"tag":"latest","name":"Latest build (main)","draft":false,"pre":false}
```

So `/releases/latest` returns `latest`, `parse_version("latest")` returns `None`, and `compare` falls to `UpdateState::Failed`. Every install has been showing "Couldn't check for updates" since the feature landed.

## What changed

`pick_latest_tag` reads the release list and takes the highest tag that parses as a version. Rolling and named builds are excluded because they aren't versions, not because an endpoint was trusted to filter them. Drafts and prereleases are skipped explicitly.

`Failed` and "nothing published to compare against" were one message; they are different answers and now have different states. `NoRelease` says "No published release to compare against" and fires no toast.

## The part you have to do

**This still will not notify anyone until you publish a release.** Every versioned release in the repo is a draft, and the API hides drafts from unauthenticated callers — which is every copy of the app. Here is the actual response the app gets today:

```
$ curl -s -H "User-Agent: hookecho" \
    "https://api.github.com/repos/d4vid87/hookecho/releases?per_page=30"
entries: [('latest', draft=False, prerelease=False)]
```

One entry, not a version. With this PR that reads as "No published release to compare against" instead of a false error — correct, and still not a notification. `gh release edit v0.10.0 --draft=false` is what switches the feature on, and that is yours to run, not mine.

## Verification

Full bar green: clippy `--workspace --all-targets` (one pre-existing `settings.rs:1649` warning, untouched file) · `cargo test --workspace` **509 passed, 28 ignored** (was 507) · wasm check, 7 warnings identical to `main` · `shoot.sh check`.

Two new tests: one feeds the real response shape (rolling `latest` above the version tags, plus a draft and a prerelease) and asserts `v0.10.0` comes back; one asserts an all-drafts repo yields no tag, since that must not read as "you're on the latest release".

Not verified by me: the toast and About window on screen with a real newer release, since none can be published from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
