### PR TITLE
land the five R17 commits that never reached main

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -58,7 +58,14 @@ jobs:
 
       # The same bundle on Netlify. Skipped entirely when the secrets are absent, so a fork — or
       # this repo before the site exists — still gets a green Cloudflare deploy.
+      #
+      # Advisory, because the two hosts fail for unrelated reasons and only one of them is the
+      # primary. Netlify blocked deploys on an account credit limit for a week; that aborted the
+      # job *after* Cloudflare had already published, so every smoke test below was skipped and
+      # the demo went unverified while looking merely "red". The step still reports its own
+      # failure — this only stops one host's billing from silencing the other host's checks.
       - name: Deploy to Netlify
+        continue-on-error: true
         if: ${{ env.NETLIFY_AUTH_TOKEN != '' && env.NETLIFY_SITE_ID != '' }}
         run: npx --yes netlify-cli@17 deploy --dir web --prod --message "$GITHUB_SHA"
 

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -6339,6 +6339,7 @@ impl HookEchoApp {
     /// windows — searchable) with the app's own commands below it. It replaces a wall of parallel
     /// entry points; the map keeps nothing but transient status.
     fn sidebar(&mut self, root: &mut egui::Ui, ctx: &egui::Context) {
+        crate::prof_scope!("sidebar");
         let accent = crate::theme::accent(self.settings.theme);
         let entries = self.palette_entries();
         let mut query = std::mem::take(&mut self.layers_query);
@@ -6559,6 +6560,7 @@ impl HookEchoApp {
     }
 
     fn timeline_bar(&mut self, root: &mut egui::Ui) {
+        crate::prof_scope!("timeline_bar");
         use egui_phosphor::regular as ph;
         let accent = crate::theme::accent(self.settings.theme);
         let tz = self.active_tz();
@@ -9339,6 +9341,7 @@ impl HookEchoApp {
     /// `(item, opacity, loaded-placefile index)`. Iterated in `settings.placefiles` order, which
     /// is the paint order the Layer Manager reorders.
     fn visible_placefile_items(&self) -> Vec<(&wxdata::placefile::PlaceItem, f32, usize)> {
+        crate::prof_scope!("visible_placefile_items");
         let range = self.view_range_nmi();
         let now = Utc::now();
         let mut out = Vec::new();
@@ -9385,6 +9388,7 @@ impl HookEchoApp {
     /// Owned labels/markers for the visible placefile items (drawn by the egui painter).
     /// Icons resolve their sheet cell here, so the painter just blits a quad.
     fn placefile_labels(&self) -> Vec<PlaceLabel> {
+        crate::prof_scope!("placefile_labels");
         use wxdata::placefile::PlaceKind;
         self.visible_placefile_items()
             .iter()
@@ -10608,6 +10612,7 @@ impl HookEchoApp {
         first: bool,
         placefile_labels: &[PlaceLabel],
     ) {
+        crate::prof_scope!("render_pane");
         use crate::tiles::BasemapStyle;
         let vp = (prect.width(), prect.height());
         let response = ui.interact(
@@ -12486,6 +12491,7 @@ impl HookEchoApp {
 
         // Surface obs (METAR station plots): fltCat-colored circle, wind barb, T/Td in °F.
         if self.show_metar && cam.zoom >= 6.0 {
+            crate::prof_scope!("metar_plots");
             let show_labels = cam.zoom >= 7.0;
             let flt_color = |c: &str| match c {
                 "VFR" => egui::Color32::from_rgb(60, 200, 90),
@@ -12605,6 +12611,7 @@ impl HookEchoApp {
                 FloodCat::NoFlooding => "no flooding",
                 FloodCat::Unknown => "no current reading",
             };
+            crate::prof_scope!("river_gauges");
             let mut placed: Vec<egui::Rect> = Vec::new();
             for g in &self.gauges {
                 let w = crate::render::mercator::lonlat_to_world(g.lon, g.lat);

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -11084,9 +11084,9 @@ impl HookEchoApp {
         } else {
             1.0
         };
-        let raster_bias = if pane_style.tiles_are_512() {
-            // 512-px providers already carry the extra detail in the tile itself; biasing on top
-            // would fetch four of them per screen tile for nothing.
+        let raster_bias = if pane_style.tiles_are_512() || self.tiles.is_retina(pane_style) {
+            // 512-px and `@2x` providers already carry the extra detail in the tile itself;
+            // biasing on top would fetch four of them per screen tile for nothing.
             0.0
         } else {
             ctx.pixels_per_point()
@@ -16406,7 +16406,12 @@ impl eframe::App for HookEchoApp {
             };
             self.tiles
                 .set_keys(&self.settings.mapbox_key, &self.settings.maptiler_key);
-            let mut clear_tiles = false;
+            // Ask for `@2x` tiles where the provider serves them: same tile count, twice the
+            // pixels, labels drawn for the density instead of magnified. Off on a metered link —
+            // a double-resolution tile is roughly double the bytes.
+            let mut clear_tiles = self.tiles.set_retina(
+                ctx.pixels_per_point() > 1.0 && !crate::platform::is_metered(),
+            );
             // GOES sub-hourly scrub: fetch the available frame times when a GOES style becomes
             // active, and apply the selected frame (None = latest).
             if raster_style.goes_layer().is_some() {

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -5969,7 +5969,7 @@ impl HookEchoApp {
     /// deepest level instead of an empty range).
     fn chasepack_zoom(&self) -> (u8, u8) {
         use crate::tiles::BasemapStyle;
-        let style = self.views[self.active].basemap;
+        let style = self.views[self.active].basemap.resolve(true);
         let z_lo = (self.views[self.active].camera.zoom.floor() as i64).clamp(2, 18) as u8;
         let max_z = if style.is_raster() {
             self.tiles.max_pack_z(style)
@@ -5985,7 +5985,9 @@ impl HookEchoApp {
     /// Per-frame chase-pack estimate + progress [`map_rows`](Self::map_rows) renders.
     fn chasepack_ui(&self) -> ui::layer_options::ChasePackUi {
         use crate::tiles::BasemapStyle;
-        let style = self.views[self.active].basemap;
+        // Dark and Light pack the same vector tiles (the `.pbf` cache is palette-agnostic), so
+        // resolving `Auto` either way gives the same pack.
+        let style = self.views[self.active].basemap.resolve(true);
         let packable = if style.is_raster() {
             self.tiles.packable(style)
         } else if matches!(style, BasemapStyle::Dark | BasemapStyle::Light) {
@@ -6017,6 +6019,17 @@ impl HookEchoApp {
                     vz_hi,
                 );
             }
+            if !style.is_raster() && self.settings.pack_include_satellite {
+                let sz_hi = z_hi.min(self.tiles.max_pack_z(BasemapStyle::HybridSatellite));
+                n += crate::tiles::pack_tile_count(
+                    min_lon,
+                    min_lat,
+                    max_lon,
+                    max_lat,
+                    z_lo.min(sz_hi),
+                    sz_hi,
+                );
+            }
             n
         } else {
             0
@@ -6043,7 +6056,7 @@ impl HookEchoApp {
         if self.chasepack.is_some() {
             return;
         }
-        let style = self.views[self.active].basemap;
+        let style = self.views[self.active].basemap.resolve(true);
         let (z_lo, z_hi) = self.chasepack_zoom();
         let (min_lon, min_lat, max_lon, max_lat) = self.view_bounds();
         // The DEM resolution is a per-session choice; make sure the pack fetches what the sampler
@@ -6068,6 +6081,20 @@ impl HookEchoApp {
                 self.vtiles
                     .pack_jobs(min_lon, min_lat, max_lon, max_lat, vz_lo, vz_hi),
             );
+        }
+        // And imagery alongside the streets, for the packs that went the other way round.
+        if !style.is_raster() && self.settings.pack_include_satellite {
+            let sat = BasemapStyle::HybridSatellite;
+            let sz_hi = z_hi.min(self.tiles.max_pack_z(sat));
+            jobs.extend(self.tiles.pack_jobs(
+                sat,
+                min_lon,
+                min_lat,
+                max_lon,
+                max_lat,
+                z_lo.min(sz_hi),
+                sz_hi,
+            ));
         }
         // The DEM rides along with every pack, whatever the basemap: offline chase mode wants the
         // blockage overlay as much as it wants the map under it.
@@ -6163,6 +6190,7 @@ impl HookEchoApp {
             !self.settings.mapbox_key.is_empty(),
             !self.settings.maptiler_key.is_empty(),
         );
+        let cx_ok = crate::tiles::valid_xyz_template(&self.settings.custom_tile_url);
         // Split the borrow: the combo writes both the pane's style and the persisted default.
         let (view, settings) = (&mut self.views[self.active], &mut self.settings);
         egui::ComboBox::from_label("Background")
@@ -6171,7 +6199,7 @@ impl HookEchoApp {
                 // Only styles whose provider key is set are selectable.
                 for s in BasemapStyle::ALL
                     .into_iter()
-                    .filter(|s| s.available(mb_key, mt_key))
+                    .filter(|s| s.available(mb_key, mt_key, cx_ok))
                 {
                     if ui
                         .selectable_value(&mut view.basemap, s, s.label())
@@ -6257,6 +6285,11 @@ impl HookEchoApp {
                     .on_hover_text(
                         "Pack vector street tiles beside raster imagery, so road names still \
                          render offline",
+                    );
+                ui.checkbox(&mut settings.pack_include_satellite, "Include satellite")
+                    .on_hover_text(
+                        "Pack satellite imagery beside the vector streets, so terrain still \
+                         renders offline",
                     );
                 ui.checkbox(&mut settings.pack_hires_dem, "High-detail terrain")
                     .on_hover_text(
@@ -8067,7 +8100,11 @@ impl HookEchoApp {
                     !self.settings.mapbox_key.is_empty(),
                     !self.settings.maptiler_key.is_empty(),
                 );
-                let next = self.views[self.active].basemap.next(mb, mt);
+                let next = self.views[self.active].basemap.next(
+                    mb,
+                    mt,
+                    crate::tiles::valid_xyz_template(&self.settings.custom_tile_url),
+                );
                 self.set_basemap(next);
             }
             PaletteAction::ToggleMute => self.apply_action(BindableAction::ToggleMute, ctx),
@@ -10578,8 +10615,12 @@ impl HookEchoApp {
     ) {
         use crate::tiles::BasemapStyle;
         // This pane's own basemap: panes are independent, the tile caches are keyed by style.
-        let pane_style = self.views[idx].basemap;
-        let is_vector = matches!(pane_style, BasemapStyle::Dark | BasemapStyle::Light);
+        // `Auto` resolves here rather than where it is stored, so the stored choice keeps
+        // following the theme instead of being frozen the first time it is rendered.
+        let pane_style = self.views[idx].basemap.resolve(ui.visuals().dark_mode);
+        // Hybrid satellite is both: Esri imagery from the raster path, roads and boundaries from
+        // the vector one drawn on top of it.
+        let is_vector = pane_style.vector_palette().is_some();
         let is_raster = pane_style.is_raster();
         let vp = (prect.width(), prect.height());
         let response = ui.interact(
@@ -11198,6 +11239,7 @@ impl HookEchoApp {
             new_tiles,
             visible,
             basemap_key: pane_style.key(),
+            vector_over_raster: pane_style == BasemapStyle::HybridSatellite,
             radar_upload,
             draw_radar,
             overlay_upload: if first {
@@ -11299,14 +11341,16 @@ impl HookEchoApp {
         // --- Painter overlays (clipped to this pane) ---
         let painter = ui.painter_at(prect);
         let view = &self.views[idx];
-        let basemap = view.basemap;
+        let basemap = pane_style;
 
         // City/town labels, overlaid on every basemap. On raster (satellite) the baked-in labels
         // are faint over imagery + echoes, so we draw crisp white text with a solid black halo;
         // vector basemaps use their palette's label colors. Bigger fonts + an 8-way halo read well.
         if !vlabels.is_empty() {
             let (text_col, halo_col, big) = if is_vector {
-                let st = crate::basemap_style::style(basemap == BasemapStyle::Dark);
+                let st = crate::basemap_style::style(
+                    basemap.vector_palette().unwrap_or_default(),
+                );
                 (
                     egui::Color32::from_rgb(st.label[0], st.label[1], st.label[2]),
                     egui::Color32::from_rgb(st.label_halo[0], st.label_halo[1], st.label_halo[2]),
@@ -11371,12 +11415,18 @@ impl HookEchoApp {
         }
 
         // Raster basemap attribution (provider styles + USGS satellite).
-        if view.basemap.is_raster() {
+        if pane_style.is_raster() {
             let col = egui::Color32::from_gray(200).gamma_multiply(0.6);
             painter.text(
                 egui::pos2(prect.left() + 6.0, prect.bottom() - 4.0),
                 egui::Align2::LEFT_BOTTOM,
-                view.basemap.attribution(),
+                if pane_style == BasemapStyle::CustomXyz
+                    && !self.settings.custom_tile_attribution.is_empty()
+                {
+                    self.settings.custom_tile_attribution.as_str()
+                } else {
+                    pane_style.attribution()
+                },
                 egui::FontId::proportional(10.0),
                 col,
             );
@@ -16397,8 +16447,10 @@ impl eframe::App for HookEchoApp {
             // ponytail: one GOES cursor + one vector palette for all panes; split them when
             // someone actually wants two satellite times or two vector palettes side by side.
             use crate::tiles::BasemapStyle;
-            let style = self.views[self.active.min(n - 1)].basemap;
-            let is_vector = matches!(style, BasemapStyle::Dark | BasemapStyle::Light);
+            let style = self.views[self.active.min(n - 1)]
+                .basemap
+                .resolve(ctx.theme() == egui::Theme::Dark);
+            let is_vector = style.vector_palette().is_some();
             let raster_style = if style.is_raster() {
                 style
             } else {
@@ -16406,6 +16458,9 @@ impl eframe::App for HookEchoApp {
             };
             self.tiles
                 .set_keys(&self.settings.mapbox_key, &self.settings.maptiler_key);
+            self.tiles
+                .set_custom_template(&self.settings.custom_tile_url);
+            self.tiles.set_custom_max_z(self.settings.custom_tile_max_z);
             // Ask for `@2x` tiles where the provider serves them: same tile count, twice the
             // pixels, labels drawn for the density instead of magnified. Off on a metered link —
             // a double-resolution tile is roughly double the bytes.
@@ -16449,7 +16504,9 @@ impl eframe::App for HookEchoApp {
             }
             let mut clear_vector = false;
             if is_vector {
-                clear_vector |= self.vtiles.set_style(style == BasemapStyle::Dark);
+                clear_vector |= self
+                    .vtiles
+                    .set_style(style.vector_palette().unwrap_or_default());
                 clear_vector |= self
                     .vtiles
                     .note_zoom(self.views[self.active.min(n - 1)].camera.zoom);

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -11365,7 +11365,7 @@ impl HookEchoApp {
             };
             let z = cam.zoom;
             let mut labels: Vec<&crate::vector_tiles::PlaceLabel> =
-                vlabels.iter().filter(|l| l.city || z >= 9.0).collect();
+                vlabels.iter().filter(|l| z >= l.min_zoom as f64).collect();
             labels.sort_by_key(|l| (!l.city, l.rank));
             let mut placed: Vec<egui::Rect> = Vec::new();
             let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -6184,31 +6184,29 @@ impl HookEchoApp {
     /// per-map state is edited.
     fn map_rows(&mut self, ui: &mut egui::Ui, actions: &mut ui::layer_options::UiActions) {
         use crate::settings::StartView;
-        use crate::tiles::BasemapStyle;
         let chasepack = self.chasepack_ui();
         let (mb_key, mt_key) = (
             !self.settings.mapbox_key.is_empty(),
             !self.settings.maptiler_key.is_empty(),
         );
-        let cx_ok = crate::tiles::valid_xyz_template(&self.settings.custom_tile_url);
-        // Split the borrow: the combo writes both the pane's style and the persisted default.
-        let (view, settings) = (&mut self.views[self.active], &mut self.settings);
-        egui::ComboBox::from_label("Background")
-            .selected_text(view.basemap.label())
-            .show_ui(ui, |ui| {
-                // Only styles whose provider key is set are selectable.
-                for s in BasemapStyle::ALL
-                    .into_iter()
-                    .filter(|s| s.available(mb_key, mt_key, cx_ok))
-                {
-                    if ui
-                        .selectable_value(&mut view.basemap, s, s.label())
-                        .clicked()
-                    {
-                        settings.basemap = s.slug().to_string(); // persist across restarts
-                    }
-                }
+        let current = self.views[self.active].basemap;
+        // A named button that opens the grid, rather than the grid inline: the drawer column is
+        // narrow, and fifty cards in it would push everything else off the panel.
+        let mut picked = None;
+        ui.menu_button(format!("Background: {}", current.label()), |ui| {
+            ui.set_min_width(460.0);
+            egui::ScrollArea::vertical().max_height(460.0).show(ui, |ui| {
+                picked = ui::basemap_picker::grid(ui, &mut self.tiles, current, &self.settings);
             });
+            if picked.is_some() {
+                ui.close();
+            }
+        });
+        if let Some(s) = picked {
+            self.views[self.active].basemap = s;
+            self.settings.basemap = s.slug().to_string(); // persist across restarts
+        }
+        let (view, settings) = (&mut self.views[self.active], &mut self.settings);
         ui.weak(if mb_key && mt_key {
             "Z cycles backgrounds"
         } else {
@@ -15761,6 +15759,7 @@ impl eframe::App for HookEchoApp {
             &mut self.settings,
             &mut self.views[active].basemap,
             &self.marker_icon_tex,
+            &mut self.tiles,
         ) {
             self.settings.setup_done = true;
             self.settings.save();

--- a/crates/hookecho/src/app/mobile/mod.rs
+++ b/crates/hookecho/src/app/mobile/mod.rs
@@ -445,6 +445,8 @@ impl super::HookEchoApp {
         let cur = self.views[self.active].basemap;
         let mut pick = None;
         ui.label(egui::RichText::new("Basemap").size(crate::ui::m3::T_LABEL_LG));
+        // The common styles stay a chip row: one tap, no scrolling, thumb-reachable. It is the
+        // *other* forty-odd that needed the grid.
         ui.horizontal_wrapped(|ui| {
             for s in BasemapStyle::COMMON {
                 if s.available(mb, mt, cx)
@@ -454,22 +456,15 @@ impl super::HookEchoApp {
                 }
             }
         });
-        // Everything COMMON leaves out — the other GOES products, the provider styles a key
-        // unlocks — behind one disclosure rather than in the chip row.
         egui::CollapsingHeader::new("All basemaps")
             .id_salt("m_basemap_all")
             .default_open(!BasemapStyle::COMMON.contains(&cur))
             .show(ui, |ui| {
-                ui.horizontal_wrapped(|ui| {
-                    for s in BasemapStyle::ALL {
-                        if BasemapStyle::COMMON.contains(&s) || !s.available(mb, mt, cx) {
-                            continue;
-                        }
-                        if crate::ui::m3::chip(ui, s.label(), s == cur).clicked() {
-                            pick = Some(s);
-                        }
-                    }
-                });
+                if let Some(s) =
+                    crate::ui::basemap_picker::grid(ui, &mut self.tiles, cur, &self.settings)
+                {
+                    pick = Some(s);
+                }
             });
         if let Some(s) = pick {
             self.set_basemap(s);

--- a/crates/hookecho/src/app/mobile/mod.rs
+++ b/crates/hookecho/src/app/mobile/mod.rs
@@ -441,12 +441,13 @@ impl super::HookEchoApp {
             !self.settings.mapbox_key.is_empty(),
             !self.settings.maptiler_key.is_empty(),
         );
+        let cx = crate::tiles::valid_xyz_template(&self.settings.custom_tile_url);
         let cur = self.views[self.active].basemap;
         let mut pick = None;
         ui.label(egui::RichText::new("Basemap").size(crate::ui::m3::T_LABEL_LG));
         ui.horizontal_wrapped(|ui| {
             for s in BasemapStyle::COMMON {
-                if s.available(mb, mt)
+                if s.available(mb, mt, cx)
                     && crate::ui::m3::chip(ui, s.short_label(), s == cur).clicked()
                 {
                     pick = Some(s);
@@ -461,7 +462,7 @@ impl super::HookEchoApp {
             .show(ui, |ui| {
                 ui.horizontal_wrapped(|ui| {
                     for s in BasemapStyle::ALL {
-                        if BasemapStyle::COMMON.contains(&s) || !s.available(mb, mt) {
+                        if BasemapStyle::COMMON.contains(&s) || !s.available(mb, mt, cx) {
                             continue;
                         }
                         if crate::ui::m3::chip(ui, s.label(), s == cur).clicked() {

--- a/crates/hookecho/src/basemap_style.rs
+++ b/crates/hookecho/src/basemap_style.rs
@@ -22,13 +22,159 @@ pub enum Palette {
     Light,
     /// Roads/boundaries over satellite imagery: no fills, no background, high-contrast strokes.
     HybridOverlay,
+    /// Warm, high-contrast street map in the OSM Liberty vein.
+    Liberty,
+    /// Pale, colourful, low-ink — reads well under heavy radar fill.
+    Bright,
+    /// Near-monochrome grey; the most radar gets out of the way.
+    Positron,
+    /// Very dark, desaturated navy — the night-drive look.
+    Midnight,
 }
 
 impl Palette {
-    /// The two full basemap looks share every code path; the overlay is the odd one out, so most
-    /// lookups only need to know which of the two it leans on for contrast.
-    fn dark(self) -> bool {
-        !matches!(self, Palette::Light)
+    /// Every selectable vector look, in menu order.
+    pub const ALL: [Palette; 6] = [
+        Palette::Dark,
+        Palette::Light,
+        Palette::Liberty,
+        Palette::Bright,
+        Palette::Positron,
+        Palette::Midnight,
+    ];
+
+}
+
+/// The per-palette color table. One struct rather than a pile of parallel `match` arms: adding a
+/// look is then a new `Colors` value, not an edit in five places.
+struct Colors {
+    water: u32,
+    wood: u32,
+    park: u32,
+    residential: u32,
+    building: u32,
+    motorway: u32,
+    primary: u32,
+    secondary: u32,
+    minor: u32,
+    rail: u32,
+    admin2: u32,
+    admin4: u32,
+    county: u32,
+    casing: u32,
+}
+
+const C_DARK: Colors = Colors {
+    water: 0x1b2733,
+    wood: 0x151c17,
+    park: 0x152018,
+    residential: 0x16181d,
+    building: 0x1d2028,
+    motorway: 0x3d4450,
+    primary: 0x353c47,
+    secondary: 0x2c323b,
+    minor: 0x23282f,
+    rail: 0x2a2f36,
+    admin2: 0x5a6470,
+    admin4: 0x3a424c,
+    county: 0x2f353d,
+    casing: 0x0d1015,
+};
+const C_LIGHT: Colors = Colors {
+    water: 0xc3d6e3,
+    wood: 0xd6e0cf,
+    park: 0xd9e8d2,
+    residential: 0xece8e0,
+    building: 0xe3ded4,
+    motorway: 0xf6d3a0,
+    primary: 0xf9dfb0,
+    secondary: 0xe9e3d5,
+    minor: 0xdedacf,
+    rail: 0xcdc9c0,
+    admin2: 0x9aa0a8,
+    admin4: 0xc4c0b8,
+    county: 0xd2cec6,
+    casing: 0xd8cfc0,
+};
+// Warmer paper, saturated road ladder, strong casings — the OSM Liberty look.
+const C_LIBERTY: Colors = Colors {
+    water: 0xa8ccdf,
+    wood: 0xc8dcb4,
+    park: 0xd2e8c0,
+    residential: 0xf0ece2,
+    building: 0xdfd8c8,
+    motorway: 0xf29a6a,
+    primary: 0xf7bd7a,
+    secondary: 0xfbdc9e,
+    minor: 0xf7f4ec,
+    rail: 0xb9b2a6,
+    admin2: 0x8c8478,
+    admin4: 0xb6afa2,
+    county: 0xcac3b6,
+    casing: 0xc08a5a,
+};
+// Pale and colourful but low-ink, so heavy radar fill still reads over it.
+const C_BRIGHT: Colors = Colors {
+    water: 0xd0e6f2,
+    wood: 0xdcecd4,
+    park: 0xe2f2da,
+    residential: 0xf6f4f0,
+    building: 0xeae5dc,
+    motorway: 0xffd9b0,
+    primary: 0xffe8c8,
+    secondary: 0xf4f0e6,
+    minor: 0xfbfaf6,
+    rail: 0xd8d2c8,
+    admin2: 0xb2aca4,
+    admin4: 0xd0cac2,
+    county: 0xdedad2,
+    casing: 0xe0d6c6,
+};
+// Near-monochrome. The look that gets furthest out of the radar's way.
+const C_POSITRON: Colors = Colors {
+    water: 0xd6dde2,
+    wood: 0xe4e7e4,
+    park: 0xe7eae7,
+    residential: 0xf2f2f0,
+    building: 0xe6e6e4,
+    motorway: 0xdcdcdc,
+    primary: 0xe4e4e4,
+    secondary: 0xececec,
+    minor: 0xf4f4f4,
+    rail: 0xdadada,
+    admin2: 0xb0b0b0,
+    admin4: 0xcccccc,
+    county: 0xdcdcdc,
+    casing: 0xc4c4c4,
+};
+// Darker and bluer than Dark, with slightly hotter roads — the night-drive look.
+const C_MIDNIGHT: Colors = Colors {
+    water: 0x0d1826,
+    wood: 0x0c1410,
+    park: 0x0d1712,
+    residential: 0x0e1118,
+    building: 0x141824,
+    motorway: 0x4a5570,
+    primary: 0x3c4560,
+    secondary: 0x2e3548,
+    minor: 0x232838,
+    rail: 0x282e3c,
+    admin2: 0x5a6480,
+    admin4: 0x38405a,
+    county: 0x2a3040,
+    casing: 0x05070c,
+};
+
+fn colors(p: Palette) -> &'static Colors {
+    match p {
+        Palette::Dark => &C_DARK,
+        Palette::Light => &C_LIGHT,
+        Palette::Liberty => &C_LIBERTY,
+        Palette::Bright => &C_BRIGHT,
+        Palette::Positron => &C_POSITRON,
+        Palette::Midnight => &C_MIDNIGHT,
+        // Never asked for: `fill` and `stroke` handle the overlay before they get here.
+        Palette::HybridOverlay => &C_DARK,
     }
 }
 
@@ -63,12 +209,64 @@ const HYBRID: VecStyle = VecStyle {
     label_halo: rgb(0x000000),
 };
 
+const LIBERTY: VecStyle = VecStyle {
+    background: Some(rgb(0xf7f4ec)),
+    label: rgb(0x30302c),
+    label_halo: rgb(0xfbf9f3),
+};
+const BRIGHT: VecStyle = VecStyle {
+    background: Some(rgb(0xfbfaf6)),
+    label: rgb(0x44443e),
+    label_halo: rgb(0xfdfdfa),
+};
+const POSITRON: VecStyle = VecStyle {
+    background: Some(rgb(0xf4f4f2)),
+    label: rgb(0x555555),
+    label_halo: rgb(0xfafafa),
+};
+const MIDNIGHT: VecStyle = VecStyle {
+    background: Some(rgb(0x070a12)),
+    label: rgb(0xb8c4d8),
+    label_halo: rgb(0x03050a),
+};
+
 pub fn style(p: Palette) -> &'static VecStyle {
     match p {
         Palette::Dark => &DARK,
         Palette::Light => &LIGHT,
         Palette::HybridOverlay => &HYBRID,
+        Palette::Liberty => &LIBERTY,
+        Palette::Bright => &BRIGHT,
+        Palette::Positron => &POSITRON,
+        Palette::Midnight => &MIDNIGHT,
     }
+}
+
+/// Casing (outline) color + width for a road, drawn in a pass *under* the road itself so majors
+/// read as ribbons rather than bare lines. `None` for classes that get no casing.
+///
+/// Width here is the total width of the casing stroke, so it has to exceed the road's own or the
+/// road would cover it entirely.
+pub fn casing(p: Palette, layer: &str, class: &str) -> Option<([u8; 4], f32)> {
+    if layer != "transportation" {
+        return None;
+    }
+    // Only the classes wide enough for a casing to be visible. Below tertiary the casing and the
+    // road would be a pixel apart and the result is mud.
+    let widen = match class {
+        "motorway" | "trunk" => 2.2,
+        "primary" => 1.8,
+        "secondary" => 1.4,
+        _ => return None,
+    };
+    // Over imagery the casing is what makes a pale road legible at all.
+    let c = if p == Palette::HybridOverlay {
+        [0, 0, 0, 255]
+    } else {
+        rgb(colors(p).casing)
+    };
+    let (_, w) = stroke(p, layer, class)?;
+    Some((c, w + widen))
 }
 
 /// Fill color for a polygon feature, or `None` to skip it.
@@ -77,12 +275,8 @@ pub fn fill(p: Palette, layer: &str, class: &str) -> Option<[u8; 4]> {
     if p == Palette::HybridOverlay {
         return None;
     }
-    let dark = p.dark();
-    let (water, wood, park, residential) = if dark {
-        (0x1b2733, 0x151c17, 0x152018, 0x16181d)
-    } else {
-        (0xc3d6e3, 0xd6e0cf, 0xd9e8d2, 0xece8e0)
-    };
+    let k = colors(p);
+    let (water, wood, park, residential) = (k.water, k.wood, k.park, k.residential);
     let c = match layer {
         "water" | "ocean" => water,
         "waterway" => water,
@@ -98,6 +292,10 @@ pub fn fill(p: Palette, layer: &str, class: &str) -> Option<[u8; 4]> {
             _ => return None,
         },
         "park" => park,
+        // Flat footprints, a touch off the background so blocks read without shouting.
+        // ponytail: flat fills, no extrusion — `render_height` is in the tile if that ever
+        // becomes worth the depth buffer.
+        "building" => k.building,
         _ => return None,
     };
     Some(rgb(c))
@@ -125,28 +323,26 @@ pub fn stroke(p: Palette, layer: &str, class: &str) -> Option<([u8; 4], f32)> {
         };
         return Some((rgb(c), w));
     }
-    let dark = p.dark();
-    let (motorway, primary, secondary, minor, rail, water, admin2, admin4, county) = if dark {
-        (
-            0x3d4450, 0x353c47, 0x2c323b, 0x23282f, 0x2a2f36, 0x24333f, 0x5a6470, 0x3a424c,
-            0x2f353d,
-        )
-    } else {
-        (
-            0xf6d3a0, 0xf9dfb0, 0xe9e3d5, 0xdedacf, 0xcdc9c0, 0xa9c4d6, 0x9aa0a8, 0xc4c0b8,
-            0xd2cec6,
-        )
-    };
+    let k = colors(p);
+    let (motorway, primary, secondary, minor, rail) =
+        (k.motorway, k.primary, k.secondary, k.minor, k.rail);
+    let (admin2, admin4, county) = (k.admin2, k.admin4, k.county);
+    // Waterway lines lean on the water fill so the two agree.
+    let water = k.water;
     let (c, w) = match layer {
         "transportation" => match class {
-            "motorway" | "trunk" => (motorway, 2.0),
-            "primary" => (primary, 1.5),
-            "secondary" => (secondary, 1.2),
-            "tertiary" => (secondary, 1.0),
-            "minor" | "service" | "street" => (minor, 0.8),
+            "motorway" => (motorway, 2.2),
+            "trunk" => (motorway, 1.9),
+            "primary" => (primary, 1.6),
+            "secondary" => (secondary, 1.3),
+            "tertiary" => (secondary, 1.05),
+            "minor" | "street" => (minor, 0.85),
+            "service" | "track" => (minor, 0.55),
+            "path" | "footway" | "cycleway" | "pedestrian" => (minor, 0.4),
             "rail" | "transit" => (rail, 0.8),
             _ => return None,
         },
+        "aeroway" => (rail, 1.4),
         "waterway" => (water, 1.0),
         // caller passes admin_level as the class string; maritime boundaries filtered upstream.
         "boundary" => match class {
@@ -178,9 +374,10 @@ mod tests {
             assert!(stroke(p, "transportation", "motorway").is_some());
             assert!(stroke(p, "boundary", "2").is_some());
             assert!(stroke(p, "waterway", "").is_some());
+            assert!(fill(p, "building", "").is_some());
             // Unstyled input is skipped, not defaulted.
             assert!(fill(p, "aeroway", "").is_none());
-            assert!(stroke(p, "transportation", "path").is_none());
+            assert!(stroke(p, "transportation", "elevator").is_none());
         }
     }
 
@@ -204,5 +401,41 @@ mod tests {
         assert!(hybrid_w > dark_w);
         // No minor-road mesh over imagery.
         assert!(stroke(p, "transportation", "minor").is_none());
+    }
+
+    /// A casing only works if it is wider than the road it sits under and darker than it — get
+    /// either backwards and the road disappears into its own outline.
+    #[test]
+    fn casings_sit_under_the_roads_they_outline() {
+        for p in [Palette::Dark, Palette::Light, Palette::HybridOverlay] {
+            for class in ["motorway", "trunk", "primary", "secondary"] {
+                let Some((_, road_w)) = stroke(p, "transportation", class) else {
+                    continue;
+                };
+                let (_, case_w) = casing(p, "transportation", class)
+                    .unwrap_or_else(|| panic!("{p:?}/{class} should have a casing"));
+                assert!(case_w > road_w, "{p:?}/{class}: casing must be wider");
+            }
+            // Small roads get none: at a pixel apart the two strokes are just mud.
+            assert!(casing(p, "transportation", "minor").is_none());
+            // And nothing else in the tile has a casing at all.
+            assert!(casing(p, "boundary", "2").is_none());
+            assert!(casing(p, "waterway", "").is_none());
+        }
+    }
+
+    /// The road ladder has to be monotonic, or a residential street outdraws an interstate.
+    #[test]
+    fn road_widths_descend_by_importance() {
+        for p in [Palette::Dark, Palette::Light] {
+            let w = |c: &str| stroke(p, "transportation", c).unwrap().1;
+            assert!(w("motorway") > w("trunk"));
+            assert!(w("trunk") > w("primary"));
+            assert!(w("primary") > w("secondary"));
+            assert!(w("secondary") > w("tertiary"));
+            assert!(w("tertiary") > w("minor"));
+            assert!(w("minor") > w("service"));
+            assert!(w("service") > w("path"));
+        }
     }
 }

--- a/crates/hookecho/src/basemap_style.rs
+++ b/crates/hookecho/src/basemap_style.rs
@@ -1,4 +1,4 @@
-//! Color/width styling for the OpenMapTiles vector basemap (dark + light).
+//! Color/width styling for the OpenMapTiles vector basemap.
 //!
 //! Pure lookups keyed by MVT layer name + a per-layer "class" discriminator (the caller pulls
 //! the right property: `class` for transportation, `admin_level` for boundary, empty otherwise).
@@ -10,10 +10,33 @@ const fn rgb(hex: u32) -> [u8; 4] {
     [(hex >> 16) as u8, (hex >> 8) as u8, hex as u8, 255]
 }
 
+/// Which look the vector pipeline tessellates for.
+///
+/// This used to be a bare `dark: bool`. It is an enum because the hybrid satellite basemap needs
+/// a third look — roads and boundaries only, no land or water fills — drawn *over* raster imagery
+/// rather than instead of it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Palette {
+    #[default]
+    Dark,
+    Light,
+    /// Roads/boundaries over satellite imagery: no fills, no background, high-contrast strokes.
+    HybridOverlay,
+}
+
+impl Palette {
+    /// The two full basemap looks share every code path; the overlay is the odd one out, so most
+    /// lookups only need to know which of the two it leans on for contrast.
+    fn dark(self) -> bool {
+        !matches!(self, Palette::Light)
+    }
+}
+
 /// Whole-tile constants (drawn before per-feature geometry).
 pub struct VecStyle {
-    /// Land quad under everything.
-    pub background: [u8; 4],
+    /// Land quad under everything. `None` draws no quad at all — the overlay palette wants
+    /// whatever is underneath (satellite imagery) to show through.
+    pub background: Option<[u8; 4]>,
     /// City/town label text.
     pub label: [u8; 4],
     /// Label halo/outline for contrast.
@@ -21,26 +44,40 @@ pub struct VecStyle {
 }
 
 const DARK: VecStyle = VecStyle {
-    background: rgb(0x111318),
+    background: Some(rgb(0x111318)),
     label: rgb(0xc8d0da),
     label_halo: rgb(0x0b0d11),
 };
 const LIGHT: VecStyle = VecStyle {
-    background: rgb(0xf2efe9),
+    background: Some(rgb(0xf2efe9)),
     label: rgb(0x3a3a3a),
     label_halo: rgb(0xf7f5f0),
 };
+// Imagery is busy and mid-tone in both directions, so the overlay leans on contrast rather than
+// hue: near-white lines and text, near-black halo.
+// ponytail: one fixed overlay palette. Per-style overlay tuning if a second raster basemap ever
+// wants a different one.
+const HYBRID: VecStyle = VecStyle {
+    background: None,
+    label: rgb(0xffffff),
+    label_halo: rgb(0x000000),
+};
 
-pub fn style(dark: bool) -> &'static VecStyle {
-    if dark {
-        &DARK
-    } else {
-        &LIGHT
+pub fn style(p: Palette) -> &'static VecStyle {
+    match p {
+        Palette::Dark => &DARK,
+        Palette::Light => &LIGHT,
+        Palette::HybridOverlay => &HYBRID,
     }
 }
 
 /// Fill color for a polygon feature, or `None` to skip it.
-pub fn fill(dark: bool, layer: &str, class: &str) -> Option<[u8; 4]> {
+pub fn fill(p: Palette, layer: &str, class: &str) -> Option<[u8; 4]> {
+    // Nothing is filled over imagery — the imagery *is* the land cover.
+    if p == Palette::HybridOverlay {
+        return None;
+    }
+    let dark = p.dark();
     let (water, wood, park, residential) = if dark {
         (0x1b2733, 0x151c17, 0x152018, 0x16181d)
     } else {
@@ -67,7 +104,28 @@ pub fn fill(dark: bool, layer: &str, class: &str) -> Option<[u8; 4]> {
 }
 
 /// Stroke color + pixel width for a line feature, or `None` to skip it.
-pub fn stroke(dark: bool, layer: &str, class: &str) -> Option<([u8; 4], f32)> {
+pub fn stroke(p: Palette, layer: &str, class: &str) -> Option<([u8; 4], f32)> {
+    if p == Palette::HybridOverlay {
+        // Wider than the vector basemap's own roads: a 0.8 px hairline vanishes against imagery.
+        // Only the classes worth having over aerial photography — the minor-road mesh would turn
+        // a city into a white smear.
+        let (c, w) = match layer {
+            "transportation" => match class {
+                "motorway" | "trunk" => (0xffe9a8, 2.6),
+                "primary" => (0xfff4d2, 2.0),
+                "secondary" | "tertiary" => (0xf0f0f0, 1.4),
+                _ => return None,
+            },
+            "boundary" => match class {
+                "2" => (0xffd9d9, 1.6),
+                "3" | "4" => (0xe8c8c8, 1.0),
+                _ => return None,
+            },
+            _ => return None,
+        };
+        return Some((rgb(c), w));
+    }
+    let dark = p.dark();
     let (motorway, primary, secondary, minor, rail, water, admin2, admin4, county) = if dark {
         (
             0x3d4450, 0x353c47, 0x2c323b, 0x23282f, 0x2a2f36, 0x24333f, 0x5a6470, 0x3a424c,
@@ -110,23 +168,41 @@ mod tests {
 
     #[test]
     fn dark_and_light_differ_and_resolve() {
-        assert_ne!(style(true).background, style(false).background);
+        assert_ne!(style(Palette::Dark).background, style(Palette::Light).background);
         // Every documented class resolves in both themes.
-        for dark in [true, false] {
-            assert!(fill(dark, "water", "").is_some());
-            assert!(fill(dark, "landcover", "wood").is_some());
-            assert!(fill(dark, "landuse", "residential").is_some());
-            assert!(fill(dark, "park", "").is_some());
-            assert!(stroke(dark, "transportation", "motorway").is_some());
-            assert!(stroke(dark, "transportation", "minor").is_some());
-            assert!(stroke(dark, "waterway", "").is_some());
-            assert!(stroke(dark, "boundary", "2").is_some());
-            assert!(stroke(dark, "boundary", "4").is_some());
-            assert!(stroke(dark, "boundary", "6").is_some());
+        for p in [Palette::Dark, Palette::Light] {
+            assert!(fill(p, "water", "").is_some());
+            assert!(fill(p, "landcover", "wood").is_some());
+            assert!(fill(p, "landuse", "residential").is_some());
+            assert!(fill(p, "park", "").is_some());
+            assert!(stroke(p, "transportation", "motorway").is_some());
+            assert!(stroke(p, "boundary", "2").is_some());
+            assert!(stroke(p, "waterway", "").is_some());
+            // Unstyled input is skipped, not defaulted.
+            assert!(fill(p, "aeroway", "").is_none());
+            assert!(stroke(p, "transportation", "path").is_none());
         }
-        // Unstyled -> skipped.
-        assert!(fill(true, "building", "").is_none());
-        assert!(stroke(true, "transportation", "path").is_none());
-        assert!(stroke(true, "boundary", "8").is_none());
+    }
+
+    /// The hybrid overlay's whole job is to add lines to imagery without hiding it. If it ever
+    /// starts returning fills or a background quad, it paints over the satellite photo.
+    #[test]
+    fn hybrid_overlay_covers_nothing_it_should_not() {
+        let p = Palette::HybridOverlay;
+        assert!(style(p).background.is_none());
+        for (layer, class) in [
+            ("water", ""),
+            ("landcover", "wood"),
+            ("landuse", "residential"),
+            ("park", ""),
+        ] {
+            assert!(fill(p, layer, class).is_none(), "{layer}/{class} fills over imagery");
+        }
+        // It still draws the roads it exists for, and thicker than the vector basemap's.
+        let (_, hybrid_w) = stroke(p, "transportation", "motorway").unwrap();
+        let (_, dark_w) = stroke(Palette::Dark, "transportation", "motorway").unwrap();
+        assert!(hybrid_w > dark_w);
+        // No minor-road mesh over imagery.
+        assert!(stroke(p, "transportation", "minor").is_none());
     }
 }

--- a/crates/hookecho/src/headless.rs
+++ b/crates/hookecho/src/headless.rs
@@ -85,7 +85,13 @@ fn national_basemap(
     let tiles = rt.block_on(async {
         let template = crate::vector_tiles::fetch_tilejson(&client, None).await?;
         Some(
-            crate::vector_tiles::fetch_visible_vector(&client, &template, true, camera.zoom, &vis)
+            crate::vector_tiles::fetch_visible_vector(
+                &client,
+                &template,
+                crate::basemap_style::Palette::Dark,
+                camera.zoom,
+                &vis,
+            )
                 .await
                 .0,
         )
@@ -223,7 +229,15 @@ pub fn run(
             println!("tilejson template: {template}");
             Ok::<_, anyhow::Error>(
                 crate::vector_tiles::fetch_visible_vector(
-                    &client, &template, dark, tess_zoom, &vis,
+                    &client,
+                    &template,
+                    if dark {
+                        crate::basemap_style::Palette::Dark
+                    } else {
+                        crate::basemap_style::Palette::Light
+                    },
+                    tess_zoom,
+                    &vis,
                 )
                 .await,
             )
@@ -252,6 +266,7 @@ pub fn run(
         new_tiles,
         visible,
         basemap_key: basemap.key(),
+        vector_over_raster: false,
         radar_upload: Some(crate::app::to_upload(
             &sweep, &table, None, smooth, storm_uv,
         )),
@@ -303,6 +318,7 @@ pub fn run_multipane(site: &str, out_a: &str, out_b: &str) -> anyhow::Result<()>
             camera_center: center,
             camera_scale: scale,
             basemap_key: 0,
+            vector_over_raster: false,
             new_tiles: Vec::new(),
             visible: Vec::new(),
             radar_upload: Some(crate::app::to_upload(&sweep, &table, None, false, None)),
@@ -954,6 +970,7 @@ pub fn run_live(out_path: &str, site: &str, moment: Moment) -> anyhow::Result<()
         camera_center: center,
         camera_scale: scale,
         basemap_key: 0,
+        vector_over_raster: false,
         new_tiles: Vec::new(),
         visible: Vec::new(),
         radar_upload: Some(crate::app::to_upload(&sweep, &table, None, false, None)),
@@ -1034,6 +1051,7 @@ pub fn run_placefile(path: &str, out_path: &str) -> anyhow::Result<()> {
         camera_center: center,
         camera_scale: scale,
         basemap_key: 0,
+        vector_over_raster: false,
         new_tiles: Vec::new(),
         visible: Vec::new(),
         radar_upload: None,
@@ -1093,6 +1111,7 @@ pub fn run_overlay(out_path: &str) -> anyhow::Result<()> {
         camera_center: center,
         camera_scale: scale,
         basemap_key: 0,
+        vector_over_raster: false,
         new_tiles,
         visible,
         radar_upload: None,
@@ -1193,6 +1212,7 @@ pub fn run_mrms(out_path: &str) -> anyhow::Result<()> {
         camera_center: center,
         camera_scale: scale,
         basemap_key: 0,
+        vector_over_raster: false,
         new_tiles,
         visible,
         radar_upload: None,
@@ -1247,6 +1267,7 @@ pub fn run_lightning(out_path: &str) -> anyhow::Result<()> {
         camera_center: center,
         camera_scale: scale,
         basemap_key: 0,
+        vector_over_raster: false,
         new_tiles,
         visible,
         radar_upload: None,
@@ -1317,6 +1338,7 @@ pub fn run_field(slug: &str, out_path: &str) -> anyhow::Result<()> {
         camera_center: center,
         camera_scale: scale,
         basemap_key: 0,
+        vector_over_raster: false,
         new_tiles,
         visible,
         radar_upload: None,
@@ -1415,6 +1437,7 @@ pub fn run_global(model: &str, slug: &str, out_path: &str) -> anyhow::Result<()>
         camera_center: center,
         camera_scale: scale,
         basemap_key: 0,
+        vector_over_raster: false,
         new_tiles,
         visible,
         radar_upload: None,
@@ -1528,6 +1551,7 @@ pub fn run_diff(slug: &str, out_path: &str) -> anyhow::Result<()> {
         camera_center: center,
         camera_scale: scale,
         basemap_key: 0,
+        vector_over_raster: false,
         new_tiles,
         visible,
         radar_upload: None,
@@ -1846,6 +1870,7 @@ pub fn run_l3grid(kind: &str, site: &str, out_path: &str) -> anyhow::Result<()> 
         camera_center: center,
         camera_scale: scale,
         basemap_key: 0,
+        vector_over_raster: false,
         new_tiles,
         visible,
         radar_upload: None,
@@ -1918,6 +1943,7 @@ pub fn run_env(slug: &str, out_path: &str) -> anyhow::Result<()> {
         camera_center: center,
         camera_scale: scale,
         basemap_key: 0,
+        vector_over_raster: false,
         new_tiles,
         visible,
         radar_upload: None,
@@ -2099,6 +2125,7 @@ pub fn run_hrrr_layer(
         camera_center: center,
         camera_scale: scale,
         basemap_key: 0,
+        vector_over_raster: false,
         new_tiles,
         visible,
         radar_upload: None,
@@ -2134,6 +2161,7 @@ fn render_field_png(
         camera_center: center,
         camera_scale: scale,
         basemap_key: 0,
+        vector_over_raster: false,
         new_tiles,
         visible,
         radar_upload: None,
@@ -2858,6 +2886,7 @@ mod golden_tests {
             camera_center: center,
             camera_scale: scale,
             basemap_key: 0,
+            vector_over_raster: false,
             new_tiles: Vec::new(),
             visible: Vec::new(),
             radar_upload: Some(crate::app::to_upload(&sweep, &table, None, false, None)),

--- a/crates/hookecho/src/render/mod.rs
+++ b/crates/hookecho/src/render/mod.rs
@@ -289,6 +289,9 @@ pub struct MapCallback {
     pub visible: Vec<VisibleTile>,
     /// Which basemap style this pane draws ([`crate::tiles::BasemapStyle::key`]).
     pub basemap_key: u8,
+    /// Draw the vector basemap *after* the raster tiles instead of under them — the hybrid
+    /// satellite style, where the vector geometry is roads over imagery.
+    pub vector_over_raster: bool,
     pub radar_upload: Option<RadarUpload>,
     pub draw_radar: bool,
     /// `Some` only when the overlay geometry changed (else the last upload is reused).
@@ -377,6 +380,7 @@ struct PaneGpu {
     /// a missing tile is stood in for by resident children or an ancestor.
     frame_visible: Vec<TileKey>,
     frame_visible_vector: Vec<TileId>,
+    vector_over_raster: bool,
     frame_draw_radar: bool,
     frame_draw_overlay: bool,
 }
@@ -693,6 +697,7 @@ impl RenderResources {
                 radar: None,
                 frame_visible: Vec::new(),
                 frame_visible_vector: Vec::new(),
+                vector_over_raster: false,
                 frame_draw_radar: false,
                 frame_draw_overlay: false,
             }
@@ -1049,6 +1054,7 @@ impl RenderResources {
         }
         pane.frame_visible = visible;
         pane.frame_visible_vector = cb.visible_vector.clone();
+        pane.vector_over_raster = cb.vector_over_raster;
         pane.frame_draw_radar = cb.draw_radar && pane.radar.is_some();
         pane.frame_draw_overlay = cb.draw_overlay && overlay_present;
     }
@@ -1241,17 +1247,10 @@ impl RenderResources {
             return;
         };
         let cam = &pane.camera_bg;
-        // Vector basemap first (opaque, under everything).
-        if !pane.frame_visible_vector.is_empty() {
-            pass.set_pipeline(&self.overlay_pipeline);
-            pass.set_bind_group(0, cam, &[]);
-            for tid in &pane.frame_visible_vector {
-                if let Some(t) = self.vector_tiles.get(tid) {
-                    pass.set_vertex_buffer(0, t.vbuf.slice(..));
-                    pass.set_index_buffer(t.ibuf.slice(..), wgpu::IndexFormat::Uint32);
-                    pass.draw_indexed(0..t.index_count, 0, 0..1);
-                }
-            }
+        // Vector basemap first (opaque, under everything) — unless it is the hybrid overlay, in
+        // which case it is roads drawn *onto* the raster imagery and has to come after it.
+        if !pane.vector_over_raster {
+            self.draw_vector_basemap(pane, cam, pass);
         }
         pass.set_pipeline(&self.tile_pipeline);
         pass.set_bind_group(0, cam, &[]);
@@ -1262,6 +1261,9 @@ impl RenderResources {
                 let base = (i * 6) as u32;
                 pass.draw(base..base + 6, 0..1);
             }
+        }
+        if pane.vector_over_raster {
+            self.draw_vector_basemap(pane, cam, pass);
         }
         // Field layers under the radar (national mosaic context).
         self.draw_fields(cam, pass, true);
@@ -1294,6 +1296,28 @@ impl RenderResources {
     }
 
     /// Stage a pane's uploads (mirrors the egui `prepare` phase). Public for the headless harness.
+    /// Draw one pane's resident vector-basemap tiles. Extracted so the caller can put it either
+    /// side of the raster tiles (see [`MapCallback::vector_over_raster`]).
+    fn draw_vector_basemap(
+        &self,
+        pane: &PaneGpu,
+        cam: &wgpu::BindGroup,
+        pass: &mut wgpu::RenderPass<'_>,
+    ) {
+        if pane.frame_visible_vector.is_empty() {
+            return;
+        }
+        pass.set_pipeline(&self.overlay_pipeline);
+        pass.set_bind_group(0, cam, &[]);
+        for tid in &pane.frame_visible_vector {
+            if let Some(t) = self.vector_tiles.get(tid) {
+                pass.set_vertex_buffer(0, t.vbuf.slice(..));
+                pass.set_index_buffer(t.ibuf.slice(..), wgpu::IndexFormat::Uint32);
+                pass.draw_indexed(0..t.index_count, 0, 0..1);
+            }
+        }
+    }
+
     pub fn prepare_pane(&mut self, device: &wgpu::Device, queue: &wgpu::Queue, cb: &MapCallback) {
         self.upload_frame(device, queue, cb);
     }

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -111,6 +111,10 @@ impl AlertSound {
     }
 }
 
+fn default_custom_tile_max_z() -> u8 {
+    19
+}
+
 fn default_volume() -> f32 {
     0.2
 }
@@ -155,6 +159,16 @@ pub struct Settings {
     /// MapTiler API key (enables the MapTiler raster basemap styles). Held locally only.
     #[serde(default)]
     pub maptiler_key: String,
+    /// `{z}/{x}/{y}` tile URL template for the "Custom (XYZ URL)" basemap. Validated at the
+    /// settings boundary — see [`crate::tiles::valid_xyz_template`] — and desktop/Android only.
+    #[serde(default)]
+    pub custom_tile_url: String,
+    /// Max zoom the custom tile source serves. Deeper views stretch the deepest tile that loaded.
+    #[serde(default = "default_custom_tile_max_z")]
+    pub custom_tile_max_z: u8,
+    /// Attribution line to paint for the custom tile source.
+    #[serde(default)]
+    pub custom_tile_attribution: String,
     /// WeatherFlow Tempest personal access token — adds your Tempest stations to the live station
     /// cards. Held locally only, same as the basemap keys.
     #[serde(default)]
@@ -254,6 +268,11 @@ pub struct Settings {
     /// are what a chase pack is for; the raster imagery alone leaves you without road names.
     #[serde(default = "default_true")]
     pub pack_include_vector: bool,
+    /// Include satellite imagery in a chase pack even when the active basemap is vector. The
+    /// mirror of `pack_include_vector`: a road map offline is no help for spotting a wall cloud
+    /// against terrain you have never seen.
+    #[serde(default)]
+    pub pack_include_satellite: bool,
     /// User-drawn zones that alert when an NWS warning polygon intersects them. The Android
     /// background service reads this file too, so the name is load-bearing across the boundary.
     #[serde(default)]
@@ -880,6 +899,9 @@ impl Default for Settings {
             detectors: DetectorTuning::default(),
             alert_rules: Vec::new(),
             serve_token: String::new(),
+            custom_tile_url: String::new(),
+            custom_tile_max_z: default_custom_tile_max_z(),
+            custom_tile_attribution: String::new(),
             quiet_pending: Vec::new(),
             volume_cache_mb: 0,
             tile_disk_cache_mb: 0,
@@ -933,6 +955,7 @@ impl Default for Settings {
             background_alerts: false,
             pack_hires_dem: false,
             pack_include_vector: true,
+            pack_include_satellite: false,
             alert_polygons: Vec::new(),
             plugins: Vec::new(),
             close_to_tray: false,
@@ -1256,6 +1279,9 @@ mod tests {
     #[test]
     fn roundtrips() {
         let s = Settings {
+            custom_tile_url: String::new(),
+            custom_tile_max_z: default_custom_tile_max_z(),
+            custom_tile_attribution: String::new(),
             detectors: DetectorTuning::default(),
             alert_rules: Vec::new(),
             serve_token: String::new(),
@@ -1330,6 +1356,7 @@ mod tests {
             background_alerts: false,
             pack_hires_dem: false,
             pack_include_vector: true,
+            pack_include_satellite: false,
             alert_polygons: Vec::new(),
             plugins: Vec::new(),
             close_to_tray: true,

--- a/crates/hookecho/src/tiles.rs
+++ b/crates/hookecho/src/tiles.rs
@@ -28,6 +28,37 @@ pub enum Provider {
     MapTiler,
 }
 
+/// Picker grouping for a [`BasemapStyle`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Category {
+    Vector,
+    Streets,
+    Satellite,
+    Topo,
+    Other,
+}
+
+impl Category {
+    /// Groups in picker order.
+    pub const ALL: [Category; 5] = [
+        Category::Vector,
+        Category::Streets,
+        Category::Satellite,
+        Category::Topo,
+        Category::Other,
+    ];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Category::Vector => "Vector",
+            Category::Streets => "Streets",
+            Category::Satellite => "Satellite",
+            Category::Topo => "Terrain",
+            Category::Other => "Other",
+        }
+    }
+}
+
 /// A selectable basemap under the radar. Dark/Light are the vector MVT basemap
 /// (see [`crate::vector_tiles`]); Satellite is raster USGS imagery. The Mapbox*/MapTiler* styles
 /// are provider raster tiles, available only when the matching Settings API key is set.
@@ -486,6 +517,44 @@ impl BasemapStyle {
         self
     }
 
+    /// Which group this style belongs to in the picker.
+    pub fn category(self) -> Category {
+        if self.goes_layer().is_some() {
+            return Category::Satellite;
+        }
+        match self {
+            BasemapStyle::None | BasemapStyle::Auto | BasemapStyle::CustomXyz => Category::Other,
+            BasemapStyle::Dark
+            | BasemapStyle::Light
+            | BasemapStyle::VectorLiberty
+            | BasemapStyle::VectorBright
+            | BasemapStyle::VectorPositron
+            | BasemapStyle::VectorMidnight => Category::Vector,
+            BasemapStyle::Satellite
+            | BasemapStyle::EsriImagery
+            | BasemapStyle::HybridSatellite
+            | BasemapStyle::MapboxSatellite
+            | BasemapStyle::MapboxSatelliteStreets
+            | BasemapStyle::MapTilerSatellite => Category::Satellite,
+            BasemapStyle::OpenTopoMap
+            | BasemapStyle::UsgsTopo
+            | BasemapStyle::UsgsImageryTopo
+            | BasemapStyle::EsriTopo
+            | BasemapStyle::MapboxOutdoors
+            | BasemapStyle::MapTilerOutdoor
+            | BasemapStyle::MapTilerTopo
+            | BasemapStyle::EsriOcean => Category::Topo,
+            _ => Category::Streets,
+        }
+    }
+
+    /// URL of the one tile used as this style's picker thumbnail: z6 over the middle of CONUS,
+    /// which is the view the app opens on. Fetched through the same per-style disk cache as any
+    /// other tile, so opening the picker twice costs nothing.
+    pub(crate) fn thumb_url(self, mapbox: &str, maptiler: &str, custom: &str) -> Option<String> {
+        self.url(6, 14, 24, false, mapbox, maptiler, custom)
+    }
+
     /// [`Self::Auto`] resolved against the current theme; every other style is itself.
     ///
     /// Call this at the point a style is about to be *rendered or fetched*, not where it is
@@ -820,6 +889,13 @@ struct FetchedTile {
     height: u32,
 }
 
+/// A picker thumbnail's state.
+enum Thumb {
+    Loading,
+    Ready(egui::TextureHandle),
+    Failed,
+}
+
 /// A finished fetch, or the id of one that failed (so it can leave `requested` and be retried).
 type TileResult = Result<FetchedTile, crate::render::TileKey>;
 
@@ -864,11 +940,16 @@ pub struct TileManager {
     custom_template: String,
     /// Deepest zoom the custom source is configured to serve.
     custom_max_z: u8,
+    /// Picker thumbnails, keyed by [`BasemapStyle::key`].
+    thumbs: std::collections::HashMap<u8, Thumb>,
+    thumb_tx: Sender<(u8, Option<FetchedTile>)>,
+    thumb_rx: Receiver<(u8, Option<FetchedTile>)>,
 }
 
 impl TileManager {
     pub fn new(spawner: crate::rt::Spawner) -> Self {
         let (tx, rx) = std::sync::mpsc::channel();
+        let (thumb_tx, thumb_rx) = std::sync::mpsc::channel();
         let client =
             crate::platform::http_timeouts(reqwest::Client::builder().user_agent(USER_AGENT))
                 .build()
@@ -891,6 +972,9 @@ impl TileManager {
             frame_visible: 0,
             custom_template: String::new(),
             custom_max_z: 19,
+            thumbs: std::collections::HashMap::new(),
+            thumb_tx,
+            thumb_rx,
             cache_root,
             mapbox_key: String::new(),
             maptiler_key: String::new(),
@@ -938,6 +1022,85 @@ impl TileManager {
             self.requested.clear();
             self.uploaded.clear();
         }
+    }
+
+    /// This style's picker thumbnail, fetching it the first time it is asked for.
+    ///
+    /// One z6 tile over the middle of CONUS per style, through the same disk cache as any other
+    /// tile. Returns `None` while it is in flight, if it failed, or if the style has no raster
+    /// URL — the picker paints a palette swatch in all of those cases, so nothing ever waits on
+    /// a network round trip to draw.
+    pub fn thumb(&mut self, style: BasemapStyle, ctx: &egui::Context) -> Option<egui::TextureHandle> {
+        while let Ok((key, fetched)) = self.thumb_rx.try_recv() {
+            let state = match fetched {
+                Some(f) => {
+                    let img = egui::ColorImage::from_rgba_unmultiplied(
+                        [f.width as usize, f.height as usize],
+                        &f.rgba,
+                    );
+                    Thumb::Ready(ctx.load_texture(
+                        format!("basemap-thumb-{key}"),
+                        img,
+                        egui::TextureOptions::LINEAR,
+                    ))
+                }
+                None => Thumb::Failed,
+            };
+            self.thumbs.insert(key, state);
+        }
+        let key = style.key();
+        match self.thumbs.get(&key) {
+            Some(Thumb::Ready(t)) => return Some(t.clone()),
+            Some(_) => return None,
+            None => {}
+        }
+        // A cellular link should not spend a screenful of tiles on decoration.
+        if crate::platform::is_metered() {
+            return None;
+        }
+        // Small separate budget: the picker opening must not stall the map's own tile fetches.
+        // ponytail: flat 4, independent of MAX_INFLIGHT.
+        if self
+            .thumbs
+            .values()
+            .filter(|t| matches!(t, Thumb::Loading))
+            .count()
+            >= 4
+        {
+            return None;
+        }
+        let url = style.thumb_url(&self.mapbox_key, &self.maptiler_key, &self.custom_template)?;
+        let path = self.cache_root.as_ref().map(|d| {
+            d.join(style.provider(false, &self.custom_template))
+                .join("default")
+                .join("6/14/24")
+        });
+        self.thumbs.insert(key, Thumb::Loading);
+        let client = self.client.clone();
+        let tx = self.thumb_tx.clone();
+        let ctx2 = self.ctx.clone();
+        let blocking = self.spawner.clone();
+        self.spawner.spawn(async move {
+            let bytes = load_tile_bytes(&client, &url, path.as_deref()).await;
+            blocking.spawn_blocking(move || {
+                let decoded = bytes.ok().and_then(|b| image::load_from_memory(&b).ok()).map(|img| {
+                    let rgba = img.to_rgba8();
+                    let (w, h) = rgba.dimensions();
+                    FetchedTile {
+                        id: (6, 14, 24),
+                        style: key,
+                        rgba: rgba.into_raw(),
+                        width: w,
+                        height: h,
+                    }
+                });
+                let _ = tx.send((key, decoded));
+                if let Some(ctx) = ctx2 {
+                    ctx.request_repaint();
+                }
+            });
+        });
+        None
     }
 
     /// Point the custom-XYZ slot at a template. Clears the caches on change, like the key setter
@@ -1736,6 +1899,36 @@ mod tests {
                     .any(|s| s.vector_palette() == Some(pal)),
                 "{pal:?} is not reachable from the basemap list"
             );
+        }
+    }
+
+    /// The picker draws one section per category. A style in no section is invisible, and a
+    /// section with nothing in it is a stray heading.
+    #[test]
+    fn categories_partition_the_style_list() {
+        let mut seen = 0;
+        for cat in Category::ALL {
+            let n = BasemapStyle::ALL
+                .iter()
+                .filter(|s| s.category() == cat)
+                .count();
+            assert!(n > 0, "{cat:?} has no styles");
+            seen += n;
+        }
+        assert_eq!(seen, BasemapStyle::ALL.len());
+        // The three that are not a map of anywhere belong together, away from the imagery.
+        for s in [
+            BasemapStyle::None,
+            BasemapStyle::Auto,
+            BasemapStyle::CustomXyz,
+        ] {
+            assert_eq!(s.category(), Category::Other, "{s:?}");
+        }
+        // Every GOES product lands under Satellite whatever else the match says.
+        for s in BasemapStyle::ALL {
+            if s.goes_layer().is_some() {
+                assert_eq!(s.category(), Category::Satellite, "{s:?}");
+            }
         }
     }
 }

--- a/crates/hookecho/src/tiles.rs
+++ b/crates/hookecho/src/tiles.rs
@@ -82,11 +82,24 @@ pub enum BasemapStyle {
     UsgsImageryTopo,
     OsmHot,
     CyclOsm,
+    EsriDarkGray,
+    EsriLightGray,
+    EsriNatGeo,
+    EsriOcean,
+    /// Esri World Imagery with our own vector roads/boundaries/labels drawn over it. Keyless, and
+    /// the closest thing to the "hybrid" layer every commercial provider charges for.
+    HybridSatellite,
+    /// Follows the app theme: resolves to [`Self::Dark`] or [`Self::Light`]. Never rendered
+    /// directly — see [`Self::resolve`].
+    Auto,
+    /// User-supplied `{z}/{x}/{y}` URL template from settings. Desktop and Android only; the web
+    /// build's proxy is exact-host allowlisted, so an arbitrary host cannot be fetched there.
+    CustomXyz,
 }
 
 impl BasemapStyle {
     /// Cycle order for the `z` hotkey; provider styles trail the built-ins.
-    pub const ALL: [BasemapStyle; 40] = [
+    pub const ALL: [BasemapStyle; 47] = [
         BasemapStyle::Dark,
         BasemapStyle::Light,
         BasemapStyle::Satellite,
@@ -103,6 +116,13 @@ impl BasemapStyle {
         BasemapStyle::UsgsImageryTopo,
         BasemapStyle::OsmHot,
         BasemapStyle::CyclOsm,
+        BasemapStyle::HybridSatellite,
+        BasemapStyle::EsriDarkGray,
+        BasemapStyle::EsriLightGray,
+        BasemapStyle::EsriNatGeo,
+        BasemapStyle::EsriOcean,
+        BasemapStyle::Auto,
+        BasemapStyle::CustomXyz,
         BasemapStyle::GoesEast,
         BasemapStyle::GoesWest,
         BasemapStyle::GoesEastIR,
@@ -149,6 +169,12 @@ impl BasemapStyle {
         match self {
             BasemapStyle::Satellite => "USGS",
             BasemapStyle::EsriImagery => "Satellite",
+            BasemapStyle::HybridSatellite => "Hybrid",
+            BasemapStyle::EsriDarkGray => "Dark Gray",
+            BasemapStyle::EsriLightGray => "Light Gray",
+            BasemapStyle::EsriNatGeo => "NatGeo",
+            BasemapStyle::EsriOcean => "Ocean",
+            BasemapStyle::CustomXyz => "Custom",
             BasemapStyle::OsmStandard => "Streets",
             BasemapStyle::OpenTopoMap => "Topo",
             BasemapStyle::GoesEast => "GOES-East",
@@ -193,6 +219,13 @@ impl BasemapStyle {
             BasemapStyle::UsgsImageryTopo => "USGS Imagery Topo",
             BasemapStyle::OsmHot => "OSM Humanitarian",
             BasemapStyle::CyclOsm => "CyclOSM",
+            BasemapStyle::EsriDarkGray => "Esri Dark Gray Canvas",
+            BasemapStyle::EsriLightGray => "Esri Light Gray Canvas",
+            BasemapStyle::EsriNatGeo => "Esri National Geographic",
+            BasemapStyle::EsriOcean => "Esri Ocean",
+            BasemapStyle::HybridSatellite => "Hybrid Satellite",
+            BasemapStyle::Auto => "Auto (follow theme)",
+            BasemapStyle::CustomXyz => "Custom (XYZ URL)",
             BasemapStyle::MapTilerStreets => "MapTiler Streets",
             BasemapStyle::MapTilerSatellite => "MapTiler Satellite",
             BasemapStyle::MapTilerOutdoor => "MapTiler Outdoor",
@@ -239,6 +272,13 @@ impl BasemapStyle {
             BasemapStyle::UsgsImageryTopo => "usgs-imagery-topo",
             BasemapStyle::OsmHot => "osm-hot",
             BasemapStyle::CyclOsm => "cyclosm",
+            BasemapStyle::EsriDarkGray => "esri-dark-gray",
+            BasemapStyle::EsriLightGray => "esri-light-gray",
+            BasemapStyle::EsriNatGeo => "esri-natgeo",
+            BasemapStyle::EsriOcean => "esri-ocean",
+            BasemapStyle::HybridSatellite => "hybrid-satellite",
+            BasemapStyle::Auto => "auto",
+            BasemapStyle::CustomXyz => "custom",
             BasemapStyle::MapTilerStreets => "maptiler-streets",
             BasemapStyle::MapTilerSatellite => "maptiler-satellite",
             BasemapStyle::MapTilerOutdoor => "maptiler-outdoor",
@@ -293,8 +333,17 @@ impl BasemapStyle {
                 BasemapStyle::CartoPositron
                 | BasemapStyle::CartoDarkMatter
                 | BasemapStyle::CartoVoyager => "© CARTO © OpenStreetMap",
-                BasemapStyle::EsriImagery => "© Esri, Maxar, Earthstar Geographics",
+                BasemapStyle::EsriImagery | BasemapStyle::HybridSatellite => {
+                    "© Esri, Maxar, Earthstar Geographics"
+                }
                 BasemapStyle::EsriStreets | BasemapStyle::EsriTopo => "© Esri © OpenStreetMap",
+                BasemapStyle::EsriDarkGray | BasemapStyle::EsriLightGray => {
+                    "© Esri © OpenStreetMap, HERE, Garmin"
+                }
+                BasemapStyle::EsriNatGeo => "© Esri, National Geographic",
+                BasemapStyle::EsriOcean => "© Esri, GEBCO, NOAA",
+                // The template is the user's; we cannot know whose data it serves.
+                BasemapStyle::CustomXyz => "Custom tile source",
                 _ if self.goes_layer().is_some() => "NASA GIBS · NOAA GOES",
                 _ => "© OpenMapTiles © OpenStreetMap",
             },
@@ -324,7 +373,7 @@ impl BasemapStyle {
     pub fn is_raster(self) -> bool {
         !matches!(
             self,
-            BasemapStyle::Dark | BasemapStyle::Light | BasemapStyle::None
+            BasemapStyle::Dark | BasemapStyle::Light | BasemapStyle::None | BasemapStyle::Auto
         )
     }
 
@@ -344,6 +393,18 @@ impl BasemapStyle {
             // USGS ArcGIS services (imagery and topo alike) stop at 16.
             BasemapStyle::Satellite | BasemapStyle::UsgsTopo | BasemapStyle::UsgsImageryTopo => 16,
             BasemapStyle::OpenTopoMap => 17,
+            // Measured over Dallas: the Canvas and NatGeo services hand back a fixed 2521-byte
+            // placeholder from 17 up, and the ocean base does the same from 11.
+            BasemapStyle::EsriOcean => 10,
+            BasemapStyle::EsriDarkGray | BasemapStyle::EsriLightGray | BasemapStyle::EsriNatGeo => {
+                16
+            }
+            // World Imagery serves real tiles through 20 and placeholders at 21.
+            BasemapStyle::HybridSatellite => 20,
+            // We cannot probe the user's own server, so we trust the max zoom they configured;
+            // overzoom covers an overshoot by stretching the deepest tile that did load.
+            // ponytail: no validation of the user's max_z beyond the settings clamp.
+            BasemapStyle::CustomXyz => 22,
             BasemapStyle::OsmHot => 18,
             BasemapStyle::OsmStandard | BasemapStyle::CyclOsm => 19,
             BasemapStyle::CartoPositron | BasemapStyle::CartoDarkMatter | BasemapStyle::CartoVoyager => 20,
@@ -370,8 +431,15 @@ impl BasemapStyle {
         matches!(self.provider_kind(), Provider::Mapbox | Provider::MapTiler)
     }
 
-    /// Is this style selectable given which provider keys are set?
-    pub fn available(self, mapbox_key: bool, maptiler_key: bool) -> bool {
+    /// Is this style selectable given which provider keys are set and whether the user has
+    /// configured a custom tile template?
+    pub fn available(self, mapbox_key: bool, maptiler_key: bool, custom: bool) -> bool {
+        if self == BasemapStyle::CustomXyz {
+            // Nothing to fetch without a template, and the web build cannot fetch an arbitrary
+            // host at all: the proxy allowlist is exact-match, and a direct fetch is at the mercy
+            // of whatever CORS headers the user's server happens to send.
+            return custom && !cfg!(target_arch = "wasm32");
+        }
         match self.provider_kind() {
             Provider::Mapbox => mapbox_key,
             Provider::MapTiler => maptiler_key,
@@ -380,15 +448,39 @@ impl BasemapStyle {
     }
 
     /// Next *available* style in [`Self::ALL`] (wraps) — the `z`-cycle step.
-    pub fn next(self, mapbox_key: bool, maptiler_key: bool) -> BasemapStyle {
+    pub fn next(self, mapbox_key: bool, maptiler_key: bool, custom: bool) -> BasemapStyle {
         let i = Self::ALL.iter().position(|s| *s == self).unwrap_or(0);
         for step in 1..=Self::ALL.len() {
             let cand = Self::ALL[(i + step) % Self::ALL.len()];
-            if cand.available(mapbox_key, maptiler_key) {
+            if cand.available(mapbox_key, maptiler_key, custom) {
                 return cand;
             }
         }
         self
+    }
+
+    /// [`Self::Auto`] resolved against the current theme; every other style is itself.
+    ///
+    /// Call this at the point a style is about to be *rendered or fetched*, not where it is
+    /// stored — the stored value has to stay `Auto` or it would stop following the theme.
+    pub fn resolve(self, dark_theme: bool) -> BasemapStyle {
+        match self {
+            BasemapStyle::Auto if dark_theme => BasemapStyle::Dark,
+            BasemapStyle::Auto => BasemapStyle::Light,
+            other => other,
+        }
+    }
+
+    /// Which vector palette this style tessellates with, or `None` if it draws no vector geometry
+    /// (raster basemaps other than hybrid, and `None`). Labels are drawn over every basemap
+    /// regardless — this is about the roads/fills.
+    pub fn vector_palette(self) -> Option<crate::basemap_style::Palette> {
+        match self {
+            BasemapStyle::Dark => Some(crate::basemap_style::Palette::Dark),
+            BasemapStyle::Light => Some(crate::basemap_style::Palette::Light),
+            BasemapStyle::HybridSatellite => Some(crate::basemap_style::Palette::HybridOverlay),
+            _ => None,
+        }
     }
 
     /// Stable small id for this style, used to key the GPU/fetch caches so panes showing
@@ -398,7 +490,12 @@ impl BasemapStyle {
     }
 
     /// Per-style cache subdir so sources don't collide on disk. Keys never appear here.
-    fn provider(self, retina: bool) -> String {
+    fn provider(self, retina: bool, custom: &str) -> String {
+        // The user can repoint the custom slot at a different server; hashing the template keeps
+        // the old server's tiles from being served for the new one.
+        if self == BasemapStyle::CustomXyz {
+            return format!("custom-{:08x}", template_hash(custom));
+        }
         // 512-px tiles share the tile grid with the 256-px ones they replace, so a cache written
         // before the switch would keep serving blurry 256s from the same paths. Separate dir —
         // and `@2x` tiles get their own for the same reason.
@@ -442,6 +539,7 @@ impl BasemapStyle {
         retina: bool,
         mapbox_key: &str,
         maptiler_key: &str,
+        custom: &str,
     ) -> Option<String> {
         // `@2x` on the sources that serve it; empty everywhere else, so the URL is unchanged.
         let hi = if retina && self.has_2x() { "@2x" } else { "" };
@@ -466,6 +564,27 @@ impl BasemapStyle {
                 BasemapStyle::EsriTopo => Some(format!(
                     "https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}"
                 )),
+                // Hybrid is World Imagery underneath; the roads and labels on top come from the
+                // vector pipeline, not from a second raster fetch.
+                BasemapStyle::HybridSatellite => Some(format!(
+                    "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
+                )),
+                // The extra Esri services live on `services.` rather than `server.`; both hosts
+                // are already in the proxy allowlist.
+                BasemapStyle::EsriDarkGray => Some(format!(
+                    "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}"
+                )),
+                BasemapStyle::EsriLightGray => Some(format!(
+                    "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}"
+                )),
+                BasemapStyle::EsriNatGeo => Some(format!(
+                    "https://services.arcgisonline.com/ArcGIS/rest/services/NatGeo_World_Map/MapServer/tile/{z}/{y}/{x}"
+                )),
+                BasemapStyle::EsriOcean => Some(format!(
+                    "https://services.arcgisonline.com/ArcGIS/rest/services/Ocean/World_Ocean_Base/MapServer/tile/{z}/{y}/{x}"
+                )),
+                BasemapStyle::CustomXyz => valid_xyz_template(custom)
+                    .then(|| crate::vector_tiles::fill_template(custom, z, x, y)),
                 // Standard XYZ `{z}/{x}/{y}.png` slippy tiles. Single subdomain shard where the
                 // provider uses them (ponytail: rotate a-c only if throttled).
                 BasemapStyle::OsmStandard => {
@@ -511,6 +630,28 @@ impl BasemapStyle {
             }),
         }
     }
+}
+
+/// Is this a tile-URL template we are willing to fetch?
+///
+/// Trust boundary: the string comes from the user's settings file, and whatever it points at gets
+/// fetched with the app's HTTP client. `https` only — a plain-http template would silently
+/// downgrade every tile request — and it has to actually be a slippy template, or every tile
+/// would be the same URL hammered a screenful at a time.
+pub fn valid_xyz_template(t: &str) -> bool {
+    t.starts_with("https://") && t.contains("{z}") && t.contains("{x}") && t.contains("{y}")
+}
+
+/// Short stable hash of a custom template, for its cache directory name.
+fn template_hash(t: &str) -> u32 {
+    // ponytail: FNV-1a, not a crypto hash. This names a cache directory; a collision would serve
+    // one custom source's tiles for another, which is why it is 32 bits and not 8.
+    let mut h: u32 = 0x811c9dc5;
+    for b in t.as_bytes() {
+        h ^= *b as u32;
+        h = h.wrapping_mul(0x01000193);
+    }
+    h
 }
 
 /// Integer tile ids covering `cam`'s view (zoom clamped to `max_z`) with their world rects.
@@ -688,6 +829,10 @@ pub struct TileManager {
     goes_time: Option<chrono::DateTime<chrono::Utc>>,
     /// Ask sources that serve them for `@2x` tiles (high-DPI screen, unmetered link).
     retina: bool,
+    /// `{z}/{x}/{y}` template for [`BasemapStyle::CustomXyz`]. Empty until the user sets one.
+    custom_template: String,
+    /// Deepest zoom the custom source is configured to serve.
+    custom_max_z: u8,
 }
 
 impl TileManager {
@@ -713,6 +858,8 @@ impl TileManager {
             uploaded: LruCache::new(NonZeroUsize::new(RASTER_TILE_CACHE).unwrap()),
             evicted: Vec::new(),
             frame_visible: 0,
+            custom_template: String::new(),
+            custom_max_z: 19,
             cache_root,
             mapbox_key: String::new(),
             maptiler_key: String::new(),
@@ -762,6 +909,22 @@ impl TileManager {
         }
     }
 
+    /// Point the custom-XYZ slot at a template. Clears the caches on change, like the key setter
+    /// above: the same `(z, x, y)` now means a different server's imagery.
+    pub fn set_custom_max_z(&mut self, z: u8) {
+        // Clamped rather than trusted: `tile_cover` builds a grid of `4^z` tiles, and a typo in
+        // the settings file should not turn into an unbounded fetch loop.
+        self.custom_max_z = z.clamp(1, 22);
+    }
+
+    pub fn set_custom_template(&mut self, template: &str) {
+        if self.custom_template != template {
+            self.custom_template = template.to_string();
+            self.requested.clear();
+            self.uploaded.clear();
+        }
+    }
+
     /// Integer tile ids covering the current view, and their world-space rects. `zoom_bias`
     /// pulls sharper tiles on high-DPI displays (see [`tile_cover`]).
     pub fn visible(
@@ -771,7 +934,17 @@ impl TileManager {
         viewport_px: (f32, f32),
         zoom_bias: f64,
     ) -> Vec<VisibleTile> {
-        tile_cover(cam, viewport_px, style.max_raster_z(), zoom_bias)
+        tile_cover(cam, viewport_px, self.max_z(style), zoom_bias)
+    }
+
+    /// Deepest zoom to fetch for `style` — the measured provider cap, except for the custom slot
+    /// where only the user knows.
+    fn max_z(&self, style: BasemapStyle) -> u8 {
+        if style == BasemapStyle::CustomXyz {
+            self.custom_max_z
+        } else {
+            style.max_raster_z()
+        }
     }
 
     /// Kick off fetches for any visible tiles not yet requested.
@@ -795,7 +968,7 @@ impl TileManager {
             }
             let (z, x, y) = v.id;
             let Some(mut url) =
-                style.url(z, x, y, self.retina, &self.mapbox_key, &self.maptiler_key)
+                style.url(z, x, y, self.retina, &self.mapbox_key, &self.maptiler_key, &self.custom_template)
             else {
                 continue;
             };
@@ -814,7 +987,7 @@ impl TileManager {
             };
             self.requested.insert((skey, v.id));
             let path = self.cache_root.as_ref().map(|d| {
-                d.join(style.provider(self.retina))
+                d.join(style.provider(self.retina, &self.custom_template))
                     .join(&time_tag)
                     .join(format!("{z}/{x}/{y}"))
             });
@@ -855,7 +1028,7 @@ impl TileManager {
 
     /// Max zoom `style` serves (for the chase-pack depth cap).
     pub fn max_pack_z(&self, style: BasemapStyle) -> u8 {
-        style.max_raster_z()
+        self.max_z(style)
     }
 
     /// Whether `style` produces raster tiles a chase pack can pre-download (has a URL, isn't a
@@ -864,7 +1037,7 @@ impl TileManager {
     pub fn packable(&self, style: BasemapStyle) -> bool {
         style.goes_layer().is_none()
             && style
-                .url(0, 0, 0, false, &self.mapbox_key, &self.maptiler_key)
+                .url(0, 0, 0, false, &self.mapbox_key, &self.maptiler_key, &self.custom_template)
                 .is_some()
     }
 
@@ -888,13 +1061,13 @@ impl TileManager {
         if style.goes_layer().is_some() {
             return Vec::new();
         }
-        let z_hi = z_hi.min(style.max_raster_z());
+        let z_hi = z_hi.min(self.max_z(style));
         // Packs are always 1x: a pack is written once and read on whatever device opens it later.
-        let dir = root.join(style.provider(false)).join("default");
+        let dir = root.join(style.provider(false, &self.custom_template)).join("default");
         pack_tile_ids(min_lon, min_lat, max_lon, max_lat, z_lo, z_hi)
             .into_iter()
             .filter_map(|(z, x, y)| {
-                let url = style.url(z, x, y, false, &self.mapbox_key, &self.maptiler_key)?;
+                let url = style.url(z, x, y, false, &self.mapbox_key, &self.maptiler_key, &self.custom_template)?;
                 Some((url, dir.join(format!("{z}/{x}/{y}"))))
             })
             .collect()
@@ -1020,7 +1193,7 @@ pub async fn fetch_visible(
     let mut out = Vec::new();
     for v in visible {
         let (z, x, y) = v.id;
-        let Some(url) = style.url(z, x, y, false, mapbox_key, maptiler_key) else {
+        let Some(url) = style.url(z, x, y, false, mapbox_key, maptiler_key, "") else {
             continue;
         };
         match load_tile_bytes(client, &url, None).await {
@@ -1410,23 +1583,28 @@ mod tests {
             BasemapStyle::UsgsImageryTopo,
             BasemapStyle::OsmHot,
             BasemapStyle::CyclOsm,
+            BasemapStyle::EsriDarkGray,
+            BasemapStyle::EsriLightGray,
+            BasemapStyle::EsriNatGeo,
+            BasemapStyle::EsriOcean,
+            BasemapStyle::HybridSatellite,
         ];
         for s in keyless {
             assert!(s.is_raster(), "{s:?} should be raster");
             assert!(
-                s.url(6, 15, 25, false, "", "").is_some(),
+                s.url(6, 15, 25, false, "", "", "").is_some(),
                 "{s:?} should have a keyless URL"
             );
         }
         // ArcGIS services use {z}/{y}/{x}: y before x in the path.
-        let esri = BasemapStyle::EsriImagery.url(6, 15, 25, false, "", "").unwrap();
+        let esri = BasemapStyle::EsriImagery.url(6, 15, 25, false, "", "", "").unwrap();
         assert!(esri.ends_with("/6/25/15"), "Esri y/x order: {esri}");
         // Standard slippy tiles use {z}/{x}/{y}.
-        let osm = BasemapStyle::OsmStandard.url(6, 15, 25, false, "", "").unwrap();
+        let osm = BasemapStyle::OsmStandard.url(6, 15, 25, false, "", "", "").unwrap();
         assert!(osm.ends_with("/6/15/25.png"), "OSM x/y order: {osm}");
         // Mapbox nav styles stay key-gated.
-        assert!(BasemapStyle::MapboxNavDay.url(6, 15, 25, false, "", "").is_none());
-        assert!(BasemapStyle::MapboxNavDay.url(6, 15, 25, false, "k", "").is_some());
+        assert!(BasemapStyle::MapboxNavDay.url(6, 15, 25, false, "", "", "").is_none());
+        assert!(BasemapStyle::MapboxNavDay.url(6, 15, 25, false, "k", "", "").is_some());
     }
 
     /// Retina asks for the `@2x` tile only where the provider serves one, and those tiles get
@@ -1434,13 +1612,13 @@ mod tests {
     #[test]
     fn retina_only_changes_the_sources_that_serve_2x() {
         let carto = BasemapStyle::CartoDarkMatter;
-        assert!(carto.url(6, 15, 25, true, "", "").unwrap().ends_with("@2x.png"));
-        assert!(carto.url(6, 15, 25, false, "", "").unwrap().ends_with("/25.png"));
-        assert_ne!(carto.provider(true), carto.provider(false));
+        assert!(carto.url(6, 15, 25, true, "", "", "").unwrap().ends_with("@2x.png"));
+        assert!(carto.url(6, 15, 25, false, "", "", "").unwrap().ends_with("/25.png"));
+        assert_ne!(carto.provider(true, ""), carto.provider(false, ""));
         // No `@2x` upstream: the URL and the cache path are identical either way.
         let osm = BasemapStyle::OsmStandard;
-        assert_eq!(osm.url(6, 15, 25, true, "", ""), osm.url(6, 15, 25, false, "", ""));
-        assert_eq!(osm.provider(true), osm.provider(false));
+        assert_eq!(osm.url(6, 15, 25, true, "", "", ""), osm.url(6, 15, 25, false, "", "", ""));
+        assert_eq!(osm.provider(true, ""), osm.provider(false, ""));
     }
 
     /// The USGS satellite basemap serves nothing past zoom 16; asking for 17 got a 404 and left a
@@ -1458,3 +1636,62 @@ mod tests {
         );
     }
 }
+
+    /// `Auto` is a marker, not something the tile layer should ever be asked to fetch.
+    #[test]
+    fn auto_resolves_to_a_real_style_and_nothing_else_moves() {
+        assert_eq!(BasemapStyle::Auto.resolve(true), BasemapStyle::Dark);
+        assert_eq!(BasemapStyle::Auto.resolve(false), BasemapStyle::Light);
+        assert!(!BasemapStyle::Auto.is_raster());
+        for s in BasemapStyle::ALL {
+            if s != BasemapStyle::Auto {
+                assert_eq!(s.resolve(true), s, "{s:?} should not follow the theme");
+                assert_eq!(s.resolve(false), s, "{s:?} should not follow the theme");
+            }
+        }
+    }
+
+    /// Hybrid satellite is the one style that is raster *and* draws vector geometry.
+    #[test]
+    fn only_hybrid_is_both_raster_and_vector() {
+        for s in BasemapStyle::ALL {
+            let both = s.is_raster() && s.vector_palette().is_some();
+            assert_eq!(
+                both,
+                s == BasemapStyle::HybridSatellite,
+                "{s:?} raster+vector should only be hybrid"
+            );
+        }
+        assert_eq!(
+            BasemapStyle::HybridSatellite.vector_palette(),
+            Some(crate::basemap_style::Palette::HybridOverlay)
+        );
+    }
+
+    /// The custom template comes out of the settings file, so it is a trust boundary: anything
+    /// that is not an https slippy template must not be fetched at all.
+    #[test]
+    fn custom_template_is_validated_and_keyed_by_content() {
+        assert!(valid_xyz_template("https://t.example/{z}/{x}/{y}.png"));
+        assert!(!valid_xyz_template("http://t.example/{z}/{x}/{y}.png"));
+        assert!(!valid_xyz_template("https://t.example/tiles.png"));
+        assert!(!valid_xyz_template(""));
+        assert!(!valid_xyz_template("file:///etc/{z}/{x}/{y}"));
+
+        let good = "https://t.example/{z}/{x}/{y}.png";
+        assert_eq!(
+            BasemapStyle::CustomXyz.url(6, 15, 25, false, "", "", good),
+            Some("https://t.example/6/15/25.png".to_string())
+        );
+        // An invalid template produces no URL rather than a request to something unexpected.
+        assert!(BasemapStyle::CustomXyz
+            .url(6, 15, 25, false, "", "", "http://t.example/{z}/{x}/{y}")
+            .is_none());
+        // Repointing the slot must not read the previous server's tiles out of the cache.
+        assert_ne!(
+            BasemapStyle::CustomXyz.provider(false, good),
+            BasemapStyle::CustomXyz.provider(false, "https://other.example/{z}/{x}/{y}.png")
+        );
+        // And it is only selectable once a template exists.
+        assert!(!BasemapStyle::CustomXyz.available(true, true, false));
+    }

--- a/crates/hookecho/src/tiles.rs
+++ b/crates/hookecho/src/tiles.rs
@@ -328,16 +328,38 @@ impl BasemapStyle {
         )
     }
 
-    /// Max zoom the raster source serves; deeper views upscale rather than fetch 404s. GIBS
-    /// GOES layers top out at their matrix level; the USGS ArcGIS services cap at 16.
+    /// Max zoom the raster source serves; deeper views upscale rather than fetch 404s. GIBS GOES
+    /// layers top out at their matrix level.
+    ///
+    /// Every value below was checked against the live endpoint over Dallas: one level past the
+    /// number here either 404s or returns the provider's fixed "no data" placeholder (OpenTopoMap
+    /// hands back the same 4343-byte image at 18, 19 and 20). Guessing high is not free — a 404
+    /// leaves a hole until an ancestor tile happens to be resident, which is what made the USGS
+    /// satellite basemap blank out on close zoom: it served nothing past 16 but was asked for 18.
     fn max_raster_z(self) -> u8 {
         if let Some((_, level)) = self.goes_layer() {
             return level;
         }
         match self {
-            BasemapStyle::UsgsTopo | BasemapStyle::UsgsImageryTopo => 16,
-            _ => 18,
+            // USGS ArcGIS services (imagery and topo alike) stop at 16.
+            BasemapStyle::Satellite | BasemapStyle::UsgsTopo | BasemapStyle::UsgsImageryTopo => 16,
+            BasemapStyle::OpenTopoMap => 17,
+            BasemapStyle::OsmHot => 18,
+            BasemapStyle::OsmStandard | BasemapStyle::CyclOsm => 19,
+            BasemapStyle::CartoPositron | BasemapStyle::CartoDarkMatter | BasemapStyle::CartoVoyager => 20,
+            BasemapStyle::EsriImagery | BasemapStyle::EsriStreets | BasemapStyle::EsriTopo => 20,
+            _ => 20, // Mapbox and MapTiler raster both serve past 20; the vector styles never get here.
         }
+    }
+
+    /// Whether this source serves a true double-resolution tile at the same grid position (the
+    /// `@2x` suffix). Worth more than the retina zoom bias it replaces: same tile count, twice the
+    /// pixels, and the labels are drawn for the higher density instead of being magnified.
+    fn has_2x(self) -> bool {
+        matches!(
+            self,
+            BasemapStyle::CartoPositron | BasemapStyle::CartoDarkMatter | BasemapStyle::CartoVoyager
+        )
     }
 
     /// Whether this style's tiles are 512 px rather than 256. Mapbox and MapTiler both serve the
@@ -376,11 +398,14 @@ impl BasemapStyle {
     }
 
     /// Per-style cache subdir so sources don't collide on disk. Keys never appear here.
-    fn provider(self) -> String {
+    fn provider(self, retina: bool) -> String {
         // 512-px tiles share the tile grid with the 256-px ones they replace, so a cache written
-        // before the switch would keep serving blurry 256s from the same paths. Separate dir.
+        // before the switch would keep serving blurry 256s from the same paths. Separate dir —
+        // and `@2x` tiles get their own for the same reason.
         if self.tiles_are_512() {
             format!("{}-512", self.slug())
+        } else if retina && self.has_2x() {
+            format!("{}-2x", self.slug())
         } else {
             self.slug().to_string()
         }
@@ -409,7 +434,17 @@ impl BasemapStyle {
 
     /// Raster tile URL for `(z, x, y)`. Built-in Dark/Light are the vector MVT basemap and return
     /// `None` here. Provider styles inject the matching key (never logged/cached in a path).
-    fn url(self, z: u8, x: u32, y: u32, mapbox_key: &str, maptiler_key: &str) -> Option<String> {
+    fn url(
+        self,
+        z: u8,
+        x: u32,
+        y: u32,
+        retina: bool,
+        mapbox_key: &str,
+        maptiler_key: &str,
+    ) -> Option<String> {
+        // `@2x` on the sources that serve it; empty everywhere else, so the URL is unchanged.
+        let hi = if retina && self.has_2x() { "@2x" } else { "" };
         match self.provider_kind() {
             Provider::Builtin => match self {
                 // ArcGIS MapServer tiles (public). All use `{z}/{y}/{x}` order and serve JPEG.
@@ -440,13 +475,13 @@ impl BasemapStyle {
                     Some(format!("https://a.tile.opentopomap.org/{z}/{x}/{y}.png"))
                 }
                 BasemapStyle::CartoPositron => {
-                    Some(format!("https://basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"))
+                    Some(format!("https://basemaps.cartocdn.com/light_all/{z}/{x}/{y}{hi}.png"))
                 }
                 BasemapStyle::CartoDarkMatter => {
-                    Some(format!("https://basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png"))
+                    Some(format!("https://basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{hi}.png"))
                 }
                 BasemapStyle::CartoVoyager => {
-                    Some(format!("https://basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"))
+                    Some(format!("https://basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{hi}.png"))
                 }
                 BasemapStyle::OsmHot => {
                     Some(format!("https://a.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png"))
@@ -651,6 +686,8 @@ pub struct TileManager {
     maptiler_key: String,
     /// Selected GOES frame time (`None` = latest/`default`). Only affects GOES styles.
     goes_time: Option<chrono::DateTime<chrono::Utc>>,
+    /// Ask sources that serve them for `@2x` tiles (high-DPI screen, unmetered link).
+    retina: bool,
 }
 
 impl TileManager {
@@ -680,6 +717,7 @@ impl TileManager {
             mapbox_key: String::new(),
             maptiler_key: String::new(),
             goes_time: None,
+            retina: false,
         }
     }
 
@@ -693,6 +731,24 @@ impl TileManager {
         self.requested.clear();
         self.uploaded.clear();
         true
+    }
+
+    /// Turn `@2x` tiles on or off (high-DPI screen, and not on a metered link). Returns true if it
+    /// changed, so the caller can clear the GPU cache: the old tiles are a different size.
+    pub fn set_retina(&mut self, retina: bool) -> bool {
+        if self.retina == retina {
+            return false;
+        }
+        self.retina = retina;
+        self.requested.clear();
+        self.uploaded.clear();
+        true
+    }
+
+    /// Whether `style` is being fetched at double resolution right now — the caller drops its
+    /// retina zoom bias when this is true, since the extra pixels are already in the tile.
+    pub fn is_retina(&self, style: BasemapStyle) -> bool {
+        self.retina && style.has_2x()
     }
 
     /// Update the provider API keys (from Settings). Clears fetch state if a key changed so the
@@ -738,7 +794,8 @@ impl TileManager {
                 break;
             }
             let (z, x, y) = v.id;
-            let Some(mut url) = style.url(z, x, y, &self.mapbox_key, &self.maptiler_key)
+            let Some(mut url) =
+                style.url(z, x, y, self.retina, &self.mapbox_key, &self.maptiler_key)
             else {
                 continue;
             };
@@ -757,7 +814,7 @@ impl TileManager {
             };
             self.requested.insert((skey, v.id));
             let path = self.cache_root.as_ref().map(|d| {
-                d.join(style.provider())
+                d.join(style.provider(self.retina))
                     .join(&time_tag)
                     .join(format!("{z}/{x}/{y}"))
             });
@@ -807,7 +864,7 @@ impl TileManager {
     pub fn packable(&self, style: BasemapStyle) -> bool {
         style.goes_layer().is_none()
             && style
-                .url(0, 0, 0, &self.mapbox_key, &self.maptiler_key)
+                .url(0, 0, 0, false, &self.mapbox_key, &self.maptiler_key)
                 .is_some()
     }
 
@@ -832,11 +889,12 @@ impl TileManager {
             return Vec::new();
         }
         let z_hi = z_hi.min(style.max_raster_z());
-        let dir = root.join(style.provider()).join("default");
+        // Packs are always 1x: a pack is written once and read on whatever device opens it later.
+        let dir = root.join(style.provider(false)).join("default");
         pack_tile_ids(min_lon, min_lat, max_lon, max_lat, z_lo, z_hi)
             .into_iter()
             .filter_map(|(z, x, y)| {
-                let url = style.url(z, x, y, &self.mapbox_key, &self.maptiler_key)?;
+                let url = style.url(z, x, y, false, &self.mapbox_key, &self.maptiler_key)?;
                 Some((url, dir.join(format!("{z}/{x}/{y}"))))
             })
             .collect()
@@ -962,7 +1020,7 @@ pub async fn fetch_visible(
     let mut out = Vec::new();
     for v in visible {
         let (z, x, y) = v.id;
-        let Some(url) = style.url(z, x, y, mapbox_key, maptiler_key) else {
+        let Some(url) = style.url(z, x, y, false, mapbox_key, maptiler_key) else {
             continue;
         };
         match load_tile_bytes(client, &url, None).await {
@@ -1002,7 +1060,16 @@ pub(crate) async fn load_tile_bytes(
             return Ok(bytes);
         }
     }
-    let resp = client.get(url).send().await?.error_for_status()?;
+    // Browser builds cannot fetch most tile hosts directly — they send no CORS header — so the
+    // request goes to the page's own `/proxy/{host}/...` instead, which also means one visitor's
+    // tile is the next visitor's edge-cache hit. `fetch_url` leaves the keyed providers alone:
+    // api.mapbox.com and api.maptiler.com answer CORS themselves, and proxying them would put a
+    // user's API key in a shared cache. Native builds get the URL back unchanged.
+    let resp = client
+        .get(wxdata::net::fetch_url(url))
+        .send()
+        .await?
+        .error_for_status()?;
     let bytes = resp.bytes().await?.to_vec();
     if let Some(p) = path {
         if let Some(parent) = p.parent() {
@@ -1347,18 +1414,47 @@ mod tests {
         for s in keyless {
             assert!(s.is_raster(), "{s:?} should be raster");
             assert!(
-                s.url(6, 15, 25, "", "").is_some(),
+                s.url(6, 15, 25, false, "", "").is_some(),
                 "{s:?} should have a keyless URL"
             );
         }
         // ArcGIS services use {z}/{y}/{x}: y before x in the path.
-        let esri = BasemapStyle::EsriImagery.url(6, 15, 25, "", "").unwrap();
+        let esri = BasemapStyle::EsriImagery.url(6, 15, 25, false, "", "").unwrap();
         assert!(esri.ends_with("/6/25/15"), "Esri y/x order: {esri}");
         // Standard slippy tiles use {z}/{x}/{y}.
-        let osm = BasemapStyle::OsmStandard.url(6, 15, 25, "", "").unwrap();
+        let osm = BasemapStyle::OsmStandard.url(6, 15, 25, false, "", "").unwrap();
         assert!(osm.ends_with("/6/15/25.png"), "OSM x/y order: {osm}");
         // Mapbox nav styles stay key-gated.
-        assert!(BasemapStyle::MapboxNavDay.url(6, 15, 25, "", "").is_none());
-        assert!(BasemapStyle::MapboxNavDay.url(6, 15, 25, "k", "").is_some());
+        assert!(BasemapStyle::MapboxNavDay.url(6, 15, 25, false, "", "").is_none());
+        assert!(BasemapStyle::MapboxNavDay.url(6, 15, 25, false, "k", "").is_some());
+    }
+
+    /// Retina asks for the `@2x` tile only where the provider serves one, and those tiles get
+    /// their own cache directory so a 1x and a 2x tile never overwrite each other on disk.
+    #[test]
+    fn retina_only_changes_the_sources_that_serve_2x() {
+        let carto = BasemapStyle::CartoDarkMatter;
+        assert!(carto.url(6, 15, 25, true, "", "").unwrap().ends_with("@2x.png"));
+        assert!(carto.url(6, 15, 25, false, "", "").unwrap().ends_with("/25.png"));
+        assert_ne!(carto.provider(true), carto.provider(false));
+        // No `@2x` upstream: the URL and the cache path are identical either way.
+        let osm = BasemapStyle::OsmStandard;
+        assert_eq!(osm.url(6, 15, 25, true, "", ""), osm.url(6, 15, 25, false, "", ""));
+        assert_eq!(osm.provider(true), osm.provider(false));
+    }
+
+    /// The USGS satellite basemap serves nothing past zoom 16; asking for 17 got a 404 and left a
+    /// hole in the map, which is what "blurry, then blank, when you zoom in" turned out to be.
+    #[test]
+    fn max_zoom_matches_what_the_providers_actually_serve() {
+        assert_eq!(BasemapStyle::Satellite.max_raster_z(), 16);
+        assert_eq!(BasemapStyle::OpenTopoMap.max_raster_z(), 17);
+        assert_eq!(BasemapStyle::OsmStandard.max_raster_z(), 19);
+        assert_eq!(BasemapStyle::CartoDarkMatter.max_raster_z(), 20);
+        // GOES layers keep their own matrix level, whatever the table above says.
+        assert_eq!(
+            BasemapStyle::GoesEast.max_raster_z(),
+            BasemapStyle::GoesEast.goes_layer().unwrap().1
+        );
     }
 }

--- a/crates/hookecho/src/tiles.rs
+++ b/crates/hookecho/src/tiles.rs
@@ -82,6 +82,14 @@ pub enum BasemapStyle {
     UsgsImageryTopo,
     OsmHot,
     CyclOsm,
+    /// Vector basemap, OSM Liberty look.
+    VectorLiberty,
+    /// Vector basemap, pale low-ink look.
+    VectorBright,
+    /// Vector basemap, near-monochrome look.
+    VectorPositron,
+    /// Vector basemap, night-drive look.
+    VectorMidnight,
     EsriDarkGray,
     EsriLightGray,
     EsriNatGeo,
@@ -99,7 +107,7 @@ pub enum BasemapStyle {
 
 impl BasemapStyle {
     /// Cycle order for the `z` hotkey; provider styles trail the built-ins.
-    pub const ALL: [BasemapStyle; 47] = [
+    pub const ALL: [BasemapStyle; 51] = [
         BasemapStyle::Dark,
         BasemapStyle::Light,
         BasemapStyle::Satellite,
@@ -116,6 +124,10 @@ impl BasemapStyle {
         BasemapStyle::UsgsImageryTopo,
         BasemapStyle::OsmHot,
         BasemapStyle::CyclOsm,
+        BasemapStyle::VectorLiberty,
+        BasemapStyle::VectorBright,
+        BasemapStyle::VectorPositron,
+        BasemapStyle::VectorMidnight,
         BasemapStyle::HybridSatellite,
         BasemapStyle::EsriDarkGray,
         BasemapStyle::EsriLightGray,
@@ -219,6 +231,10 @@ impl BasemapStyle {
             BasemapStyle::UsgsImageryTopo => "USGS Imagery Topo",
             BasemapStyle::OsmHot => "OSM Humanitarian",
             BasemapStyle::CyclOsm => "CyclOSM",
+            BasemapStyle::VectorLiberty => "Liberty",
+            BasemapStyle::VectorBright => "Bright",
+            BasemapStyle::VectorPositron => "Positron",
+            BasemapStyle::VectorMidnight => "Midnight",
             BasemapStyle::EsriDarkGray => "Esri Dark Gray Canvas",
             BasemapStyle::EsriLightGray => "Esri Light Gray Canvas",
             BasemapStyle::EsriNatGeo => "Esri National Geographic",
@@ -272,6 +288,10 @@ impl BasemapStyle {
             BasemapStyle::UsgsImageryTopo => "usgs-imagery-topo",
             BasemapStyle::OsmHot => "osm-hot",
             BasemapStyle::CyclOsm => "cyclosm",
+            BasemapStyle::VectorLiberty => "liberty",
+            BasemapStyle::VectorBright => "bright",
+            BasemapStyle::VectorPositron => "positron",
+            BasemapStyle::VectorMidnight => "midnight",
             BasemapStyle::EsriDarkGray => "esri-dark-gray",
             BasemapStyle::EsriLightGray => "esri-light-gray",
             BasemapStyle::EsriNatGeo => "esri-natgeo",
@@ -373,7 +393,14 @@ impl BasemapStyle {
     pub fn is_raster(self) -> bool {
         !matches!(
             self,
-            BasemapStyle::Dark | BasemapStyle::Light | BasemapStyle::None | BasemapStyle::Auto
+            BasemapStyle::Dark
+                | BasemapStyle::Light
+                | BasemapStyle::None
+                | BasemapStyle::Auto
+                | BasemapStyle::VectorLiberty
+                | BasemapStyle::VectorBright
+                | BasemapStyle::VectorPositron
+                | BasemapStyle::VectorMidnight
         )
     }
 
@@ -478,6 +505,10 @@ impl BasemapStyle {
         match self {
             BasemapStyle::Dark => Some(crate::basemap_style::Palette::Dark),
             BasemapStyle::Light => Some(crate::basemap_style::Palette::Light),
+            BasemapStyle::VectorLiberty => Some(crate::basemap_style::Palette::Liberty),
+            BasemapStyle::VectorBright => Some(crate::basemap_style::Palette::Bright),
+            BasemapStyle::VectorPositron => Some(crate::basemap_style::Palette::Positron),
+            BasemapStyle::VectorMidnight => Some(crate::basemap_style::Palette::Midnight),
             BasemapStyle::HybridSatellite => Some(crate::basemap_style::Palette::HybridOverlay),
             _ => None,
         }
@@ -1635,7 +1666,6 @@ mod tests {
             BasemapStyle::GoesEast.goes_layer().unwrap().1
         );
     }
-}
 
     /// `Auto` is a marker, not something the tile layer should ever be asked to fetch.
     #[test]
@@ -1695,3 +1725,17 @@ mod tests {
         // And it is only selectable once a template exists.
         assert!(!BasemapStyle::CustomXyz.available(true, true, false));
     }
+
+    /// Every vector look has to be selectable, or it is dead code that still costs a review.
+    #[test]
+    fn every_palette_has_a_basemap_entry() {
+        for pal in crate::basemap_style::Palette::ALL {
+            assert!(
+                BasemapStyle::ALL
+                    .iter()
+                    .any(|s| s.vector_palette() == Some(pal)),
+                "{pal:?} is not reachable from the basemap list"
+            );
+        }
+    }
+}

--- a/crates/hookecho/src/tiles.rs
+++ b/crates/hookecho/src/tiles.rs
@@ -631,6 +631,10 @@ impl BasemapStyle {
 
     /// Raster tile URL for `(z, x, y)`. Built-in Dark/Light are the vector MVT basemap and return
     /// `None` here. Provider styles inject the matching key (never logged/cached in a path).
+    // Eight arguments because a URL needs all eight: the tile, whether to ask for @2x, and the
+    // three user-supplied strings a style might interpolate. A struct here would be one field per
+    // argument and one more thing to keep in sync.
+    #[allow(clippy::too_many_arguments)]
     fn url(
         self,
         z: u8,

--- a/crates/hookecho/src/ui/basemap_picker.rs
+++ b/crates/hookecho/src/ui/basemap_picker.rs
@@ -1,0 +1,186 @@
+//! The basemap chooser: a thumbnail grid, grouped by category.
+//!
+//! Replaces a fifty-one-entry combo box on desktop and an eight-chip row plus a disclosure on the
+//! phone. The complaint that started this was "basemaps very lacking" — there were forty of them,
+//! but a flat alphabetical-ish list of names is not a way to choose a *look*.
+//!
+//! Raster styles show one real tile (z6 over the middle of CONUS, fetched through the normal
+//! per-style disk cache). Vector styles show a painted swatch of their own palette rather than a
+//! rasterised MVT tile: the swatch is honest about the colors, which is what the choice is
+//! actually between, and it needs no fetch at all.
+//!
+//! ponytail: painted swatches, not rendered MVT; one fixed thumbnail tile per style.
+
+use crate::settings::Settings;
+use crate::tiles::{BasemapStyle, Category, TileManager};
+
+/// Card size. Wide enough for a 256-px tile to read at a glance without the grid needing a
+/// scrollbar on a phone.
+const CARD_W: f32 = 104.0;
+const CARD_H: f32 = 72.0;
+
+/// Paint the swatch a vector style gets instead of a fetched tile: its background with a band of
+/// its own road and water colors, so the cards differ the way the maps do.
+fn swatch(painter: &egui::Painter, rect: egui::Rect, style: BasemapStyle) {
+    let Some(pal) = style.vector_palette() else {
+        painter.rect_filled(rect, 4.0, egui::Color32::from_gray(40));
+        return;
+    };
+    let c = |v: [u8; 4]| egui::Color32::from_rgb(v[0], v[1], v[2]);
+    let vs = crate::basemap_style::style(pal);
+    let bg = vs.background.map(c).unwrap_or(egui::Color32::from_gray(60));
+    painter.rect_filled(rect, 4.0, bg);
+    // A road, a casing under it, and a river: the three things the palettes differ most in.
+    if let Some((road, w)) = crate::basemap_style::stroke(pal, "transportation", "motorway") {
+        if let Some((case, cw)) = crate::basemap_style::casing(pal, "transportation", "motorway") {
+            painter.line_segment(
+                [
+                    egui::pos2(rect.left() + 6.0, rect.bottom() - 22.0),
+                    egui::pos2(rect.right() - 6.0, rect.top() + 20.0),
+                ],
+                egui::Stroke::new(cw * 2.2, c(case)),
+            );
+        }
+        painter.line_segment(
+            [
+                egui::pos2(rect.left() + 6.0, rect.bottom() - 22.0),
+                egui::pos2(rect.right() - 6.0, rect.top() + 20.0),
+            ],
+            egui::Stroke::new(w * 2.2, c(road)),
+        );
+    }
+    if let Some(water) = crate::basemap_style::fill(pal, "water", "") {
+        painter.rect_filled(
+            egui::Rect::from_min_size(
+                egui::pos2(rect.left(), rect.bottom() - 14.0),
+                egui::vec2(rect.width(), 14.0),
+            ),
+            0.0,
+            c(water),
+        );
+    }
+}
+
+/// The `Auto` card: half the Dark swatch, half the Light one, because that is what it does.
+fn auto_swatch(painter: &egui::Painter, rect: egui::Rect) {
+    let (l, r) = rect.split_left_right_at_fraction(0.5);
+    swatch(painter, l, BasemapStyle::Dark);
+    swatch(painter, r, BasemapStyle::Light);
+}
+
+/// One card. Returns its click response.
+fn card(
+    ui: &mut egui::Ui,
+    tiles: &mut TileManager,
+    style: BasemapStyle,
+    selected: bool,
+    enabled: bool,
+) -> egui::Response {
+    let (rect, response) = ui.allocate_exact_size(
+        egui::vec2(CARD_W, CARD_H + 16.0),
+        if enabled {
+            egui::Sense::click()
+        } else {
+            egui::Sense::hover()
+        },
+    );
+    if !ui.is_rect_visible(rect) {
+        return response;
+    }
+    let img_rect = egui::Rect::from_min_size(rect.min, egui::vec2(CARD_W, CARD_H));
+    let painter = ui.painter_at(rect);
+    // Only ask for a thumbnail once the card is on screen, so opening the picker does not fire
+    // fifty fetches for cards nobody scrolled to.
+    let thumb = if style.is_raster() {
+        tiles.thumb(style, ui.ctx())
+    } else {
+        None
+    };
+    match thumb {
+        Some(tex) => {
+            egui::Image::new(&tex)
+                .corner_radius(4.0)
+                .paint_at(ui, img_rect);
+        }
+        None if style == BasemapStyle::Auto => auto_swatch(&painter, img_rect),
+        None => swatch(&painter, img_rect, style),
+    }
+    if !enabled {
+        painter.rect_filled(
+            img_rect,
+            4.0,
+            egui::Color32::from_black_alpha(150),
+        );
+        painter.text(
+            img_rect.center(),
+            egui::Align2::CENTER_CENTER,
+            "🔒",
+            egui::FontId::proportional(18.0),
+            egui::Color32::from_gray(210),
+        );
+    }
+    let border = if selected {
+        egui::Stroke::new(2.0, ui.visuals().selection.bg_fill)
+    } else if response.hovered() {
+        egui::Stroke::new(1.0, ui.visuals().widgets.hovered.bg_stroke.color)
+    } else {
+        egui::Stroke::new(1.0, ui.visuals().widgets.inactive.bg_stroke.color)
+    };
+    painter.rect_stroke(img_rect, 4.0, border, egui::StrokeKind::Inside);
+    painter.text(
+        egui::pos2(rect.center().x, img_rect.bottom() + 2.0),
+        egui::Align2::CENTER_TOP,
+        style.short_label(),
+        egui::FontId::proportional(11.0),
+        ui.visuals().text_color(),
+    );
+    response
+}
+
+/// The whole grid. Returns the style the user picked, if any.
+///
+/// Takes `Settings` rather than three loose flags because availability depends on two API keys
+/// and the custom template, and passing those separately is how they get out of step.
+pub fn grid(
+    ui: &mut egui::Ui,
+    tiles: &mut TileManager,
+    current: BasemapStyle,
+    settings: &Settings,
+) -> Option<BasemapStyle> {
+    let mb = !settings.mapbox_key.is_empty();
+    let mt = !settings.maptiler_key.is_empty();
+    let cx = crate::tiles::valid_xyz_template(&settings.custom_tile_url);
+    let mut picked = None;
+    for cat in Category::ALL {
+        let styles: Vec<BasemapStyle> = BasemapStyle::ALL
+            .into_iter()
+            .filter(|s| s.category() == cat)
+            // A style whose key is missing is still shown, locked — that is how anyone finds out
+            // the key would unlock it. A custom slot with no template is not, because there is
+            // nothing to say about it that the settings row does not already say.
+            .filter(|s| *s != BasemapStyle::CustomXyz || cx)
+            .collect();
+        if styles.is_empty() {
+            continue;
+        }
+        ui.label(egui::RichText::new(cat.label()).strong());
+        ui.horizontal_wrapped(|ui| {
+            for s in styles {
+                let enabled = s.available(mb, mt, cx);
+                let r = card(ui, tiles, s, s == current, enabled);
+                if r.clicked() {
+                    picked = Some(s);
+                }
+                if !enabled {
+                    r.on_hover_text(match s.provider_kind() {
+                        crate::tiles::Provider::Mapbox => "Needs a Mapbox access token (Settings)",
+                        crate::tiles::Provider::MapTiler => "Needs a MapTiler API key (Settings)",
+                        crate::tiles::Provider::Builtin => "Not available in this build",
+                    });
+                }
+            }
+        });
+        ui.add_space(6.0);
+    }
+    picked
+}

--- a/crates/hookecho/src/ui/mod.rs
+++ b/crates/hookecho/src/ui/mod.rs
@@ -73,6 +73,7 @@ pub(crate) fn csv_buttons(
 pub mod about_window;
 pub mod afd_window;
 pub mod alert_panel;
+pub mod basemap_picker;
 pub mod cappi_window;
 pub mod cell_window;
 pub mod cells_window;

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -512,6 +512,50 @@ fn units_tab(ui: &mut egui::Ui, settings: &mut Settings) {
     ui.weak("Reflectivity stays dBZ; internal data is unchanged (display-only).");
 }
 
+/// The "Custom (XYZ URL)" basemap's template, zoom cap and attribution.
+///
+/// Hidden on web: the tile proxy is an exact-host allowlist, so an arbitrary host cannot be
+/// fetched there at all (see `BasemapStyle::available`).
+fn custom_tile_source(ui: &mut egui::Ui, settings: &mut Settings) {
+    if cfg!(target_arch = "wasm32") {
+        return;
+    }
+    ui.separator();
+    ui.label("Custom tile source");
+    ui.weak("An XYZ template adds a \"Custom\" entry to the basemap list. Desktop and Android only.");
+    ui.add_space(6.0);
+    ui.horizontal(|ui| {
+        ui.label("URL template");
+        ui.add(
+            egui::TextEdit::singleline(&mut settings.custom_tile_url)
+                .hint_text("https://tiles.example.com/{z}/{x}/{y}.png")
+                .desired_width(340.0),
+        );
+    });
+    if !settings.custom_tile_url.is_empty()
+        && !crate::tiles::valid_xyz_template(&settings.custom_tile_url)
+    {
+        // Says why rather than silently dropping the entry from the list.
+        ui.colored_label(
+            egui::Color32::from_rgb(220, 120, 100),
+            "Needs to be an https URL containing {z}, {x} and {y}.",
+        );
+    }
+    ui.horizontal(|ui| {
+        ui.label("Max zoom");
+        ui.add(egui::DragValue::new(&mut settings.custom_tile_max_z).range(1..=22))
+            .on_hover_text("Deeper views stretch the deepest tile that loaded rather than blanking");
+    });
+    ui.horizontal(|ui| {
+        ui.label("Attribution");
+        ui.add(
+            egui::TextEdit::singleline(&mut settings.custom_tile_attribution)
+                .hint_text("© Your data source")
+                .desired_width(340.0),
+        );
+    });
+}
+
 fn basemaps_tab(ui: &mut egui::Ui, settings: &mut Settings) {
     ui.label("Provider API keys unlock additional raster basemap styles.");
     ui.add_space(6.0);
@@ -520,6 +564,8 @@ fn basemaps_tab(ui: &mut egui::Ui, settings: &mut Settings) {
     key_field(ui, "MapTiler API key", &mut settings.maptiler_key);
     ui.add_space(6.0);
     ui.weak("Keys are stored locally in settings.json and sent only to the provider's tile API.");
+    ui.add_space(12.0);
+    custom_tile_source(ui, settings);
     ui.add_space(12.0);
     ui.separator();
     ui.label("Live station cards");

--- a/crates/hookecho/src/ui/wizard.rs
+++ b/crates/hookecho/src/ui/wizard.rs
@@ -49,6 +49,7 @@ pub fn show(
     settings: &mut Settings,
     basemap: &mut BasemapStyle,
     icon_tex: &IconTextures,
+    tiles: &mut crate::tiles::TileManager,
 ) -> Option<Finish> {
     if !wiz.open {
         return None;
@@ -65,7 +66,7 @@ pub fn show(
             ui.set_width(420.0_f32.min(ctx.content_rect().width() - 40.0));
             match wiz.step {
                 0 => card_site(ui, wiz, settings),
-                1 => card_map(ui, settings, basemap),
+                1 => card_map(ui, settings, basemap, tiles),
                 2 => card_alerts(ui, settings, icon_tex),
                 _ => {
                     if let Some(take_tour) = card_done(ui, settings, *basemap) {
@@ -127,7 +128,12 @@ fn card_site(ui: &mut egui::Ui, wiz: &mut Wizard, settings: &mut Settings) {
         });
 }
 
-fn card_map(ui: &mut egui::Ui, settings: &mut Settings, basemap: &mut BasemapStyle) {
+fn card_map(
+    ui: &mut egui::Ui,
+    settings: &mut Settings,
+    basemap: &mut BasemapStyle,
+    tiles: &mut crate::tiles::TileManager,
+) {
     heading(ui, 1);
     ui.small(
         "Plenty of basemaps work with no key at all. Free keys from mapbox.com and maptiler.com \
@@ -140,24 +146,13 @@ fn card_map(ui: &mut egui::Ui, settings: &mut Settings, basemap: &mut BasemapSty
     ui.add_space(4.0);
     super::settings_window::key_field(ui, "MapTiler key", &mut settings.maptiler_key);
     ui.add_space(6.0);
-    // Basemap picker, filtered by whichever keys are set this frame (typing a key unlocks styles).
-    let mb = !settings.mapbox_key.is_empty();
-    let mt = !settings.maptiler_key.is_empty();
-    let cx = crate::tiles::valid_xyz_template(&settings.custom_tile_url);
-    ui.horizontal(|ui| {
-        ui.label("Basemap");
-        egui::ComboBox::from_id_salt("wiz_basemap")
-            .selected_text(basemap.label())
-            .show_ui(ui, |ui| {
-                for s in BasemapStyle::ALL {
-                    if s.available(mb, mt, cx)
-                        && ui.selectable_label(*basemap == s, s.label()).clicked()
-                    {
-                        *basemap = s;
-                        settings.basemap = s.slug().to_string();
-                    }
-                }
-            });
+    // Same grid the drawer and the phone sheet use: the first thing a new user picks should look
+    // like the thing they will use to change it later. It re-filters as keys are typed above.
+    egui::ScrollArea::vertical().max_height(300.0).show(ui, |ui| {
+        if let Some(s) = crate::ui::basemap_picker::grid(ui, tiles, *basemap, settings) {
+            *basemap = s;
+            settings.basemap = s.slug().to_string();
+        }
     });
     ui.add_space(8.0);
     ui.label("Theme");

--- a/crates/hookecho/src/ui/wizard.rs
+++ b/crates/hookecho/src/ui/wizard.rs
@@ -143,13 +143,14 @@ fn card_map(ui: &mut egui::Ui, settings: &mut Settings, basemap: &mut BasemapSty
     // Basemap picker, filtered by whichever keys are set this frame (typing a key unlocks styles).
     let mb = !settings.mapbox_key.is_empty();
     let mt = !settings.maptiler_key.is_empty();
+    let cx = crate::tiles::valid_xyz_template(&settings.custom_tile_url);
     ui.horizontal(|ui| {
         ui.label("Basemap");
         egui::ComboBox::from_id_salt("wiz_basemap")
             .selected_text(basemap.label())
             .show_ui(ui, |ui| {
                 for s in BasemapStyle::ALL {
-                    if s.available(mb, mt)
+                    if s.available(mb, mt, cx)
                         && ui.selectable_label(*basemap == s, s.label()).clicked()
                     {
                         *basemap = s;

--- a/crates/hookecho/src/vector_tiles.rs
+++ b/crates/hookecho/src/vector_tiles.rs
@@ -141,7 +141,7 @@ fn maybe_gunzip(bytes: &[u8]) -> Vec<u8> {
 pub fn build_tile(
     bytes: &[u8],
     id: TileId,
-    dark: bool,
+    palette: basemap_style::Palette,
     tess_zoom: f64,
 ) -> (Vec<OverlayVertex>, Vec<u32>, Vec<PlaceLabel>) {
     let (z, tx, ty) = id;
@@ -151,30 +151,33 @@ pub fn build_tile(
     let mut verts: Vec<OverlayVertex> = Vec::new();
     let mut indices: Vec<u32> = Vec::new();
 
-    // Background land quad covering the whole tile.
-    let bg = color(basemap_style::style(dark).background);
-    let (x0, y0) = (txf / n, tyf / n);
-    let (x1, y1) = ((txf + 1.0) / n, (tyf + 1.0) / n);
-    let base = verts.len() as u32;
-    verts.extend_from_slice(&[
-        OverlayVertex {
-            world: [x0 as f32, y0 as f32],
-            color: bg,
-        },
-        OverlayVertex {
-            world: [x1 as f32, y0 as f32],
-            color: bg,
-        },
-        OverlayVertex {
-            world: [x1 as f32, y1 as f32],
-            color: bg,
-        },
-        OverlayVertex {
-            world: [x0 as f32, y1 as f32],
-            color: bg,
-        },
-    ]);
-    indices.extend_from_slice(&[base, base + 1, base + 2, base, base + 2, base + 3]);
+    // Background land quad covering the whole tile — skipped entirely by the overlay palette,
+    // which draws on top of raster imagery and must not hide it.
+    if let Some(bg) = basemap_style::style(palette).background {
+        let bg = color(bg);
+        let (x0, y0) = (txf / n, tyf / n);
+        let (x1, y1) = ((txf + 1.0) / n, (tyf + 1.0) / n);
+        let base = verts.len() as u32;
+        verts.extend_from_slice(&[
+            OverlayVertex {
+                world: [x0 as f32, y0 as f32],
+                color: bg,
+            },
+            OverlayVertex {
+                world: [x1 as f32, y0 as f32],
+                color: bg,
+            },
+            OverlayVertex {
+                world: [x1 as f32, y1 as f32],
+                color: bg,
+            },
+            OverlayVertex {
+                world: [x0 as f32, y1 as f32],
+                color: bg,
+            },
+        ]);
+        indices.extend_from_slice(&[base, base + 1, base + 2, base, base + 2, base + 3]);
+    }
 
     let data = maybe_gunzip(bytes);
     let Ok(reader) = Reader::new(data) else {
@@ -197,7 +200,7 @@ pub fn build_tile(
         let feats = reader.get_features(i).unwrap_or_default();
         for f in &feats {
             let cls = prop(&f.properties, key);
-            let Some(c) = basemap_style::fill(dark, layer, &cls) else {
+            let Some(c) = basemap_style::fill(palette, layer, &cls) else {
                 continue;
             };
             let mut b = Path::builder();
@@ -256,7 +259,7 @@ pub fn build_tile(
             if *layer == "boundary" && cls == "6" && z < 7 {
                 continue;
             }
-            let Some((c, wpx)) = basemap_style::stroke(dark, layer, &cls) else {
+            let Some((c, wpx)) = basemap_style::stroke(palette, layer, &cls) else {
                 continue;
             };
             let w = (wpx as f64 * px_to_world) as f32;
@@ -359,7 +362,7 @@ fn extract_labels(
     out
 }
 
-fn fill_template(template: &str, z: u8, x: u32, y: u32) -> String {
+pub(crate) fn fill_template(template: &str, z: u8, x: u32, y: u32) -> String {
     template
         .replace("{z}", &z.to_string())
         .replace("{x}", &x.to_string())
@@ -413,7 +416,7 @@ pub async fn fetch_tilejson(
 pub async fn fetch_visible_vector(
     client: &reqwest::Client,
     template: &str,
-    dark: bool,
+    palette: basemap_style::Palette,
     tess_zoom: f64,
     visible: &[VisibleTile],
 ) -> (Vec<PendingVectorTile>, Vec<PlaceLabel>) {
@@ -424,7 +427,7 @@ pub async fn fetch_visible_vector(
         let url = fill_template(template, z, x, y);
         match load_tile_bytes(client, &url, None).await {
             Ok(bytes) => {
-                let (verts, indices, lbls) = build_tile(&bytes, v.id, dark, tess_zoom);
+                let (verts, indices, lbls) = build_tile(&bytes, v.id, palette, tess_zoom);
                 labels.extend(lbls);
                 out.push(PendingVectorTile {
                     id: v.id,
@@ -462,7 +465,7 @@ pub struct VectorTileManager {
     labels: HashMap<TileId, Vec<PlaceLabel>>,
     /// Bumped on every change to `labels` (see [`Self::label_generation`]).
     label_gen: u64,
-    dark: bool,
+    palette: basemap_style::Palette,
     tess_zoom: i32,
     /// Candidate new tessellation zoom and when it was first seen — see [`Self::note_zoom`].
     zoom_settled: Option<(i32, wxdata::clock::Instant)>,
@@ -497,7 +500,7 @@ impl VectorTileManager {
             vevicted: Vec::new(),
             labels: HashMap::new(),
             label_gen: 0,
-            dark: true,
+            palette: basemap_style::Palette::Dark,
             tess_zoom: 7,
             zoom_settled: None,
             cache_root,
@@ -513,12 +516,16 @@ impl VectorTileManager {
         self.ctx = Some(ctx);
     }
 
-    /// Switch dark/light. Returns true if changed (caller should clear the GPU vector cache).
-    pub fn set_style(&mut self, dark: bool) -> bool {
-        if self.dark == dark {
+    /// Switch palette. Returns true if changed (caller should clear the GPU vector cache).
+    ///
+    /// Colors are baked in at tessellation, so a palette change has to re-tessellate everything —
+    /// the same cost the dark/light switch always paid. ponytail: draw-time color indirection if
+    /// palette switching ever stops being a rare user action.
+    pub fn set_style(&mut self, palette: basemap_style::Palette) -> bool {
+        if self.palette == palette {
             return false;
         }
-        self.dark = dark;
+        self.palette = palette;
         self.requested.clear();
         self.uploaded.clear();
         self.labels.clear();
@@ -595,7 +602,7 @@ impl VectorTileManager {
         let Some(template) = self.template.clone() else {
             return;
         };
-        let dark = self.dark;
+        let palette = self.palette;
         let tess_zoom = self.tess_zoom as f64;
         for v in visible {
             if !self.requested.insert(v.id) {
@@ -617,7 +624,7 @@ impl VectorTileManager {
                     // gunzip + lyon tessellation is the heaviest CPU in the app after the volume
                     // decode; running it on the async worker starves every other fetch.
                     blocking.spawn_blocking(move || {
-                        let (vertices, indices, labels) = build_tile(&bytes, id, dark, tess_zoom);
+                        let (vertices, indices, labels) = build_tile(&bytes, id, palette, tess_zoom);
                         let _ = tx.send(FetchedVector {
                             id,
                             vertices,
@@ -739,10 +746,21 @@ mod tests {
     #[test]
     fn empty_bytes_yield_background_quad_only() {
         // Not a valid tile: build_tile still emits the background land quad (2 triangles).
-        let (verts, indices, labels) = build_tile(b"", (7, 30, 49), true, 7.0);
+        let (verts, indices, labels) =
+            build_tile(b"", (7, 30, 49), basemap_style::Palette::Dark, 7.0);
         assert_eq!(verts.len(), 4);
         assert_eq!(indices.len(), 6);
         assert!(labels.is_empty());
+    }
+
+    /// The hybrid overlay draws no background, so it must emit nothing at all for a tile with no
+    /// features — otherwise every hybrid tile would be a solid quad over the satellite imagery.
+    #[test]
+    fn overlay_palette_emits_no_background_quad() {
+        let (verts, indices, _) =
+            build_tile(b"", (7, 30, 49), basemap_style::Palette::HybridOverlay, 7.0);
+        assert!(verts.is_empty());
+        assert!(indices.is_empty());
     }
 
     #[test]

--- a/crates/hookecho/src/vector_tiles.rs
+++ b/crates/hookecho/src/vector_tiles.rs
@@ -36,13 +36,28 @@ const FILL_LAYERS: &[(&str, &str)] = &[
     ("landuse", "class"),
     ("park", "class"),
     ("water", "class"),
+    // Buildings only exist in the tiles from z13 (checked against the OpenFreeMap tilejson), so
+    // this costs nothing at the zooms most of the app is used at.
+    ("building", "class"),
 ];
-// Stroke layers, drawn last (over the fills).
-const STROKE_LAYERS: &[(&str, &str)] = &[
-    ("waterway", ""),
-    ("transportation", "class"),
-    ("boundary", "admin_level"),
+/// Stroke layers, drawn last (over the fills), in draw order.
+///
+/// `transportation` appears twice on purpose: the first pass lays the casings for every road, the
+/// second lays the roads on top. Casing-then-road per feature would let the next road's casing
+/// paint over the previous road.
+const STROKE_LAYERS: &[(&str, &str, StrokePass)] = &[
+    ("waterway", "", StrokePass::Road),
+    ("aeroway", "class", StrokePass::Road),
+    ("transportation", "class", StrokePass::Casing),
+    ("transportation", "class", StrokePass::Road),
+    ("boundary", "admin_level", StrokePass::Road),
 ];
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum StrokePass {
+    Casing,
+    Road,
+}
 
 /// A city/town label to draw with the egui painter (never appears in GPU/headless PNGs).
 #[derive(Clone, Debug)]
@@ -53,6 +68,9 @@ pub struct PlaceLabel {
     pub rank: i64,
     /// True for `city` class (always shown); towns only appear when zoomed in.
     pub city: bool,
+    /// Camera zoom below which this label is not worth the screen space. Cities are 0 (always),
+    /// towns 9, points of interest 13 — a POI at CONUS zoom is noise.
+    pub min_zoom: f32,
 }
 
 fn srgb_to_linear(c: u8) -> f32 {
@@ -244,7 +262,7 @@ pub fn build_tile(
     }
 
     // Strokes.
-    for (layer, key) in STROKE_LAYERS {
+    for (layer, key, pass) in STROKE_LAYERS {
         let Some(i) = names.iter().position(|nm| nm == layer) else {
             continue;
         };
@@ -259,7 +277,11 @@ pub fn build_tile(
             if *layer == "boundary" && cls == "6" && z < 7 {
                 continue;
             }
-            let Some((c, wpx)) = basemap_style::stroke(palette, layer, &cls) else {
+            let styled = match pass {
+                StrokePass::Casing => basemap_style::casing(palette, layer, &cls),
+                StrokePass::Road => basemap_style::stroke(palette, layer, &cls),
+            };
+            let Some((c, wpx)) = styled else {
                 continue;
             };
             let w = (wpx as f64 * px_to_world) as f32;
@@ -356,7 +378,87 @@ fn extract_labels(
                 name,
                 rank,
                 city,
+                min_zoom: if city { 0.0 } else { 9.0 },
             });
+        }
+    }
+    out.extend(extract_pois(reader, names, n, txf, tyf));
+    out
+}
+
+/// The handful of POI classes worth a label on a weather map: somewhere to be, or somewhere to
+/// take shelter. The full `poi` layer is hundreds of classes and would bury the map.
+///
+/// ponytail: fixed class list. If it ever needs to be user-configurable, it becomes a setting,
+/// not a bigger list.
+const POI_CLASSES: &[&str] = &[
+    "hospital",
+    "college",
+    "town_hall",
+    "police",
+    "fire_station",
+    "stadium",
+    "airport",
+    "aerodrome",
+    "railway",
+];
+
+/// Most labels any one tile may contribute. The first pass of this shipped with `school` and
+/// `park` in the class list and no cap, and downtown Oklahoma City came out as a solid mat of
+/// text with the map invisible underneath. Both the list and this number exist because of that.
+const MAX_POIS_PER_TILE: usize = 12;
+
+/// Pull the interesting subset of the `poi` layer. Present in the tiles from z11.
+fn extract_pois(
+    reader: &Reader,
+    names: &[String],
+    n: f64,
+    txf: f64,
+    tyf: f64,
+) -> Vec<PlaceLabel> {
+    let Some(i) = names.iter().position(|nm| nm == "poi") else {
+        return Vec::new();
+    };
+    let extent = reader
+        .get_layer_metadata()
+        .ok()
+        .and_then(|m| m.get(i).map(|l| l.extent as f64))
+        .unwrap_or(4096.0);
+    let mut out = Vec::new();
+    for f in reader.get_features(i).unwrap_or_default() {
+        let cls = prop(&f.properties, "class");
+        if !POI_CLASSES.contains(&cls.as_str()) {
+            continue;
+        }
+        let name = {
+            let en = prop(&f.properties, "name:en");
+            if en.is_empty() {
+                prop(&f.properties, "name")
+            } else {
+                en
+            }
+        };
+        if name.is_empty() {
+            continue;
+        }
+        let pt = match &f.geometry {
+            geo_types::Geometry::Point(p) => Some((p.x(), p.y())),
+            geo_types::Geometry::MultiPoint(mp) => mp.0.first().map(|p| (p.x(), p.y())),
+            _ => None,
+        };
+        if let Some((px, py)) = pt {
+            let p = tw(px, py, n, txf, tyf, extent);
+            out.push(PlaceLabel {
+                world: [p.x, p.y],
+                name,
+                // Below every town: the collision pass drops these first when space runs out.
+                rank: 500,
+                city: false,
+                min_zoom: 14.0,
+            });
+        }
+        if out.len() >= MAX_POIS_PER_TILE {
+            break;
         }
     }
     out
@@ -555,17 +657,19 @@ impl VectorTileManager {
             return false;
         }
         self.zoom_settled = None;
-        let overzoom = self.tess_zoom > MAX_VECTOR_Z as i32 || tz > MAX_VECTOR_Z as i32;
         self.tess_zoom = tz;
-        if overzoom {
-            self.requested.clear();
-            self.uploaded.clear();
-            self.labels.clear();
-            self.label_gen += 1;
-            true
-        } else {
-            false
-        }
+        // Every resident tile was tessellated for the *old* zoom, and stroke widths are baked in
+        // at tessellation. This used to re-tessellate only when overzooming past the deepest tile
+        // level, on the theory that below that the tile ids change anyway and the new tiles pick
+        // up the new width. They do — but the tiles already on screen do not, and a jump straight
+        // to z12 from the z7 the manager starts at left roads roughly thirty times too wide until
+        // something else happened to clear them. The 700 ms settle above is what makes doing this
+        // unconditionally affordable.
+        self.requested.clear();
+        self.uploaded.clear();
+        self.labels.clear();
+        self.label_gen += 1;
+        true
     }
 
     pub fn visible(&self, cam: &Camera, viewport_px: (f32, f32)) -> Vec<VisibleTile> {

--- a/crates/wxdata/src/net.rs
+++ b/crates/wxdata/src/net.rs
@@ -12,6 +12,23 @@
 /// does not parse as `https://host/...`, and any page with no reachable `window`, is left alone
 /// and fails the same way it would today.
 ///
+/// Hosts that answer a cross-origin browser fetch on their own, so the browser build asks them
+/// directly instead of going through `/proxy/`.
+///
+/// The two keyed tile providers are here for a second reason as well: their tile URLs carry the
+/// user's API key in the query string, and the proxy is a *shared* edge cache. Routing them
+/// through it would store one user's key against a cacheable URL. They must stay direct.
+// The live-chunk bucket is here rather than proxied on purpose: those objects are seconds old and
+// fetched one at a time as the radar writes them, so an extra hop buys nothing and costs latency.
+// The *archive* bucket is not in this list — it goes through the proxy, so one visitor's volume
+// download is the next visitor's cache hit.
+pub const CORS_OK: &[&str] = &[
+    "api.open-meteo.com",
+    "api.mapbox.com",
+    "api.maptiler.com",
+    "unidata-nexrad-level2-chunks.s3.amazonaws.com",
+];
+
 // ponytail: string surgery over a URL crate, and a short known-good list rather than a preflight
 // probe; the ceiling is "the app's own feeds", and any host it cannot parse just goes unproxied.
 pub fn fetch_url(url: &str) -> String {
@@ -21,17 +38,6 @@ pub fn fetch_url(url: &str) -> String {
     }
     #[cfg(target_arch = "wasm32")]
     {
-        /// Hosts that answer a cross-origin browser fetch on their own.
-        // The live-chunk bucket is here rather than proxied on purpose: those objects are seconds
-        // old and fetched one at a time as the radar writes them, so an extra hop buys nothing and
-        // costs latency. The *archive* bucket is not in this list — it goes through the proxy, so
-        // one visitor's volume download is the next visitor's cache hit.
-        const CORS_OK: &[&str] = &[
-            "api.open-meteo.com",
-            "api.mapbox.com",
-            "api.maptiler.com",
-            "unidata-nexrad-level2-chunks.s3.amazonaws.com",
-        ];
         let Some(rest) = url.strip_prefix("https://") else {
             return url.to_string();
         };
@@ -60,6 +66,18 @@ pub fn install_s3_proxy_rewriter() {
 
 #[cfg(test)]
 mod tests {
+    /// A keyed tile URL must never be rewritten to `/proxy/…`: the proxy is a shared edge cache
+    /// and the key rides in the query string.
+    #[test]
+    fn keyed_tile_hosts_are_never_proxied() {
+        for host in ["api.mapbox.com", "api.maptiler.com"] {
+            assert!(
+                super::CORS_OK.contains(&host),
+                "{host} must stay direct — proxying it would cache a user's API key"
+            );
+        }
+    }
+
     #[test]
     fn native_urls_are_left_alone() {
         let url = "https://api.weather.gov/alerts/active";


### PR DESCRIPTION
The basemap work is not on the demo because it is not on `main`. Five commits from R17 were never merged there, despite GitHub reporting their PRs as merged.

## What happened

PRs #49, #52, #53 and #54 were a stack — each one's *base* was the branch below it, not `main`:

```
#49 base=feat/per-pane-basemaps  head=feat/sharp-tiles
#52 base=feat/sharp-tiles        head=feat/basemap-sources
#53 base=feat/basemap-sources    head=feat/vector-cartography
#54 base=feat/vector-cartography head=feat/basemap-picker
```

Merging #54 put its commits on `feat/vector-cartography`. Nothing merged that branch into `main`, so only #48, the bottom of the stack, ever landed. #51 went the same way into `feat/live-data-path` after #50 had already merged. GitHub says "merged" for all five, because they were — into each other.

Stranded until now:

- `568f139` tiles: stop asking providers for zoom levels they do not serve (#49)
- `d08beae` keyless hybrid satellite, four more Esri looks, Auto and custom XYZ (#52)
- `f21a41f` buildings, a real road ladder and four more vector looks (#53)
- `c30cc1f` a thumbnail grid instead of a fifty-one-entry list (#54)
- `8cbd26e` scope the UI frame finely enough to rank its costs (#51)

This is the same trap #60 fell into, which is why #58 was the last thing standing that time.

## Conflicts, and how they were resolved

Two, both where a stranded branch and later `main` work touched the same lines.

**Vector place labels.** The branch filtered labels by the new per-label `min_zoom`; `main` had since replaced the local greedy declutter with the shared collision pass (#56), including sticky placement. Kept both halves that matter: the `min_zoom` filter (that *is* the cartography feature — POIs gated so they don't appear at CONUS zoom) with `main`'s sticky sort, and dropped the branch's local `placed` vec, which the shared pass owns now.

**River gauges.** The branch added a `prof_scope!` and a local `placed`; same resolution — keep the scope, drop the vec.

## Also here

`ci(demo)`: the Netlify deploy step is now advisory. It has been failing for a week on `"Account credit usage exceeded - new deploys are blocked until credits are added"`, and because it runs *after* Cloudflare has already published, its failure aborted the job and skipped everything below it — the wait-for-bundle poll, the boot smoke test, and the proxy allow/deny test. The demo has been deploying unverified. The step still reports its own failure; it no longer takes the other host's checks down with it.

`chore(tiles)`: one pedantic lint that neither branch saw alone, since the argument that tripped it was added on one branch and the threshold crossed on another.

## Verification

`cargo test --workspace` **516 passed, 27 ignored** · `cargo clippy --workspace --all-targets` down to the one pre-existing `settings.rs` warning · wasm check, 7 warnings identical to `main` · `shoot.sh check` · the demo workflow's own allowlist drift check run locally, in sync · `scripts/web/build.sh` produces a 12.79 MB wasm, under the 25 MiB Pages limit.

**Not verified by me:** the deployed smoke test, and the basemaps on screen. There is no Chrome for puppeteer on this machine, so `scripts/web/smoke.mjs` could not run locally — and I have not looked at a single one of these new basemaps rendering. This branch proves the five commits compile and pass their tests together on top of current `main`. Whether the hybrid satellite and the thumbnail grid look right is what you will see on the demo once this merges and the workflow deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
