### PR TITLE
fix: stop calling a stopped feed LIVE

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -6884,14 +6884,29 @@ impl HookEchoApp {
                         t.step(1);
                     }
                     // Live / archive badge: click to re-pin to the newest volume.
-                    let (col, text) = if t.following && fresh {
-                        (mobile::OMEGA_GREEN, "LIVE".to_string())
+                    //
+                    // Pinned to live but the newest volume is old means the site's feed has
+                    // stopped, not that playback drifted — there is nothing newer to jump to.
+                    // The colour said so already; saying "LIVE" over a volume hours old did not.
+                    let (col, text, hint) = if t.following && fresh {
+                        (
+                            mobile::OMEGA_GREEN,
+                            "LIVE".to_string(),
+                            "Following the newest volume.",
+                        )
                     } else if t.following {
-                        (egui::Color32::from_rgb(220, 180, 0), "LIVE".to_string())
+                        (
+                            egui::Color32::from_rgb(220, 180, 0),
+                            "STALE".to_string(),
+                            "Following the newest volume, but this site has not produced one \
+                             recently — its feed has stopped. The age next to the clock is how \
+                             far behind it is.",
+                        )
                     } else {
                         (
                             egui::Color32::from_gray(150),
                             format!("ARCHIVE {}", t.date.format("%m/%d")),
+                            "Scrubbed to an archive day. Click to jump back to live.",
                         )
                     };
                     let badge = ui.add(
@@ -6903,7 +6918,8 @@ impl HookEchoApp {
                         )
                         .fill(col)
                         .corner_radius(9.0),
-                    );
+                    )
+                    .on_hover_text(hint);
                     if badge.clicked() {
                         go_head = true;
                     }

--- a/crates/hookecho/src/timeline.rs
+++ b/crates/hookecho/src/timeline.rs
@@ -112,6 +112,24 @@ impl Timeline {
         } else if self.following || self.playhead >= self.frames.len() {
             self.playhead = self.frames.len().saturating_sub(1);
         }
+        self.pin_to_live_window();
+    }
+
+    /// Pull the playhead back inside the live window when a fresh listing is installed.
+    ///
+    /// `following` means "showing live": the newest volume, or — while looping — one of the
+    /// newest `live_window`. A listing replaces the whole axis under the playhead, and nothing
+    /// used to check the index still meant anything afterwards: a day listing that arrives
+    /// hundreds of frames long, or a window shrunk in settings, left the LIVE badge lit over a
+    /// volume hours old. Deliberately not applied to `append_head`/`tick` — a head arriving
+    /// mid-loop slides the window on the next wrap, which is what
+    /// `appended_head_slides_the_window` pins down.
+    fn pin_to_live_window(&mut self) {
+        if !self.following || self.frames.is_empty() {
+            return;
+        }
+        let oldest_live = self.frames.len().saturating_sub(self.live_window.max(1));
+        self.playhead = self.playhead.clamp(oldest_live, self.frames.len() - 1);
     }
 
     /// Append a newly-arrived live head frame (keeps the loop window sliding forward). The
@@ -291,6 +309,30 @@ mod tests {
         t.playhead = 0;
         t.set_frames(day("KFWS", 280), ("KFWS".into(), today));
         assert_eq!(t.current().unwrap().date_time(), Some(want));
+    }
+
+    #[test]
+    fn live_never_installs_a_listing_older_than_the_loop_window() {
+        let mut t = Timeline::default();
+        let today = t.date;
+        t.set_frames(day("KFTG", 24), ("KFTG".into(), today));
+        t.live_window = 10;
+        t.playing = true;
+        t.playhead = 2; // looping near the start of a short listing
+
+        // The day's full listing lands: the same index is now the small hours of the morning.
+        t.set_frames(day("KFTG", 280), ("KFTG".into(), today));
+        assert!(
+            t.playhead >= 270,
+            "LIVE must land inside the live window, got {}",
+            t.playhead
+        );
+
+        // A scrubbed timeline is not pinned and keeps the frame the user chose.
+        t.following = false;
+        t.playhead = 2;
+        t.set_frames(day("KFTG", 280), ("KFTG".into(), today));
+        assert_eq!(t.playhead, 2, "archive scrubbing is untouched");
     }
 
     #[test]

--- a/crates/wxdata/src/level2.rs
+++ b/crates/wxdata/src/level2.rs
@@ -212,6 +212,17 @@ static DAY_LIST_CACHE: std::sync::OnceLock<std::sync::Mutex<DayListCache>> =
 /// sees a new one promptly and long enough to collapse the burst a site switch makes.
 const DAY_LIST_TTL: std::time::Duration = std::time::Duration::from_secs(20);
 
