### PR TITLE
feat(tokens): one token module, two densities

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1793,8 +1793,8 @@ pub struct HookEchoApp {
     chasepack: Option<ChasePack>,
     /// Per-pane "what's uploaded" key, so each pane re-bins/re-uploads only on a real change.
     pane_shown: std::collections::HashMap<usize, ShownKey>,
-    /// Last `(theme, system_dark)` handed to `theme::apply`.
-    theme_applied: Option<(crate::settings::Theme, bool)>,
+    /// Last `(theme, system_dark, density)` handed to `theme::apply`.
+    theme_applied: Option<(crate::settings::Theme, bool, crate::ui::m3::Density)>,
     /// When the settings tree was last diffed against the saved copy.
     settings_checked: Option<Instant>,
     /// Frame counter, only used to invalidate within-frame memos.
@@ -15965,9 +15965,9 @@ impl eframe::App for HookEchoApp {
         // or the system light/dark preference changes — it rebuilds and installs a whole
         // `egui::Style`, which is wasted work on every other frame.
         let system_dark = ctx.input(|i| i.raw.system_theme) != Some(egui::Theme::Light);
-        if self.theme_applied != Some((self.settings.theme, system_dark)) {
-            crate::theme::apply(ctx, self.settings.theme, system_dark);
-            self.theme_applied = Some((self.settings.theme, system_dark));
+        if self.theme_applied != Some((self.settings.theme, system_dark, self.settings.density)) {
+            crate::theme::apply(ctx, self.settings.theme, system_dark, self.settings.density);
+            self.theme_applied = Some((self.settings.theme, system_dark, self.settings.density));
         }
 
         // UI scale: apply the setting when the slider moved, else absorb built-in keyboard zoom

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -4,6 +4,7 @@
 //! land in later milestones. `#[serde(default)]` makes old config files forward-compatible
 //! — new fields fill from `Default`, unknown fields are ignored.
 
+use crate::ui::m3::Density;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -131,6 +132,9 @@ pub struct Settings {
     /// Seconds between live-update polls for the newest volume.
     pub poll_interval_secs: u64,
     pub theme: Theme,
+    /// UI density (spacing/type token table). Comfortable by default; Compact restores the
+    /// pre-0.12 pro-dense desktop metrics.
+    pub density: Density,
     /// Starred radar sites shown in the toolbox presets dropdown.
     pub presets: Vec<String>,
     /// Per-moment color-table override: moment short name (`REF`, `VEL`, …) -> `.pal` path.
@@ -993,6 +997,7 @@ impl Default for Settings {
             etop_dbz: default_etop_dbz(),
             poll_interval_secs: 30,
             theme: Theme::Dark,
+            density: Density::default(),
             presets: Vec::new(),
             palettes: BTreeMap::new(),
             velocity_unit: VelocityUnit::default(),
@@ -1419,6 +1424,7 @@ mod tests {
             mping_key: String::new(),
             etop_dbz: 30.0,
             default_site: "KFWS".to_string(),
+            density: Density::Compact,
             poll_interval_secs: 45,
             theme: Theme::Synthwave,
             presets: vec!["KTLX".to_string(), "KOUN".to_string()],
@@ -1678,9 +1684,11 @@ mod tests {
 
     #[test]
     fn a_good_file_is_unchanged_and_a_broken_one_still_loads() {
-        let mut original = Settings::default();
-        original.mapbox_key = "abc".to_string();
-        original.ui_scale = 1.1;
+        let original = Settings {
+            mapbox_key: "abc".to_string(),
+            ui_scale: 1.1,
+            ..Default::default()
+        };
         let text = serde_json::to_string(&original).unwrap();
         let round = Settings::from_json_lossy(&text);
         assert_eq!(round.mapbox_key, "abc");

--- a/crates/hookecho/src/theme.rs
+++ b/crates/hookecho/src/theme.rs
@@ -5,6 +5,7 @@
 //! switches. `// ponytail: no bundled font — egui's default proportional face is fine; drop an
 //! Inter/IBM-Plex TTF into data/fonts/ and install it here if a distinct face is wanted.`
 
+use crate::ui::m3::{self, Density};
 use crate::settings::Theme;
 use egui::{Color32, CornerRadius, Margin, Stroke, Style, Visuals};
 
@@ -239,7 +240,7 @@ pub fn preview_bg(theme: Theme) -> Color32 {
     palette(theme, true).bg
 }
 
-pub fn apply(ctx: &egui::Context, theme: Theme, system_dark: bool) {
+pub fn apply(ctx: &egui::Context, theme: Theme, system_dark: bool, density: Density) {
     let pal = palette(theme, system_dark);
     let mut visuals = if pal.is_dark {
         Visuals::dark()
@@ -253,12 +254,14 @@ pub fn apply(ctx: &egui::Context, theme: Theme, system_dark: bool) {
         ..Default::default()
     };
 
-    // Spacing.
-    style.spacing.item_spacing = egui::vec2(8.0, 6.0);
-    style.spacing.button_padding = egui::vec2(10.0, 5.0);
-    style.spacing.interact_size.y = 26.0;
-    style.spacing.window_margin = Margin::same(10);
-    style.spacing.menu_margin = Margin::same(8);
+    // Spacing and type come from one token table: touch on Android, else the density the user
+    // picked (`m3::COMFORT` / `m3::COMPACT`). No widget branches on density.
+    let m = m3::metrics(density, cfg!(target_os = "android"));
+    style.spacing.item_spacing = m.item_spacing;
+    style.spacing.button_padding = m.button_padding;
+    style.spacing.interact_size.y = m.interact_h;
+    style.spacing.window_margin = Margin::same(m.window_margin);
+    style.spacing.menu_margin = Margin::same(m.menu_margin);
 
     // Rounding on every widget state.
     let r = CornerRadius::same(6);
@@ -277,54 +280,16 @@ pub fn apply(ctx: &egui::Context, theme: Theme, system_dark: bool) {
     // Type scale (egui's default face; sizes only).
     use egui::{FontFamily::Proportional, FontId, TextStyle};
     style.text_styles = [
-        (TextStyle::Heading, FontId::new(15.0, Proportional)),
-        (TextStyle::Body, FontId::new(13.5, Proportional)),
-        (TextStyle::Button, FontId::new(13.5, Proportional)),
-        (TextStyle::Small, FontId::new(11.0, Proportional)),
+        (TextStyle::Heading, FontId::new(m.heading, Proportional)),
+        (TextStyle::Body, FontId::new(m.body, Proportional)),
+        (TextStyle::Button, FontId::new(m.button, Proportional)),
+        (TextStyle::Small, FontId::new(m.small, Proportional)),
         (
             TextStyle::Monospace,
-            FontId::new(12.5, egui::FontFamily::Monospace),
+            FontId::new(m.mono, egui::FontFamily::Monospace),
         ),
     ]
     .into();
-
-    // Desktop runs denser than touch: the sidebar has to fit a product section, a category row,
-    // a tree and three disclosures in 320 px, and a mouse doesn't need 26 px targets. Android
-    // gets the Material 3 type scale and a touch-sized interact height instead.
-    if cfg!(target_os = "android") {
-        use crate::ui::m3;
-        style.spacing.item_spacing = egui::vec2(m3::SP_2, m3::SP_2);
-        style.spacing.button_padding = egui::vec2(m3::SP_3, m3::SP_2);
-        // 44, not 48: `interact_size` is the *minimum* egui pads every widget to, and 48 there
-        // bloats inline rows. Real tap targets get `MIN_TARGET` explicitly.
-        style.spacing.interact_size.y = 44.0;
-        style.text_styles = [
-            (TextStyle::Heading, FontId::new(m3::T_TITLE, Proportional)),
-            (TextStyle::Body, FontId::new(m3::T_BODY, Proportional)),
-            (TextStyle::Button, FontId::new(m3::T_LABEL_LG, Proportional)),
-            (TextStyle::Small, FontId::new(m3::T_LABEL_SM, Proportional)),
-            (
-                TextStyle::Monospace,
-                FontId::new(m3::T_LABEL, egui::FontFamily::Monospace),
-            ),
-        ]
-        .into();
-    } else {
-        style.spacing.item_spacing = egui::vec2(6.0, 4.0);
-        style.spacing.button_padding = egui::vec2(8.0, 3.0);
-        style.spacing.interact_size.y = 22.0;
-        style.text_styles = [
-            (TextStyle::Heading, FontId::new(14.0, Proportional)),
-            (TextStyle::Body, FontId::new(12.5, Proportional)),
-            (TextStyle::Button, FontId::new(12.5, Proportional)),
-            (TextStyle::Small, FontId::new(11.0, Proportional)),
-            (
-                TextStyle::Monospace,
-                FontId::new(12.0, egui::FontFamily::Monospace),
-            ),
-        ]
-        .into();
-    }
 
     let egui_theme = if pal.is_dark {
         egui::Theme::Dark

--- a/crates/hookecho/src/ui/m3.rs
+++ b/crates/hookecho/src/ui/m3.rs
@@ -312,3 +312,101 @@ mod tests {
         assert!(!is_landscape(square));
     }
 }
+
+// ---------- Density ----------
+
+/// UI density. `Comfortable` is the product default; `Compact` restores the pro-dense desktop
+/// metrics the app shipped with through 0.11.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]
+pub enum Density {
+    #[default]
+    Comfortable,
+    Compact,
+}
+
+impl Density {
+    pub const ALL: [Density; 2] = [Density::Comfortable, Density::Compact];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Density::Comfortable => "Comfortable",
+            Density::Compact => "Compact",
+        }
+    }
+}
+
+/// The spacing/type numbers `theme::apply` installs, as one table per density.
+///
+/// ponytail: a plain struct of values, not a trait or a config file — density is a table swap,
+/// so widgets never branch on it. Add a third table here if a "spacious" mode ever matters.
+#[derive(Debug, Clone, Copy)]
+pub struct Metrics {
+    pub item_spacing: Vec2,
+    pub button_padding: Vec2,
+    pub interact_h: f32,
+    pub window_margin: i8,
+    pub menu_margin: i8,
+    pub heading: f32,
+    pub body: f32,
+    pub button: f32,
+    pub small: f32,
+    pub mono: f32,
+}
+
+/// Touch metrics (Android): the M3 type scale and a touch-sized interact height, independent of
+/// density — a finger is the same size in either mode.
+pub const TOUCH: Metrics = Metrics {
+    item_spacing: vec2(SP_2, SP_2),
+    button_padding: vec2(SP_3, SP_2),
+    // 44, not 48: `interact_size` is the *minimum* egui pads every widget to, and 48 there
+    // bloats inline rows. Real tap targets get `MIN_TARGET` explicitly.
+    interact_h: 44.0,
+    window_margin: 10,
+    menu_margin: 8,
+    heading: T_TITLE,
+    body: T_BODY,
+    button: T_LABEL_LG,
+    small: T_LABEL_SM,
+    mono: T_LABEL,
+};
+
+/// Pointer metrics, comfortable: roomier rows and readable type for a map-first product.
+pub const COMFORT: Metrics = Metrics {
+    item_spacing: vec2(8.0, 6.0),
+    button_padding: vec2(10.0, 5.0),
+    interact_h: 26.0,
+    window_margin: 10,
+    menu_margin: 8,
+    heading: 15.0,
+    body: 13.5,
+    button: 13.5,
+    small: 11.0,
+    mono: 12.5,
+};
+
+/// Pointer metrics, compact: the pre-0.12 desktop density, for users who want a section, a
+/// category row, a tree and three disclosures in one panel.
+pub const COMPACT: Metrics = Metrics {
+    item_spacing: vec2(6.0, 4.0),
+    button_padding: vec2(8.0, 3.0),
+    interact_h: 22.0,
+    window_margin: 10,
+    menu_margin: 8,
+    heading: 14.0,
+    body: 12.5,
+    button: 12.5,
+    small: 11.0,
+    mono: 12.0,
+};
+
+/// The table `theme::apply` should install. Touch wins over density.
+pub fn metrics(density: Density, touch: bool) -> Metrics {
+    if touch {
+        TOUCH
+    } else {
+        match density {
+            Density::Comfortable => COMFORT,
+            Density::Compact => COMPACT,
+        }
+    }
+}

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -751,6 +751,16 @@ fn general_tab(
             });
             ui.end_row();
 
+            ui.label("Density");
+            ui.horizontal(|ui| {
+                for d in crate::ui::m3::Density::ALL {
+                    ui.selectable_value(&mut settings.density, d, d.label());
+                }
+            })
+            .response
+            .on_hover_text("Compact restores the denser spacing of earlier releases.");
+            ui.end_row();
+
             ui.label("UI scale");
             // Phones start denser: 0.5 × a 4.0 density factor ≈ a desktop-density canvas.
             let lo = if cfg!(target_os = "android") {


### PR DESCRIPTION
R18 wave A, PR A1 — foundations for the UI modernization.

Spacing/type values move out of `theme::apply`'s inline block and the
Android/desktop if-else into one token table set in `ui/m3.rs`:

- `TOUCH` — Android, same M3 numbers as before (no visual change on phone)
- `COMFORT` — new pointer default, the roomier of the two desktop tables
- `COMPACT` — the density 0.11 shipped with, now a user choice

`m3::Density` is serde-backed and lands in `Settings::density` (`#[serde(default)]`
via the struct-level attribute, so old settings files load unchanged). The
settings window gets a Density row next to Theme; `app.rs` includes density in
the `theme_applied` cache key so switching re-styles immediately.

Drive-by: one test used `Settings::default()` + field assignment, which clippy
1.96 rejects under `-D warnings`; converted to struct-update syntax.

Verification: clippy clean, `cargo test --workspace` 560 passed / 29 ignored,
wasm check clean, `shoot.sh check` passed, `web/build.sh` 4,743,157 gzipped
against the 4,800,000 budget (unchanged by this PR).