### PR TITLE
ship USGS Imagery Topo as the default basemap

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -13875,7 +13875,7 @@ impl HookEchoApp {
                 let mut on = v.basemap != crate::tiles::BasemapStyle::None;
                 if ui.checkbox(&mut on, "Basemap").changed() {
                     v.basemap = if on {
-                        crate::tiles::BasemapStyle::Dark
+                        crate::tiles::BasemapStyle::default()
                     } else {
                         crate::tiles::BasemapStyle::None
                     };

--- a/crates/hookecho/src/main.rs
+++ b/crates/hookecho/src/main.rs
@@ -922,7 +922,7 @@ fn main() -> eframe::Result<()> {
         let basemap = match flag_value(&args, "--basemap") {
             Some("sat") => tiles::BasemapStyle::Satellite,
             Some(s) => tiles::BasemapStyle::from_slug(s),
-            None => tiles::BasemapStyle::Dark,
+            None => tiles::BasemapStyle::default(),
         };
         headless::set_output(
             flag_value(&args, "--size").and_then(|v| v.parse().ok()),

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -394,7 +394,7 @@ pub struct Settings {
     /// Number of newest volumes the live loop cycles over when playing.
     #[serde(default = "default_live_loop_frames")]
     pub live_loop_frames: usize,
-    /// Persisted basemap style slug for startup (empty = pane default Dark).
+    /// Persisted basemap style slug for startup (empty = the pane default, [`crate::tiles::BasemapStyle::default`]).
     #[serde(default)]
     pub basemap: String,
     /// Overlay toggles that were on when the app last ran, by name (see `OverlayToggle::slug`).

--- a/crates/hookecho/src/tiles.rs
+++ b/crates/hookecho/src/tiles.rs
@@ -64,7 +64,6 @@ impl Category {
 /// are provider raster tiles, available only when the matching Settings API key is set.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum BasemapStyle {
-    #[default]
     Dark,
     Light,
     Satellite,
@@ -110,6 +109,10 @@ pub enum BasemapStyle {
     EsriStreets,
     EsriTopo,
     UsgsTopo,
+    /// USGS aerial imagery with the topographic map drawn over it. The shipped default: keyless,
+    /// so it works on a fresh install with no account anywhere, and it reads as terrain rather
+    /// than as an abstraction, which is what a radar echo needs to sit on top of.
+    #[default]
     UsgsImageryTopo,
     OsmHot,
     CyclOsm,
@@ -196,9 +199,11 @@ impl BasemapStyle {
     /// ground, roads, terrain, live satellite, and nothing at all. Everything else in [`Self::ALL`]
     /// is a variation on one of these and lives behind the picker's "All basemaps".
     pub const COMMON: [BasemapStyle; 8] = [
+        // The shipped default leads: a phone's quick chips are the only basemap UI most people
+        // will use, and a default they cannot get back to from there is not much of a default.
+        BasemapStyle::UsgsImageryTopo,
         BasemapStyle::Dark,
         BasemapStyle::Light,
-        BasemapStyle::Satellite,
         BasemapStyle::EsriImagery,
         BasemapStyle::OsmStandard,
         BasemapStyle::OpenTopoMap,
@@ -211,6 +216,7 @@ impl BasemapStyle {
     pub fn short_label(self) -> &'static str {
         match self {
             BasemapStyle::Satellite => "USGS",
+            BasemapStyle::UsgsImageryTopo => "Imagery Topo",
             BasemapStyle::EsriImagery => "Satellite",
             BasemapStyle::HybridSatellite => "Hybrid",
             BasemapStyle::EsriDarkGray => "Dark Gray",
@@ -1678,6 +1684,26 @@ pub fn start_pack_download(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The shipped default. A fresh install with no settings file and no API key anywhere lands
+    /// here, so it has to be keyless, reachable on the web build, and offered on a phone.
+    #[test]
+    fn the_default_basemap_ships_usable() {
+        let d = BasemapStyle::default();
+        assert_eq!(d, BasemapStyle::UsgsImageryTopo);
+        assert_eq!(d.slug(), "usgs-imagery-topo");
+        // Keyless: `available` says yes with no Mapbox key, no MapTiler key, no custom template.
+        assert!(d.available(false, false, false));
+        // It draws something. `url` returning None would mean the vector path, which this is not.
+        let url = d
+            .url(6, 14, 24, false, "", "", "")
+            .expect("the default basemap must resolve to a tile URL");
+        // The host the browser build fetches through must be one the proxy will pass.
+        assert!(url.starts_with("https://basemap.nationalmap.gov/"), "{url}");
+        // Reachable from the phone's quick chips, and named short enough to fit one.
+        assert!(BasemapStyle::COMMON.contains(&d));
+        assert!(d.short_label().len() <= 14, "{}", d.short_label());
+    }
 
     /// Panes render their own basemap, so the caches are keyed by style as well as tile id. Two
     /// styles must never collapse onto the same key — that is what put one pane's imagery under

--- a/web/index.src.html
+++ b/web/index.src.html
@@ -11,7 +11,7 @@
     <link rel="preload" href="./dist/hookecho_bg.wasm" as="fetch" type="application/wasm" crossorigin />
     <!-- The first two hosts the app talks to once it is up: basemap tiles, and the live radar
          chunk bucket (the only radar host it reaches cross-origin — volumes go via /proxy). -->
-    <link rel="preconnect" href="https://basemaps.cartocdn.com" crossorigin />
+    <link rel="preconnect" href="https://basemap.nationalmap.gov" crossorigin />
     <link rel="preconnect" href="https://unidata-nexrad-level2-chunks.s3.amazonaws.com" crossorigin />
     <style>
       html, body { margin: 0; height: 100%; background: #101014; overflow: hidden; }


### PR DESCRIPTION
This was pushed to #65 a few minutes after it merged, so it missed the boat. Same commit, on its own.

USGS Imagery Topo — aerial imagery with the topographic map drawn over it — becomes `BasemapStyle::default()`, which is what desktop, Android and the web demo all resolve a pane's default through. Keyless, so a fresh install lands on it with no account anywhere. The old default was the Dark vector basemap.

Rather than write the new style in three places, the two spots that hardcoded `Dark` as the fallback — the headless renderer's `--basemap` and the Basemap checkbox that restores a style after you toggle it off — now ask for `default()`. Next change to the shipped default is one line.

Two things that would have made this half-done:

- It was not in `COMMON`, the phone's quick chips. A default you cannot get back to on mobile is barely a default, so it leads that list now with a chip-sized name. It displaces plain USGS imagery, which Esri's aerial already covers.
- `index.src.html` preconnected to Carto, which is where the first tiles used to come from. It points at the USGS host now, which is where they come from today.

Stored settings are untouched: an existing `basemap` slug still wins, and only an empty one falls through.

## Verification

Tiles serve, direct and through the deployed Pages proxy:

```
direct z6:        200 image/jpeg 19133B
direct z12:       200 image/jpeg 21306B
via pages proxy:  200
```

New test pins what a shipped default has to be: keyless (`available(false, false, false)`), resolves to a tile URL on an allowlisted host, present in `COMMON`, and named short enough for a phone chip.

Full bar green: `cargo test --workspace` **522 passed, 28 ignored** · clippy unchanged from `main` (the one pre-existing `settings.rs` warning) · wasm check, 7 warnings identical to `main` · `shoot.sh check`. Goldens are unaffected — `settings.template.json` pins `mapbox-satellite-streets` explicitly.

## Worth knowing

Max native zoom for this style is 16, where the vector basemap went deeper. #49's overzoom (now on `main`) stretches the deepest resident tile past that instead of blanking, so hard zoom into a city gives soft imagery rather than empty squares. If that reads badly to you in practice, the honest fix is a different default, not more overzoom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