+/// Whether an archive object name is a radar volume rather than one of the sidecar objects the
+/// bucket carries alongside them.
+///
+/// `..._V06_MDM` is a Metadata Message file: the volume's metadata records with none of the
+/// radials. It sorts in among the volumes and, taken for one, becomes a "newest volume" that is
+/// really a few minutes older and has nothing to draw — which is how a site whose feed had
+/// stopped ended up showing 09:55 when its last actual volume was 10:12.
+fn is_volume(name: &str) -> bool {
+    !name.ends_with("_MDM")
+}
+
 async fn list_day(site: &str, date: chrono::NaiveDate) -> anyhow::Result<Vec<Identifier>> {
     use nexrad_data::aws::archive;
     let key = (site.to_string(), date);
@@ -226,6 +237,7 @@ async fn list_day(site: &str, date: chrono::NaiveDate) -> anyhow::Result<Vec<Ide
     let mut ids = archive::list_files(site, &date)
         .await
         .map_err(|e| anyhow::anyhow!("list_files({site}, {date}): {e}"))?;
+    ids.retain(|id| is_volume(id.name()));
     ids.sort_by_key(|id| id.date_time());
     if let Ok(mut map) = cache.lock() {
         map.insert(key, (crate::clock::Instant::now(), ids.clone()));
@@ -633,6 +645,21 @@ pub fn bin_sweep_opts(
 mod tests {
     use super::*;
     use nexrad_model::data::{MomentData, Radial};
+
+    /// The bucket carries a metadata-message sidecar next to the volumes. It parses as an
+    /// identifier and sorts in among them, so nothing downstream notices it is not a volume.
+    #[test]
+    fn a_metadata_sidecar_is_not_a_volume() {
+        assert!(is_volume("KTLH20260819_101257_V06"));
+        assert!(!is_volume("KTLH20260819_095548_V06_MDM"));
+        // The newest object for a site whose feed had stopped was the sidecar, so "latest"
+        // resolved to 09:55 while the last real volume was 10:12.
+        let newest = ["KTLH20260819_095548_V06_MDM", "KTLH20260819_101257_V06"]
+            .into_iter()
+            .filter(|n| is_volume(n))
+            .max();
+        assert_eq!(newest, Some("KTLH20260819_101257_V06"));
+    }
 
     /// Just after 00Z the current UTC day holds only a volume or two, which is not a loop. The
     /// missing minutes are at the end of yesterday, so they get borrowed — but only as many as


### PR DESCRIPTION
Follow-on to #68. These three commits were pushed to that branch after it was merged, so they never landed; this rebases them onto current main.

Investigating "switching radar shows old data" turned up that the main complaint was not a bug at all. Probing the archive directly:

| site | newest volume |
|---|---|
| KTLH | `20260819_101257` — feed stopped ~14 h ago |
| KPUX | nothing at all, today or yesterday |
| KLIX | nothing at all |
| KFTG / KGLD / KLNX | `20260820_0047` — current |

A pane on KTLH was showing the newest volume that exists. What was wrong was that the app said `LIVE` over it.

## `fix(level2)`: a metadata sidecar is not the newest volume

The one genuine data bug found. The bucket carries `..._V06_MDM` objects — Metadata Message files holding a volume's metadata records and none of its radials — alongside the volumes. They parse as identifiers and sort in among them, so a listing took one for a volume. When it was the newest object for a site, "latest" resolved to the sidecar: KTLH showed 09:55 when its last real volume was 10:12.

Filtered in `list_day`, the choke point every listing path goes through — head poll, day listing, prefetch.

## `fix(timeline)`: LIVE cannot display a volume outside the live window

`following` means "showing live": the newest volume, or one of the newest `live_window` while looping. Nothing enforced it. A listing replaces the whole frame axis under the playhead, so an index that sat inside the window of a short 24-frame listing is the small hours of the morning once the full ~280-frame day arrives — with the badge still lit.

`set_frames` now pins the playhead into the live window whenever the timeline is following. Deliberately not applied to `append_head`/`tick`: a head arriving mid-loop is meant to slide the window on the next wrap rather than skip the playhead forward, which `appended_head_slides_the_window` already pins down.

## `feat(timeline)`: the amber badge reads STALE, not LIVE

The badge already turned amber when following a volume that is not fresh, but kept the word `LIVE`, so a dead feed looked like a playback bug. Amber now reads `STALE`, and all three states carry a hover line explaining what they mean and where to read the age. Click behaviour and the right-click menu are unchanged.

No golden-screenshot churn: `scripts/shots/shoot.sh` captures, it does not compare.

## Verification

- `cargo clippy --workspace --all-targets` — 0 errors, only the pre-existing `settings.rs:1675/1676` warning
- `cargo test --workspace` — 526 passed, 28 ignored
- `RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check --target wasm32-unknown-unknown -p hookecho --lib` — 7 warnings, identical to main
- `./scripts/shots/shoot.sh check` — passed

New tests: `a_metadata_sidecar_is_not_a_volume` (level2), `live_never_installs_a_listing_older_than_the_loop_window` (timeline).

Manual check: click KTLH — the badge should read STALE with the age beside the clock, rather than claiming LIVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
