### PR TITLE
feat(theme): curate to 7 themes + free accent color

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ clearing a cache costs the next fetch and nothing else.
   newest still instead, refreshed on the poll clock (a phone can't spawn ffmpeg,
   and a video decoder per open card is not what its battery is for).
 - Multi-pane layouts, placefiles with icon sheets and a layer manager, a sensor
-  dashboard, range rings, 15 themes, and tray-based background alerting.
+  dashboard, range rings, 7 themes with a custom accent color, and tray-based background alerting.
 
 ### On your phone
 

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1793,8 +1793,13 @@ pub struct HookEchoApp {
     chasepack: Option<ChasePack>,
     /// Per-pane "what's uploaded" key, so each pane re-bins/re-uploads only on a real change.
     pane_shown: std::collections::HashMap<usize, ShownKey>,
-    /// Last `(theme, system_dark, density)` handed to `theme::apply`.
-    theme_applied: Option<(crate::settings::Theme, bool, crate::ui::m3::Density)>,
+    /// Last `(theme, system_dark, density, accent)` handed to `theme::apply`.
+    theme_applied: Option<(
+        crate::settings::Theme,
+        bool,
+        crate::ui::m3::Density,
+        Option<[u8; 3]>,
+    )>,
     /// When the settings tree was last diffed against the saved copy.
     settings_checked: Option<Instant>,
     /// Frame counter, only used to invalidate within-frame memos.
@@ -15965,9 +15970,21 @@ impl eframe::App for HookEchoApp {
         // or the system light/dark preference changes — it rebuilds and installs a whole
         // `egui::Style`, which is wasted work on every other frame.
         let system_dark = ctx.input(|i| i.raw.system_theme) != Some(egui::Theme::Light);
-        if self.theme_applied != Some((self.settings.theme, system_dark, self.settings.density)) {
-            crate::theme::apply(ctx, self.settings.theme, system_dark, self.settings.density);
-            self.theme_applied = Some((self.settings.theme, system_dark, self.settings.density));
+        let theme_key = (
+            self.settings.theme,
+            system_dark,
+            self.settings.density,
+            self.settings.accent,
+        );
+        if self.theme_applied != Some(theme_key) {
+            crate::theme::apply(
+                ctx,
+                self.settings.theme,
+                system_dark,
+                self.settings.density,
+                self.settings.accent,
+            );
+            self.theme_applied = Some(theme_key);
         }
 
         // UI scale: apply the setting when the slider moved, else absorb built-in keyboard zoom

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -13,39 +13,27 @@ use std::path::PathBuf;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum Theme {
     #[default]
+    #[serde(alias = "Magma", alias = "Redline", alias = "AcidStorm")]
     Dark,
+    #[serde(alias = "Glacier")]
     Light,
     System,
+    #[serde(alias = "Ultraviolet", alias = "Bubblegum", alias = "Voltage")]
     Synthwave,
-    AcidStorm,
+    #[serde(alias = "Riptide")]
     Aurora,
-    Magma,
-    Bubblegum,
-    Riptide,
-    Ultraviolet,
-    Voltage,
-    Redline,
-    Glacier,
     HighContrast,
     Oled,
 }
 
 impl Theme {
     /// All themes in menu order.
-    pub const ALL: [Theme; 15] = [
+    pub const ALL: [Theme; 7] = [
         Theme::Dark,
         Theme::Light,
         Theme::System,
         Theme::Synthwave,
-        Theme::AcidStorm,
         Theme::Aurora,
-        Theme::Magma,
-        Theme::Bubblegum,
-        Theme::Riptide,
-        Theme::Ultraviolet,
-        Theme::Voltage,
-        Theme::Redline,
-        Theme::Glacier,
         Theme::HighContrast,
         Theme::Oled,
     ];
@@ -56,15 +44,7 @@ impl Theme {
             Theme::Light => "Light",
             Theme::System => "System",
             Theme::Synthwave => "Synthwave",
-            Theme::AcidStorm => "Acid Storm",
             Theme::Aurora => "Aurora",
-            Theme::Magma => "Magma",
-            Theme::Bubblegum => "Bubblegum",
-            Theme::Riptide => "Riptide",
-            Theme::Ultraviolet => "Ultraviolet",
-            Theme::Voltage => "Voltage",
-            Theme::Redline => "Redline",
-            Theme::Glacier => "Glacier",
             Theme::HighContrast => "High contrast",
             Theme::Oled => "OLED black",
         }
@@ -135,6 +115,8 @@ pub struct Settings {
     /// UI density (spacing/type token table). Comfortable by default; Compact restores the
     /// pre-0.12 pro-dense desktop metrics.
     pub density: Density,
+    /// User accent override as RGB. `None` keeps the theme's own accent.
+    pub accent: Option<[u8; 3]>,
     /// Starred radar sites shown in the toolbox presets dropdown.
     pub presets: Vec<String>,
     /// Per-moment color-table override: moment short name (`REF`, `VEL`, …) -> `.pal` path.
@@ -998,6 +980,7 @@ impl Default for Settings {
             poll_interval_secs: 30,
             theme: Theme::Dark,
             density: Density::default(),
+            accent: None,
             presets: Vec::new(),
             palettes: BTreeMap::new(),
             velocity_unit: VelocityUnit::default(),
@@ -1425,6 +1408,7 @@ mod tests {
             etop_dbz: 30.0,
             default_site: "KFWS".to_string(),
             density: Density::Compact,
+            accent: Some([255, 0, 128]),
             poll_interval_secs: 45,
             theme: Theme::Synthwave,
             presets: vec!["KTLX".to_string(), "KOUN".to_string()],
@@ -1582,7 +1566,7 @@ mod tests {
         }"#;
         let s = Settings::import_bundle(json).expect("import");
         assert_eq!(s.default_site, "KFWS");
-        assert_eq!(s.theme, Theme::Magma);
+        assert_eq!(s.theme, Theme::Dark); // "Magma" is aliased onto Dark
         let ref_path = s.palettes.get("REF").expect("REF palette path set");
         let text = std::fs::read_to_string(ref_path).expect("palette file written");
         assert!(text.contains("test palette"));

--- a/crates/hookecho/src/theme.rs
+++ b/crates/hookecho/src/theme.rs
@@ -86,18 +86,6 @@ fn palette(theme: Theme, system_dark: bool) -> Palette {
             text: c(0xe8e2ff),
             accent: c(0xff3d9e),
         },
-        // Acid Storm — radar scope on energy drinks.
-        Theme::AcidStorm => Palette {
-            is_dark: true,
-            bg: c(0x111a11),
-            extreme: c(0x0a0f0a),
-            faint: c(0x162216),
-            stroke: c(0x2a3f2a),
-            widget: c(0x162216),
-            widget_hover: c(0x1f2f1f),
-            text: c(0xe4ffe0),
-            accent: c(0xaaff00),
-        },
         // Aurora — northern lights over ice.
         Theme::Aurora => Palette {
             is_dark: true,
@@ -109,90 +97,6 @@ fn palette(theme: Theme, system_dark: bool) -> Palette {
             widget_hover: c(0x1c2f45),
             text: c(0xd6f2ea),
             accent: c(0x3dffb0),
-        },
-        // Magma — lava glow, warm and loud.
-        Theme::Magma => Palette {
-            is_dark: true,
-            bg: c(0x221310),
-            extreme: c(0x160b09),
-            faint: c(0x2e1a15),
-            stroke: c(0x502a20),
-            widget: c(0x2e1a15),
-            widget_hover: c(0x3d221a),
-            text: c(0xffe8d6),
-            accent: c(0xff6b1a),
-        },
-        // Bubblegum — candy-shop light theme.
-        Theme::Bubblegum => Palette {
-            is_dark: false,
-            bg: c(0xffe9f2),
-            extreme: c(0xfff4f8),
-            faint: c(0xffdcea),
-            stroke: c(0xf5b8d2),
-            widget: c(0xffd4e6),
-            widget_hover: c(0xffc2da),
-            text: c(0x3a1030),
-            accent: c(0xff2d78),
-        },
-        // Riptide — electric cyan on deep ocean navy.
-        Theme::Riptide => Palette {
-            is_dark: true,
-            bg: c(0x0a1a2a),
-            extreme: c(0x06101a),
-            faint: c(0x0e2236),
-            stroke: c(0x1a4a66),
-            widget: c(0x0e2236),
-            widget_hover: c(0x132d46),
-            text: c(0xd8f4ff),
-            accent: c(0x00e5ff),
-        },
-        // Ultraviolet — electric purple under blacklight.
-        Theme::Ultraviolet => Palette {
-            is_dark: true,
-            bg: c(0x190e2b),
-            extreme: c(0x100821),
-            faint: c(0x22133a),
-            stroke: c(0x452a70),
-            widget: c(0x22133a),
-            widget_hover: c(0x2e1a4e),
-            text: c(0xece0ff),
-            accent: c(0xb44bff),
-        },
-        // Voltage — cyber yellow hi-vis HUD on graphite.
-        Theme::Voltage => Palette {
-            is_dark: true,
-            bg: c(0x141418),
-            extreme: c(0x0d0d10),
-            faint: c(0x1c1c22),
-            stroke: c(0x3a3a26),
-            widget: c(0x1c1c22),
-            widget_hover: c(0x26262e),
-            text: c(0xf2f0dc),
-            accent: c(0xffe600),
-        },
-        // Redline — signal crimson on ember maroon.
-        Theme::Redline => Palette {
-            is_dark: true,
-            bg: c(0x1c0d11),
-            extreme: c(0x120809),
-            faint: c(0x29141a),
-            stroke: c(0x55222e),
-            widget: c(0x29141a),
-            widget_hover: c(0x371b23),
-            text: c(0xffdfe3),
-            accent: c(0xff2b4a),
-        },
-        // Glacier — vivid azure on polar-morning frost (light).
-        Theme::Glacier => Palette {
-            is_dark: false,
-            bg: c(0xe6f1fc),
-            extreme: c(0xf2f8fe),
-            faint: c(0xd9e8f8),
-            stroke: c(0xa9c9e8),
-            widget: c(0xd2e3f6),
-            widget_hover: c(0xc2d9f2),
-            text: c(0x0d2440),
-            accent: c(0x0077ff),
         },
         // High contrast — black, white and one saturated yellow, for low vision and for direct
         // sunlight, which is the same problem from a different direction.
@@ -231,8 +135,30 @@ fn palette(theme: Theme, system_dark: bool) -> Palette {
 
 /// The primary accent color for a theme (map markers, active-pane outline, status highlights).
 pub fn accent(theme: Theme) -> Color32 {
+    if let Some(c) = accent_override() {
+        return c;
+    }
     // system_dark doesn't affect any accent (Dark and Light share ACCENT), so pass true.
     palette(theme, true).accent
+}
+
+/// User accent override, packed as `0xFF_RR_GG_BB` (0 = none).
+///
+/// ponytail: a process-global instead of threading `&Settings` through 19 `accent()` call sites —
+/// the accent is one app-wide value and `apply()` is the only writer. If accent ever becomes
+/// per-window, pass it explicitly instead.
+static ACCENT_OVERRIDE: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+
+pub fn set_accent_override(rgb: Option<[u8; 3]>) {
+    let packed = rgb.map_or(0, |[r, g, b]| {
+        0xFF00_0000 | (u32::from(r) << 16) | (u32::from(g) << 8) | u32::from(b)
+    });
+    ACCENT_OVERRIDE.store(packed, std::sync::atomic::Ordering::Relaxed);
+}
+
+fn accent_override() -> Option<Color32> {
+    let p = ACCENT_OVERRIDE.load(std::sync::atomic::Ordering::Relaxed);
+    (p != 0).then(|| Color32::from_rgb((p >> 16) as u8, (p >> 8) as u8, p as u8))
 }
 
 /// The background fill for a theme, for the settings swatch preview.
@@ -240,8 +166,18 @@ pub fn preview_bg(theme: Theme) -> Color32 {
     palette(theme, true).bg
 }
 
-pub fn apply(ctx: &egui::Context, theme: Theme, system_dark: bool, density: Density) {
-    let pal = palette(theme, system_dark);
+pub fn apply(
+    ctx: &egui::Context,
+    theme: Theme,
+    system_dark: bool,
+    density: Density,
+    accent_rgb: Option<[u8; 3]>,
+) {
+    set_accent_override(accent_rgb);
+    let mut pal = palette(theme, system_dark);
+    if let Some(c) = accent_override() {
+        pal.accent = c;
+    }
     let mut visuals = if pal.is_dark {
         Visuals::dark()
     } else {

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -751,6 +751,21 @@ fn general_tab(
             });
             ui.end_row();
 
+            ui.label("Accent color");
+            ui.horizontal(|ui| {
+                let mut on = settings.accent.is_some();
+                let theme_accent = crate::theme::accent(settings.theme);
+                if ui.checkbox(&mut on, "Custom").changed() {
+                    settings.accent = on.then(|| {
+                        [theme_accent.r(), theme_accent.g(), theme_accent.b()]
+                    });
+                }
+                if let Some(rgb) = settings.accent.as_mut() {
+                    ui.color_edit_button_srgb(rgb);
+                }
+            });
+            ui.end_row();
+
             ui.label("Density");
             ui.horizontal(|ui| {
                 for d in crate::ui::m3::Density::ALL {

--- a/crates/hookecho/src/ui/style.rs
+++ b/crates/hookecho/src/ui/style.rs
@@ -51,7 +51,7 @@ pub const LANE_BOTTOM_CHASE: f32 = -92.0;
 
 /// Translucent card used by the floating bars, in the current theme's colors.
 ///
-/// The fill used to be a hardcoded near-black, which meant the light themes (Glacier, Light)
+/// The fill used to be a hardcoded near-black, which meant the light themes (Light)
 /// painted dark cards full of dark text over a light map. Reading `ui.visuals()` keeps it honest
 /// without plumbing a `Theme` through every call site — `theme::apply` has already put the
 /// palette there.


### PR DESCRIPTION
R18 wave A, PR A2. Stacked on #77 (`feat/tokens-density`) — merge that first.

Fifteen palettes was a novelty menu. This keeps seven (Dark, Light, System,
Synthwave, Aurora, High contrast, OLED black) and deletes the rest, then gives
every theme a user accent override.

Compatibility: each survivor absorbs the deleted names via `#[serde(alias)]`
(Magma/Redline/AcidStorm → Dark, Glacier → Light, Ultraviolet/Bubblegum/Voltage
→ Synthwave, Riptide → Aurora), so existing settings files load to a sensible
theme rather than falling back to default; `from_json_lossy` remains the
backstop for anything else. Existing test that asserted `"Magma"` now asserts
the alias target.

Accent: `Settings::accent: Option<[u8;3]>`, edited with egui's sRGB color
button next to the theme picker. Applied at the two chokepoints only —
`theme::apply` tints the palette before building the style, and `theme::accent`
returns the override for the 19 direct callers. The override lives in a process
global written solely by `apply()` (documented `ponytail:` note) rather than
threading `&Settings` through every call site.

Verification: clippy clean, `cargo test --workspace` 560 passed / 29 ignored,
wasm check clean, `shoot.sh check` passed. README theme count updated.