### PR TITLE
chore(ci): don't announce prereleases

### DIFF
--- a/.github/workflows/announce.yml
+++ b/.github/workflows/announce.yml
@@ -23,6 +23,12 @@ permissions:
 jobs:
   announce:
     runs-on: ubuntu-latest
+    # Prereleases are checkpoints, not releases: `v0.12.0-alpha.1` is for people already following
+    # the work, and broadcasting one to Bluesky/Mastodon/X/Discord announces a version most
+    # readers cannot sensibly install. A hyphen in the tag is the same prerelease test
+    # `release.yml` uses. A manual dispatch is exempt — asking for it by hand, tag and all, is
+    # saying you meant it (and its `dry_run` default is still true).
+    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.ref_name, '-') }}
     steps:
       # On a tag push this is the tag itself; a manual dispatch takes the default branch, so a
       # rehearsal works for a version that has not been tagged yet.


### PR DESCRIPTION
`announce.yml` triggers on any `v*` tag and posts to Bluesky, Mastodon, X and a Discord webhook. All of those secrets are set on this repo, and the job had no prerelease test — so `v0.12.0-alpha.1` was queued to broadcast an alpha as a release. I cancelled that run by hand before it posted (it waits for the release to exist first, which bought the time), but a cancelled run is not a guard.

Job-level `if`: a hyphen in the tag name skips it, the same test `release.yml` now uses for `prerelease` / `make_latest`. `workflow_dispatch` stays exempt — naming a tag by hand is intent, and that path's `dry_run` still defaults to true.

The drafts-upload step is inside the same job, so a prerelease gets no `announce-drafts.md` attached either. That matches the launch waves in `docs/promotion.md`, which are written against real releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)