### PR TITLE
feat(chrome): anchored popovers for map-click results

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1422,12 +1422,12 @@ const ANDROID_LOOP_WINDOW: usize = 6;
 ///
 /// A phone (or a browser tab) on a cell radio gets nothing from a deeper queue: the frames arrive
 /// in the same total time and each one lands later than it would have with a queue behind it.
-const MAX_PREFETCH_INFLIGHT: usize =
-    if cfg!(target_os = "android") || cfg!(target_arch = "wasm32") {
-        2
-    } else {
-        4
-    };
+const MAX_PREFETCH_INFLIGHT: usize = if cfg!(target_os = "android") || cfg!(target_arch = "wasm32")
+{
+    2
+} else {
+    4
+};
 
 /// Which frames to pull in around the playhead, nearest first.
 ///
@@ -1947,6 +1947,8 @@ pub struct HookEchoApp {
     rules_window: ui::rules_window::RulesWindow,
     /// The one slide-over surface every browsable tool page renders into.
     drawer: ui::drawer::Drawer,
+    /// Anchors for the cards that answer a click on the map.
+    popovers: ui::popover::Popovers,
     /// Warning verification lab and its in-flight query.
     verify_window: ui::verify_window::VerifyWindow,
     verify_rx: Option<std::sync::mpsc::Receiver<Result<wxdata::verify::Verification, String>>>,
@@ -2007,7 +2009,11 @@ pub struct HookEchoApp {
     spoke_pos: Option<(Instant, i32)>,
     /// Detections seen recently, for compound rules to ask "and was there also…". Trimmed to the
     /// compound window every pass, so it stays a handful of entries.
-    recent_hits: Vec<(crate::settings::RuleTrigger, crate::rules::Detection, Instant)>,
+    recent_hits: Vec<(
+        crate::settings::RuleTrigger,
+        crate::rules::Detection,
+        Instant,
+    )>,
     /// Chase mode: follow a position, auto-switching the active pane to the nearest radar.
     chase_mode: bool,
     chase_pos: Option<(f64, f64)>,
@@ -2186,8 +2192,7 @@ pub struct HookEchoApp {
     afd_rx: Option<std::sync::mpsc::Receiver<Result<wxdata::afd::Afd, String>>>,
     /// NHC public advisory / forecast discussion reader.
     tropical_window: ui::tropical_window::TropicalWindow,
-    tropical_text_rx:
-        Option<std::sync::mpsc::Receiver<Result<wxdata::tropical::Advisory, String>>>,
+    tropical_text_rx: Option<std::sync::mpsc::Receiver<Result<wxdata::tropical::Advisory, String>>>,
     /// Range rings + azimuth spokes around the active site (feature HH).
     show_range_rings: bool,
     /// Draw all NEXRAD radar sites on the map; clicking one switches the pane to that radar.
@@ -2565,7 +2570,9 @@ impl HookEchoApp {
             }
             let sep = if search.is_empty() { "?" } else { "&" };
             // Setting `search` navigates; the spec keeps the fragment, so `#goto=…` survives.
-            let _ = win.location().set_search(&format!("{search}{sep}relaunched"));
+            let _ = win
+                .location()
+                .set_search(&format!("{search}{sep}relaunched"));
         });
         // The GPU's 2D texture-size cap: desktop/Adreno do 16384, but many mobile GPUs cap at
         // 4096. Field grids (MRMS rotation/AzShear reach 14000 px) are decimated to fit this.
@@ -2832,6 +2839,7 @@ impl HookEchoApp {
             glossary: Default::default(),
             rules_window: Default::default(),
             drawer: Default::default(),
+            popovers: Default::default(),
             verify_window: Default::default(),
             verify_rx: None,
             xsection_moment: Moment::Reflectivity,
@@ -3119,13 +3127,7 @@ impl HookEchoApp {
             use OverlayToggle as T;
             matches!(
                 t,
-                T::Tropical
-                    | T::ProbSevere
-                    | T::Aviation
-                    | T::Tfr
-                    | T::Alerts
-                    | T::Mds
-                    | T::Fires
+                T::Tropical | T::ProbSevere | T::Aviation | T::Tfr | T::Alerts | T::Mds | T::Fires
             )
         });
         for t in restore {
@@ -3872,7 +3874,11 @@ impl HookEchoApp {
             let units = m.units();
             let value = match (g.value, g.folded) {
                 (Some(v), _) => {
-                    let precision = if m == Moment::CorrelationCoefficient { 3 } else { 1 };
+                    let precision = if m == Moment::CorrelationCoefficient {
+                        3
+                    } else {
+                        1
+                    };
                     if units.is_empty() {
                         format!("{v:.*}", precision)
                     } else {
@@ -4091,8 +4097,9 @@ impl HookEchoApp {
                             .filter(|r| !r.is_empty())
                             .map(|ring| {
                                 let n = ring.len() as f64;
-                                let (x, y) =
-                                    ring.iter().fold((0.0, 0.0), |(x, y), p| (x + p[0], y + p[1]));
+                                let (x, y) = ring
+                                    .iter()
+                                    .fold((0.0, 0.0), |(x, y), p| (x + p[0], y + p[1]));
                                 crate::rules::Detection::at(x / n, y / n)
                             })
                             .unwrap_or(crate::rules::Detection::at(0.0, 0.0));
@@ -4326,7 +4333,9 @@ impl HookEchoApp {
                 let pct = crate::rules::probsevere_percent(&f.detail)?;
                 let ring = f.rings.first()?;
                 let n = ring.len().max(1) as f64;
-                let (lon, lat) = ring.iter().fold((0.0, 0.0), |(x, y), p| (x + p[0], y + p[1]));
+                let (lon, lat) = ring
+                    .iter()
+                    .fold((0.0, 0.0), |(x, y), p| (x + p[0], y + p[1]));
                 Some(Detection::with_strength(lon / n, lat / n, pct))
             })
             .collect();
@@ -4377,14 +4386,17 @@ impl HookEchoApp {
         let shared: crate::backtest::Shared = Default::default();
         self.rules_window.backtest = Some(shared.clone());
         let settings = self.settings.clone();
-        self.spawner.spawn(crate::backtest::run(
-            site, day, rule, settings, shared,
-        ));
+        self.spawner
+            .spawn(crate::backtest::run(site, day, rule, settings, shared));
     }
 
     /// Remember detections so a compound rule can ask about them next pass, and forget anything
     /// older than the compound window.
-    fn note_hits(&mut self, trigger: &crate::settings::RuleTrigger, hits: &[crate::rules::Detection]) {
+    fn note_hits(
+        &mut self,
+        trigger: &crate::settings::RuleTrigger,
+        hits: &[crate::rules::Detection],
+    ) {
         let window = std::time::Duration::from_secs_f64(crate::rules::COMPOUND_WINDOW_MIN * 60.0);
         self.recent_hits.retain(|(_, _, t)| t.elapsed() < window);
         for h in hits {
@@ -5019,14 +5031,24 @@ impl HookEchoApp {
             let cfg_path = path.with_extension("onnx.json");
             if let Some(dir) = path.parent() {
                 if let Err(e) = std::fs::create_dir_all(dir) {
-                    crate::speech::set_voice_status(false, format!("could not create {dir:?}: {e}"));
+                    crate::speech::set_voice_status(
+                        false,
+                        format!("could not create {dir:?}: {e}"),
+                    );
                     return;
                 }
             }
             crate::speech::set_voice_status(true, "downloading voice (~60 MB)…");
             let get = |url: String| {
                 let http = http.clone();
-                async move { http.get(url).send().await?.error_for_status()?.bytes().await }
+                async move {
+                    http.get(url)
+                        .send()
+                        .await?
+                        .error_for_status()?
+                        .bytes()
+                        .await
+                }
             };
             let cfg = match get(cfg_url).await {
                 Ok(b) => b,
@@ -5058,7 +5080,9 @@ impl HookEchoApp {
                 .and_then(|()| std::fs::write(&cfg_path, &cfg));
             match wrote {
                 Ok(()) => crate::speech::set_voice_status(false, "voice ready"),
-                Err(e) => crate::speech::set_voice_status(false, format!("writing the voice failed: {e}")),
+                Err(e) => {
+                    crate::speech::set_voice_status(false, format!("writing the voice failed: {e}"))
+                }
             }
         });
     }
@@ -5778,9 +5802,7 @@ impl HookEchoApp {
             .and_then(|v| v.binned(Moment::CorrelationCoefficient, 0, false).ok())
             .cloned();
         let out = match (z, cc) {
-            (Some(z), Some(cc)) => {
-                wxdata::dualpol::tbss(&z, &cc, core_dbz, 20.0, 0.8, 4.0, 150.0)
-            }
+            (Some(z), Some(cc)) => wxdata::dualpol::tbss(&z, &cc, core_dbz, 20.0, 0.8, 4.0, 150.0),
             _ => Vec::new(),
         };
         self.tbss_cache = Some((key, out.clone()));
@@ -6390,9 +6412,11 @@ impl HookEchoApp {
         let mut picked = None;
         ui.menu_button(format!("Background: {}", current.label()), |ui| {
             ui.set_min_width(460.0);
-            egui::ScrollArea::vertical().max_height(460.0).show(ui, |ui| {
-                picked = ui::basemap_picker::grid(ui, &mut self.tiles, current, &self.settings);
-            });
+            egui::ScrollArea::vertical()
+                .max_height(460.0)
+                .show(ui, |ui| {
+                    picked = ui::basemap_picker::grid(ui, &mut self.tiles, current, &self.settings);
+                });
             if picked.is_some() {
                 ui.close();
             }
@@ -6750,9 +6774,9 @@ impl HookEchoApp {
         // user turns off. Reported in whole miles, so a storm parked in place says nothing.
         if self.settings.speak_position && !self.settings.mute_alerts {
             let miles = (km * 0.621_371).round() as i32;
-            let fresh = self
-                .spoke_pos
-                .is_none_or(|(t, m)| m != miles && t.elapsed() >= std::time::Duration::from_secs(60));
+            let fresh = self.spoke_pos.is_none_or(|(t, m)| {
+                m != miles && t.elapsed() >= std::time::Duration::from_secs(60)
+            });
             if fresh {
                 self.spoke_pos = Some((Instant::now(), miles));
                 crate::speech::speak(&wxdata::spoken::position_script(
@@ -7481,12 +7505,20 @@ impl HookEchoApp {
             return;
         };
         let Some(url) = product.url(&storm).map(str::to_string) else {
-            self.tropical_window.error =
-                Some(format!("no {} published for {}", product.label(), storm.name));
+            self.tropical_window.error = Some(format!(
+                "no {} published for {}",
+                product.label(),
+                storm.name
+            ));
             self.tropical_window.text = None;
             return;
         };
-        let title = format!("{} {} — {}", storm.classification, storm.name, product.label());
+        let title = format!(
+            "{} {} — {}",
+            storm.classification,
+            storm.name,
+            product.label()
+        );
         let (tx, rx) = std::sync::mpsc::channel();
         self.tropical_text_rx = Some(rx);
         self.tropical_window.busy = true;
@@ -9393,9 +9425,7 @@ impl HookEchoApp {
             self.palettes.gen,
             uv_key,
             dealias,
-            self.settings
-                .precip_tint
-                .then_some(self.precip_flag_gen),
+            self.settings.precip_tint.then_some(self.precip_flag_gen),
         );
         if self.pane_shown.get(&idx) == Some(&key) {
             return (None, true);
@@ -9450,10 +9480,10 @@ impl HookEchoApp {
         let idx = self.active.min(self.views.len() - 1);
         let caption = {
             let v = &self.views[idx];
-            let time = v
-                .volume
-                .as_ref()
-                .map_or_else(|| "—".to_string(), |vol| vol.time.format("%H:%MZ").to_string());
+            let time = v.volume.as_ref().map_or_else(
+                || "—".to_string(),
+                |vol| vol.time.format("%H:%MZ").to_string(),
+            );
             format!(
                 "{} {} {time}",
                 v.site.as_deref().unwrap_or("—"),
@@ -9530,15 +9560,20 @@ impl HookEchoApp {
                         // Swap this window's camera in around the render, and take back whatever
                         // the pointer did to it. Nothing returns early in between, so the pane
                         // always gets its own camera back.
-                        let mine = self
-                            .mini_cam
-                            .take()
-                            .unwrap_or(self.views[idx].camera);
+                        let mine = self.mini_cam.take().unwrap_or(self.views[idx].camera);
                         let pane_cam = std::mem::replace(&mut self.views[idx].camera, mine);
                         self.render_pane(
                             // `first`/`last` false: the mini-loop viewport is a passenger — the
                             // main window's pane loop owns draining and evicting the tile caches.
-                            ui, &vctx, idx, prect, false, false, false, false, &[],
+                            ui,
+                            &vctx,
+                            idx,
+                            prect,
+                            false,
+                            false,
+                            false,
+                            false,
+                            &[],
                         );
                         self.mini_cam =
                             Some(std::mem::replace(&mut self.views[idx].camera, pane_cam));
@@ -10325,10 +10360,26 @@ impl HookEchoApp {
             self.evaluate_scan_rules(idx, &tds_hits, &tbss_hits, &zdr_hits, &couplets);
         }
         // Hidden layers computed only for a rule must not also be drawn.
-        let tds_hits = if self.filters.show_tds { tds_hits } else { Vec::new() };
-        let tbss_hits = if self.filters.show_tbss { tbss_hits } else { Vec::new() };
-        let zdr_hits = if self.filters.show_zdr_columns { zdr_hits } else { Vec::new() };
-        let couplets = if self.filters.show_couplets { couplets } else { Vec::new() };
+        let tds_hits = if self.filters.show_tds {
+            tds_hits
+        } else {
+            Vec::new()
+        };
+        let tbss_hits = if self.filters.show_tbss {
+            tbss_hits
+        } else {
+            Vec::new()
+        };
+        let zdr_hits = if self.filters.show_zdr_columns {
+            zdr_hits
+        } else {
+            Vec::new()
+        };
+        let couplets = if self.filters.show_couplets {
+            couplets
+        } else {
+            Vec::new()
+        };
 
         // Radar values under the cursor. Computed here, before the long immutable borrow of the
         // pane below, because sampling the volume needs it mutably — the binned sweeps are
@@ -10352,44 +10403,43 @@ impl HookEchoApp {
         // themselves are drawn much further down with the rest of the cell layer. Reserving here
         // and drawing there is the whole reason the placer separates the two: a warning label
         // must not lose its slot to a town name that merely happened to be painted earlier.
-        let cell_labels_shown: std::collections::HashSet<String> =
-            if self.filters.show_cells && self.cells_site.as_deref() == view.site.as_deref() {
-                let ids: Vec<(String, egui::Pos2)> = self
-                    .active_storm_cells()
-                    .iter()
-                    .filter(|c| c.kind == CellKind::Storm && !c.id.is_empty())
-                    .map(|c| {
-                        let w = crate::render::mercator::lonlat_to_world(c.lon, c.lat);
-                        let (sx, sy) = cam.world_to_screen(w, vp);
-                        (
-                            c.id.clone(),
-                            egui::pos2(prect.left() + sx, prect.top() + sy),
-                        )
-                    })
-                    .collect();
-                ids.into_iter()
-                    .filter(|(_, p)| prect.contains(*p))
-                    .filter(|(id, p)| {
-                        // Matches the draw below: 11 pt text, left-bottom anchored, up and right
-                        // of the marker.
-                        let anchor = *p + egui::vec2(8.0, -8.0);
-                        let size = egui::vec2(id.len() as f32 * 6.5, 13.0);
-                        let rect = egui::Rect::from_min_size(
-                            egui::pos2(anchor.x, anchor.y - size.y),
-                            size,
-                        )
-                        .expand(2.0);
-                        self.labels.place(
-                            crate::labelplace::key(id),
-                            rect,
-                            crate::labelplace::Priority::Warning,
-                        )
-                    })
-                    .map(|(id, _)| id)
-                    .collect()
-            } else {
-                std::collections::HashSet::new()
-            };
+        let cell_labels_shown: std::collections::HashSet<String> = if self.filters.show_cells
+            && self.cells_site.as_deref() == view.site.as_deref()
+        {
+            let ids: Vec<(String, egui::Pos2)> = self
+                .active_storm_cells()
+                .iter()
+                .filter(|c| c.kind == CellKind::Storm && !c.id.is_empty())
+                .map(|c| {
+                    let w = crate::render::mercator::lonlat_to_world(c.lon, c.lat);
+                    let (sx, sy) = cam.world_to_screen(w, vp);
+                    (
+                        c.id.clone(),
+                        egui::pos2(prect.left() + sx, prect.top() + sy),
+                    )
+                })
+                .collect();
+            ids.into_iter()
+                .filter(|(_, p)| prect.contains(*p))
+                .filter(|(id, p)| {
+                    // Matches the draw below: 11 pt text, left-bottom anchored, up and right
+                    // of the marker.
+                    let anchor = *p + egui::vec2(8.0, -8.0);
+                    let size = egui::vec2(id.len() as f32 * 6.5, 13.0);
+                    let rect =
+                        egui::Rect::from_min_size(egui::pos2(anchor.x, anchor.y - size.y), size)
+                            .expand(2.0);
+                    self.labels.place(
+                        crate::labelplace::key(id),
+                        rect,
+                        crate::labelplace::Priority::Warning,
+                    )
+                })
+                .map(|(id, _)| id)
+                .collect()
+        } else {
+            std::collections::HashSet::new()
+        };
         let view = &self.views[idx];
 
         // City/town labels, overlaid on every basemap. On raster (satellite) the baked-in labels
@@ -10397,9 +10447,7 @@ impl HookEchoApp {
         // vector basemaps use their palette's label colors. Bigger fonts + an 8-way halo read well.
         if !vlabels.is_empty() {
             let (text_col, halo_col, big) = if is_vector {
-                let st = crate::basemap_style::style(
-                    basemap.vector_palette().unwrap_or_default(),
-                );
+                let st = crate::basemap_style::style(basemap.vector_palette().unwrap_or_default());
                 (
                     egui::Color32::from_rgb(st.label[0], st.label[1], st.label[2]),
                     egui::Color32::from_rgb(st.label_halo[0], st.label_halo[1], st.label_halo[2]),
@@ -13345,7 +13393,6 @@ impl HookEchoApp {
             }
         }
     }
-
 }
 
 /// Convert a binned sweep into a GPU upload with its world-space bounding box.
@@ -14765,15 +14812,14 @@ impl eframe::App for HookEchoApp {
             login_url: self.sync_login.as_ref().map(|p| p.url.as_str()),
             last_sync: self.sync_state.last_sync,
         };
-        let sync_action =
-            self.settings_window.show(
-                ctx,
-                &mut self.settings,
-                &self.palettes,
-                sync_view,
-                &entries,
-                &mut self.drawer,
-            );
+        let sync_action = self.settings_window.show(
+            ctx,
+            &mut self.settings,
+            &self.palettes,
+            sync_view,
+            &entries,
+            &mut self.drawer,
+        );
         self.capture_key = self.settings_window.capturing;
         if std::mem::take(&mut self.settings_window.run_wizard) {
             self.wizard.start();
@@ -15085,8 +15131,15 @@ impl eframe::App for HookEchoApp {
                 .forecast_obs_cache
                 .get(&key)
                 .map(|(_, station, ob)| (station.as_str(), ob));
-            if !ui::forecast_window::show(ctx, &self.forecast_state, at, tz, minute.as_deref(), now)
-            {
+            if !ui::forecast_window::show(
+                ctx,
+                &self.forecast_state,
+                at,
+                tz,
+                minute.as_deref(),
+                now,
+                &mut self.popovers,
+            ) {
                 self.forecast_open = false;
             }
         }
@@ -15160,7 +15213,7 @@ impl eframe::App for HookEchoApp {
                 .as_ref()
                 .and_then(|k| self.pf_icon_tex.get(k))
                 .and_then(|t| t.as_ref());
-            if !ui::detail_window::show(ctx, detail, tex) {
+            if !ui::detail_window::show(ctx, detail, tex, &mut self.popovers) {
                 self.detail = None;
             }
         }
@@ -15227,7 +15280,8 @@ impl eframe::App for HookEchoApp {
                 .follow_cell
                 .as_ref()
                 .is_some_and(|(_, c, _)| c.id == cell.id);
-            let (open, toggled) = ui::cell_window::show(ctx, cell, trend, following);
+            let (open, toggled) =
+                ui::cell_window::show(ctx, cell, trend, following, &mut self.popovers);
             if toggled {
                 if following {
                     self.follow_cell = None;
@@ -15245,7 +15299,7 @@ impl eframe::App for HookEchoApp {
                 // The list shrank under us (the manager window deleted a row this frame).
                 None => self.marker_popup = None,
                 Some(m) => {
-                    let r = ui::marker_popup::show(ctx, m);
+                    let r = ui::marker_popup::show(ctx, m, &mut self.popovers);
                     let watch = r
                         .watch
                         .then(|| (m.name.clone(), m.video_url.trim().to_string()));
@@ -15264,74 +15318,8 @@ impl eframe::App for HookEchoApp {
                 }
             }
         }
-        if let Some(i) = self.zone_popup {
-            match self.settings.alert_polygons.get_mut(i) {
-                None => self.zone_popup = None,
-                Some(z) => {
-                    let mut open = true;
-                    let mut remove = false;
-                    egui::Window::new("Watch zone")
-                        .open(&mut open)
-                        .resizable(false)
-                        .vscroll(false)
-                        .default_width(240.0)
-                        .show(ctx, |ui| {
-                            ui.add(
-                                egui::TextEdit::singleline(&mut z.name)
-                                    .hint_text("Name")
-                                    .desired_width(ui.available_width()),
-                            );
-                            ui.weak(format!("{} corners", z.ring.len()));
-                            // ponytail: no vertex editing — redrawing a four-click shape is
-                            // faster than any handle-dragging UI would be to build.
-                            remove = ui.button("✖ Remove").clicked();
-                        });
-                    if remove {
-                        self.settings.alert_polygons.remove(i);
-                        self.zone_popup = None;
-                        self.settings.save();
-                    } else if !open {
-                        self.zone_popup = None;
-                        self.settings.save();
-                    }
-                }
-            }
-        }
-        if self.zone_naming.is_some() {
-            let mut save = false;
-            let mut cancel = false;
-            if let Some((ring, name)) = &mut self.zone_naming {
-                egui::Window::new("Name this watch zone")
-                    .collapsible(false)
-                    .resizable(false)
-                    .anchor(egui::Align2::CENTER_CENTER, egui::vec2(0.0, 0.0))
-                    .show(ctx, |ui| {
-                        ui.weak(format!("{} corners", ring.len()));
-                        let edit = ui.add(
-                            egui::TextEdit::singleline(name)
-                                .hint_text("Home area")
-                                .desired_width(220.0),
-                        );
-                        edit.request_focus();
-                        ui.weak("Alerts fire when a warning polygon touches this area.");
-                        ui.horizontal(|ui| {
-                            save = ui.button("Save").clicked()
-                                || ui.input(|i| i.key_pressed(egui::Key::Enter));
-                            cancel = ui.button("Cancel").clicked();
-                        });
-                    });
-            }
-            if save {
-                if let Some((ring, name)) = self.zone_naming.take() {
-                    self.settings
-                        .alert_polygons
-                        .push(crate::settings::AlertPolygon { name, ring });
-                    self.settings.save();
-                }
-            } else if cancel {
-                self.zone_naming = None;
-            }
-        }
+        self.zone_popup_card(ctx);
+        self.zone_naming_dialog(ctx);
         if let Some(sp) = self.pending_spotter.take() {
             self.open_spotter(&sp);
         }
@@ -15345,7 +15333,7 @@ impl eframe::App for HookEchoApp {
             self.chase_hud(ctx);
         }
         if let Some(popup) = &mut self.warning_popup {
-            if !ui::warning_window::show(ctx, popup) {
+            if !ui::warning_window::show(ctx, popup, &mut self.popovers) {
                 self.warning_popup = None;
             }
         }
@@ -15395,16 +15383,10 @@ impl eframe::App for HookEchoApp {
         }
         if self.show_cappi {
             self.update_cappi(ctx);
-            let mut open = true;
-            if let Some(tex) = self.cappi_tex.clone() {
-                open = ui::cappi_window::show(ctx, &tex, &mut self.cappi_alt_km, 300.0);
-            } else {
-                crate::ui::phone_surface(ctx, egui::Window::new("CAPPI slice"))
-                    .open(&mut open)
-                    .show(ctx, |ui| {
-                        ui.weak("No volume loaded in the active pane.");
-                    });
-            }
+            let open = match self.cappi_tex.clone() {
+                Some(tex) => ui::cappi_window::show(ctx, &tex, &mut self.cappi_alt_km, 300.0),
+                None => ui::cappi_window::show_empty(ctx),
+            };
             self.show_cappi = open;
         }
         self.show_warning_banners(ctx);
@@ -15478,9 +15460,9 @@ impl eframe::App for HookEchoApp {
             // Ask for `@2x` tiles where the provider serves them: same tile count, twice the
             // pixels, labels drawn for the density instead of magnified. Off on a metered link —
             // a double-resolution tile is roughly double the bytes.
-            let mut clear_tiles = self.tiles.set_retina(
-                ctx.pixels_per_point() > 1.0 && !crate::platform::is_metered(),
-            );
+            let mut clear_tiles = self
+                .tiles
+                .set_retina(ctx.pixels_per_point() > 1.0 && !crate::platform::is_metered());
             // GOES sub-hourly scrub: fetch the available frame times when a GOES style becomes
             // active, and apply the selected frame (None = latest).
             if raster_style.goes_layer().is_some() {
@@ -15634,7 +15616,8 @@ impl eframe::App for HookEchoApp {
         // An untouched embed is a still picture on someone else's dashboard: one frame a minute
         // keeps the clocks honest without spending the host's CPU. The first interaction wakes it
         // for good; data arrivals still request their own repaints either way.
-        if self.embed && !self.embed_live && ctx.input(|i| i.pointer.any_down() || i.any_touches()) {
+        if self.embed && !self.embed_live && ctx.input(|i| i.pointer.any_down() || i.any_touches())
+        {
             self.embed_live = true;
         }
         let idle = if self.embed && !self.embed_live {
@@ -16046,7 +16029,9 @@ mod tests {
     fn goto_parses_a_threshold_by_shape() {
         // Order does not matter, and the field is sniffed by shape like every other extra.
         assert_eq!(
-            parse_goto("KTLX,-97.3,35.3,8,thr:25,VEL").unwrap().threshold,
+            parse_goto("KTLX,-97.3,35.3,8,thr:25,VEL")
+                .unwrap()
+                .threshold,
             Some(Some(25.0))
         );
         // Off is a deliberate instruction, distinct from saying nothing at all.
@@ -16114,7 +16099,9 @@ fn archive_day_input(ui: &mut egui::Ui, date: chrono::NaiveDate) -> Option<chron
 fn archive_day_input(ui: &mut egui::Ui, date: chrono::NaiveDate) -> Option<chrono::NaiveDate> {
     let id = egui::Id::new("archive-day-text");
     let shown = date.format("%Y-%m-%d").to_string();
-    let mut buf: String = ui.data_mut(|d| d.get_temp(id)).unwrap_or_else(|| shown.clone());
+    let mut buf: String = ui
+        .data_mut(|d| d.get_temp(id))
+        .unwrap_or_else(|| shown.clone());
     // Someone else moved the day (a caret, a deep link): follow it rather than argue.
     if !buf.starts_with(&shown[..4]) && chrono::NaiveDate::parse_from_str(&buf, "%Y-%m-%d").is_ok()
     {

--- a/crates/hookecho/src/app/chrome/windows.rs
+++ b/crates/hookecho/src/app/chrome/windows.rs
@@ -163,4 +163,81 @@ impl HookEchoApp {
             self.crash_report = None;
         }
     }
+    /// The card behind a click on one of your own watch zones: rename it, or get rid of it.
+    pub(crate) fn zone_popup_card(&mut self, ctx: &egui::Context) {
+        if let Some(i) = self.zone_popup {
+            match self.settings.alert_polygons.get_mut(i) {
+                None => self.zone_popup = None,
+                Some(z) => {
+                    let mut open = true;
+                    let mut remove = false;
+                    self.popovers
+                        .card(ctx, "zone", egui::Window::new("Watch zone"))
+                        .open(&mut open)
+                        .resizable(false)
+                        .vscroll(false)
+                        .default_width(240.0)
+                        .show(ctx, |ui| {
+                            ui.add(
+                                egui::TextEdit::singleline(&mut z.name)
+                                    .hint_text("Name")
+                                    .desired_width(ui.available_width()),
+                            );
+                            ui.weak(format!("{} corners", z.ring.len()));
+                            // ponytail: no vertex editing — redrawing a four-click shape is
+                            // faster than any handle-dragging UI would be to build.
+                            remove = ui.button("✖ Remove").clicked();
+                        });
+                    if remove {
+                        self.settings.alert_polygons.remove(i);
+                        self.zone_popup = None;
+                        self.settings.save();
+                    } else if !open {
+                        self.zone_popup = None;
+                        self.settings.save();
+                    }
+                }
+            }
+        }
+    }
+
+    /// Naming step for a watch zone that was just drawn — modal in spirit, so it stays centered
+    /// rather than anchored to the last corner clicked.
+    pub(crate) fn zone_naming_dialog(&mut self, ctx: &egui::Context) {
+        if self.zone_naming.is_some() {
+            let mut save = false;
+            let mut cancel = false;
+            if let Some((ring, name)) = &mut self.zone_naming {
+                egui::Window::new("Name this watch zone")
+                    .collapsible(false)
+                    .resizable(false)
+                    .anchor(egui::Align2::CENTER_CENTER, egui::vec2(0.0, 0.0))
+                    .show(ctx, |ui| {
+                        ui.weak(format!("{} corners", ring.len()));
+                        let edit = ui.add(
+                            egui::TextEdit::singleline(name)
+                                .hint_text("Home area")
+                                .desired_width(220.0),
+                        );
+                        edit.request_focus();
+                        ui.weak("Alerts fire when a warning polygon touches this area.");
+                        ui.horizontal(|ui| {
+                            save = ui.button("Save").clicked()
+                                || ui.input(|i| i.key_pressed(egui::Key::Enter));
+                            cancel = ui.button("Cancel").clicked();
+                        });
+                    });
+            }
+            if save {
+                if let Some((ring, name)) = self.zone_naming.take() {
+                    self.settings
+                        .alert_polygons
+                        .push(crate::settings::AlertPolygon { name, ring });
+                    self.settings.save();
+                }
+            } else if cancel {
+                self.zone_naming = None;
+            }
+        }
+    }
 }

--- a/crates/hookecho/src/ui/cappi_window.rs
+++ b/crates/hookecho/src/ui/cappi_window.rs
@@ -39,3 +39,14 @@ pub fn show(ctx: &egui::Context, tex: &egui::TextureHandle, alt_km: &mut f32, le
         });
     open
 }
+
+/// The same window with nothing to slice yet. Its own function so `app` keeps no window bodies.
+pub fn show_empty(ctx: &egui::Context) -> bool {
+    let mut open = true;
+    crate::ui::phone_surface(ctx, egui::Window::new("CAPPI slice"))
+        .open(&mut open)
+        .show(ctx, |ui| {
+            ui.weak("No volume loaded in the active pane.");
+        });
+    open
+}

--- a/crates/hookecho/src/ui/cell_window.rs
+++ b/crates/hookecho/src/ui/cell_window.rs
@@ -22,135 +22,138 @@ pub fn show(
     cell: &Cell,
     trend: &[CellSample],
     following: bool,
+    popovers: &mut crate::ui::popover::Popovers,
 ) -> (bool, bool) {
     let mut open = true;
     let mut follow_toggled = false;
-    crate::ui::phone_surface(
-        ctx,
-        egui::Window::new(format!("Storm {} Attributes", cell.id)),
-    )
-    .open(&mut open)
-    .default_size([380.0, 460.0])
-    .show(ctx, |ui| {
-        egui::ScrollArea::vertical().show(ui, |ui| {
-            let label = if following {
-                "Following ✓ (tap to stop)"
-            } else {
-                "⌖ Follow"
-            };
-            if ui
-                .add(egui::Button::new(label).min_size(egui::vec2(ui.available_width(), 0.0)))
-                .on_hover_text(
-                    "Keep the camera centered on this cell as it moves through each new volume",
-                )
-                .clicked()
-            {
-                follow_toggled = true;
-            }
-            theme::section(ui, "Current Position", |ui| {
-                grid(
-                    ui,
-                    &[
-                        ("Latitude", format!("{:.3}°", cell.lat)),
-                        ("Longitude", format!("{:.3}°", cell.lon)),
-                        ("Range", opt(cell.range_nm, " NM", 0)),
-                        ("Bearing", opt(cell.az_deg, "°", 0)),
-                    ],
-                );
-            });
-            theme::section(ui, "Movement", |ui| {
-                let mph = cell.mvt_kt.map(|k| k * KT_TO_MPH);
-                grid(
-                    ui,
-                    &[
-                        ("Speed", opt(mph, " mph", 0)),
-                        ("Direction", opt(cell.mvt_deg, "°", 0)),
-                    ],
-                );
-            });
-            theme::section(ui, "Intensity & Structure", |ui| {
-                let base = cell
-                    .base_kft
-                    .map(|b| format!("{}{:.1} kft", if cell.base_below { "<" } else { "" }, b));
-                grid(
-                    ui,
-                    &[
-                        ("Max dBZ", opt(cell.max_dbz, " dBZ", 0)),
-                        ("Max ref hgt", opt(cell.max_dbz_hgt_kft, " kft", 1)),
-                        ("Cell top", opt(cell.top_kft, " kft", 1)),
-                        ("Cell base", base.unwrap_or_else(|| "—".into())),
-                        ("Cell-based VIL", opt(cell.vil, "", 0)),
-                    ],
-                );
-            });
-            theme::section(ui, "Hail Potential", |ui| {
-                grid(
-                    ui,
-                    &[
-                        (
-                            "POH",
-                            cell.poh
-                                .map(|v| format!("{v}%"))
-                                .unwrap_or_else(|| "—".into()),
-                        ),
-                        (
-                            "POSH",
-                            cell.posh
-                                .map(|v| format!("{v}%"))
-                                .unwrap_or_else(|| "—".into()),
-                        ),
-                        ("Max size", opt(cell.hail_in, " in", 2)),
-                    ],
-                );
-            });
-            theme::section(ui, "Features", |ui| {
-                grid(
-                    ui,
-                    &[
-                        ("TVS", cell.tvs.clone().unwrap_or_else(|| "None".into())),
-                        (
-                            "Mesocyclone",
-                            cell.meso.clone().unwrap_or_else(|| "None".into()),
-                        ),
-                    ],
-                );
-            });
-            theme::section(ui, "Error Metrics", |ui| {
-                grid(
-                    ui,
-                    &[
-                        ("Forecast error", opt(cell.fcst_err_nm, " NM", 1)),
-                        ("Mean error", opt(cell.mean_err_nm, " NM", 1)),
-                    ],
-                );
-            });
-            if trend.len() >= 2 {
-                theme::section(ui, "Trends (per volume)", |ui| {
-                    trend_row(
+    popovers
+        .card(
+            ctx,
+            "cell",
+            egui::Window::new(format!("Storm {} Attributes", cell.id)),
+        )
+        .open(&mut open)
+        .default_size([380.0, 460.0])
+        .show(ctx, |ui| {
+            egui::ScrollArea::vertical().show(ui, |ui| {
+                let label = if following {
+                    "Following ✓ (tap to stop)"
+                } else {
+                    "⌖ Follow"
+                };
+                if ui
+                    .add(egui::Button::new(label).min_size(egui::vec2(ui.available_width(), 0.0)))
+                    .on_hover_text(
+                        "Keep the camera centered on this cell as it moves through each new volume",
+                    )
+                    .clicked()
+                {
+                    follow_toggled = true;
+                }
+                theme::section(ui, "Current Position", |ui| {
+                    grid(
                         ui,
-                        "Max dBZ",
-                        trend,
-                        |s| s.dbz,
-                        egui::Color32::from_rgb(255, 140, 90),
-                    );
-                    trend_row(
-                        ui,
-                        "Cell top kft",
-                        trend,
-                        |s| s.top,
-                        egui::Color32::from_rgb(120, 200, 140),
-                    );
-                    trend_row(
-                        ui,
-                        "Cell-based VIL",
-                        trend,
-                        |s| s.vil,
-                        egui::Color32::from_rgb(90, 170, 255),
+                        &[
+                            ("Latitude", format!("{:.3}°", cell.lat)),
+                            ("Longitude", format!("{:.3}°", cell.lon)),
+                            ("Range", opt(cell.range_nm, " NM", 0)),
+                            ("Bearing", opt(cell.az_deg, "°", 0)),
+                        ],
                     );
                 });
-            }
+                theme::section(ui, "Movement", |ui| {
+                    let mph = cell.mvt_kt.map(|k| k * KT_TO_MPH);
+                    grid(
+                        ui,
+                        &[
+                            ("Speed", opt(mph, " mph", 0)),
+                            ("Direction", opt(cell.mvt_deg, "°", 0)),
+                        ],
+                    );
+                });
+                theme::section(ui, "Intensity & Structure", |ui| {
+                    let base = cell
+                        .base_kft
+                        .map(|b| format!("{}{:.1} kft", if cell.base_below { "<" } else { "" }, b));
+                    grid(
+                        ui,
+                        &[
+                            ("Max dBZ", opt(cell.max_dbz, " dBZ", 0)),
+                            ("Max ref hgt", opt(cell.max_dbz_hgt_kft, " kft", 1)),
+                            ("Cell top", opt(cell.top_kft, " kft", 1)),
+                            ("Cell base", base.unwrap_or_else(|| "—".into())),
+                            ("Cell-based VIL", opt(cell.vil, "", 0)),
+                        ],
+                    );
+                });
+                theme::section(ui, "Hail Potential", |ui| {
+                    grid(
+                        ui,
+                        &[
+                            (
+                                "POH",
+                                cell.poh
+                                    .map(|v| format!("{v}%"))
+                                    .unwrap_or_else(|| "—".into()),
+                            ),
+                            (
+                                "POSH",
+                                cell.posh
+                                    .map(|v| format!("{v}%"))
+                                    .unwrap_or_else(|| "—".into()),
+                            ),
+                            ("Max size", opt(cell.hail_in, " in", 2)),
+                        ],
+                    );
+                });
+                theme::section(ui, "Features", |ui| {
+                    grid(
+                        ui,
+                        &[
+                            ("TVS", cell.tvs.clone().unwrap_or_else(|| "None".into())),
+                            (
+                                "Mesocyclone",
+                                cell.meso.clone().unwrap_or_else(|| "None".into()),
+                            ),
+                        ],
+                    );
+                });
+                theme::section(ui, "Error Metrics", |ui| {
+                    grid(
+                        ui,
+                        &[
+                            ("Forecast error", opt(cell.fcst_err_nm, " NM", 1)),
+                            ("Mean error", opt(cell.mean_err_nm, " NM", 1)),
+                        ],
+                    );
+                });
+                if trend.len() >= 2 {
+                    theme::section(ui, "Trends (per volume)", |ui| {
+                        trend_row(
+                            ui,
+                            "Max dBZ",
+                            trend,
+                            |s| s.dbz,
+                            egui::Color32::from_rgb(255, 140, 90),
+                        );
+                        trend_row(
+                            ui,
+                            "Cell top kft",
+                            trend,
+                            |s| s.top,
+                            egui::Color32::from_rgb(120, 200, 140),
+                        );
+                        trend_row(
+                            ui,
+                            "Cell-based VIL",
+                            trend,
+                            |s| s.vil,
+                            egui::Color32::from_rgb(90, 170, 255),
+                        );
+                    });
+                }
+            });
         });
-    });
     (open, follow_toggled)
 }
 

--- a/crates/hookecho/src/ui/detail_window.rs
+++ b/crates/hookecho/src/ui/detail_window.rs
@@ -15,9 +15,15 @@ pub struct Detail {
 
 /// Show the detail window. Returns `false` when it should close. `image` is the resolved texture
 /// for `detail.image`, if it has finished loading.
-pub fn show(ctx: &egui::Context, detail: &Detail, image: Option<&egui::TextureHandle>) -> bool {
+pub fn show(
+    ctx: &egui::Context,
+    detail: &Detail,
+    image: Option<&egui::TextureHandle>,
+    popovers: &mut crate::ui::popover::Popovers,
+) -> bool {
     let mut open = true;
-    crate::ui::phone_surface(ctx, egui::Window::new("Feature Details"))
+    popovers
+        .card(ctx, "detail", egui::Window::new("Feature Details"))
         .open(&mut open)
         // Wide enough for a 69-column fixed-width product (SPC bulletins, L3 attribute
         // tables) to land on its own line breaks instead of the wrap point.

--- a/crates/hookecho/src/ui/forecast_window.rs
+++ b/crates/hookecho/src/ui/forecast_window.rs
@@ -24,9 +24,11 @@ pub fn show(
     tz: Option<wxdata::tz::Tz>,
     minute: Option<&[Option<f32>]>,
     now: Option<(&str, &wxdata::obs::Observation)>,
+    popovers: &mut crate::ui::popover::Popovers,
 ) -> bool {
     let mut open = true;
-    crate::ui::phone_surface(ctx, egui::Window::new("Forecast"))
+    popovers
+        .card(ctx, "forecast", egui::Window::new("Forecast"))
         .open(&mut open)
         .default_size([460.0, 460.0])
         .show(ctx, |ui| {
@@ -68,7 +70,7 @@ fn body(ui: &mut egui::Ui, f: &PointForecast, tz: Option<wxdata::tz::Tz>) {
     if !f.hourly.is_empty() {
         ui.label(RichText::new("Next 24 hours").strong());
         hourly_strip(ui, &f.hourly, tz);
-    wind_strip(ui, &f.hourly);
+        wind_strip(ui, &f.hourly);
         ui.add_space(6.0);
     }
     ui.label(RichText::new("This week").strong());

--- a/crates/hookecho/src/ui/marker_popup.rs
+++ b/crates/hookecho/src/ui/marker_popup.rs
@@ -19,12 +19,17 @@ pub struct MarkerPopupResult {
 }
 
 /// Show the popup for `m`, editing its name in place.
-pub fn show(ctx: &egui::Context, m: &mut Marker) -> MarkerPopupResult {
+pub fn show(
+    ctx: &egui::Context,
+    m: &mut Marker,
+    popovers: &mut crate::ui::popover::Popovers,
+) -> MarkerPopupResult {
     let mut r = MarkerPopupResult {
         open: true,
         ..Default::default()
     };
-    crate::ui::phone_surface(ctx, egui::Window::new("Marker"))
+    popovers
+        .card(ctx, "marker", egui::Window::new("Marker"))
         .open(&mut r.open)
         .resizable(false)
         // Three fixed rows: nothing to scroll, and `phone_surface`'s vscroll would otherwise stretch

--- a/crates/hookecho/src/ui/mod.rs
+++ b/crates/hookecho/src/ui/mod.rs
@@ -96,6 +96,7 @@ pub mod marker_popup;
 pub mod marker_window;
 pub mod palette_editor;
 pub mod placefile_window;
+pub mod popover;
 pub mod rules_window;
 pub mod sensor_window;
 pub mod settings_window;

--- a/crates/hookecho/src/ui/popover.rs
+++ b/crates/hookecho/src/ui/popover.rs
@@ -1,0 +1,81 @@
+//! Cards that answer a click on the map, anchored where the click was.
+//!
+//! A storm cell, a warning polygon, a marker, a point forecast: none of these is a place you go,
+//! they are all a thing you pointed at. Answering in a window that opens wherever egui last left
+//! one — halfway across the display, over the storm you were looking at — makes the user connect
+//! the answer to the question themselves. So these open next to the pointer instead, and stay
+//! inside the map area rather than under the chrome that surrounds it.
+//!
+//! The anchor is latched the first frame a card draws and thrown away when it stops drawing, so
+//! the card does not follow the mouse and a reopened card takes the new click, not the old one.
+//! Nothing about that needs the caller's help, which is why it lives here and not in `app`.
+//!
+//! ponytail: `egui::Window` again, same reason as [`crate::ui::drawer`] — it already has the title
+//! row, the ✕ wired to the caller's `open` flag, and a body. All this adds is where it lands.
+
+use egui::{pos2, Pos2, Rect};
+
+/// Gap between the click and the card's corner, so the card never covers what was clicked.
+const OFFSET: f32 = 14.0;
+/// Keep-out margins for the floating chrome: the search pill on top, the control column on the
+/// right, the scrubber along the bottom. Same numbers the chrome itself uses.
+const KEEPOUT_TOP: f32 = 58.0;
+const KEEPOUT_RIGHT: f32 = 74.0;
+const KEEPOUT_BOTTOM: f32 = 96.0;
+const KEEPOUT_SIDE: f32 = 10.0;
+
+#[derive(Default)]
+pub struct Popovers {
+    /// Where each open card was summoned from, keyed by the id its caller passes.
+    at: Vec<(String, Pos2)>,
+    /// Ids that drew this frame; anything else has closed and loses its anchor.
+    seen: Vec<String>,
+    frame: u64,
+}
+
+impl Popovers {
+    /// Place `w` at the click that opened it. Call once per frame per open card.
+    pub fn card<'a>(
+        &mut self,
+        ctx: &egui::Context,
+        id: &str,
+        w: egui::Window<'a>,
+    ) -> egui::Window<'a> {
+        // A phone has no room to put a card beside anything: Material 3's compact width class
+        // wants the whole screen, which is what `phone_surface` already gives it.
+        if cfg!(target_os = "android") {
+            return crate::ui::phone_surface(ctx, w);
+        }
+        let frame = ctx.cumulative_pass_nr();
+        if frame != self.frame {
+            self.at.retain(|(k, _)| self.seen.iter().any(|s| s == k));
+            self.seen.clear();
+            self.frame = frame;
+        }
+        self.seen.push(id.to_string());
+        let field = field(ctx);
+        let anchor = match self.at.iter().find(|(k, _)| k == id) {
+            Some((_, p)) => *p,
+            None => {
+                // No pointer at all (a card opened by a hotkey, or a touch that already lifted):
+                // the middle of the map is the least wrong place left.
+                let p = ctx
+                    .pointer_interact_pos()
+                    .map(|p| p + egui::vec2(OFFSET, OFFSET))
+                    .unwrap_or_else(|| field.center());
+                self.at.push((id.to_string(), p));
+                p
+            }
+        };
+        w.fixed_pos(anchor).constrain_to(field)
+    }
+}
+
+/// The part of the screen a card may occupy: the map, minus the floating chrome around it.
+fn field(ctx: &egui::Context) -> Rect {
+    let r = ctx.content_rect();
+    let min = pos2(r.left() + KEEPOUT_SIDE, r.top() + KEEPOUT_TOP);
+    let max = pos2(r.right() - KEEPOUT_RIGHT, r.bottom() - KEEPOUT_BOTTOM);
+    // A window small enough to matter still needs a rect that isn't inside-out.
+    Rect::from_min_max(min, max.max(min + egui::vec2(200.0, 200.0)))
+}

--- a/crates/hookecho/src/ui/warning_window.rs
+++ b/crates/hookecho/src/ui/warning_window.rs
@@ -17,9 +17,14 @@ pub struct WarningPopup {
 }
 
 /// Show the warning window. Returns `false` when it should close.
-pub fn show(ctx: &egui::Context, popup: &mut WarningPopup) -> bool {
+pub fn show(
+    ctx: &egui::Context,
+    popup: &mut WarningPopup,
+    popovers: &mut crate::ui::popover::Popovers,
+) -> bool {
     let mut open = true;
-    crate::ui::phone_surface(ctx, egui::Window::new("Active Warnings"))
+    popovers
+        .card(ctx, "warning", egui::Window::new("Active Warnings"))
         .open(&mut open)
         .default_size([460.0, 560.0])
         .show(ctx, |ui| match popup.selected {

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -18,6 +18,8 @@ also carries the color scale for what you're looking at), and the **scrubber**
 settings, the event library, alert rules — open as pages in a slide-over
 **drawer** on that same left edge, one page at a time, with a back arrow to the
 page you came from.
+Anything you click *on the map* — a storm cell, a warning polygon, one of your
+own markers — answers in a card next to the click instead.
 
 **If you remember one thing, remember `Ctrl+K`.** It searches the panel, and
 Enter runs the top match. Every action in the app is in there, described in


### PR DESCRIPTION
Wave B5. Map-click results stop being free-floating windows and become cards anchored to the click.

**What changed**

- New `ui/popover.rs`: latches the pointer position the first frame a card draws, keyed by id, prunes on `cumulative_pass_nr()` the same way the drawer's back-stack does. No lifecycle plumbing in `app.rs`.
- Converted: cell, warning, forecast, detail (where the interrogate tool lands), marker, watch zone. Wrappers swap `phone_surface` for `Popovers::card` and gain one parameter — bodies are byte-identical.
- Cards are clamped to the map area: content rect minus the search pill (58), the control column (74) and the scrubber (96).
- Android keeps `phone_surface` — a compact screen has no room to put a card beside anything, and that's still M3's answer.
- `app.rs` loses its last three inline window bodies: the watch-zone card and its naming dialog move to `app/chrome/windows.rs`, the CAPPI empty state becomes `cappi_window::show_empty`.

**Check #3 (egui 0.35 popover anchoring)**: resolved in favour of `Window::fixed_pos().constrain_to()`. `egui::Popup` anchors to a widget `Response`, not an arbitrary screen point, so it doesn't fit a map click; `constrain_to` is the native clamp and already handles the inside-out cases.

**Gates**: clippy `-D warnings` clean · tests green (283 + 259 + rest, 0 failed) · wasm check clean · `shoot.sh check` passed · wasm 12,936,560 raw / 4,779,847 gzipped (budget 4,850,000).

**Verified visually** on a nested Xvfb: point-forecast tool → click the map → card opens beside the click and clamps off the scrubber and control column when it would overhang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)