### PR TITLE
feat: wave G — the inspector, longer nowcasts, and the words that come with a hurricane

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1258,6 +1258,8 @@ fn field_refresh_secs(layer: crate::render::FieldLayer) -> u64 {
         FL::Lightning | FL::AzShear => 60,
         FL::Mrms | FL::Mesh | FL::Rotation | FL::Hrrr | FL::Mosaic => 120,
         // QPE accumulations update on a ~2-minute MRMS cadence.
+        // The rate product lands every 2 minutes; the accumulations move far more slowly.
+        FL::PrecipRate => 120,
         FL::Qpe1h | FL::Qpe24h => 120,
         // MRMS precip type / flash-flood ARI on the ~2-min cadence; L3 grids on the 120 s L3 cadence.
         FL::PrecipType | FL::FlashFlood | FL::Vil | FL::EchoTops | FL::Hca => 120,
@@ -5741,6 +5743,10 @@ impl HookEchoApp {
             Some(s) => s.clone(),
             None => return Vec::new(),
         };
+        // Confidence in a pure advection falls off with lead: it moves the echo that exists and
+        // cannot grow, decay or turn it. Fading the points says so without a disclaimer nobody
+        // reads.
+        let alpha = (150.0 * nowcast_confidence(self.filters.nowcast_lead_min)) as u8;
         let table = self.palettes.table(Moment::Reflectivity);
         let span = (sweep.value_max - sweep.value_min).max(1e-3);
         let radar = [sweep.radar_lon as f64, sweep.radar_lat as f64];
@@ -5763,7 +5769,7 @@ impl HookEchoApp {
                 out.push((
                     adv[0],
                     adv[1],
-                    egui::Color32::from_rgba_unmultiplied(c[0], c[1], c[2], 150),
+                    egui::Color32::from_rgba_unmultiplied(c[0], c[1], c[2], alpha),
                 ));
             }
         }
