### PR TITLE
feat: wave F — the five things the other radar apps have that we did not

### DIFF
--- a/crates/hookecho/Cargo.toml
+++ b/crates/hookecho/Cargo.toml
@@ -46,13 +46,7 @@ eframe = { version = "0.35", default-features = false, features = ["default_font
 # `serde` gives Key/Modifiers/KeyboardShortcut their Serialize/Deserialize impls, which is what
 # lets user keybinds live in settings.json.
 egui = { version = "0.35", features = ["serde"] }
-egui_extras = { version = "0.35", features = ["datepicker"] }
-# Only to speak to egui_extras's date picker, which takes a jiff date rather than a chrono one.
-# Already in the tree via that feature; the app's own dates stay chrono.
-# Default features bundle the IANA timezone database, which on wasm is ~117 KB gzipped of
-# data the app never reads — it formats a civil date and nothing else. Feature unification
-# means enabling it here would have turned it on for egui_extras too.
-jiff = { version = "0.2", default-features = false, features = ["std"] }
+egui_extras = "0.35"
 wgpu = { version = "29", default-features = false, features = ["wgsl", "std"] }
 bytemuck.workspace = true
 anyhow.workspace = true
@@ -86,6 +80,12 @@ getrandom = "0.3"
 # and none on the web, where there is no winit; tokio is a native runtime and simply does not
 # build for wasm (the browser's event loop is the runtime there — see `rt.rs`).
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# The archive date picker is native-only. The widget plus its `jiff` date type cost ~120 KB
+# gzipped of wasm, which is real money on a first visit for a convenience the web build can
+# get from a typed date instead. `default-features = false` keeps jiff's bundled IANA
+# timezone database out even here — the app formats a civil date and reads no zone.
+egui_extras = { version = "0.35", features = ["datepicker"] }
+jiff = { version = "0.2", default-features = false, features = ["std"] }
 egui-wgpu = { version = "0.35", default-features = false, features = ["winit"] }
 tokio.workspace = true
 eframe = { version = "0.35", default-features = false, features = ["accesskit"] }

--- a/crates/hookecho/Cargo.toml
+++ b/crates/hookecho/Cargo.toml
@@ -49,7 +49,10 @@ egui = { version = "0.35", features = ["serde"] }
 egui_extras = { version = "0.35", features = ["datepicker"] }
 # Only to speak to egui_extras's date picker, which takes a jiff date rather than a chrono one.
 # Already in the tree via that feature; the app's own dates stay chrono.
-jiff = "0.2"
+# Default features bundle the IANA timezone database, which on wasm is ~117 KB gzipped of
+# data the app never reads — it formats a civil date and nothing else. Feature unification
+# means enabling it here would have turned it on for egui_extras too.
+jiff = { version = "0.2", default-features = false, features = ["std"] }
 wgpu = { version = "29", default-features = false, features = ["wgsl", "std"] }
 bytemuck.workspace = true
 anyhow.workspace = true

--- a/crates/hookecho/Cargo.toml
+++ b/crates/hookecho/Cargo.toml
@@ -46,7 +46,10 @@ eframe = { version = "0.35", default-features = false, features = ["default_font
 # `serde` gives Key/Modifiers/KeyboardShortcut their Serialize/Deserialize impls, which is what
 # lets user keybinds live in settings.json.
 egui = { version = "0.35", features = ["serde"] }
-egui_extras = "0.35"
+egui_extras = { version = "0.35", features = ["datepicker"] }
+# Only to speak to egui_extras's date picker, which takes a jiff date rather than a chrono one.
+# Already in the tree via that feature; the app's own dates stay chrono.
+jiff = "0.2"
 wgpu = { version = "29", default-features = false, features = ["wgsl", "std"] }
 bytemuck.workspace = true
 anyhow.workspace = true

--- a/crates/hookecho/data/colortables/KDP.pal
+++ b/crates/hookecho/data/colortables/KDP.pal
@@ -1,0 +1,18 @@
+; Hook Echo default specific differential phase color table (GRLevelX .pal v2)
+; Range matches Moment::value_range for KDP: -2..8 deg/km. Negative KDP is not a rain
+; signature (it is noise, or non-meteorological scatter) so it stays grey; the warm end is
+; where the heavy rain lives.
+Product: KDP
+Units: deg/km
+Step: 1
+RF: 128 128 128
+SolidColor: -2 60 60 60
+SolidColor: -0.5 90 90 90
+SolidColor: 0 0 0 140
+SolidColor: 0.5 0 120 200
+SolidColor: 1 0 200 200
+SolidColor: 1.5 0 200 0
+SolidColor: 2.5 230 230 0
+SolidColor: 4 230 120 0
+SolidColor: 6 230 0 0
+SolidColor: 8 250 0 250

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -16625,6 +16625,7 @@ impl eframe::App for HookEchoApp {
             ctx,
             cells,
             &zdr_cells,
+            &self.cell_trends,
             crate::theme::accent(self.settings.theme),
         ) {
             if let Some(c) = self

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -6944,11 +6944,34 @@ impl HookEchoApp {
                                         t.following = false;
                                     }
                                 }
-                                ui.monospace(t.date.format("%Y-%m-%d").to_string())
+                                // The carets are still the fastest way to step a day, but they
+                                // were the *only* way: reaching a storm from years back meant
+                                // thousands of clicks. The archive runs to June 1991.
+                                let today = chrono::Utc::now().date_naive();
+                                // The picker speaks jiff; the rest of the app speaks chrono.
+                                // Convert at this one boundary rather than churn either.
+                                let mut picked_date = to_jiff(t.date);
+                                let picked = ui
+                                    .add(
+                                        egui_extras::DatePickerButton::new(&mut picked_date)
+                                            .id_salt("archive-day")
+                                            .format("%Y-%m-%d")
+                                            .highlight_weekends(false),
+                                    )
                                     .on_hover_text(
                                         "Archive days are UTC days — the S3 buckets are \
                                              bucketed that way",
                                     );
+                                if picked.changed() {
+                                    if let Some(d) = from_jiff(picked_date) {
+                                        // Clamp rather than trust the widget: it has no notion
+                                        // of where the archive starts or that the future is
+                                        // empty.
+                                        t.date =
+                                            d.clamp(wxdata::level2::ARCHIVE_START, today);
+                                        t.following = t.date >= today;
+                                    }
+                                }
                                 let is_today = t.date >= chrono::Utc::now().date_naive();
                                 if ui
                                     .add_enabled(
@@ -17446,5 +17469,34 @@ mod tests {
         strokes.pop(); // Undo
         assert_eq!(strokes.len(), 1);
         assert_eq!(strokes[0].color, red);
+    }
+}
+
+/// A chrono date as a jiff one, for `egui_extras`'s date picker.
+///
+/// ponytail: the two crates model a civil date identically, so this is a field copy. It exists
+/// because the picker is the only jiff-speaking thing in the app and converting one widget's
+/// argument is cheaper than migrating every date in the codebase. Out-of-range dates cannot
+/// happen — chrono's year range is a subset of jiff's — so the fallback is the epoch.
+fn to_jiff(d: chrono::NaiveDate) -> jiff::civil::Date {
+    use chrono::Datelike;
+    jiff::civil::Date::new(d.year() as i16, d.month() as i8, d.day() as i8)
+        .unwrap_or(jiff::civil::Date::ZERO)
+}
+
+/// The inverse of [`to_jiff`]; `None` for a date chrono cannot represent.
+fn from_jiff(d: jiff::civil::Date) -> Option<chrono::NaiveDate> {
+    chrono::NaiveDate::from_ymd_opt(d.year() as i32, d.month() as u32, d.day() as u32)
+}
+
+#[cfg(test)]
+mod date_picker_tests {
+    /// The picker's date must survive the round trip, or picking a day would move it.
+    #[test]
+    fn dates_round_trip_through_jiff() {
+        for (y, m, d) in [(1991, 6, 5), (2026, 8, 24), (2000, 2, 29), (2011, 12, 31)] {
+            let orig = chrono::NaiveDate::from_ymd_opt(y, m, d).unwrap();
+            assert_eq!(super::from_jiff(super::to_jiff(orig)), Some(orig));
+        }
     }
 }

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -6948,29 +6948,12 @@ impl HookEchoApp {
                                 // were the *only* way: reaching a storm from years back meant
                                 // thousands of clicks. The archive runs to June 1991.
                                 let today = chrono::Utc::now().date_naive();
-                                // The picker speaks jiff; the rest of the app speaks chrono.
-                                // Convert at this one boundary rather than churn either.
-                                let mut picked_date = to_jiff(t.date);
-                                let picked = ui
-                                    .add(
-                                        egui_extras::DatePickerButton::new(&mut picked_date)
-                                            .id_salt("archive-day")
-                                            .format("%Y-%m-%d")
-                                            .highlight_weekends(false),
-                                    )
-                                    .on_hover_text(
-                                        "Archive days are UTC days — the S3 buckets are \
-                                             bucketed that way",
-                                    );
-                                if picked.changed() {
-                                    if let Some(d) = from_jiff(picked_date) {
-                                        // Clamp rather than trust the widget: it has no notion
-                                        // of where the archive starts or that the future is
-                                        // empty.
-                                        t.date =
-                                            d.clamp(wxdata::level2::ARCHIVE_START, today);
-                                        t.following = t.date >= today;
-                                    }
+                                if let Some(d) = archive_day_input(ui, t.date) {
+                                    // Clamp rather than trust the input: neither a calendar
+                                    // widget nor a typed string knows where the archive starts
+                                    // or that the future is empty.
+                                    t.date = d.clamp(wxdata::level2::ARCHIVE_START, today);
+                                    t.following = t.date >= today;
                                 }
                                 let is_today = t.date >= chrono::Utc::now().date_naive();
                                 if ui
@@ -17473,12 +17456,66 @@ mod tests {
     }
 }
 
+/// The archive-day control inside the LIVE/ARCHIVE badge menu. `Some` on the frame the user
+/// picks a new day.
+///
+/// Native gets a calendar. The web build does not: the picker widget and the `jiff` date type
+/// it takes cost about 120 KB gzipped, which is a real share of the wasm budget to spend on a
+/// convenience, and a typed date reaches 1991 just as directly. Everything else about the menu
+/// — the carets, the UTC-day caveat — is the same on both.
+#[cfg(not(target_arch = "wasm32"))]
+fn archive_day_input(ui: &mut egui::Ui, date: chrono::NaiveDate) -> Option<chrono::NaiveDate> {
+    let mut picked = to_jiff(date);
+    let changed = ui
+        .add(
+            egui_extras::DatePickerButton::new(&mut picked)
+                .id_salt("archive-day")
+                .format("%Y-%m-%d")
+                .highlight_weekends(false),
+        )
+        .on_hover_text("Archive days are UTC days — the S3 buckets are bucketed that way")
+        .changed();
+    changed.then(|| from_jiff(picked)).flatten()
+}
+
+/// Web: type the day instead. The buffer lives in egui's own memory rather than app state,
+/// because a half-typed date is not something the app has any use for.
+#[cfg(target_arch = "wasm32")]
+fn archive_day_input(ui: &mut egui::Ui, date: chrono::NaiveDate) -> Option<chrono::NaiveDate> {
+    let id = egui::Id::new("archive-day-text");
+    let shown = date.format("%Y-%m-%d").to_string();
+    let mut buf: String = ui.data_mut(|d| d.get_temp(id)).unwrap_or_else(|| shown.clone());
+    // Someone else moved the day (a caret, a deep link): follow it rather than argue.
+    if !buf.starts_with(&shown[..4]) && chrono::NaiveDate::parse_from_str(&buf, "%Y-%m-%d").is_ok()
+    {
+        buf = shown.clone();
+    }
+    let resp = ui
+        .add(
+            egui::TextEdit::singleline(&mut buf)
+                .desired_width(84.0)
+                .font(egui::TextStyle::Monospace),
+        )
+        .on_hover_text(
+            "Archive days are UTC days — the S3 buckets are bucketed that way. \
+             Type YYYY-MM-DD; the archive starts 1991-06-05.",
+        );
+    let out = chrono::NaiveDate::parse_from_str(&buf, "%Y-%m-%d")
+        .ok()
+        .filter(|d| *d != date);
+    ui.data_mut(|d| d.insert_temp(id, buf));
+    // Only commit on a complete, parseable date — otherwise every keystroke mid-typing would
+    // send the timeline somewhere.
+    resp.changed().then_some(out).flatten()
+}
+
 /// A chrono date as a jiff one, for `egui_extras`'s date picker.
 ///
 /// ponytail: the two crates model a civil date identically, so this is a field copy. It exists
 /// because the picker is the only jiff-speaking thing in the app and converting one widget's
 /// argument is cheaper than migrating every date in the codebase. Out-of-range dates cannot
 /// happen — chrono's year range is a subset of jiff's — so the fallback is the epoch.
+#[cfg(not(target_arch = "wasm32"))]
 fn to_jiff(d: chrono::NaiveDate) -> jiff::civil::Date {
     use chrono::Datelike;
     jiff::civil::Date::new(d.year() as i16, d.month() as i8, d.day() as i8)
@@ -17486,11 +17523,12 @@ fn to_jiff(d: chrono::NaiveDate) -> jiff::civil::Date {
 }
 
 /// The inverse of [`to_jiff`]; `None` for a date chrono cannot represent.
+#[cfg(not(target_arch = "wasm32"))]
 fn from_jiff(d: jiff::civil::Date) -> Option<chrono::NaiveDate> {
     chrono::NaiveDate::from_ymd_opt(d.year() as i32, d.month() as u32, d.day() as u32)
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod date_picker_tests {
     /// The picker's date must survive the round trip, or picking a day would move it.
     #[test]

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -3227,7 +3227,7 @@ impl HookEchoApp {
     /// Spawn a background overlay fetch, routing the result to `overlay_rx`.
     /// Which moments the active pane's volume carries. All true when nothing is loaded, so an
     /// empty pane still offers the full product list.
-    fn available_moments(&self) -> [bool; 6] {
+    fn available_moments(&self) -> [bool; Moment::ALL.len()] {
         // The pane's remembered union, not this instant's volume: a half-arrived live volume
         // carries fewer moments than the radar sends, and the rows must not blink.
         self.views[self.active].moments()
@@ -10341,7 +10341,7 @@ impl HookEchoApp {
             let v = &mut self.views[idx];
             v.loaded_site = v.site.clone();
             v.volume = None;
-            v.moments_seen = [false; 6];
+            v.moments_seen = [false; Moment::ALL.len()];
             v.error = None;
             // Clear a stuck in-flight flag: if the previous site's fetch is still running when the
             // site changes, its result is dropped on arrival (site mismatch) without clearing

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1280,7 +1280,12 @@ fn field_refresh_secs(layer: crate::render::FieldLayer) -> u64 {
         // Environment (HRRR CAPE/SRH) refreshes slowly — 15 min.
         FL::Cape | FL::Srh => 900,
         // Derived products cost no network: they recompute when the volume does, not on a clock.
-        FL::VilLocal | FL::VilDensity | FL::EtopLocal | FL::HailMehs | FL::HailPosh => 60,
+        FL::CompositeLocal
+        | FL::VilLocal
+        | FL::VilDensity
+        | FL::EtopLocal
+        | FL::HailMehs
+        | FL::HailPosh => 60,
         // Gridded from the GLM feed the app already polls every 20 s; regridding is local work.
         FL::GlmFed => 60,
     }
@@ -3303,7 +3308,8 @@ impl HookEchoApp {
     /// work in archive replay and on each live tilt.
     fn recompute_derived(&mut self, ctx: &egui::Context) {
         use crate::render::FieldLayer as FL;
-        const LAYERS: [FL; 5] = [
+        const LAYERS: [FL; 6] = [
+            FL::CompositeLocal,
             FL::VilLocal,
             FL::VilDensity,
             FL::EtopLocal,
@@ -3372,6 +3378,7 @@ impl HookEchoApp {
             if mask & !HAIL_BITS != 0 {
                 if let Some(d) = wxdata::derived::derive(&sweeps, &opts) {
                     out.extend([
+                        (FL::CompositeLocal, d.composite),
                         (FL::VilLocal, d.vil),
                         (FL::VilDensity, d.vild),
                         (FL::EtopLocal, d.etop),
@@ -7611,6 +7618,13 @@ impl HookEchoApp {
                 false,
             ),
             (
+                FL::CompositeLocal,
+                "Radar",
+                "Composite reflectivity",
+                "The strongest echo anywhere above each point, not just what this tilt cuts through",
+                false,
+            ),
+            (
                 FL::VilLocal,
                 "Radar",
                 "VIL (derived)",
@@ -10315,6 +10329,7 @@ impl HookEchoApp {
             | FL::UpdraftHelicity
             | FL::Smoke
             | FL::Mosaic
+            | FL::CompositeLocal
             | FL::VilLocal
             | FL::VilDensity
             | FL::EtopLocal

--- a/crates/hookecho/src/app/mobile/sheet.rs
+++ b/crates/hookecho/src/app/mobile/sheet.rs
@@ -318,14 +318,17 @@ impl crate::app::HookEchoApp {
         // ---- Products ----
         // Same rows the old modal picker had; the difference is that they are two taps closer.
         type Row = (Moment, bool, &'static str);
-        let rows: [Row; 7] = [
+        let rows: [Row; 8] = [
             (Moment::Reflectivity, false, "Reflectivity"),
             (Moment::Velocity, false, "Velocity"),
             (Moment::Velocity, true, "Storm-Relative"),
             (Moment::SpectrumWidth, false, "Spectrum Width"),
             (Moment::CorrelationCoefficient, false, "CC"),
             (Moment::DifferentialReflectivity, false, "ZDR"),
-            (Moment::DifferentialPhase, false, "KDP"),
+            // This chip was labelled KDP while selecting ΦDP, which is a different field.
+            // Now that KDP is derived it gets its own chip and PHI gets its real name.
+            (Moment::DifferentialPhase, false, "PHI"),
+            (Moment::SpecificDifferentialPhase, false, "KDP"),
         ];
         let chips = ui.horizontal_wrapped(|ui| {
             for (m, want_srv, label) in rows {

--- a/crates/hookecho/src/colormap.rs
+++ b/crates/hookecho/src/colormap.rs
@@ -268,16 +268,17 @@ pub fn parse_pal(text: &str) -> anyhow::Result<ColorTable> {
 
 // --- Built-in defaults: real .pal files parsed through the one code path above ---
 
-const BUILTIN_SRC: [(&str, &str); 6] = [
+const BUILTIN_SRC: [(&str, &str); Moment::ALL.len()] = [
     ("REF", include_str!("../data/colortables/REF.pal")),
     ("VEL", include_str!("../data/colortables/VEL.pal")),
     ("SW", include_str!("../data/colortables/SW.pal")),
     ("ZDR", include_str!("../data/colortables/ZDR.pal")),
     ("PHI", include_str!("../data/colortables/PHI.pal")),
+    ("KDP", include_str!("../data/colortables/KDP.pal")),
     ("RHO", include_str!("../data/colortables/RHO.pal")),
 ];
 
-static BUILTINS: LazyLock<[ColorTable; 6]> = LazyLock::new(|| {
+static BUILTINS: LazyLock<[ColorTable; Moment::ALL.len()]> = LazyLock::new(|| {
     BUILTIN_SRC
         .map(|(name, src)| parse_pal(src).unwrap_or_else(|e| panic!("built-in {name}.pal: {e}")))
 });
@@ -326,8 +327,8 @@ pub fn default_table(moment: Moment) -> &'static ColorTable {
 ///
 /// `gen` bumps on every reload so the render sync can detect a table change and re-bake LUTs.
 pub struct Palettes {
-    pub tables: [ColorTable; 6],
-    pub errors: [Option<String>; 6],
+    pub tables: [ColorTable; Moment::ALL.len()],
+    pub errors: [Option<String>; Moment::ALL.len()],
     pub gen: u64,
 }
 
@@ -335,7 +336,7 @@ impl Default for Palettes {
     fn default() -> Self {
         Self {
             tables: BUILTINS.clone(),
-            errors: [const { None }; 6],
+            errors: [const { None }; Moment::ALL.len()],
             gen: 0,
         }
     }
@@ -349,7 +350,7 @@ impl Palettes {
 
     /// Reload each moment's table from `paths` (`None` = built-in default). A parse/read
     /// failure keeps the built-in and records the error. Bumps `gen`.
-    pub fn reload(&mut self, paths: &[Option<std::path::PathBuf>; 6]) {
+    pub fn reload(&mut self, paths: &[Option<std::path::PathBuf>; Moment::ALL.len()]) {
         for (i, moment) in Moment::ALL.into_iter().enumerate() {
             let (table, err) = match &paths[i] {
                 None => (default_table(moment).clone(), None),
@@ -406,7 +407,7 @@ mod tests {
         assert_eq!(alt_names(Moment::SpectrumWidth).count(), 0);
 
         let mut p = Palettes::default();
-        let mut paths: [Option<std::path::PathBuf>; 6] = Default::default();
+        let mut paths: [Option<std::path::PathBuf>; Moment::ALL.len()] = Default::default();
         let name = alt_names(Moment::Reflectivity).next().unwrap();
         paths[0] = Some(format!("{BUILTIN_PREFIX}{name}").into());
         paths[1] = Some(format!("{BUILTIN_PREFIX}nope").into());
@@ -449,7 +450,7 @@ SolidColorRange: 60 70 255 0 0
         std::fs::write(&path, src).unwrap();
 
         let mut p = Palettes::default();
-        let mut paths: [Option<std::path::PathBuf>; 6] = Default::default();
+        let mut paths: [Option<std::path::PathBuf>; Moment::ALL.len()] = Default::default();
         paths[Moment::Reflectivity.index()] = Some(path.clone());
         p.reload(&paths);
 

--- a/crates/hookecho/src/hotkeys.rs
+++ b/crates/hookecho/src/hotkeys.rs
@@ -72,6 +72,10 @@ pub(crate) fn defaults() -> Vec<Binding> {
         ),
         plain(
             K::Num6,
+            A::Palette(P::SetMoment(Moment::SpecificDifferentialPhase, false)),
+        ),
+        plain(
+            K::Num7,
             A::Palette(P::SetMoment(Moment::CorrelationCoefficient, false)),
         ),
         plain(K::PageUp, A::TiltUp),

--- a/crates/hookecho/src/products.rs
+++ b/crates/hookecho/src/products.rs
@@ -1,6 +1,6 @@
 //! The one place a radar product gets its name, its plain-English blurb, and its hotkey.
 //!
-//! Before this table the six moments had four different sets of labels — `REF`/`VEL` on the toolbox
+//! Before this table the moments had four different sets of labels — `REF`/`VEL` on the toolbox
 //! buttons, "Hi-Res Reflectivity" on mobile, "Correlation Coefficient (CC)" in the command palette,
 //! and bare numbers in the hotkey hints. A layman met a different vocabulary in every surface.
 
@@ -20,7 +20,7 @@ pub struct ProductInfo {
 }
 
 /// Every product, in hotkey order.
-pub const PRODUCTS: [ProductInfo; 6] = [
+pub const PRODUCTS: [ProductInfo; 7] = [
     ProductInfo {
         short: "REF",
         name: "Reflectivity",
@@ -51,16 +51,23 @@ pub const PRODUCTS: [ProductInfo; 6] = [
     },
     ProductInfo {
         short: "PHI",
-        name: "Specific Differential Phase",
-        blurb: "Rainfall rate in the heaviest cores, unaffected by hail",
+        name: "Differential Phase",
+        blurb: "Total phase shift the beam has picked up on its way out and back",
         hotkey: 5,
         moment: Moment::DifferentialPhase,
+    },
+    ProductInfo {
+        short: "KDP",
+        name: "Specific Differential Phase",
+        blurb: "Rainfall rate in the heaviest cores, unaffected by hail",
+        hotkey: 6,
+        moment: Moment::SpecificDifferentialPhase,
     },
     ProductInfo {
         short: "CC",
         name: "Correlation Coefficient",
         blurb: "How uniform the targets are — tells rain from hail, debris and birds",
-        hotkey: 6,
+        hotkey: 7,
         moment: Moment::CorrelationCoefficient,
     },
 ];
@@ -117,6 +124,7 @@ mod tests {
                 4 => egui::Key::Num4,
                 5 => egui::Key::Num5,
                 6 => egui::Key::Num6,
+                7 => egui::Key::Num7,
                 n => panic!("no key for hotkey {n}"),
             };
             let bound = crate::hotkeys::defaults()

--- a/crates/hookecho/src/render/field_ramps.rs
+++ b/crates/hookecho/src/render/field_ramps.rs
@@ -606,7 +606,11 @@ pub fn ramp_for(layer: FieldLayer) -> Option<&'static FieldRamp> {
         FL::GlobalPrecip => &GLOBAL_PRECIP,
         FL::Hca => &HCA,
         FL::GlmFed => &GLM_FED,
-        FL::Mrms | FL::Mosaic | FL::Hrrr | FL::Lightning | FL::ModelDiff => return None,
+        // Composite is reflectivity in dBZ, so like the mosaic it follows the user's own
+        // reflectivity `.pal` rather than a fixed ramp of its own.
+        FL::Mrms | FL::Mosaic | FL::CompositeLocal | FL::Hrrr | FL::Lightning | FL::ModelDiff => {
+            return None
+        }
     })
 }
 
@@ -616,9 +620,10 @@ mod tests {
 
     /// Layers colored outside this table. A new `FieldLayer` must join the table or this list —
     /// forgetting both silently ships a layer with no legend.
-    const NO_RAMP: [FieldLayer; 5] = [
+    const NO_RAMP: [FieldLayer; 6] = [
         FieldLayer::Mrms,
         FieldLayer::Mosaic,
+        FieldLayer::CompositeLocal,
         FieldLayer::Hrrr,
         FieldLayer::Lightning,
         // The difference layer's ramp is symmetric about zero and rebuilt whenever the field

--- a/crates/hookecho/src/render/mod.rs
+++ b/crates/hookecho/src/render/mod.rs
@@ -86,6 +86,10 @@ pub enum FieldLayer {
     Smoke,
     /// Multi-radar base-reflectivity composite (L3 N0B from every radar covering the view).
     Mosaic,
+    /// Column-maximum reflectivity from this radar's own volume — the strongest echo anywhere
+    /// above each point. Unlike the MRMS composite this is one site at its own resolution, and
+    /// it works in archive replay.
+    CompositeLocal,
     /// VIL integrated locally from the Level 2 volume (works in archive replay, unlike L3 DVL).
     VilLocal,
     /// VIL density — VIL over echo-top height, the classic large-hail discriminator.
@@ -140,7 +144,7 @@ impl FieldLayer {
     }
 
     /// Fixed bottom-to-top paint order within each band.
-    pub const DRAW_ORDER: [FieldLayer; 33] = [
+    pub const DRAW_ORDER: [FieldLayer; 34] = [
         // Below-radar context band (bottom to top). The global models sit at the very bottom:
         // they are the synoptic backdrop everything else is drawn against.
         FieldLayer::GlobalMslp,
@@ -163,6 +167,7 @@ impl FieldLayer {
         FieldLayer::Qpe24h,
         FieldLayer::FlashFlood,
         FieldLayer::HailSwath,
+        FieldLayer::CompositeLocal,
         FieldLayer::Vil,
         FieldLayer::VilLocal,
         FieldLayer::EchoTops,
@@ -202,6 +207,7 @@ impl FieldLayer {
             FieldLayer::UpdraftHelicity => "updrafthelicity",
             FieldLayer::Smoke => "smoke",
             FieldLayer::Mosaic => "mosaic",
+            FieldLayer::CompositeLocal => "composite-local",
             FieldLayer::VilLocal => "vil-local",
             FieldLayer::VilDensity => "vil-density",
             FieldLayer::EtopLocal => "etop-local",

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -1099,7 +1099,7 @@ impl Settings {
 
     /// Resolve the per-moment `.pal` override paths (`None` = built-in default), indexed by
     /// [`wxdata::level2::Moment::index`].
-    pub fn palette_paths(&self) -> [Option<PathBuf>; 6] {
+    pub fn palette_paths(&self) -> [Option<PathBuf>; wxdata::level2::Moment::ALL.len()] {
         use wxdata::level2::Moment;
         Moment::ALL.map(|m| {
             let mut p = self.palettes.get(m.short_name());

--- a/crates/hookecho/src/theme.rs
+++ b/crates/hookecho/src/theme.rs
@@ -406,10 +406,21 @@ pub fn stat_card(ui: &mut egui::Ui, label: &str, value: &str) {
 
 /// A min-max normalized sparkline of `vals` (oldest→newest) in a fixed-height row.
 pub fn sparkline(ui: &mut egui::Ui, vals: &[f32], color: Color32) {
-    let (rect, _) = ui.allocate_exact_size(
-        egui::vec2(ui.available_width().min(300.0), 34.0),
-        egui::Sense::hover(),
-    );
+    let size = egui::vec2(ui.available_width().min(300.0), 34.0);
+    sparkline_sized(ui, vals, color, size);
+}
+
+/// [`sparkline`] at a caller-chosen size, for places with a row height to fit inside — a table
+/// cell has ~20 px, where the default 34 would overlap its neighbours.
+///
+/// Returns the response so a caller can hang a tooltip on it.
+pub fn sparkline_sized(
+    ui: &mut egui::Ui,
+    vals: &[f32],
+    color: Color32,
+    size: egui::Vec2,
+) -> egui::Response {
+    let (rect, response) = ui.allocate_exact_size(size, egui::Sense::hover());
     let painter = ui.painter_at(rect);
     painter.rect_filled(rect, 3.0, ui.visuals().extreme_bg_color);
     if vals.len() < 2 {
@@ -420,7 +431,7 @@ pub fn sparkline(ui: &mut egui::Ui, vals: &[f32], color: Color32) {
             egui::FontId::proportional(10.0),
             ui.visuals().weak_text_color(),
         );
-        return;
+        return response;
     }
     let (mut lo, mut hi) = (f32::INFINITY, f32::NEG_INFINITY);
     for &v in vals {
@@ -455,6 +466,7 @@ pub fn sparkline(ui: &mut egui::Ui, vals: &[f32], color: Color32) {
         egui::FontId::proportional(9.0),
         weak,
     );
+    response
 }
 
 /// A collapsible, accent-labelled section with consistent inner spacing.

--- a/crates/hookecho/src/ui/cells_window.rs
+++ b/crates/hookecho/src/ui/cells_window.rs
@@ -155,6 +155,9 @@ pub fn show(
     // Cell ids with a ZDR column detected near them — an updraft the storm table cannot see on
     // its own, badged next to the rotation flags it already carries.
     zdr_cells: &std::collections::HashSet<String>,
+    // Per-cell-id history across volumes, oldest→newest — the same map the attributes popup
+    // draws its trend rows from.
+    trends: &std::collections::HashMap<String, Vec<crate::ui::cell_window::CellSample>>,
     accent: egui::Color32,
 ) -> Option<String> {
     if !w.open {
@@ -248,6 +251,7 @@ pub fn show(
                     .column(Column::exact(48.0)) // poh
                     .column(Column::exact(52.0)) // posh
                     .column(Column::exact(56.0)) // hail
+                    .column(Column::exact(64.0)) // trend
                     .column(Column::remainder()) // flags
                     .min_scrolled_height(0.0)
                     .header(22.0, |mut h| {
@@ -262,6 +266,12 @@ pub fn show(
                         h.col(|ui| header(ui, "POH", SortCol::Poh, w));
                         h.col(|ui| header(ui, "SVR", SortCol::Posh, w));
                         h.col(|ui| header(ui, "Hail", SortCol::Hail, w));
+                        h.col(|ui| {
+                            ui.label("Trend").on_hover_text(
+                                "Peak reflectivity over the volumes this cell has been tracked \
+                                 for \u{2014} whether it is strengthening or falling apart",
+                            );
+                        });
                         h.col(|ui| {
                             ui.label("Flags");
                         });
@@ -301,6 +311,48 @@ pub fn show(
                                 } else {
                                     t
                                 });
+                            });
+                            row.col(|ui| {
+                                // A column of numbers says how strong a storm is now; it cannot
+                                // say which way it is going, which is the thing you actually
+                                // triage on when six cells are on screen.
+                                let hist = trends.get(&c.id).map(Vec::as_slice).unwrap_or(&[]);
+                                let dbz: Vec<f32> = hist.iter().filter_map(|s| s.dbz).collect();
+                                let resp = crate::theme::sparkline_sized(
+                                    ui,
+                                    &dbz,
+                                    egui::Color32::from_rgb(240, 170, 60),
+                                    egui::vec2(60.0, 16.0),
+                                );
+                                if !hist.is_empty() {
+                                    resp.on_hover_ui(|ui| {
+                                        ui.label(
+                                            RichText::new(format!("{} over {} volumes", c.title, hist.len()))
+                                                .strong(),
+                                        );
+                                        for (label, vals, color) in [
+                                            ("Peak dBZ", dbz.clone(), egui::Color32::from_rgb(240, 170, 60)),
+                                            (
+                                                "VIL",
+                                                hist.iter().filter_map(|s| s.vil).collect::<Vec<_>>(),
+                                                egui::Color32::from_rgb(120, 200, 240),
+                                            ),
+                                            (
+                                                "Top (kft)",
+                                                hist.iter().filter_map(|s| s.top).collect::<Vec<_>>(),
+                                                egui::Color32::from_rgb(150, 230, 170),
+                                            ),
+                                        ] {
+                                            ui.label(RichText::new(label).small().weak());
+                                            crate::theme::sparkline_sized(
+                                                ui,
+                                                &vals,
+                                                color,
+                                                egui::vec2(160.0, 26.0),
+                                            );
+                                        }
+                                    });
+                                }
                             });
                             row.col(|ui| {
                                 ui.with_layout(Layout::left_to_right(Align::Center), |ui| {

--- a/crates/hookecho/src/ui/forecast_window.rs
+++ b/crates/hookecho/src/ui/forecast_window.rs
@@ -68,6 +68,7 @@ fn body(ui: &mut egui::Ui, f: &PointForecast, tz: Option<wxdata::tz::Tz>) {
     if !f.hourly.is_empty() {
         ui.label(RichText::new("Next 24 hours").strong());
         hourly_strip(ui, &f.hourly, tz);
+    wind_strip(ui, &f.hourly);
         ui.add_space(6.0);
     }
     ui.label(RichText::new("This week").strong());
@@ -240,6 +241,77 @@ fn hourly_strip(ui: &mut egui::Ui, hours: &[wxdata::forecast::Period], tz: Optio
             Color32::from_gray(170),
         );
     }
+}
+
+/// Wind speed over the same 24 hours the temperature curve covers, with an arrow every third
+/// hour showing where the wind is coming from.
+///
+/// The window showed wind only as prose on the current-conditions line, which answers "what is
+/// it doing now" but not "when does it get windy" — the question that decides whether you tie
+/// something down. Gusts are missing on purpose: neither feed publishes an hourly gust, so
+/// there is nothing honest to draw.
+fn wind_strip(ui: &mut egui::Ui, hours: &[wxdata::forecast::Period]) {
+    let hours: Vec<_> = hours.iter().take(24).collect();
+    // Nothing to say if the feed gave no numbers — the NWS publishes wind as prose, and a
+    // string it cannot parse must not become a flat line at zero.
+    if hours.len() < 2 || hours.iter().all(|h| h.wind_mph.is_none()) {
+        return;
+    }
+    let w = ui.available_width().max(220.0);
+    let h = 46.0;
+    let (rect, resp) = ui.allocate_exact_size(Vec2::new(w, h), Sense::hover());
+    let p = ui.painter_at(rect);
+    p.rect_filled(rect, 4.0, Color32::from_black_alpha(90));
+    let body = rect.shrink2(Vec2::new(6.0, 5.0));
+
+    let peak = hours
+        .iter()
+        .filter_map(|x| x.wind_mph)
+        .fold(0.0f32, f32::max)
+        .max(10.0); // a calm day still gets a sensible scale rather than a magnified wobble
+    let x_of = |i: usize| body.left() + (i as f32 + 0.5) / hours.len() as f32 * body.width();
+    let y_of = |v: f32| body.bottom() - (v / peak) * body.height() * 0.62;
+
+    let pts: Vec<egui::Pos2> = hours
+        .iter()
+        .enumerate()
+        .filter_map(|(i, x)| Some(egui::pos2(x_of(i), y_of(x.wind_mph?))))
+        .collect();
+    p.add(egui::Shape::line(
+        pts,
+        Stroke::new(1.6, Color32::from_rgb(120, 210, 190)),
+    ));
+
+    // Direction arrows: every third hour, pointing the way the wind is going (the compass
+    // reading is where it comes *from*, so the arrow is the reverse).
+    for (i, x) in hours.iter().enumerate() {
+        if i % 3 != 0 {
+            continue;
+        }
+        let (Some(v), Some(from_deg)) = (x.wind_mph, x.wind_deg) else {
+            continue;
+        };
+        let to = (from_deg + 180.0).to_radians();
+        // Screen y grows downward, so north is -y.
+        let dir = Vec2::new(to.sin(), -to.cos());
+        let c = egui::pos2(x_of(i), y_of(v) - 9.0);
+        let tip = c + dir * 4.5;
+        let tail = c - dir * 4.5;
+        let wing = Vec2::new(-dir.y, dir.x) * 2.4;
+        let grey = Color32::from_gray(180);
+        p.line_segment([tail, tip], Stroke::new(1.0, grey));
+        p.line_segment([tip, tip - dir * 3.0 + wing], Stroke::new(1.0, grey));
+        p.line_segment([tip, tip - dir * 3.0 - wing], Stroke::new(1.0, grey));
+    }
+
+    p.text(
+        rect.left_top() + Vec2::new(6.0, 2.0),
+        Align2::LEFT_TOP,
+        format!("wind · peak {peak:.0} mph"),
+        FontId::proportional(9.0),
+        Color32::from_gray(170),
+    );
+    resp.on_hover_text("Sustained wind over the next 24 hours; arrows show which way it blows");
 }
 
 /// One-line current conditions, skipping whatever the station didn't report:

--- a/crates/hookecho/src/view.rs
+++ b/crates/hookecho/src/view.rs
@@ -12,7 +12,7 @@ use wxdata::level2::{self, BinnedSweep, Moment, Scan};
 
 /// How many binned sweeps one volume keeps. A sweep is ~1.3 MB, and the working set while
 /// flipping through moments and tilts is a handful — 12 covers it without the old unbounded
-/// map's ~120 MB worst case (6 moments x ~15 tilts, all resident at once).
+/// map's ~140 MB worst case (7 moments x ~15 tilts, all resident at once).
 const BINNED_CACHE: usize = 12;
 
 /// A decoded volume plus lazily-binned sweeps for the moments/tilts the user has viewed.
@@ -28,7 +28,7 @@ pub struct Volume {
     /// Sorted, deduped tilt angles; the tilt index selects into this.
     pub elevations: Vec<f32>,
     /// Which moments *this* volume carries (the pane keeps the wider union for its UI rows).
-    pub moments: [bool; 6],
+    pub moments: [bool; Moment::ALL.len()],
     binned: LruCache<(Moment, usize, bool), BinnedSweep>,
 }
 
@@ -126,8 +126,8 @@ pub struct MapView {
     pub moment: Moment,
     pub tilt: usize,
     /// Per-moment display threshold (physical units), indexed by [`Moment::index`].
-    pub thresholds: [Option<f32>; 6],
-    pub threshold_enabled: [bool; 6],
+    pub thresholds: [Option<f32>; Moment::ALL.len()],
+    pub threshold_enabled: [bool; Moment::ALL.len()],
     pub volume: Option<Volume>,
     /// The site the current volume/fetch belongs to; drives site-change detection.
     pub loaded_site: Option<String>,
@@ -156,7 +156,7 @@ pub struct MapView {
     /// the merged volume is reflectivity-only, so reading availability off it alone made the
     /// dual-pol rows blink out of the sidebar once a volume. What a radar sends doesn't change
     /// mid-session, so remember it.
-    pub moments_seen: [bool; 6],
+    pub moments_seen: [bool; Moment::ALL.len()],
 }
 
 impl MapView {
@@ -166,8 +166,8 @@ impl MapView {
             site,
             moment: Moment::Reflectivity,
             tilt: 0,
-            thresholds: [None; 6],
-            threshold_enabled: [false; 6],
+            thresholds: [None; Moment::ALL.len()],
+            threshold_enabled: [false; Moment::ALL.len()],
             volume: None,
             loaded_site: None,
             camera_placed: false,
@@ -182,7 +182,7 @@ impl MapView {
             loading: false,
             last_poll: None,
             error: None,
-            moments_seen: [false; 6],
+            moments_seen: [false; Moment::ALL.len()],
         }
     }
 
@@ -218,11 +218,11 @@ impl MapView {
 
     /// What this site's radar sends: the union over every volume seen since the site was
     /// selected, or "everything" before the first one lands.
-    pub fn moments(&self) -> [bool; 6] {
+    pub fn moments(&self) -> [bool; Moment::ALL.len()] {
         if self.moments_seen.iter().any(|m| *m) {
             self.moments_seen
         } else {
-            [true; 6]
+            [true; Moment::ALL.len()]
         }
     }
 
@@ -330,7 +330,7 @@ mod tests {
     fn moment_availability_is_remembered_across_volumes() {
         let mut v = MapView::new(Some("KTLX".into()), Camera::at_lonlat(-97.0, 35.0, 8.0));
         // Nothing loaded yet: assume the radar sends everything rather than hiding rows.
-        assert_eq!(v.moments(), [true; 6]);
+        assert_eq!(v.moments(), [true; Moment::ALL.len()]);
         v.volume = Some(Volume::new(scan_at(&[0.5]), "a".into(), chrono::Utc::now()));
         v.clamp_moment();
         let refl_only = v.moments();

--- a/crates/wxdata/src/derived.rs
+++ b/crates/wxdata/src/derived.rs
@@ -1,4 +1,5 @@
-//! Products derived locally from a Level 2 volume: VIL, VIL density, echo tops, MEHS/POSH hail.
+//! Products derived locally from a Level 2 volume: composite reflectivity, VIL, VIL density,
+//! echo tops, MEHS/POSH hail.
 //!
 //! The NWS ships some of these as Level 3 grids (DVL, EET, and per-cell hail attributes in HI),
 //! but only for the products and resolutions it chooses to distribute, and only for the current
@@ -40,6 +41,9 @@ impl Default for DerivedOpts {
 
 /// The three integrated products, on one shared grid.
 pub struct Derived {
+    /// Column-maximum reflectivity (dBZ) — the strongest echo anywhere above each point,
+    /// rather than what one tilt happens to cut through.
+    pub composite: MrmsField,
     /// Vertically integrated liquid, kg/m².
     pub vil: MrmsField,
     /// VIL density, g/m³ (VIL over echo-top height).
@@ -155,16 +159,26 @@ pub fn derive(sweeps: &[BinnedSweep], opts: &DerivedOpts) -> Option<Derived> {
     let g = Grid::for_sweeps(sweeps)?;
     let n = g.nx * g.ny;
     let (mut vil, mut vild, mut etop) = (vec![f32::NAN; n], vec![f32::NAN; n], vec![f32::NAN; n]);
+    let mut composite = vec![f32::NAN; n];
     let mut samples: Vec<(f64, f32)> = Vec::with_capacity(sweeps.len());
 
     for gy in 0..g.ny {
         for gx in 0..g.nx {
             let (ground_km, az) = g.ground_az(gx, gy);
             column_samples(sweeps, ground_km, az, &mut samples);
+            let i = gy * g.nx + gx;
+            // Composite is a maximum, not an integral, so unlike VIL and echo tops it means
+            // something from a single sample — it is taken before the two-sample guard.
+            if let Some(max) = samples
+                .iter()
+                .map(|(_, dbz)| *dbz)
+                .fold(None, |acc: Option<f32>, d| Some(acc.map_or(d, |a| a.max(d))))
+            {
+                composite[i] = max;
+            }
             if samples.len() < 2 {
                 continue;
             }
-            let i = gy * g.nx + gx;
             let v = vil_of(&samples);
             if v > 0.0 {
                 vil[i] = v;
@@ -179,6 +193,7 @@ pub fn derive(sweeps: &[BinnedSweep], opts: &DerivedOpts) -> Option<Derived> {
     }
 
     Some(Derived {
+        composite: g.field(composite, opts.time),
         vil: g.field(vil, opts.time),
         vild: g.field(vild, opts.time),
         etop: g.field(etop, opts.time),
@@ -342,8 +357,26 @@ mod tests {
         assert!(sample(&d.vil, -97.0, 35.3) > 0.0);
         assert!(sample(&d.etop, -97.0, 35.3) > 0.0);
         assert!(sample(&d.vild, -97.0, 35.3) > 0.0);
+        assert!(sample(&d.composite, -97.0, 35.3) > 0.0);
         // The grid corner is past the 200 km range disk.
         assert!(sample(&d.vil, d.lon_west_corner(), d.lat_north_corner()).is_nan());
+        assert!(sample(&d.composite, d.lon_west_corner(), d.lat_north_corner()).is_nan());
+    }
+
+    /// Composite is the column maximum, so it must equal the strongest tilt over that point —
+    /// never the tilt the display happens to be sitting on.
+    #[test]
+    fn composite_takes_the_strongest_tilt_in_the_column() {
+        // Three tilts, and the middle one is the hot one.
+        let mut sweeps = uniform_sweeps(20.0, &[0.5]);
+        sweeps.extend(uniform_sweeps(58.0, &[2.4]));
+        sweeps.extend(uniform_sweeps(35.0, &[6.0]));
+        let d = derive(&sweeps, &DerivedOpts::default()).unwrap();
+        let gx = ((-97.0 - d.composite.lon_west) / RES_DEG) as usize;
+        let gy = ((d.composite.lat_north - 35.3) / RES_DEG) as usize;
+        let v = d.composite.values[gy * d.composite.nx + gx];
+        // Quantization through the u8 band costs a fraction of a dBZ.
+        assert!((v - 58.0).abs() < 0.6, "column max read {v}, wanted the 58 dBZ tilt");
     }
 
     #[test]

--- a/crates/wxdata/src/forecast.rs
+++ b/crates/wxdata/src/forecast.rs
@@ -26,7 +26,39 @@ pub struct Period {
     pub short: String,
     /// "10 to 15 mph".
     pub wind: String,
+    /// Sustained wind in mph, parsed out of [`Period::wind`] for charting.
+    ///
+    /// This endpoint publishes wind as prose, not numbers, and it publishes no gust at all —
+    /// gusts live in the raw gridpoint product, which is a different fetch. A range ("10 to 15")
+    /// reads as its upper bound, which is what a wind chart should show.
+    pub wind_mph: Option<f32>,
+    /// Wind direction in degrees the wind blows *from*, parsed from the compass point.
+    pub wind_deg: Option<f32>,
     pub is_day: bool,
+}
+
+/// Largest number of mph in a National Weather Service wind string.
+///
+/// The strings are "10 mph", "10 to 15 mph", or empty. Taking the maximum makes a plain speed
+/// and the top of a range read the same way.
+fn parse_wind_mph(s: &str) -> Option<f32> {
+    s.split(|c: char| !c.is_ascii_digit())
+        .filter(|t| !t.is_empty())
+        .filter_map(|t| t.parse::<f32>().ok())
+        .fold(None, |acc: Option<f32>, v| Some(acc.map_or(v, |a| a.max(v))))
+}
+
+/// A compass point ("NNW") as degrees the wind blows from.
+fn parse_wind_deg(s: &str) -> Option<f32> {
+    const POINTS: [&str; 16] = [
+        "N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE", "S", "SSW", "SW", "WSW", "W", "WNW",
+        "NW", "NNW",
+    ];
+    let s = s.trim();
+    POINTS
+        .iter()
+        .position(|p| p.eq_ignore_ascii_case(s))
+        .map(|i| i as f32 * 22.5)
 }
 
 /// A point forecast: named periods out ~7 days, plus hour-by-hour for the near term.
@@ -81,6 +113,14 @@ fn parse_periods(body: &str) -> anyhow::Result<Vec<Period>> {
                     (Some(s), _) => s.to_string(),
                     _ => String::new(),
                 },
+                wind_mph: p
+                    .get("windSpeed")
+                    .and_then(|s| s.as_str())
+                    .and_then(parse_wind_mph),
+                wind_deg: p
+                    .get("windDirection")
+                    .and_then(|s| s.as_str())
+                    .and_then(parse_wind_deg),
                 is_day: p.get("isDaytime").and_then(|b| b.as_bool()).unwrap_or(true),
             })
         })
@@ -214,5 +254,25 @@ mod tests {
     fn missing_periods_is_an_error_not_a_panic() {
         assert!(parse_periods("{}").is_err());
         assert!(parse_periods("not json").is_err());
+    }
+
+    /// A range reads as its top; a plain speed reads as itself; prose without a number is None,
+    /// not zero — a chart must not draw calm where the feed said nothing.
+    #[test]
+    fn wind_speed_comes_out_of_the_prose() {
+        assert_eq!(parse_wind_mph("10 mph"), Some(10.0));
+        assert_eq!(parse_wind_mph("10 to 15 mph"), Some(15.0));
+        assert_eq!(parse_wind_mph(""), None);
+        assert_eq!(parse_wind_mph("calm"), None);
+    }
+
+    #[test]
+    fn compass_points_become_degrees() {
+        assert_eq!(parse_wind_deg("N"), Some(0.0));
+        assert_eq!(parse_wind_deg("E"), Some(90.0));
+        assert_eq!(parse_wind_deg("SW"), Some(225.0));
+        assert_eq!(parse_wind_deg("NNW"), Some(337.5));
+        assert_eq!(parse_wind_deg(""), None);
+        assert_eq!(parse_wind_deg("variable"), None);
     }
 }

--- a/crates/wxdata/src/kdp.rs
+++ b/crates/wxdata/src/kdp.rs
@@ -1,0 +1,161 @@
+//! Specific differential phase (KDP) derived from differential phase (ΦDP).
+//!
+//! KDP is not transmitted in an Archive II volume — it is the range derivative of ΦDP,
+//! halved because ΦDP accumulates on both the outbound and return legs:
+//! `KDP = ½ · dΦDP/dr`, in degrees per kilometre.
+//!
+//! Two things make that derivative awkward on real data. ΦDP is reported modulo 360°, so a
+//! radial that accumulates past a full turn wraps and would read as a huge negative slope;
+//! and it is noisy gate to gate, so a two-point difference is mostly noise. This unwraps the
+//! phase along each radial, then fits a least-squares line over a short window of gates.
+
+/// Gates in the fitting window. Nine gates is 2.25 km at the 250 m gate spacing of a
+/// super-res split cut — long enough to average down ΦDP noise, short enough to keep a
+/// hail core's signature from smearing across the storm.
+const WINDOW: usize = 9;
+
+/// A jump larger than this between adjacent gates is read as a modulo-360 wrap rather than
+/// real phase accumulation. ΦDP never climbs this fast over one gate in nature.
+const WRAP_THRESHOLD: f32 = 180.0;
+
+/// Derive KDP (deg/km) from a ΦDP field (degrees), row-major `[az_bin][gate]`.
+///
+/// `None` in means no measurement; `None` out means the window around that gate had too few
+/// measurements to fit a line through.
+pub fn from_differential_phase(
+    phi: &[Option<f32>],
+    az_bins: usize,
+    gate_count: usize,
+    gate_interval_km: f32,
+) -> Vec<Option<f32>> {
+    debug_assert_eq!(phi.len(), az_bins * gate_count);
+    let mut out = vec![None; phi.len()];
+    if gate_count < WINDOW || gate_interval_km <= 0.0 {
+        return out;
+    }
+    let mut unwrapped = vec![None; gate_count];
+    for (row, dst) in phi.chunks(gate_count).zip(out.chunks_mut(gate_count)) {
+        unwrap_into(row, &mut unwrapped);
+        slopes_into(&unwrapped, gate_interval_km, dst);
+    }
+    out
+}
+
+/// Undo the modulo-360 wrapping along one radial, writing into `out` (same length as `row`).
+fn unwrap_into(row: &[Option<f32>], out: &mut [Option<f32>]) {
+    let mut turns = 0.0f32;
+    let mut previous: Option<f32> = None;
+    for (slot, raw) in out.iter_mut().zip(row) {
+        *slot = match raw {
+            None => None,
+            Some(v) => {
+                if let Some(p) = previous {
+                    // Compare against the *raw* previous value, so a run of gaps does not
+                    // invent a wrap out of two unrelated readings.
+                    if v - p < -WRAP_THRESHOLD {
+                        turns += 360.0;
+                    } else if v - p > WRAP_THRESHOLD {
+                        turns -= 360.0;
+                    }
+                }
+                previous = Some(*v);
+                Some(v + turns)
+            }
+        };
+    }
+}
+
+/// Least-squares slope of `phi` over a sliding [`WINDOW`], halved into KDP.
+///
+/// ponytail: a plain sliding fit, recomputed per gate — O(gates · WINDOW), which at 9 gates is
+/// nothing next to the volume decode that produced the field. Running sums would make it O(gates)
+/// if the window ever needs to be long.
+fn slopes_into(phi: &[Option<f32>], gate_interval_km: f32, out: &mut [Option<f32>]) {
+    /// Below this many real samples in a window the fit is noise, not a trend.
+    const MIN_SAMPLES: usize = 5;
+
+    let half = WINDOW / 2;
+    for (g, slot) in out.iter_mut().enumerate() {
+        *slot = None;
+        if g < half || g + half >= phi.len() {
+            continue;
+        }
+        let window = &phi[g - half..=g + half];
+        let n = window.iter().filter(|v| v.is_some()).count();
+        if n < MIN_SAMPLES {
+            continue;
+        }
+        // x is the gate offset within the window, in kilometres.
+        let mean_x: f32 = window
+            .iter()
+            .enumerate()
+            .filter(|(_, v)| v.is_some())
+            .map(|(i, _)| i as f32)
+            .sum::<f32>()
+            / n as f32;
+        let mean_y: f32 = window.iter().flatten().sum::<f32>() / n as f32;
+        let mut num = 0.0f32;
+        let mut den = 0.0f32;
+        for (i, v) in window.iter().enumerate() {
+            let Some(y) = v else { continue };
+            let dx = i as f32 - mean_x;
+            num += dx * (y - mean_y);
+            den += dx * dx;
+        }
+        if den <= f32::EPSILON {
+            continue;
+        }
+        // num/den is deg per gate; divide by the gate length for deg/km, halve for the two-way path.
+        *slot = Some(0.5 * (num / den) / gate_interval_km);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A radial whose phase climbs at a known rate must read back that rate, halved.
+    #[test]
+    fn a_linear_phase_ramp_has_a_constant_kdp() {
+        let gate_km = 0.25;
+        // 2 deg per gate = 8 deg/km of ΦDP = 4 deg/km of KDP.
+        let phi: Vec<Option<f32>> = (0..40).map(|g| Some(g as f32 * 2.0)).collect();
+        let kdp = from_differential_phase(&phi, 1, 40, gate_km);
+        let middle = kdp[20].expect("mid-radial gate is fittable");
+        assert!((middle - 4.0).abs() < 1e-3, "got {middle}");
+    }
+
+    /// The same ramp, but wrapping past 360 — the wrap must not read as a cliff.
+    #[test]
+    fn a_wrapped_phase_ramp_does_not_read_as_a_cliff() {
+        let phi: Vec<Option<f32>> = (0..80)
+            .map(|g| Some((g as f32 * 6.0).rem_euclid(360.0)))
+            .collect();
+        let kdp = from_differential_phase(&phi, 1, 80, 0.25);
+        // 6 deg/gate at 0.25 km = 24 deg/km of ΦDP = 12 deg/km of KDP, everywhere it is defined.
+        for (g, v) in kdp.iter().enumerate() {
+            if let Some(v) = v {
+                assert!((v - 12.0).abs() < 1e-2, "gate {g} read {v}");
+            }
+        }
+        assert!(kdp.iter().filter(|v| v.is_some()).count() > 60);
+    }
+
+    /// Gates with no measurement nearby produce no KDP rather than a fabricated one.
+    #[test]
+    fn an_empty_radial_produces_nothing() {
+        let kdp = from_differential_phase(&vec![None; 40], 1, 40, 0.25);
+        assert!(kdp.iter().all(|v| v.is_none()));
+    }
+
+    /// Rows are independent: one radial's phase must not leak into the next one's fit.
+    #[test]
+    fn radials_do_not_bleed_into_each_other() {
+        let gate_count = 20;
+        let mut phi = vec![Some(0.0f32); gate_count]; // flat: KDP 0
+        phi.extend((0..gate_count).map(|g| Some(g as f32 * 4.0))); // ramp: KDP 8 at 0.25 km
+        let kdp = from_differential_phase(&phi, 2, gate_count, 0.25);
+        assert!((kdp[10].unwrap() - 0.0).abs() < 1e-3);
+        assert!((kdp[gate_count + 10].unwrap() - 8.0).abs() < 1e-3);
+    }
+}

--- a/crates/wxdata/src/level2.rs
+++ b/crates/wxdata/src/level2.rs
@@ -19,17 +19,21 @@ pub enum Moment {
     SpectrumWidth,
     DifferentialReflectivity,
     DifferentialPhase,
+    /// Specific differential phase — not transmitted; derived from [`Moment::DifferentialPhase`]
+    /// at bin time by [`crate::kdp`].
+    SpecificDifferentialPhase,
     CorrelationCoefficient,
 }
 
 impl Moment {
     /// All moments, in toolbox/hotkey display order (REF..RHO).
-    pub const ALL: [Moment; 6] = [
+    pub const ALL: [Moment; 7] = [
         Moment::Reflectivity,
         Moment::Velocity,
         Moment::SpectrumWidth,
         Moment::DifferentialReflectivity,
         Moment::DifferentialPhase,
+        Moment::SpecificDifferentialPhase,
         Moment::CorrelationCoefficient,
     ];
 
@@ -41,6 +45,7 @@ impl Moment {
             Moment::SpectrumWidth => "SW",
             Moment::DifferentialReflectivity => "ZDR",
             Moment::DifferentialPhase => "PHI",
+            Moment::SpecificDifferentialPhase => "KDP",
             Moment::CorrelationCoefficient => "CC",
         }
     }
@@ -52,6 +57,7 @@ impl Moment {
             Moment::Velocity | Moment::SpectrumWidth => "m/s",
             Moment::DifferentialReflectivity => "dB",
             Moment::DifferentialPhase => "deg",
+            Moment::SpecificDifferentialPhase => "deg/km",
             Moment::CorrelationCoefficient => "",
         }
     }
@@ -81,7 +87,11 @@ impl Moment {
             Moment::Velocity => radial.velocity(),
             Moment::SpectrumWidth => radial.spectrum_width(),
             Moment::DifferentialReflectivity => radial.differential_reflectivity(),
-            Moment::DifferentialPhase => radial.differential_phase(),
+            // KDP rides on the phase field: it is what the derivative is taken of, so sweep
+            // selection and gate geometry are decided by ΦDP's presence.
+            Moment::DifferentialPhase | Moment::SpecificDifferentialPhase => {
+                radial.differential_phase()
+            }
             Moment::CorrelationCoefficient => radial.correlation_coefficient(),
         }
     }
@@ -95,6 +105,7 @@ impl Moment {
             Moment::SpectrumWidth => (0.0, 63.0),            // m/s
             Moment::DifferentialReflectivity => (-7.9, 7.9), // dB
             Moment::DifferentialPhase => (0.0, 360.0),       // deg
+            Moment::SpecificDifferentialPhase => (-2.0, 8.0), // deg/km
             Moment::CorrelationCoefficient => (0.0, 1.05),
         }
     }
@@ -385,8 +396,8 @@ pub fn elevation_angles(scan: &Scan) -> Vec<f32> {
 /// Not every radar sends everything: a TDWR has only reflectivity and velocity, and volumes from
 /// before the 2011-13 dual-polarization upgrade have no ZDR/PHI/CC. The UI reads this so those
 /// products are absent rather than selectable-and-blank.
-pub fn available_moments(scan: &Scan) -> [bool; 6] {
-    let mut got = [false; 6];
+pub fn available_moments(scan: &Scan) -> [bool; Moment::ALL.len()] {
+    let mut got = [false; Moment::ALL.len()];
     for sweep in scan.sweeps() {
         for radial in sweep.radials() {
             for m in Moment::ALL {
@@ -546,33 +557,59 @@ pub fn bin_sweep_opts(
         by_bin[bin].push(radial);
     }
 
+    // Gather one radial's worth of raw f32 values into `row`. Below-threshold and range-folded
+    // gates stay `None` — derived moments must not read them as measurements.
+    let gather_row = |bin: usize, row: &mut [Option<f32>], by_bin: &Vec<Vec<&_>>| {
+        for radial in &by_bin[bin] {
+            let Some(m) = moment.select(radial) else {
+                continue;
+            };
+            for (g, value) in m.iter().enumerate().take(gate_count) {
+                if let MomentValue::Value(v) = value {
+                    row[g] = Some(v);
+                }
+            }
+        }
+    };
+
     let mut data = vec![0u8; AZ_BINS * gate_count];
-    if dealias && moment == Moment::Velocity {
+    if moment == Moment::SpecificDifferentialPhase {
+        // KDP is the range derivative of ΦDP, so it has to be taken on the physical field:
+        // the u8 band quantizes 0..360 deg into 253 steps (~1.4 deg), which is the same order
+        // as the per-gate phase change being measured. Differentiating that reads mostly
+        // quantization staircase.
+        let mut phi = vec![None; AZ_BINS * gate_count];
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            use rayon::prelude::*;
+            phi.par_chunks_mut(gate_count)
+                .enumerate()
+                .for_each(|(bin, row)| gather_row(bin, row, &by_bin));
+        }
+        #[cfg(target_arch = "wasm32")]
+        for (bin, row) in phi.chunks_mut(gate_count).enumerate() {
+            gather_row(bin, row, &by_bin);
+        }
+        let kdp = crate::kdp::from_differential_phase(&phi, AZ_BINS, gate_count, gate_interval_km);
+        for (i, v) in kdp.iter().enumerate() {
+            if let Some(v) = v {
+                data[i] = normalize(*v);
+            }
+        }
+    } else if dealias && moment == Moment::Velocity {
         // Gather the raw velocity field (m/s) into the az×gate grid, unfold it region-based,
         // then normalize. Below-threshold/range-folded gates stay None → code 0.
         let mut vel = vec![None; AZ_BINS * gate_count];
-        let gather_row = |bin: usize, row: &mut [Option<f32>]| {
-            for radial in &by_bin[bin] {
-                let Some(m) = moment.select(radial) else {
-                    continue;
-                };
-                for (g, value) in m.iter().enumerate().take(gate_count) {
-                    if let MomentValue::Value(v) = value {
-                        row[g] = Some(v);
-                    }
-                }
-            }
-        };
         #[cfg(not(target_arch = "wasm32"))]
         {
             use rayon::prelude::*;
             vel.par_chunks_mut(gate_count)
                 .enumerate()
-                .for_each(|(bin, row)| gather_row(bin, row));
+                .for_each(|(bin, row)| gather_row(bin, row, &by_bin));
         }
         #[cfg(target_arch = "wasm32")]
         for (bin, row) in vel.chunks_mut(gate_count).enumerate() {
-            gather_row(bin, row);
+            gather_row(bin, row, &by_bin);
         }
         let nyq = crate::dealias::estimate_nyquist(&vel);
         // Continuity: hand the previous pass over this same tilt to the dealiaser, so a storm

--- a/crates/wxdata/src/level2.rs
+++ b/crates/wxdata/src/level2.rs
@@ -132,6 +132,17 @@ pub struct BinnedSweep {
     pub value_max: f32,
 }
 
+/// The first UTC day with volumes in the AWS NEXRAD archive.
+///
+/// Nothing before this exists to be asked for, so it is where a date picker has to stop. The
+/// early years are legacy pre-dual-pol Type-1 messages, which decode but carry reflectivity
+/// and velocity only.
+pub const ARCHIVE_START: chrono::NaiveDate =
+    match chrono::NaiveDate::from_ymd_opt(1991, 6, 5) {
+        Some(d) => d,
+        None => panic!("1991-06-05 is a real date"),
+    };
+
 /// An AWS archive volume identifier (re-exported so callers needn't depend on `nexrad-data`).
 pub use nexrad_data::aws::archive::Identifier;
 

--- a/crates/wxdata/src/lib.rs
+++ b/crates/wxdata/src/lib.rs
@@ -20,6 +20,7 @@ pub mod geocode;
 pub mod glm;
 pub mod global;
 pub mod hrrr;
+pub mod kdp;
 pub mod level2;
 pub mod level3;
 pub mod live;

--- a/crates/wxdata/src/openmeteo.rs
+++ b/crates/wxdata/src/openmeteo.rs
@@ -50,6 +50,8 @@ pub fn parse_forecast(body: &str) -> anyhow::Result<PointForecast> {
                 (Some(s), None) => format!("{s:.0} mph"),
                 _ => String::new(),
             },
+            wind_mph: wind.get(i).map(|s| *s as f32),
+            wind_deg: wind_dir.get(i).map(|d| *d as f32),
             // A daily row covers a whole day; the window colors it as a day period.
             is_day: true,
         });
@@ -70,6 +72,8 @@ fn parse_hourly(hourly: &serde_json::Value) -> Vec<Period> {
     let times = arr_i64(hourly, "time");
     let temps = arr_f64(hourly, "temperature_2m");
     let precip = arr_f64(hourly, "precipitation_probability");
+    let wind = arr_f64(hourly, "wind_speed_10m");
+    let wind_dir = arr_f64(hourly, "wind_direction_10m");
     let now = Utc::now().timestamp();
     times
         .iter()
@@ -82,7 +86,13 @@ fn parse_hourly(hourly: &serde_json::Value) -> Vec<Period> {
                 temp_f: temps.get(i).copied().unwrap_or(f64::NAN) as f32,
                 precip_pct: precip.get(i).map(|p| *p as u8),
                 short: String::new(),
-                wind: String::new(),
+                wind: match (wind.get(i), wind_dir.get(i)) {
+                    (Some(s), Some(d)) => format!("{} {s:.0} mph", compass(*d)),
+                    (Some(s), None) => format!("{s:.0} mph"),
+                    _ => String::new(),
+                },
+                wind_mph: wind.get(i).map(|s| *s as f32),
+                wind_deg: wind_dir.get(i).map(|d| *d as f32),
                 is_day: true,
             })
         })
@@ -152,7 +162,7 @@ pub async fn fetch(http: &reqwest::Client, lat: f64, lon: f64) -> anyhow::Result
     let url = format!(
         "{BASE}?latitude={lat:.4}&longitude={lon:.4}\
          &temperature_unit=fahrenheit&wind_speed_unit=mph&timeformat=unixtime&timezone=UTC\
-         &hourly=temperature_2m,precipitation_probability\
+         &hourly=temperature_2m,precipitation_probability,wind_speed_10m,wind_direction_10m\
          &daily=temperature_2m_max,precipitation_probability_max,weather_code,\
 wind_speed_10m_max,wind_direction_10m_dominant&forecast_days=7"
     );


### PR DESCRIPTION
A gap scan against RadarScope, Windy, MyRadar, RainViewer, RadarOmega and
WeatherFront turned up less than expected — six Level 2 moments, SRV,
dealiasing, the 3D raymarch, cross-sections, CAPPI, the MRMS suite, GLM and
NLDN lightning, NHC cones and surge, skew-T and hodographs, wind particles,
SPC outlooks, model differencing, nowcasting, placefiles and multi-pane are
all already here.

Eleven real gaps came out of it. These are the five that are small,
independent, and touch nothing the basemap/perf/alert work is going to touch.

**KDP** (`crates/wxdata/src/kdp.rs`) — specific differential phase, the field
you read for rainfall rate in a core that has hail in it. It is not
transmitted; it is the range derivative of the phase that is. Unwrapped along
the radial, least-squares fitted over nine gates, halved for the two-way path,
and taken on the f32 field because the u8 band quantizes phase at about the
size of the signal being differentiated.

This also fixes a mislabel it made visible: PHI was named "Specific
Differential Phase" and its mobile chip read "KDP". Those are different
fields. PHI is now "Differential Phase" and KDP takes the blurb that was
always describing it.

**Composite reflectivity** — column maximum from this radar's own volume. The
two composites already in the app are someone else's national grid and a
six-site stitch of *base* reflectivity, which has a single tilt's blind spot.
One `max()` inside a loop `derive()` was already running.

**Archive date picker** — the archive reaches to June 1991 and the only way in
was a caret stepping one day at a time. Thousands of clicks to reach El Reno.

**Meteogram wind row** — wind was prose on the conditions line, which says
what it is doing now and not when it gets windy. Both feeds needed numbers
they were not producing: the NWS publishes wind as text, and Open-Meteo simply
was not asked for it.

**Cell trend sparkline** — the storm table could not say which way a cell was
going. The history was already being kept; you just had to open cells one at a
time to see it.

## Notes

Two things that were assumed and turned out otherwise, both handled:

* `egui_extras`'s date picker takes a `jiff` date, not a chrono one. Converted
  at the one widget boundary rather than migrating every date in the app. jiff
  was already in the tree via the feature that provides the picker.
* Neither hourly forecast product publishes a wind gust — gusts are in the raw
  gridpoint product. So there are no gusts in the wind row rather than a
  fabricated one.

Per-moment arrays are now sized `Moment::ALL.len()` instead of a hardcoded 6,
so the next moment is one line rather than a compile-error tour.

Hotkeys: KDP is 6, CC moves to 7.

## Verification

`cargo clippy --workspace --all-targets` clean · `cargo test --workspace` 534
passing · wasm32 check clean (including the date picker) · `shoot.sh check`
passing.

New tests: KDP on a linear ramp and across a 360 wrap, row independence, empty
radials; composite takes the strongest tilt in the column; the jiff/chrono date
round trip; wind speed out of prose and compass points to degrees.

Not verified by machine: the wind row and the trend column want an eyeball in
a running build.