### PR TITLE
feat(chrome): invariants — tour, cheatsheet, workspaces

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -7029,7 +7029,7 @@ impl HookEchoApp {
             }
             PaletteAction::ApplyWorkspace(i) => {
                 if let Some(ws) = self.settings.workspaces.get(i).cloned() {
-                    self.apply_workspace(&ws);
+                    self.apply_workspace(&ws, ctx);
                     self.toast(ToastKind::Info, format!("Workspace: {}", ws.name));
                 }
             }
@@ -12566,12 +12566,13 @@ impl HookEchoApp {
                 .filter(|(_, st)| st.show)
                 .map(|(l, _)| l.slug().to_string())
                 .collect(),
+            chrome: Some(self.capture_chrome()),
         }
     }
 
     /// Restore a saved arrangement. Panes come back empty of data and fill through the normal
     /// poll, exactly as a freshly split pane does.
-    fn apply_workspace(&mut self, ws: &crate::workspace::Workspace) {
+    fn apply_workspace(&mut self, ws: &crate::workspace::Workspace, ctx: &egui::Context) {
         if ws.panes.is_empty() {
             return;
         }
@@ -12604,6 +12605,9 @@ impl HookEchoApp {
         // doesn't have, which is a thing to skip rather than an error.
         for (layer, st) in self.fields.iter_mut() {
             st.show = ws.fields_on.iter().any(|s| s == layer.slug());
+        }
+        if let Some(c) = &ws.chrome {
+            self.apply_chrome(c, ctx);
         }
         self.rebuild_overlays();
         self.pane_shown.clear();

--- a/crates/hookecho/src/app/chrome/mod.rs
+++ b/crates/hookecho/src/app/chrome/mod.rs
@@ -6,6 +6,7 @@ mod chips;
 mod overlay;
 mod registry;
 mod scrubber;
+mod state;
 mod window_frame;
 mod windows;
 

--- a/crates/hookecho/src/app/chrome/overlay.rs
+++ b/crates/hookecho/src/app/chrome/overlay.rs
@@ -24,6 +24,11 @@ impl HookEchoApp {
     /// app's own commands below it, plus the alerts tab. Closed by default; the search pill and
     /// the control column are the ways in.
     pub(crate) fn panel(&mut self, ctx: &egui::Context) {
+        // The tour's product stop spotlights the site and tilt rows, which are in here.
+        if self.tour.wants_panel() {
+            self.panel_open = true;
+            self.show_alert_panel = false;
+        }
         if !self.panel_open || self.drawer.is_open() {
             return;
         }
@@ -47,12 +52,10 @@ impl HookEchoApp {
         let mosaic = self.mosaic_status();
         let mut etop_dbz = self.settings.etop_dbz;
         let mut hide = false;
-        // Tour spotlights, recorded from inside the panel (no `self` reachable in there).
-        let mut alerts_rect = None;
         // Height budget: the search pill above, the scrubber pill below (which is centred and
         // grows with the window, so on a narrow one it would otherwise run under this panel).
         let max_h = (self.chrome_rect.height() - PANEL_TOP - SCRUBBER_CLEARANCE).max(160.0);
-        let panel_rect = egui::Area::new(egui::Id::new("panel"))
+        egui::Area::new(egui::Id::new("panel"))
             .constrain_to(self.chrome_rect)
             .anchor(egui::Align2::LEFT_TOP, egui::vec2(PANEL_X, PANEL_TOP))
             .show(ctx, |ui| {
@@ -81,9 +84,7 @@ impl HookEchoApp {
                         } else {
                             format!("Alerts ({alert_count})")
                         };
-                        let alerts_hit = ui.selectable_label(alerts_tab, label);
-                        alerts_rect = Some(alerts_hit.rect);
-                        if alerts_hit.clicked() {
+                        if ui.selectable_label(alerts_tab, label).clicked() {
                             alerts_tab = true;
                         }
                         // Collapse, on the row it collapses. The floating button that brings the
@@ -204,11 +205,7 @@ impl HookEchoApp {
                         .default_open(false)
                         .show(ui, |ui| self.app_rows(ui));
                 });
-            })
-            .response
-            .rect;
-        self.tour_anchors.menu = Some(panel_rect);
-        self.tour_anchors.alerts = alerts_rect;
+            });
         self.show_alert_panel = alerts_tab;
         self.settings.mute_alerts = muted;
         if hide {
@@ -254,6 +251,7 @@ impl HookEchoApp {
     /// two would need two states to keep in sync for no extra reach.
     pub(crate) fn search_pill(&mut self, ctx: &egui::Context) {
         let accent = crate::theme::accent(self.settings.theme);
+        let mut anchor = None;
         egui::Area::new(egui::Id::new("search_pill"))
             .constrain_to(self.chrome_rect)
             .anchor(egui::Align2::LEFT_TOP, egui::vec2(PANEL_X, 10.0))
@@ -273,6 +271,9 @@ impl HookEchoApp {
                             .fill(egui::Color32::TRANSPARENT)
                             .stroke(egui::Stroke::NONE),
                         );
+                        // The tour's "everything else" stop points here: the pill is always on
+                        // screen, where the panel it opens is not.
+                        anchor = Some(menu.rect);
                         if menu.on_hover_text("Show or hide the panel").clicked() {
                             self.panel_open = !self.panel_open;
                         }
@@ -296,11 +297,13 @@ impl HookEchoApp {
                     });
                 });
             });
+        self.tour_anchors.menu = anchor;
     }
 
     /// The right-edge control column: the buttons that open what floats over the map.
     pub(crate) fn control_column(&mut self, ctx: &egui::Context) {
         use crate::ui::style::square_btn;
+        let mut alerts_anchor = None;
         let accent = crate::theme::accent(self.settings.theme);
         let (alert_count, esc) = self.alert_badge();
         let layers_on = self.panel_open && !self.show_alert_panel;
@@ -330,6 +333,7 @@ impl HookEchoApp {
                     }
                     let bell = square_btn(ui, egui_phosphor::regular::BELL, alerts_on, accent)
                         .on_hover_text("Active alerts in view");
+                    alerts_anchor = Some(bell.rect);
                     if bell.clicked() {
                         self.panel_open = !alerts_on;
                         self.show_alert_panel = true;
@@ -354,6 +358,7 @@ impl HookEchoApp {
                     }
                 });
             });
