### PR TITLE
fix(timeline): a site switch no longer lands hours into the archive

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -10282,6 +10282,15 @@ impl HookEchoApp {
             // site changes, its result is dropped on arrival (site mismatch) without clearing
             // `loading`, which would then block the new site's fetch forever ("no volume").
             v.loading = false;
+            // The old site's frame list is not this site's. Left in place it is both what the
+            // scrub path displays and what it downloads until the new listing lands — i.e. the
+            // wrong radar's volumes at an index that means nothing here. A scrubbed pane keeps
+            // the time it was looking at; a live one just goes back to the head.
+            if !v.timeline.following {
+                v.timeline.seek_target = v.timeline.current().and_then(|id| id.date_time());
+            }
+            v.timeline.frames.clear();
+            v.timeline.playhead = 0;
             match &v.site {
                 // ...unless a deep link already aimed the camera at something specific.
                 Some(_) if std::mem::take(&mut v.camera_placed) => {}

--- a/crates/hookecho/src/timeline.rs
+++ b/crates/hookecho/src/timeline.rs
@@ -86,8 +86,14 @@ impl Timeline {
     }
 
     /// Install a fresh frame listing; keeps the playhead at the head while following, else
-    /// clamps it into range (so appended live frames don't move a scrubbed view).
+    /// clamps it into range (so appended live frames don't move a scrubbed view). A listing for
+    /// a different site never keeps the old index.
     pub fn set_frames(&mut self, frames: Vec<Identifier>, key: (String, NaiveDate)) {
+        // A listing for a different site is a different axis: index N of one radar's day is not
+        // the same moment as index N of another's. Carrying the playhead index across a site
+        // switch is what drops a live loop hours into the archive — the loop window is a dozen
+        // frames, a full day is hundreds, so index 8 lands just after 00Z instead of at the head.
+        let switched_site = self.frames_key.as_ref().is_some_and(|(s, _)| *s != key.0);
         self.frames = frames;
         self.frames_key = Some(key);
         self.listing = false;
@@ -101,7 +107,7 @@ impl Timeline {
         }
         // While live-looping, a fresh listing must not yank the playhead to the head — the loop
         // owns the playhead. Only clamp it back into range if it now points past the end.
-        if self.following && self.playing && !self.frames.is_empty() {
+        if self.following && self.playing && !switched_site && !self.frames.is_empty() {
             self.playhead = self.playhead.min(self.frames.len() - 1);
         } else if self.following || self.playhead >= self.frames.len() {
             self.playhead = self.frames.len().saturating_sub(1);
@@ -238,6 +244,53 @@ mod tests {
         // Still nothing to pace with an empty frame list, even once "playing".
         t.playing = true;
         assert!(t.time_to_next_frame().is_none());
+    }
+
+    /// A day of volumes for `site`, one every five minutes from 00Z.
+    fn day(site: &str, n: usize) -> Vec<Identifier> {
+        (0..n)
+            .map(|i| {
+                let (h, m) = (i * 5 / 60, i * 5 % 60);
+                Identifier::new(format!("{site}20260819_{h:02}{m:02}00_V06"))
+            })
+            .collect()
+    }
+
+    #[test]
+    fn switching_sites_mid_loop_does_not_land_in_the_small_hours() {
+        let mut t = Timeline::default();
+        let today = t.date;
+        // A live loop over the newest dozen frames of one radar's day.
+        t.set_frames(day("KTLX", 280), ("KTLX".into(), today));
+        t.toggle_play();
+        assert!(t.live_looping(), "looping the tail of KTLX");
+        let looped_at = t.playhead;
+        assert!(looped_at > 12, "loop starts near the head, not the start");
+
+        // The same index in another radar's listing is a different moment entirely.
+        t.set_frames(day("KFWS", 24), ("KFWS".into(), today));
+        assert_eq!(
+            t.playhead, 23,
+            "new site starts at its head, not index {looped_at}"
+        );
+        assert!(t.following);
+    }
+
+    #[test]
+    fn a_scrubbed_pane_keeps_its_time_across_a_site_switch() {
+        let mut t = Timeline::default();
+        let today = t.date;
+        t.set_frames(day("KTLX", 280), ("KTLX".into(), today));
+        t.step(-100); // scrub back; un-pins from live
+        assert!(!t.following);
+        let want = t.current().unwrap().date_time().unwrap();
+
+        // The app clears the old site's frames and hands the time over as a seek target.
+        t.seek_target = Some(want);
+        t.frames.clear();
+        t.playhead = 0;
+        t.set_frames(day("KFWS", 280), ("KFWS".into(), today));
+        assert_eq!(t.current().unwrap().date_time(), Some(want));
     }
 
     #[test]


### PR DESCRIPTION
Clicking a different radar showed a volume from the small hours of the UTC day instead of live data — reported as "22 hours ago", which is exactly where the bug lands when you switch late in the UTC day.

## Root cause

Two pieces of the old radar's playback state survived the switch.

1. `Timeline::set_frames` deliberately preserves the playhead while a live loop is running, so an ordinary re-listing does not yank the loop back to the head. That is correct for a new listing of the *same* site and wrong for a different one — index N of one radar's day is not the same moment as index N of another's. The live loop window is ~a dozen frames; a full day listing is a few hundred. So the preserved index (say 8) pointed at ~00:40Z of the new site's day: about 22 hours old at 23Z.

2. `sync_pane` cleared the volume on a site change but left `timeline.frames` alone. Until the new listing landed, the scrub path was both displaying and downloading identifiers belonging to the *previous* radar.

## Fix

- `set_frames` keeps the playhead only when the listing is for the same site; a different site falls through to the existing head/clamp branch.
- `sync_pane` drops the stale frames on the switch, and a scrubbed pane hands its current frame time to the existing `seek_target` mechanism so it keeps the *time* it was looking at rather than an index. A live pane goes back to the head.

No new state, no new plumbing — `seek_target` already did exactly this for event jumps and archive deep links.

## Verification

- `cargo clippy --workspace --all-targets` — 0 errors, only the pre-existing `settings.rs:1675/1676` warning
- `cargo test --workspace` — 524 passed, 28 ignored (was 522: two new)
- `RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check --target wasm32-unknown-unknown -p hookecho --lib` — 7 warnings, identical to main
- `./scripts/shots/shoot.sh check` — passed

New tests in `timeline.rs`:

- `switching_sites_mid_loop_does_not_land_in_the_small_hours` — 280-frame day, live loop running, switch to another site's listing; playhead must be at that site's head, not the carried index.
- `a_scrubbed_pane_keeps_its_time_across_a_site_switch` — scrub back 100 frames, switch sites, the displayed frame is the same wall-clock time.

Manual check worth doing: start a live loop on the home radar late in the UTC day, click another site's ring, confirm the timestamp is minutes old rather than hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
