### PR TITLE
chore(release): v0.12.0-alpha.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,10 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
+          # A hyphen in the tag is a prerelease (`v0.12.0-alpha.1`): flagged as one, and never
+          # made "Latest", so nobody lands on an alpha from the repo's front page.
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          make_latest: ${{ !contains(github.ref_name, '-') }}
           body_path: notes.md
           files: |
             dist/Hook_Echo-WX-x86_64.AppImage
@@ -188,6 +192,10 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
+          # A hyphen in the tag is a prerelease (`v0.12.0-alpha.1`): flagged as one, and never
+          # made "Latest", so nobody lands on an alpha from the repo's front page.
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          make_latest: ${{ !contains(github.ref_name, '-') }}
           files: |
             dist/hookecho-windows-x86_64.zip
             dist/Hook_Echo-WX-x86_64.msi
@@ -314,6 +322,10 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
+          # A hyphen in the tag is a prerelease (`v0.12.0-alpha.1`): flagged as one, and never
+          # made "Latest", so nobody lands on an alpha from the repo's front page.
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          make_latest: ${{ !contains(github.ref_name, '-') }}
           files: dist/Hook_Echo-WX-macos.zip
 
       - name: Update rolling release
@@ -410,6 +422,10 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
+          # A hyphen in the tag is a prerelease (`v0.12.0-alpha.1`): flagged as one, and never
+          # made "Latest", so nobody lands on an alpha from the repo's front page.
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          make_latest: ${{ !contains(github.ref_name, '-') }}
           files: Hook_Echo-WX-arm64-v8a.apk
 
       # Every push to main refreshes a rolling "latest" prerelease, so the Releases page always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ so **write the section before pushing the tag**, or the release job fails.
 
 The rolling `latest` release tracks `main` and is not listed here.
 
+## 0.12.0-alpha.1 - 2026-08-25
+
+First R18 checkpoint: the desktop and web chrome, rebuilt. A prerelease — the
+mobile chrome is still the old sheet-and-toolbar layout, and the data lanes
+land later in the cycle.
+
+- The docked sidebar and the docked timeline bar are gone. The map runs edge
+  to edge, and everything that used to eat it now floats over it: a search
+  pill top-left, a control column down the right edge beside the color scale,
+  and a scrubber pill along the bottom with time ticks, play, a LIVE badge and
+  the loop range.
+- Tools you browse rather than watch — settings, the event library, alert
+  rules — open as pages in one slide-over drawer with a back-stack, one page
+  at a time, on every platform. Anything you click *on the map* answers in a
+  card anchored next to the click instead of in a window wherever egui last
+  left one.
+- The window is borderless: its three buttons float with the rest of the
+  chrome, the empty strip along the top edge drags it, double-clicking that
+  strip maximizes, and any edge or corner resizes. `--decorated` hands the
+  frame back to your window manager if it disagrees.
+- Design tokens: one metrics module with a Comfortable default and a Compact
+  density, the theme list curated to six, a free accent color, and Inter
+  bundled on every platform including web.
+- The 60-second tour now points at the chrome that exists; the keyboard cheat
+  sheet and every hotkey work unchanged; workspaces round-trip and now also
+  remember which panel and drawer page were open.
+- Streamer (OBS) mode and `?embed=1` strip all of the new chrome, same as
+  before.
+
 ## 0.11.0 - 2026-08-25
 
 - Basemaps stopped being an afterthought: every pane now draws its own style

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ opt-level = 3
 opt-level = 3
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0-alpha.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/d4vid87/hookecho"


### PR DESCRIPTION
Version bump, CHANGELOG section, and the workflow change that makes a tagged prerelease behave like one.

- Workspace version `0.11.0` → `0.12.0-alpha.1`.
- CHANGELOG gains the `0.12.0-alpha.1` section the release job extracts as the release body (it fails the release if the section is missing).
- All four platform "Attach to release" steps now set `prerelease: ${{ contains(github.ref_name, '-') }}` and `make_latest: ${{ !contains(github.ref_name, '-') }}`. Without this an alpha tag would have published as a normal release and could have taken the "Latest" slot on the repo's front page. The in-app update check was already safe — `pick_latest_tag` skips prereleases.
- Android needed nothing: `cargoVersionCode` already splits on `-`, so `0.12.0-alpha.1` still resolves to 120000.

Gates: clippy `-D warnings` clean · 561 passed / 29 ignored · `shoot.sh check` passed.

Tag `v0.12.0-alpha.1` goes on this once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)