+        self.tour_anchors.alerts = alerts_anchor;
     }
 
     /// Background picker, slid in beside the control column.

--- a/crates/hookecho/src/app/chrome/registry.rs
+++ b/crates/hookecho/src/app/chrome/registry.rs
@@ -41,6 +41,13 @@ impl HookEchoApp {
             })
             .collect();
         let mut push = |label: &str, category, desc, common, action, on| {
+            // The panel groups rows by category, one collapsible per name in `CATEGORIES`. A row
+            // with a category that isn't in that list draws nowhere: reachable from Ctrl+K, gone
+            // from the panel. Cheaper to catch here than to notice a missing layer months later.
+            debug_assert!(
+                crate::ui::layers_panel::CATEGORIES.contains(&category),
+                "registry row {label:?} has category {category:?}, which the panel does not draw"
+            );
             out.push(PaletteEntry {
                 label: label.to_string(),
                 category,

--- a/crates/hookecho/src/app/chrome/state.rs
+++ b/crates/hookecho/src/app/chrome/state.rs
@@ -1,0 +1,57 @@
+//! What the chrome looked like, saved and restored with a workspace.
+//!
+//! A workspace is an arrangement, and after R18 the arrangement includes the floating surfaces:
+//! restoring "KTLX beside KDMX" but dropping the user back onto a bare map loses half of what
+//! they saved. Only which surface was showing is recorded — not scroll offsets, not the drawer's
+//! back-stack, which is a history rather than a layout.
+
+use super::*;
+
+/// Which window a drawer page belongs to, so a saved page can be reopened through the registry
+/// instead of through a second table of `open` flags.
+///
+/// ponytail: one arm per converted page. B4b converts the rest of `ui/*_window.rs`; each one adds
+/// its line here, and a title this build doesn't know simply doesn't reopen.
+pub(crate) fn window_for_page(title: &str) -> Option<AppWindow> {
+    Some(match title {
+        "Settings" => AppWindow::Settings,
+        "Event Library" => AppWindow::Events,
+        "Alert rules" => AppWindow::AlertRules,
+        _ => return None,
+    })
+}
+
+impl HookEchoApp {
+    pub(crate) fn capture_chrome(&self) -> crate::workspace::Chrome {
+        crate::workspace::Chrome {
+            panel_open: self.panel_open,
+            alerts_tab: self.show_alert_panel,
+            basemap_open: self.basemap_open,
+            drawer: self.drawer.top().map(str::to_string),
+        }
+    }
+
+    pub(crate) fn apply_chrome(&mut self, c: &crate::workspace::Chrome, ctx: &egui::Context) {
+        self.panel_open = c.panel_open;
+        self.show_alert_panel = c.alerts_tab;
+        self.basemap_open = c.basemap_open;
+        // The page opens the same way clicking its row in the panel opens it: one dispatch path,
+        // so a page with side effects (a fetch, a rebuild) gets them here too.
+        if let Some(w) = c.drawer.as_deref().and_then(window_for_page) {
+            self.apply_palette(PaletteAction::OpenWindow(w), ctx);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn known_pages_map_back_to_their_window() {
+        assert_eq!(
+            super::window_for_page("Settings"),
+            Some(super::AppWindow::Settings)
+        );
+        // A page from a newer build, or one that isn't a window at all: skipped, not fatal.
+        assert_eq!(super::window_for_page("Storm 42 Attributes"), None);
+    }
+}

--- a/crates/hookecho/src/ui/drawer.rs
+++ b/crates/hookecho/src/ui/drawer.rs
@@ -44,6 +44,12 @@ impl Drawer {
         !self.stack.is_empty()
     }
 
+    /// The page on top, if any. What a workspace saves; the pages underneath it are a back-stack,
+    /// which is a history, not an arrangement.
+    pub fn top(&self) -> Option<&str> {
+        self.stack.last().map(String::as_str)
+    }
+
     /// Claim the drawer for `title`, drawing its header. Returns the window to render the page
     /// body in, or `None` when another page is on top — the caller draws nothing that frame but
     /// stays open, and comes back when the page above it closes.

--- a/crates/hookecho/src/ui/tour.rs
+++ b/crates/hookecho/src/ui/tour.rs
@@ -95,6 +95,12 @@ impl Tour {
         self.open && self.step < 2
     }
 
+    /// The desktop equivalent: the product stop points at the site and tilt rows, which live in
+    /// the slide-over panel. Spotlighting a control the user has to find first is not a tour.
+    pub fn wants_panel(&self) -> bool {
+        self.open && self.step == 1
+    }
+
     fn body(&self, sig: Signals) -> String {
         let android = cfg!(target_os = "android");
         match self.step {
@@ -103,9 +109,9 @@ impl Tour {
                  newest scan. Every overlay — warnings, reports, lightning — follows you back in \
                  time."
             } else {
-                "Drag the timeline to walk back through the storm, or click LIVE to snap to the \
-                 newest scan. Every overlay — warnings, reports, lightning — follows you back in \
-                 time."
+                "Drag the scrubber along the bottom to walk back through the storm, or click LIVE \
+                 to snap to the newest scan. Every overlay — warnings, reports, lightning — \
+                 follows you back in time."
             }
             .to_string(),
             1 => {
@@ -126,9 +132,12 @@ impl Tour {
                  search box — type what you want in plain English (\"hail\", \"sounding\", a town \
                  name) and it's one tap away."
             } else {
-                "The sidebar holds everything else: products, overlays, tools, windows, settings. \
-                 Ctrl+K jumps straight to its search — type what you want in plain English \
-                 (\"hail\", \"sounding\", a town name) and Enter runs the top match."
+                "This pill opens the panel, and the panel holds everything else: products, \
+                 overlays, tools, settings. Ctrl+K jumps straight to its search — type what you \
+                 want in plain English (\"hail\", \"sounding\", a town name) and Enter runs the \
+                 top match. Tools you read rather than watch open as pages in a drawer down the \
+                 left edge; the buttons down the right edge are the layers, the background map \
+                 and the alert bell."
             }
             .to_string(),
             _ => {

--- a/crates/hookecho/src/workspace.rs
+++ b/crates/hookecho/src/workspace.rs
@@ -36,6 +36,30 @@ pub struct Workspace {
     /// overlays; `default` so a workspace written before this field existed still loads.
     #[serde(default)]
     pub fields_on: Vec<String>,
+    /// What the chrome looked like: which panel was showing, which drawer page was open. `None`
+    /// on a workspace written before this field existed, and on the starters — both mean "leave
+    /// the chrome where the user left it" rather than "close everything", which is what a
+    /// defaulted struct would have meant.
+    #[serde(default)]
+    pub chrome: Option<Chrome>,
+}
+
+/// The floating chrome's state, as far as it is worth restoring: which surface was showing, not
+/// how far it was scrolled.
+#[derive(Debug, Clone, PartialEq, Default, serde::Serialize, serde::Deserialize)]
+pub struct Chrome {
+    #[serde(default)]
+    pub panel_open: bool,
+    /// The panel's Alerts tab rather than Data.
+    #[serde(default)]
+    pub alerts_tab: bool,
+    #[serde(default)]
+    pub basemap_open: bool,
+    /// Title of the drawer page on top, if any — matched back to a window by
+    /// `app::chrome::window_for_page`. A title this build no longer has is skipped, same rule as
+    /// the overlay slugs.
+    #[serde(default)]
+    pub drawer: Option<String>,
 }
 
 /// One pane's state. Camera as lon/lat/zoom, basemap as its slug: both survive a file written by
@@ -125,6 +149,7 @@ pub fn starters() -> Vec<Workspace> {
             ],
             adopt_site: true,
             fields_on: Vec::new(),
+            chrome: None,
         },
         Workspace {
             name: "National overview".into(),
@@ -144,6 +169,7 @@ pub fn starters() -> Vec<Workspace> {
             overlays_on: vec!["Alerts".into(), "StormReports".into(), "Fronts".into()],
             adopt_site: false,
             fields_on: vec!["mrms".into()],
+            chrome: None,
         },
         Workspace {
             name: "Analysis".into(),
@@ -155,6 +181,7 @@ pub fn starters() -> Vec<Workspace> {
             overlays_on: vec!["Alerts".into(), "Cells".into(), "RangeRings".into()],
             adopt_site: true,
             fields_on: Vec::new(),
+            chrome: None,
         },
     ]
 }
@@ -208,6 +235,12 @@ mod tests {
             overlays_on: vec!["Alerts".into(), "Cells".into()],
             adopt_site: false,
             fields_on: vec!["mrms".into()],
+            chrome: Some(Chrome {
+                panel_open: true,
+                alerts_tab: false,
+                basemap_open: false,
+                drawer: Some("Settings".into()),
+            }),
         };
         let json = serde_json::to_string(&ws).unwrap();
         assert_eq!(serde_json::from_str::<Workspace>(&json).unwrap(), ws);
@@ -219,7 +252,7 @@ mod tests {
         let json = r#"{"name":"old","panes":[],"active":0,"link_cameras":false,
             "overlays_on":["Alerts"]}"#;
         let ws: Workspace = serde_json::from_str(json).unwrap();
-        assert!(ws.fields_on.is_empty() && !ws.adopt_site);
+        assert!(ws.fields_on.is_empty() && !ws.adopt_site && ws.chrome.is_none());
     }
 
     #[test]


### PR DESCRIPTION
Closes wave B of R18. The three invariants the plan says the new chrome must not break, checked against the chrome that now exists.

## Tour

The four stops pointed at surfaces that moved or are no longer always on screen:

| Stop | Was | Now |
|---|---|---|
| Time travel | docked timeline bar | scrubber track |
| The products | sidebar head | panel's site + tilt rows, panel forced open |
| Everything else | the whole open panel | the search pill's menu button |
| What's out there | the "Alerts" tab *inside* the panel | the alert bell in the control column |

Spotlighting a control the user has to find first is not a tour, so the product stop opens the panel (`Tour::wants_panel`, the desktop twin of `wants_sheet`) and the other two anchor to chrome that is always visible. Stop text follows: "the timeline" is now the scrubber, and "the sidebar" is now the pill, the drawer and the right-edge buttons.

## Cheatsheet

Unchanged, as the plan predicted — it renders from the registry and the live bindings, so the new chrome's actions were already in it.

## Workspaces

`Workspace::chrome: Option<Chrome>` records which panel was showing and which drawer page was on top. `Option` rather than a defaulted struct: an old file — and the shipped starters — then mean "leave the chrome alone" rather than "close everything", which is what `#[serde(default)]` on a bare struct would have meant. Restoring a page dispatches `apply_palette(OpenWindow(..))`, the same path the panel row takes.

`window_for_page` maps a drawer page title back to its window; three arms today, one more per page as B4b converts the rest.

## Registry audit

All 19 `AppWindow` variants have a Tools row. A `debug_assert` in the registry's `push` now catches a row whose category is not one the panel draws — reachable from Ctrl+K but invisible in the panel is exactly the failure this wave could introduce silently.

## Verification

Gates green: clippy `-D warnings` clean · 561 passed / 29 ignored · wasm check clean · `shoot.sh check` passed · web 12,944,457 raw / 4,781,224 gzipped (budget 4,850,000).

Driven on a nested X server under `kwin_x11`: all four tour stops spotlight the right control, and `?` still opens the cheat sheet.

Known: starting the tour with the panel closed leaves it open afterwards — the product stop opens it and nothing puts it back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)