@@ -7624,6 +7630,13 @@ impl HookEchoApp {
                 "National",
                 "AzShear (0–2 km)",
                 "Low-level rotation strength, right now",
+                false,
+            ),
+            (
+                FL::PrecipRate,
+                "National",
+                "Rain rate",
+                "How hard it is coming down right now, rather than how much has fallen",
                 false,
             ),
             (
@@ -10387,6 +10400,7 @@ impl HookEchoApp {
             FL::Mesh => wxdata::mrms::MESH.to_string(),
             FL::AzShear => wxdata::mrms::AZSHEAR.to_string(),
             FL::Rotation => wxdata::mrms::rotation_track(self.rotation_minutes).to_string(),
+            FL::PrecipRate => wxdata::mrms::PRECIP_RATE.to_string(),
             FL::Qpe1h => wxdata::mrms::QPE_01H.to_string(),
             FL::Qpe24h => wxdata::mrms::QPE_24H.to_string(),
             FL::PrecipType => wxdata::mrms::PRECIP_TYPE.to_string(),
@@ -12198,17 +12212,27 @@ impl HookEchoApp {
 
             // Optical-flow nowcast: advected echo ghost + a lead-time banner.
             if !nowcast_pts.is_empty() {
+                // The dots also grow with lead: a longer extrapolation is a blurrier claim
+                // about where the echo will be, and a bigger, softer dot reads that way.
+                let lead = self.filters.nowcast_lead_min;
+                let radius = 2.5 + (1.0 - nowcast_confidence(lead)) * 3.0;
                 for (lon, lat, col) in &nowcast_pts {
                     let p = to_screen(*lon, *lat);
                     if prect.contains(p) {
-                        painter.circle_filled(p, 2.5, *col);
+                        painter.circle_filled(p, radius, *col);
                     }
                 }
                 if idx == self.active {
-                    let text = format!(
-                        "◈ NOWCAST +{} min — echo extrapolated from storm motion",
-                        self.filters.nowcast_lead_min
-                    );
+                    let text = if lead > 45 {
+                        format!(
+                            "\u{25c8} NOWCAST +{lead} min \u{2014} extrapolation only; try HRRR \
+                             future radar for an hour or more"
+                        )
+                    } else {
+                        format!(
+                            "\u{25c8} NOWCAST +{lead} min \u{2014} echo extrapolated from storm motion"
+                        )
+                    };
                     let font = egui::FontId::proportional(12.0);
                     let anchor = egui::pos2(prect.left() + 8.0, prect.top() + 20.0);
                     let galley =
@@ -17622,6 +17646,45 @@ mod date_picker_tests {
         for (y, m, d) in [(1991, 6, 5), (2026, 8, 24), (2000, 2, 29), (2011, 12, 31)] {
             let orig = chrono::NaiveDate::from_ymd_opt(y, m, d).unwrap();
             assert_eq!(super::from_jiff(super::to_jiff(orig)), Some(orig));
+        }
+    }
+}
+
+/// How much to trust a pure advection at `lead_min` minutes, 1.0 down to ~0.35.
+///
+/// The nowcast moves the echo that exists along the mean storm motion. It cannot grow a cell,
+/// collapse one, or turn it, and every minute of lead is another minute for those to happen. Up
+/// to 45 minutes — the range this shipped with — it is taken at face value; past that it fades,
+/// which is the only honest way to keep offering it.
+fn nowcast_confidence(lead_min: u8) -> f32 {
+    const FULL: f32 = 45.0;
+    const FLOOR: f32 = 0.35;
+    if lead_min as f32 <= FULL {
+        return 1.0;
+    }
+    let over = (lead_min as f32 - FULL) / (120.0 - FULL);
+    (1.0 - over.clamp(0.0, 1.0) * (1.0 - FLOOR)).clamp(FLOOR, 1.0)
+}
+
+#[cfg(test)]
+mod nowcast_tests {
+    use super::nowcast_confidence;
+
+    #[test]
+    fn confidence_is_full_inside_the_old_range_and_fades_past_it() {
+        for lead in [15u8, 30, 45] {
+            assert_eq!(nowcast_confidence(lead), 1.0, "{lead} min");
+        }
+        assert!(nowcast_confidence(60) < 1.0);
+        assert!(nowcast_confidence(90) < nowcast_confidence(60));
+        assert!((nowcast_confidence(120) - 0.35).abs() < 1e-5);
+    }
+
+    /// It must never fade to invisible, or the layer would silently stop existing.
+    #[test]
+    fn confidence_never_reaches_zero() {
+        for lead in 0u8..=255 {
+            assert!(nowcast_confidence(lead) >= 0.35, "{lead} min");
         }
     }
 }

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -3724,6 +3724,72 @@ impl HookEchoApp {
         Some(wxdata::xsection::beam_height_km(km, elev) * 3280.84)
     }
 
+    /// Every moment this volume carries, at the gate under `(lon, lat)`, plus where that gate
+    /// is: azimuth and range from the radar, and how high the beam is there.
+    ///
+    /// The height is the part people forget. A 60 dBZ reading 90 km out on the 0.5 degree cut is
+    /// 1.5 km up, so it is not what is reaching the ground, and a velocity couplet is only a
+    /// low-level couplet if the beam is low. Showing the number without the height invites the
+    /// wrong reading of it.
+    ///
+    /// Returns `None` when the pointer is off the sweep entirely, so hovering empty map says
+    /// nothing rather than flashing an empty tooltip.
+    fn gate_readout(&mut self, idx: usize, lon: f64, lat: f64) -> Option<String> {
+        let tilt = self.views[idx].tilt;
+        let active = self.views[idx].moment;
+        let dealias = self.settings.dealias_velocity;
+        let carried = self.views[idx].volume.as_ref()?.moments;
+        let vol = self.views[idx].volume.as_mut()?;
+
+        // The active moment leads — it is the one being looked at — then the rest in the usual
+        // product order, skipping any this volume does not carry.
+        let order = std::iter::once(active)
+            .chain(Moment::ALL.into_iter().filter(|m| *m != active))
+            .filter(|m| carried[m.index()]);
+
+        let mut lines: Vec<String> = Vec::new();
+        let mut where_at: Option<String> = None;
+        for m in order {
+            // Velocity is read dealiased when the display is dealiased, or the number under the
+            // cursor would disagree with the colour over it.
+            let want_dealias = dealias && m == Moment::Velocity;
+            let Ok(sweep) = vol.binned(m, tilt, want_dealias) else {
+                continue;
+            };
+            let Some(g) = sweep.sample_at(lon, lat) else {
+                continue;
+            };
+            if where_at.is_none() {
+                where_at = Some(format!(
+                    "{:.0}\u{b0} at {:.0} km \u{b7} beam {:.0} ft",
+                    g.azimuth_deg,
+                    g.range_km,
+                    sweep.beam_height_ft(g.range_km)
+                ));
+            }
+            let name = crate::products::info(m).short;
+            let units = m.units();
+            let value = match (g.value, g.folded) {
+                (Some(v), _) => {
+                    let precision = if m == Moment::CorrelationCoefficient { 3 } else { 1 };
+                    if units.is_empty() {
+                        format!("{v:.*}", precision)
+                    } else {
+                        format!("{v:.*} {units}", precision)
+                    }
+                }
+                // "Range folded" and "nothing here" look identical on the map and mean opposite
+                // things, so the readout is where the difference gets said out loud.
+                (None, true) => "range folded".to_string(),
+                (None, false) => "\u{2014}".to_string(),
+            };
+            let marker = if m == active { "\u{25b8} " } else { "  " };
+            lines.push(format!("{marker}{name:<4}{value}"));
+        }
+        let where_at = where_at?;
+        Some(format!("{where_at}\n{}", lines.join("\n")))
+    }
+
     /// Chime when a new volume lands on the live pane you are watching — the "look up" cue for
     /// someone doing something else while a storm is on.
     ///
@@ -11724,6 +11790,19 @@ impl HookEchoApp {
         let zdr_hits = if self.filters.show_zdr_columns { zdr_hits } else { Vec::new() };
         let couplets = if self.filters.show_couplets { couplets } else { Vec::new() };
 
+        // Radar values under the cursor. Computed here, before the long immutable borrow of the
+        // pane below, because sampling the volume needs it mutably — the binned sweeps are
+        // cached on it as they are asked for.
+        let gate_tooltip = (self.tool == MapTool::Interrogate && self.views[idx].show_radar)
+            .then(|| {
+                let hp = response.hover_pos().filter(|p| prect.contains(*p))?;
+                let cam = self.views[idx].camera;
+                let w = cam.screen_to_world((hp.x - prect.left(), hp.y - prect.top()), vp);
+                let (lon, lat) = crate::render::mercator::world_to_lonlat(w.0, w.1);
+                self.gate_readout(idx, lon, lat)
+            })
+            .flatten();
+
         // --- Painter overlays (clipped to this pane) ---
         let painter = ui.painter_at(prect);
         let view = &self.views[idx];
@@ -13272,6 +13351,13 @@ impl HookEchoApp {
                     response.clone().show_tooltip_text(&label.hover);
                 }
             }
+        }
+
+        // The inspector readout, sampled above. Every competitor has one and this had none: the
+        // app could draw a 68 dBZ core and a velocity couplet and never tell you a single number
+        // behind either.
+        if let Some(text) = &gate_tooltip {
+            response.clone().show_tooltip_text(text);
         }
 
         // The difference layer reads as "they disagree here" and nothing more without a number,

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -2118,6 +2118,10 @@ pub struct HookEchoApp {
     afd_error: Option<String>,
     afd_busy: bool,
     afd_rx: Option<std::sync::mpsc::Receiver<Result<wxdata::afd::Afd, String>>>,
+    /// NHC public advisory / forecast discussion reader.
+    tropical_window: ui::tropical_window::TropicalWindow,
+    tropical_text_rx:
+        Option<std::sync::mpsc::Receiver<Result<wxdata::tropical::Advisory, String>>>,
     /// Range rings + azimuth spokes around the active site (feature HH).
     show_range_rings: bool,
     /// Draw all NEXRAD radar sites on the map; clicking one switches the pane to that radar.
@@ -2875,6 +2879,8 @@ impl HookEchoApp {
             afd_error: None,
             afd_busy: false,
             afd_rx: None,
+            tropical_window: ui::tropical_window::TropicalWindow::default(),
+            tropical_text_rx: None,
             show_range_rings: false,
             show_radar_sites: true,
             show_blockage: false,
@@ -8998,6 +9004,41 @@ impl HookEchoApp {
         });
     }
 
+    /// Fetch one NHC text product for `storm_id`.
+    ///
+    /// The URL comes out of the storm feed rather than being built from the id: NHC's product
+    /// filenames key off the basin bin (`EP4`), not the storm id, and the feed already carries
+    /// the exact page for the current advisory number.
+    fn fetch_tropical_text(&mut self, storm_id: &str, product: ui::tropical_window::Product) {
+        let Some(storm) = self
+            .tropical
+            .as_ref()
+            .and_then(|t| t.storms.iter().find(|s| s.id == storm_id))
+            .cloned()
+        else {
+            self.tropical_window.error = Some("that storm is no longer being advised on".into());
+            return;
+        };
+        let Some(url) = product.url(&storm).map(str::to_string) else {
+            self.tropical_window.error =
+                Some(format!("no {} published for {}", product.label(), storm.name));
+            self.tropical_window.text = None;
+            return;
+        };
+        let title = format!("{} {} — {}", storm.classification, storm.name, product.label());
+        let (tx, rx) = std::sync::mpsc::channel();
+        self.tropical_text_rx = Some(rx);
+        self.tropical_window.busy = true;
+        self.tropical_window.error = None;
+        let http = self.http.clone();
+        self.spawner.spawn(async move {
+            let res = wxdata::tropical::fetch_advisory(&http, &title, &url)
+                .await
+                .map_err(|e| e.to_string());
+            let _ = tx.send(res);
+        });
+    }
+
     /// Drive the METAR station-plot fetch (feature U): only when enabled and zoomed in enough,
     /// refetching every 75 s or when the view center drifts out of the fetched bbox's middle half.
     fn sync_metar(&mut self, ctx: &egui::Context) {
@@ -11416,7 +11457,41 @@ impl HookEchoApp {
                     // Drawing happens on drag, not on click; a bare click leaves no mark.
                     MapTool::Draw => {}
                     MapTool::AlertZone => self.zone_pts.push([lon, lat]),
-                    MapTool::Interrogate => {
+                    // Labelled so the storm-marker shortcut below can bail out of the hit-test
+                    // chain without returning from `render_pane` and costing this pane its
+                    // tiles and radar for the frame.
+                    MapTool::Interrogate => 'interrogate: {
+                        // A tropical cyclone's own marker sits above everything else: it is the
+                        // one feature whose words matter more than its geometry, and the cone
+                        // polygon underneath would otherwise swallow the click.
+                        let storm_hit = self
+                            .show_tropical
+                            .then(|| {
+                                self.tropical.as_ref().and_then(|t| {
+                                    t.storms
+                                        .iter()
+                                        .find(|s| {
+                                            let w = crate::render::mercator::lonlat_to_world(
+                                                s.lon, s.lat,
+                                            );
+                                            let (sx, sy) = cam.world_to_screen(w, vp);
+                                            let (dx, dy) = (
+                                                prect.left() + sx - pos.x,
+                                                prect.top() + sy - pos.y,
+                                            );
+                                            dx * dx + dy * dy <= tap_r2(14.0)
+                                        })
+                                        .map(|s| s.id.clone())
+                                })
+                            })
+                            .flatten();
+                        if let Some(id) = storm_hit {
+                            self.tropical_window.open = true;
+                            self.tropical_window.storm_id = Some(id.clone());
+                            let product = self.tropical_window.product;
+                            self.fetch_tropical_text(&id, product);
+                            break 'interrogate;
+                        }
                         // Storm reports sit on top: a click near a report dot opens its detail.
                         let report = self
                             .show_storm_reports
@@ -16528,6 +16603,35 @@ impl eframe::App for HookEchoApp {
             );
             if refresh {
                 self.fetch_afd();
+            }
+        }
+        // NHC text products: poll the fetch, then draw the reader.
+        if let Some(rx) = &self.tropical_text_rx {
+            if let Ok(res) = rx.try_recv() {
+                self.tropical_window.busy = false;
+                self.tropical_text_rx = None;
+                match res {
+                    Ok(a) => {
+                        self.tropical_window.text = Some(a);
+                        self.tropical_window.error = None;
+                    }
+                    Err(e) => {
+                        self.tropical_window.text = None;
+                        self.tropical_window.error = Some(e);
+                    }
+                }
+            }
+        }
+        if self.tropical_window.open {
+            let storms = self
+                .tropical
+                .as_ref()
+                .map(|t| t.storms.clone())
+                .unwrap_or_default();
+            if let Some((id, product)) =
+                ui::tropical_window::show(&mut self.tropical_window, ctx, &storms)
+            {
+                self.fetch_tropical_text(&id, product);
             }
         }
         // Point sounding: poll the async fetch, then render the Skew-T / hodograph.

--- a/crates/hookecho/src/render/field_ramps.rs
+++ b/crates/hookecho/src/render/field_ramps.rs
@@ -174,6 +174,17 @@ static QPE_STOPS: &[(f32, [u8; 3])] = &[
     (0.8, [220, 40, 60]),
     (1.0, [230, 220, 240]),
 ];
+// Rate, not accumulation: the top of the scale is a rain rate rather than a storm total, so
+// it shares the QPE colours but not its bounds. 100 mm/hr is a tropical downpour.
+static PRECIP_RATE: FieldRamp = ramp!(
+    "Rain rate",
+    "mm/hr",
+    0.25,
+    100.0,
+    RampScale::Log,
+    255,
+    QPE_STOPS
+);
 static QPE_1H: FieldRamp = ramp!(
     "Rain (1 h)",
     "mm",
@@ -581,6 +592,7 @@ pub fn ramp_for(layer: FieldLayer) -> Option<&'static FieldRamp> {
         FL::Rotation | FL::AzShear => &ROTATION,
         FL::Mesh => &MESH,
         FL::HailSwath => &HAIL_SWATH,
+        FL::PrecipRate => &PRECIP_RATE,
         FL::Qpe1h => &QPE_1H,
         FL::Qpe24h => &QPE_24H,
         FL::Cape => &CAPE,

--- a/crates/hookecho/src/render/mod.rs
+++ b/crates/hookecho/src/render/mod.rs
@@ -62,6 +62,9 @@ pub enum FieldLayer {
     Mesh,
     AzShear,
     Lightning,
+    /// Instantaneous precipitation rate (mm/hr) — how hard it is coming down right now,
+    /// as against the QPE layers' how much has fallen.
+    PrecipRate,
     Qpe1h,
     Qpe24h,
     /// HRRR surface CAPE (environment suite).
@@ -144,7 +147,7 @@ impl FieldLayer {
     }
 
     /// Fixed bottom-to-top paint order within each band.
-    pub const DRAW_ORDER: [FieldLayer; 34] = [
+    pub const DRAW_ORDER: [FieldLayer; 35] = [
         // Below-radar context band (bottom to top). The global models sit at the very bottom:
         // they are the synoptic backdrop everything else is drawn against.
         FieldLayer::GlobalMslp,
@@ -163,6 +166,7 @@ impl FieldLayer {
         FieldLayer::SnowAnalysis,
         FieldLayer::PrecipType,
         // Above-radar severe-signal band.
+        FieldLayer::PrecipRate,
         FieldLayer::Qpe1h,
         FieldLayer::Qpe24h,
         FieldLayer::FlashFlood,
@@ -194,6 +198,7 @@ impl FieldLayer {
             FieldLayer::Mesh => "mesh",
             FieldLayer::AzShear => "azshear",
             FieldLayer::Lightning => "lightning",
+            FieldLayer::PrecipRate => "preciprate",
             FieldLayer::Qpe1h => "qpe1h",
             FieldLayer::Qpe24h => "qpe24h",
             FieldLayer::Cape => "cape",

--- a/crates/hookecho/src/ui/layer_options.rs
+++ b/crates/hookecho/src/ui/layer_options.rs
@@ -385,10 +385,17 @@ pub(crate) fn show(
         header(ui, "Nowcast");
         ui.horizontal(|ui| {
             ui.label("Lead:");
-            for m in [15u8, 30, 45] {
+            for m in [15u8, 30, 45, 60, 90, 120] {
                 ui.selectable_value(&mut filters.nowcast_lead_min, m, format!("{m}m"));
             }
         });
+        if filters.nowcast_lead_min > 45 {
+            ui.small(
+                "Past 45 minutes this is extrapolation, not forecasting — it moves the echo \
+                 that exists and cannot grow or decay it. HRRR future radar is the model \
+                 answer for an hour or more.",
+            );
+        }
     }
 
     if filters.show_alerts {

--- a/crates/hookecho/src/ui/mod.rs
+++ b/crates/hookecho/src/ui/mod.rs
@@ -72,6 +72,7 @@ pub(crate) fn csv_buttons(
 
 pub mod about_window;
 pub mod afd_window;
+pub mod tropical_window;
 pub mod alert_panel;
 pub mod basemap_picker;
 pub mod cappi_window;

--- a/crates/hookecho/src/ui/tropical_window.rs
+++ b/crates/hookecho/src/ui/tropical_window.rs
@@ -1,0 +1,134 @@
+//! NHC text products for an active storm: the public advisory and the forecast discussion.
+//!
+//! The app drew the cone, the track and the wind field but carried none of the words that come
+//! with them. The discussion is where the hurricane specialist says what the guidance disagrees
+//! about and how confident the track really is — the part a cone cannot express.
+
+use wxdata::tropical::{Advisory, TropicalStorm};
+
+/// Which text product to show.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Product {
+    /// Public advisory (TCP): watches, warnings, hazards, the numbers.
+    Advisory,
+    /// Forecast discussion (TCD): the forecaster's reasoning.
+    Discussion,
+}
+
+impl Product {
+    pub fn label(self) -> &'static str {
+        match self {
+            Product::Advisory => "Advisory",
+            Product::Discussion => "Discussion",
+        }
+    }
+
+    /// This product's page for `storm`, if the feed published one.
+    pub fn url(self, storm: &TropicalStorm) -> Option<&str> {
+        match self {
+            Product::Advisory => storm.advisory_url.as_deref(),
+            Product::Discussion => storm.discussion_url.as_deref(),
+        }
+    }
+}
+
+/// What the window is currently pointed at.
+pub struct TropicalWindow {
+    pub open: bool,
+    /// Storm id the text belongs to; `None` until one is chosen.
+    pub storm_id: Option<String>,
+    pub product: Product,
+    pub text: Option<Advisory>,
+    pub busy: bool,
+    pub error: Option<String>,
+}
+
+impl Default for TropicalWindow {
+    fn default() -> Self {
+        Self {
+            open: false,
+            storm_id: None,
+            product: Product::Discussion,
+            text: None,
+            busy: false,
+            error: None,
+        }
+    }
+}
+
+/// Show the window. Returns `Some((storm id, product))` when the user asks for a fetch — either
+/// by picking a different storm or product, or by hitting refresh.
+pub fn show(
+    w: &mut TropicalWindow,
+    ctx: &egui::Context,
+    storms: &[TropicalStorm],
+) -> Option<(String, Product)> {
+    if !w.open {
+        return None;
+    }
+    let mut want: Option<(String, Product)> = None;
+    let mut open = w.open;
+    crate::ui::phone_surface(ctx, egui::Window::new("Tropical products"))
+        .open(&mut open)
+        .default_size([600.0, 540.0])
+        .show(ctx, |ui| {
+            if storms.is_empty() {
+                ui.weak("No active tropical cyclones.");
+                ui.small("The NHC publishes these only while a storm is being advised on.");
+                return;
+            }
+            ui.horizontal_wrapped(|ui| {
+                for s in storms {
+                    let selected = w.storm_id.as_deref() == Some(s.id.as_str());
+                    if ui
+                        .selectable_label(selected, format!("{} {}", s.classification, s.name))
+                        .clicked()
+                        && !selected
+                    {
+                        w.storm_id = Some(s.id.clone());
+                        want = Some((s.id.clone(), w.product));
+                    }
+                }
+            });
+            ui.horizontal(|ui| {
+                for p in [Product::Discussion, Product::Advisory] {
+                    if ui.selectable_label(w.product == p, p.label()).clicked() && w.product != p {
+                        w.product = p;
+                        if let Some(id) = w.storm_id.clone() {
+                            want = Some((id, p));
+                        }
+                    }
+                }
+                if w.busy {
+                    crate::ui::loading(ui, "Fetching…");
+                } else if ui.button("⟳ Refresh").clicked() {
+                    if let Some(id) = w.storm_id.clone() {
+                        want = Some((id, w.product));
+                    }
+                }
+            });
+            if let Some(e) = &w.error {
+                ui.colored_label(egui::Color32::from_rgb(230, 90, 90), e);
+            }
+            ui.separator();
+            egui::ScrollArea::vertical()
+                .auto_shrink([false, false])
+                .show(ui, |ui| match &w.text {
+                    // The products are column-formatted plain text; monospace or they lose it.
+                    Some(a) => {
+                        ui.add(
+                            egui::Label::new(egui::RichText::new(&a.text).monospace().size(12.0))
+                                .wrap(),
+                        );
+                    }
+                    None if w.busy => {
+                        ui.weak("Fetching…");
+                    }
+                    None => {
+                        ui.weak("Pick a storm to read its latest product.");
+                    }
+                });
+        });
+    w.open = open;
+    want
+}

--- a/crates/wxdata/src/level2.rs
+++ b/crates/wxdata/src/level2.rs
@@ -143,6 +143,69 @@ pub const ARCHIVE_START: chrono::NaiveDate =
         None => panic!("1991-06-05 is a real date"),
     };
 
+/// What a [`BinnedSweep`] holds at one gate, and where that gate is.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct GateSample {
+    /// Physical value in the moment's units; `None` when the gate is below threshold or the
+    /// value is range-folded (see [`GateSample::folded`]).
+    pub value: Option<f32>,
+    /// The gate is range-folded — the radar saw a target it cannot place in range, which is a
+    /// different statement from "nothing there".
+    pub folded: bool,
+    /// Azimuth from the radar, degrees clockwise from north.
+    pub azimuth_deg: f32,
+    /// Slant range from the radar along the beam, km.
+    pub range_km: f32,
+    /// Gate index along the radial — what a range-resolution argument is actually about.
+    pub gate: usize,
+}
+
+impl BinnedSweep {
+    /// The gate under a ground position, or `None` when it falls outside this sweep.
+    ///
+    /// This is the inverse of the binning: ground distance and bearing from the radar, the
+    /// slant range that ground distance implies at this tilt, and then the same azimuth-bin and
+    /// gate-index arithmetic [`bin_sweep_opts`] used on the way in. Deliberately no
+    /// interpolation — the question a readout answers is "what did the radar record *here*",
+    /// and a blend of neighbouring gates is a number the radar never produced.
+    pub fn sample_at(&self, lon: f64, lat: f64) -> Option<GateSample> {
+        let (ground_km, bearing) = crate::xsection::dist_bearing(
+            self.radar_lon as f64,
+            self.radar_lat as f64,
+            lon,
+            lat,
+        );
+        let slant = crate::xsection::slant_from_ground_km(ground_km, self.elevation_deg as f64);
+        let gate = ((slant - self.first_gate_km as f64) / self.gate_interval_km.max(1e-6) as f64)
+            .floor();
+        if gate < 0.0 || gate >= self.gate_count as f64 {
+            return None;
+        }
+        let gate = gate as usize;
+        let az = bearing.rem_euclid(360.0);
+        let bin = ((az / 360.0 * self.az_bins as f64) as usize) % self.az_bins;
+        let code = *self.data.get(bin * self.gate_count + gate)?;
+        // 0 and 1 are the two sentinel codes the binner writes; 2..=255 is the value band.
+        let value = (code >= 2).then(|| {
+            let t = (code - 2) as f32 / 253.0;
+            self.value_min + t * (self.value_max - self.value_min)
+        });
+        Some(GateSample {
+            value,
+            folded: code == 1,
+            azimuth_deg: az as f32,
+            range_km: slant as f32,
+            gate,
+        })
+    }
+
+    /// Height of the beam centre above the radar at `range_km`, in feet — the number that says
+    /// whether a reading is near the ground or three miles up.
+    pub fn beam_height_ft(&self, range_km: f32) -> f64 {
+        crate::xsection::beam_height_km(range_km as f64, self.elevation_deg as f64) * 3280.84
+    }
+}
+
 /// An AWS archive volume identifier (re-exported so callers needn't depend on `nexrad-data`).
 pub use nexrad_data::aws::archive::Identifier;
 
@@ -696,6 +759,99 @@ mod tests {
 
     /// The bucket carries a metadata-message sidecar next to the volumes. It parses as an
     /// identifier and sorts in among them, so nothing downstream notices it is not a volume.
+    /// A sweep sampled at a point built from a known azimuth and range must hand back that
+    /// azimuth, that range, and the value written into that gate. This is the whole inspector:
+    /// if the inverse mapping is off, every number it shows is off with it.
+    #[test]
+    fn sampling_a_gate_inverts_the_binning() {
+        let (az_bins, gate_count) = (720, 200);
+        let mut sweep = BinnedSweep {
+            moment: Moment::Reflectivity,
+            az_bins,
+            gate_count,
+            data: vec![0u8; az_bins * gate_count],
+            first_gate_km: 0.0,
+            gate_interval_km: 0.25,
+            radar_lat: 35.0,
+            radar_lon: -97.0,
+            elevation_deg: 0.5,
+            value_min: -32.0,
+            value_max: 95.0,
+        };
+        // Write a known value into one gate: azimuth bin 180 (= 90 deg, due east), gate 100.
+        let (want_az, want_gate) = (90.0_f64, 100usize);
+        let code = 200u8;
+        sweep.data[(want_az / 360.0 * az_bins as f64) as usize * gate_count + want_gate] = code;
+
+        // Where is that gate on the ground? Slant range of its centre, converted back to ground.
+        let slant = (want_gate as f64 + 0.5) * 0.25;
+        let ground = crate::xsection::ground_from_slant_km(slant, 0.5);
+        let (lon, lat) = destination(-97.0, 35.0, want_az, ground);
+
+        let got = sweep.sample_at(lon, lat).expect("point is inside the sweep");
+        assert_eq!(got.gate, want_gate, "gate index");
+        assert!((got.azimuth_deg as f64 - want_az).abs() < 0.5, "azimuth {got:?}");
+        let want_value = -32.0 + (code - 2) as f32 / 253.0 * (95.0 - -32.0);
+        assert!((got.value.unwrap() - want_value).abs() < 0.01, "value {got:?}");
+    }
+
+    /// The two sentinel codes are not values, and must not be reported as one.
+    #[test]
+    fn below_threshold_and_range_folded_are_not_values() {
+        let mut sweep = BinnedSweep {
+            moment: Moment::Velocity,
+            az_bins: 720,
+            gate_count: 10,
+            data: vec![0u8; 720 * 10],
+            first_gate_km: 0.0,
+            gate_interval_km: 1.0,
+            radar_lat: 35.0,
+            radar_lon: -97.0,
+            elevation_deg: 0.5,
+            value_min: -127.0,
+            value_max: 127.0,
+        };
+        sweep.data[1] = 1; // range folded, due north, gate 1
+        let (lon, lat) = destination(-97.0, 35.0, 0.0, 1.5);
+        let got = sweep.sample_at(lon, lat).unwrap();
+        assert!(got.folded && got.value.is_none());
+
+        let (lon, lat) = destination(-97.0, 35.0, 0.0, 3.5);
+        let got = sweep.sample_at(lon, lat).unwrap();
+        assert!(!got.folded && got.value.is_none(), "below threshold is not folded");
+    }
+
+    /// Past the last gate there is no reading — not a clamped one at the edge of the sweep.
+    #[test]
+    fn a_point_beyond_the_last_gate_has_no_sample() {
+        let sweep = BinnedSweep {
+            moment: Moment::Reflectivity,
+            az_bins: 720,
+            gate_count: 10,
+            data: vec![9u8; 720 * 10],
+            first_gate_km: 0.0,
+            gate_interval_km: 1.0,
+            radar_lat: 35.0,
+            radar_lon: -97.0,
+            elevation_deg: 0.5,
+            value_min: -32.0,
+            value_max: 95.0,
+        };
+        let (lon, lat) = destination(-97.0, 35.0, 45.0, 400.0);
+        assert!(sweep.sample_at(lon, lat).is_none());
+    }
+
+    /// Walk `km` from a point along `bearing`, for placing test points at a known gate.
+    fn destination(lon: f64, lat: f64, bearing_deg: f64, km: f64) -> (f64, f64) {
+        let r = 6371.0088_f64;
+        let (b, d) = (bearing_deg.to_radians(), km / r);
+        let (p0, l0) = (lat.to_radians(), lon.to_radians());
+        let p = (p0.sin() * d.cos() + p0.cos() * d.sin() * b.cos()).asin();
+        let l = l0
+            + (b.sin() * d.sin() * p0.cos()).atan2(d.cos() - p0.sin() * p.sin());
+        (l.to_degrees(), p.to_degrees())
+    }
+
     #[test]
     fn a_metadata_sidecar_is_not_a_volume() {
         assert!(is_volume("KTLH20260819_101257_V06"));

--- a/crates/wxdata/src/mrms.rs
+++ b/crates/wxdata/src/mrms.rs
@@ -34,6 +34,8 @@ pub const AZSHEAR: &str = "CONUS/MergedAzShear_0-2kmAGL_00.50";
 pub const QPE_01H: &str = "CONUS/MultiSensor_QPE_01H_Pass2_00.00";
 /// Multi-sensor 24-hour QPE accumulation, Pass-2 gauge-corrected (mm; storm-total scale).
 pub const QPE_24H: &str = "CONUS/MultiSensor_QPE_24H_Pass2_00.00";
+/// Instantaneous surface precipitation rate (mm/hr), 2-minute cadence.
+pub const PRECIP_RATE: &str = "CONUS/PrecipRate_00.00";
 /// Surface precipitation type flag (categorical: rain/snow/hail/convective).
 pub const PRECIP_TYPE: &str = "CONUS/PrecipFlag_00.00";
 /// FLASH flash-flood average recurrence interval over the 30-min QPE window (years).

--- a/crates/wxdata/src/tropical.rs
+++ b/crates/wxdata/src/tropical.rs
@@ -36,6 +36,10 @@ pub struct TropicalStorm {
     pub lat: f64,
     pub lon: f64,
     pub points: Vec<TrackPoint>,
+    /// Public advisory (TCP) page for this storm, straight from the feed.
+    pub advisory_url: Option<String>,
+    /// Forecast discussion (TCD) page — the hurricane specialist's own reasoning.
+    pub discussion_url: Option<String>,
 }
 
 /// The fetched tropical picture: cones (as overlay features) plus per-storm positions/tracks.
@@ -223,6 +227,13 @@ pub async fn fetch_active_opts(
             }
         }
 
+        // The feed nests each product's page under its own key; take the URL and nothing else.
+        let product_url = |key: &str| {
+            s.get(key)
+                .and_then(|p| p.get("url"))
+                .and_then(|u| u.as_str())
+                .map(str::to_string)
+        };
         data.storms.push(TropicalStorm {
             id: get("id"),
             name,
@@ -231,6 +242,8 @@ pub async fn fetch_active_opts(
             lat,
             lon,
             points,
+            advisory_url: product_url("publicAdvisory"),
+            discussion_url: product_url("forecastDiscussion"),
         });
     }
     if surge {
@@ -338,6 +351,59 @@ fn features(
     out
 }
 
+/// One fetched NHC text product.
+#[derive(Debug, Clone)]
+pub struct Advisory {
+    /// Storm name plus which product this is, for the window title.
+    pub title: String,
+    pub text: String,
+}
+
+/// The product text out of an NHC text page.
+///
+/// These pages are `.shtml` with the product in a single `<pre>` block — there is no `.txt`
+/// variant (they 404), so the block is what there is to take. Returns `None` rather than a page
+/// full of navigation chrome if the layout ever changes.
+pub fn advisory_text(html: &str) -> Option<String> {
+    let start = html.find("<pre>")? + "<pre>".len();
+    let end = html[start..].find("</pre>")? + start;
+    let body = html[start..end].trim();
+    if body.is_empty() {
+        return None;
+    }
+    // The products are plain text inside the block, but the page still escapes the handful of
+    // characters HTML reserves.
+    Some(
+        body.replace("&lt;", "<")
+            .replace("&gt;", ">")
+            .replace("&quot;", "\"")
+            .replace("&#39;", "'")
+            .replace("&amp;", "&"),
+    )
+}
+
+/// Fetch one of a storm's text products by URL.
+pub async fn fetch_advisory(
+    client: &reqwest::Client,
+    title: &str,
+    url: &str,
+) -> anyhow::Result<Advisory> {
+    let body = client
+        .get(crate::net::fetch_url(url))
+        .header("User-Agent", USER_AGENT)
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+    let text = advisory_text(&body)
+        .ok_or_else(|| anyhow::anyhow!("no product text in the NHC page"))?;
+    Ok(Advisory {
+        title: title.to_string(),
+        text,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -384,6 +450,30 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(json).unwrap();
         let active = v.get("activeStorms").and_then(|a| a.as_array()).unwrap();
         assert!(active.is_empty(), "off-season → no storms");
+    }
+
+    #[test]
+    fn advisory_text_comes_out_of_the_pre_block() {
+        let page = "<html><body><div>nav junk</div><pre>\nWTPZ44 KNHC 242032\nTCDEP4\n\n\
+                    Tropical Storm Iselle Discussion Number 6\n</pre><footer>more junk</footer>";
+        let t = advisory_text(page).expect("pre block");
+        assert!(t.starts_with("WTPZ44"), "{t}");
+        assert!(t.contains("Discussion Number 6"));
+        assert!(!t.contains("junk"), "page chrome must not come through");
+    }
+
+    #[test]
+    fn a_page_without_a_product_is_none_not_chrome() {
+        assert!(advisory_text("<html><body>no product here</body></html>").is_none());
+        assert!(advisory_text("<pre>   </pre>").is_none());
+    }
+
+    #[test]
+    fn escaped_characters_are_unescaped() {
+        assert_eq!(
+            advisory_text("<pre>winds &gt; 50 kt &amp; rising</pre>").unwrap(),
+            "winds > 50 kt & rising"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #72 (wave F) — review that first; this branch targets `feat/kdp`.

Three of the eleven competitor-parity gaps. The remaining external
verification for this wave came back clean and is recorded in the plan.

**Radar gate inspector.** The app could draw a 68 dBZ core, a velocity couplet
and a CC hole and never tell you a number behind any of them; Interrogate
hit-tested points and polygons and fell through silently over the radar
itself. Hovering now reads every moment the volume carries at that gate —
active one first — with azimuth, range, and beam height.

The height is the part people forget. A 60 dBZ reading 90 km out on 0.5
degrees is a mile and a half up, so it is not what is reaching the ground.

`BinnedSweep::sample_at` is the inverse of the binning and lives beside it. No
interpolation: the question is what the radar recorded there, and a blend of
neighbouring gates is a number it never produced. Two distinctions the map
cannot make get spelled out — below-threshold vs range-folded look identical
on screen and mean opposite things — and velocity is sampled dealiased when
the display is.

**Nowcast to two hours.** It stopped at 45 minutes, and "will this reach me
before I leave" is usually a 90-minute question. 60/90/120 now exist, and what
makes that honest rather than overreach is that they look less certain: the
dots fade toward 35% and grow softer with lead, and past 45 minutes both the
banner and the layer options say plainly that this moves the echo that exists
and cannot grow, decay or turn it.

No auto-handoff into HRRR — that layer is one checkbox away, and switching
underneath the user would make one layer mean two things depending on a number
they set.

Rider: **MRMS PrecipRate**. Two rain accumulations existed and no rate, so the
app could say how much had fallen and not how hard it was coming down.

**NHC advisory and discussion.** The cone, track, wind field and surge were all
drawn and none of the words were carried. Click a storm marker (or pick from
the list) for the public advisory or the forecast discussion.

## Verification notes

Three items resolved by probing the live feeds:

* NHC `CurrentStorms.json` does carry `publicAdvisory.url` and
  `forecastDiscussion.url`, but **the `.txt` variants the plan assumed do not
  exist — they 404**. The pages are `.shtml` with the product in a single
  `<pre>` block, so there is a small extractor with tests, including one
  asserting page chrome does not come through.
* `CONUS/PrecipRate_00.00` exists in `noaa-mrms-pds` on a 2-minute cadence.
* KDP from #72 shows up in the inspector readout as intended.

One bug caught in review of my own work: the storm-marker shortcut originally
`return`ed out of the hit-test chain, which returns from `render_pane` — that
would have cost the pane its tiles and radar for the click frame. It breaks out
of a labelled block instead.

## Bar

`cargo clippy --workspace --all-targets` clean · `cargo test --workspace` 542
passing · wasm32 clean · `shoot.sh check` passing · wasm bundle 4,729,733
gzipped against the 4,800,000 budget (~70 KB spare; CI builds ~26 KB heavier
than my machine, so that margin is real).

New tests: the gate inverse mapping against a synthetic sweep, the two sentinel
codes, out-of-sweep points, nowcast confidence falloff and its floor, and three
on the advisory extractor.

Not verified by machine: the inspector tooltip, the faded long-lead dots and
the advisory window all want an eyeball in a running build.