### PR TITLE
feat(help): one help hub

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1150,8 +1150,9 @@ pub(crate) enum AppWindow {
     Cappi,
     Volume3d,
     StormTable,
-    /// What the signatures on the map are called.
-    Glossary,
+    /// Shortcuts, vocabulary, the tour, and what changed — one searchable page.
+    #[serde(alias = "Glossary")]
+    Help,
     /// The user's own alert rules.
     AlertRules,
     /// Warning verification lab (IEM Cow): how the office's warnings scored on an event day.
@@ -1945,7 +1946,7 @@ pub struct HookEchoApp {
     // ponytail: one at a time; a Vec of players when someone wants a wall of streams.
     video_player: Option<ui::video_window::VideoPlayer>,
     cells_window: ui::cells_window::CellsWindow,
-    glossary: ui::glossary::Glossary,
+    help_hub: ui::help_hub::HelpHub,
     rules_window: ui::rules_window::RulesWindow,
     /// The one slide-over surface every browsable tool page renders into.
     drawer: ui::drawer::Drawer,
@@ -2838,7 +2839,7 @@ impl HookEchoApp {
             pending_spotter: None,
             video_player: None,
             cells_window: Default::default(),
-            glossary: Default::default(),
+            help_hub: Default::default(),
             rules_window: Default::default(),
             drawer: Default::default(),
             popovers: Default::default(),
@@ -7086,7 +7087,7 @@ impl HookEchoApp {
                     self.cappi_key = None; // force a re-slice on open
                 }
                 W::StormTable => self.cells_window.toggle(),
-                W::Glossary => self.glossary.toggle(),
+                W::Help => self.help_hub.toggle(),
                 W::AlertRules => self.rules_window.toggle(),
                 W::Verify => self.open_verify(),
                 W::Volume3d => self.build_volume3d(),
@@ -15227,6 +15228,11 @@ impl eframe::App for HookEchoApp {
         }
         // Storm attributes table: clicking a row flies there and opens that cell's popup, the
         // same destination as clicking the dot on the map.
+        let entries = self.palette_entries();
+        let bindings = crate::hotkeys::active(&self.settings).into_owned();
+        if self.help_hub.show(ctx, &mut self.drawer, &bindings, &entries) {
+            self.tour.start();
+        }
         let cells: &[Cell] = if self.archive_bucket().is_some() {
             &[]
         } else {
@@ -15249,7 +15255,6 @@ impl eframe::App for HookEchoApp {
                 .collect(),
             _ => std::collections::HashSet::new(),
         };
-        ui::glossary::show(&mut self.glossary, ctx);
         if ui::rules_window::show(
             &mut self.rules_window,
             ctx,

--- a/crates/hookecho/src/app/chrome/registry.rs
+++ b/crates/hookecho/src/app/chrome/registry.rs
@@ -856,9 +856,9 @@ impl HookEchoApp {
                 false,
             ),
             (
-                W::Glossary,
-                "Glossary\u{2026}",
-                "What a TDS, a hail spike or a ZDR column actually is",
+                W::Help,
+                "Help \u{2014} shortcuts, glossary, tour\u{2026}",
+                "What a TDS, a hail spike or a ZDR column actually is, and every keyboard shortcut",
                 false,
             ),
             (

--- a/crates/hookecho/src/app/chrome/state.rs
+++ b/crates/hookecho/src/app/chrome/state.rs
@@ -17,6 +17,7 @@ pub(crate) fn window_for_page(title: &str) -> Option<AppWindow> {
         "Settings" => AppWindow::Settings,
         "Event Library" => AppWindow::Events,
         "Alert rules" => AppWindow::AlertRules,
+        "Help" => AppWindow::Help,
         _ => return None,
     })
 }

--- a/crates/hookecho/src/hotkeys.rs
+++ b/crates/hookecho/src/hotkeys.rs
@@ -6,7 +6,7 @@
 //! are app-level variants. [`defaults`] is the shipped table; [`active`] swaps in the user's
 //! overrides from settings without touching call sites.
 
-use crate::app::PaletteAction;
+use crate::app::{AppWindow, PaletteAction};
 use crate::settings::Settings;
 use std::borrow::Cow;
 use wxdata::level2::Moment;
@@ -98,6 +98,8 @@ pub(crate) fn defaults() -> Vec<Binding> {
         plain(K::M, A::ToggleMute),
         plain(K::F11, A::Fullscreen),
         plain(K::Questionmark, A::CheatSheet),
+        // `?` stays the shortcut overlay; F1 is the searchable hub the overlay points at.
+        plain(K::F1, A::Palette(P::OpenWindow(AppWindow::Help))),
         Binding {
             shortcut: egui::KeyboardShortcut::new(egui::Modifiers::COMMAND, egui::Key::K),
             action: A::CommandSearch,

--- a/crates/hookecho/src/ui/cheatsheet.rs
+++ b/crates/hookecho/src/ui/cheatsheet.rs
@@ -48,7 +48,8 @@ pub(crate) fn show(
                 ui.label(
                     egui::RichText::new(
                         "Ctrl + = / − / 0 resize the interface · Escape closes whatever is in \
-                         front · rebind anything in Settings → Hotkeys",
+                         front · rebind anything in Settings → Hotkeys · F1 opens Help, which \
+                         searches these and the glossary together",
                     )
                     .size(style::FONT_SM)
                     .weak(),

--- a/crates/hookecho/src/ui/glossary.rs
+++ b/crates/hookecho/src/ui/glossary.rs
@@ -4,15 +4,18 @@
 //! meteorologist would. That is the right vocabulary — but somebody who installed this to watch
 //! the storm over their own house has no way to look any of it up without leaving the app for a
 //! forum post of unknown vintage. Fifteen entries, searchable, no network.
+//!
+//! The entries are the data half only: [`crate::ui::help_hub`] renders them, alongside the
+//! shortcuts and the tour, so there is one place to search rather than three.
 
 /// One term: what it is called, and the two or three sentences that make it useful.
-struct Entry {
-    term: &'static str,
+pub(crate) struct Entry {
+    pub(crate) term: &'static str,
     /// What it is, in the plainest words that stay true.
-    body: &'static str,
+    pub(crate) body: &'static str,
 }
 
-const ENTRIES: &[Entry] = &[
+pub(crate) const ENTRIES: &[Entry] = &[
     Entry {
         term: "Hook echo",
         body: "The comma-shaped notch on the back-right of a supercell's reflectivity, where the \
@@ -109,62 +112,6 @@ const ENTRIES: &[Entry] = &[
                hail size, judge the core; the spike only tells you the core is serious.",
     },
 ];
-
-#[derive(Default)]
-pub struct Glossary {
-    pub open: bool,
-    query: String,
-}
-
-impl Glossary {
-    pub fn toggle(&mut self) {
-        self.open = !self.open;
-    }
-}
-
-pub fn show(state: &mut Glossary, ctx: &egui::Context) {
-    if !state.open {
-        return;
-    }
-    let mut open = state.open;
-    let window = egui::Window::new("Glossary")
-        .open(&mut open)
-        .default_width(430.0)
-        .default_height(480.0)
-        .resizable(true);
-    crate::ui::phone_surface(ctx, window).show(ctx, |ui| {
-        ui.horizontal(|ui| {
-            ui.label("Find");
-            ui.text_edit_singleline(&mut state.query);
-            if !state.query.is_empty() && ui.button("✕").clicked() {
-                state.query.clear();
-            }
-        });
-        ui.separator();
-        let q = state.query.trim().to_ascii_lowercase();
-        // Search the bodies too: someone who only knows "the debris thing" should still land on
-        // TDS without knowing to type three letters.
-        let hits: Vec<&Entry> = ENTRIES
-            .iter()
-            .filter(|e| {
-                q.is_empty()
-                    || e.term.to_ascii_lowercase().contains(&q)
-                    || e.body.to_ascii_lowercase().contains(&q)
-            })
-            .collect();
-        egui::ScrollArea::vertical().show(ui, |ui| {
-            if hits.is_empty() {
-                ui.weak("Nothing matches that.");
-            }
-            for e in hits {
-                ui.label(egui::RichText::new(e.term).strong());
-                ui.label(e.body);
-                ui.add_space(8.0);
-            }
-        });
-    });
-    state.open = open;
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/hookecho/src/ui/help_hub.rs
+++ b/crates/hookecho/src/ui/help_hub.rs
@@ -1,0 +1,217 @@
+//! One place to look things up: shortcuts, vocabulary, the tour, and what changed.
+//!
+//! Help used to be scattered — a glossary window, a `?` overlay of key bindings, a tour you had
+//! to know lived in Settings — and none of them knew about each other. Somebody who does not
+//! know the word "TDS" also does not know which of three surfaces would have told them. So there
+//! is one search box over all of it, and the sections underneath it are what that box matched.
+//!
+//! ponytail: no index, no fuzzy matcher — a substring pass over ~15 glossary entries and ~25
+//! bindings is nothing per frame. The registry's fuzzy matcher is for the command palette, where
+//! the user is typing an action name and expects typo tolerance; here they are reading.
+
+use crate::app::PaletteEntry;
+use crate::hotkeys::{self, BindableAction, Binding};
+
+/// What's-new comes from the changelog itself: one file to write at release time, not two.
+const CHANGELOG: &str = include_str!("../../../../CHANGELOG.md");
+
+/// Small things people miss, shown one at a time and rotated so a second look is a second tip.
+const TIPS: &[&str] = &[
+    "Drag the scrubber to travel in time; the LIVE badge takes you back to now.",
+    "Ctrl+K searches every command in the app, including ones with no button.",
+    "Long-press or right-click the map to interrogate a pixel: every moment at that point.",
+    "Panes can each run their own site, product and tilt — set panes to 4 and compare tilts.",
+    "Alert rules decide what is worth interrupting you for. Nothing else makes a sound.",
+    "Save an arrangement as a workspace and it comes back exactly, panes and all.",
+    "A hook in reflectivity is a reason to look at velocity, not a tornado by itself.",
+];
+
+#[derive(Default)]
+pub(crate) struct HelpHub {
+    pub open: bool,
+    query: String,
+}
+
+impl HelpHub {
+    pub(crate) fn toggle(&mut self) {
+        self.open = !self.open;
+        if self.open {
+            self.query.clear();
+        }
+    }
+
+    /// Draw the page. Returns true when the user asked for the tour — the app owns the tour, and
+    /// starting it from here would mean this module knowing about app state.
+    pub(crate) fn show(
+        &mut self,
+        ctx: &egui::Context,
+        drawer: &mut crate::ui::drawer::Drawer,
+        bindings: &[Binding],
+        entries: &[PaletteEntry],
+    ) -> bool {
+        let mut open = self.open;
+        let Some(window) = drawer.page(ctx, "Help", &mut open, false, egui::Window::new("Help"))
+        else {
+            self.open = open;
+            return false;
+        };
+        let mut tour = false;
+        window.show(ctx, |ui| {
+            ui.horizontal(|ui| {
+                ui.add(
+                    egui::TextEdit::singleline(&mut self.query)
+                        .hint_text("Search help\u{2026}")
+                        .desired_width(f32::INFINITY),
+                );
+            });
+            let q = self.query.trim().to_ascii_lowercase();
+
+            if q.is_empty() {
+                ui.add_space(6.0);
+                // Rotates on its own so the same card is not the only thing anyone ever reads.
+                let i = (ctx.input(|i| i.time) / 12.0) as usize % TIPS.len();
+                ui.label(egui::RichText::new(TIPS[i]).italics());
+                ctx.request_repaint_after(std::time::Duration::from_secs(1));
+            }
+            ui.add_space(4.0);
+            if ui
+                .button(format!(
+                    "{} Take the 60-second tour",
+                    egui_phosphor::regular::PLAY_CIRCLE
+                ))
+                .on_hover_text("Four stops on the live map: the timeline, the products, where everything lives, and how to read a storm")
+                .clicked()
+            {
+                tour = true;
+            }
+            ui.separator();
+
+            let keys = shortcut_rows(bindings, entries, &q);
+            if !keys.is_empty() {
+                crate::theme::section(ui, "Keyboard shortcuts", |ui| {
+                    for (key, label) in &keys {
+                        ui.horizontal(|ui| {
+                            ui.label(
+                                egui::RichText::new(key)
+                                    .monospace()
+                                    .size(crate::ui::style::FONT_SM)
+                                    .background_color(egui::Color32::from_white_alpha(18)),
+                            );
+                            ui.label(label);
+                        });
+                    }
+                });
+            }
+
+            let terms: Vec<&crate::ui::glossary::Entry> = crate::ui::glossary::ENTRIES
+                .iter()
+                .filter(|e| {
+                    q.is_empty()
+                        || e.term.to_ascii_lowercase().contains(&q)
+                        || e.body.to_ascii_lowercase().contains(&q)
+                })
+                .collect();
+            if !terms.is_empty() {
+                crate::theme::section(ui, "What the map is saying", |ui| {
+                    for e in terms {
+                        ui.label(egui::RichText::new(e.term).strong());
+                        ui.label(e.body);
+                        ui.add_space(6.0);
+                    }
+                });
+            }
+
+            let news = whats_new(CHANGELOG);
+            if q.is_empty() || news.to_ascii_lowercase().contains(&q) {
+                crate::theme::section(ui, "What's new", |ui| {
+                    ui.label(&news);
+                });
+            }
+
+            if !q.is_empty() && keys.is_empty() && terms_empty(&q) && !news.to_ascii_lowercase().contains(&q) {
+                ui.weak("Nothing matches that.");
+            }
+        });
+        self.open = open;
+        tour
+    }
+}
+
+/// Did the glossary match nothing? Separate so the "nothing matches" check reads as one line.
+fn terms_empty(q: &str) -> bool {
+    !crate::ui::glossary::ENTRIES
+        .iter()
+        .any(|e| e.term.to_ascii_lowercase().contains(q) || e.body.to_ascii_lowercase().contains(q))
+}
+
+/// Live bindings as `(key, what it does)`, labelled from the registry so a renamed action renames
+/// its shortcut row too.
+fn shortcut_rows(
+    bindings: &[Binding],
+    entries: &[PaletteEntry],
+    q: &str,
+) -> Vec<(String, String)> {
+    bindings
+        .iter()
+        .filter_map(|b| {
+            let label = match b.action {
+                BindableAction::Palette(p) => entries.iter().find(|e| e.action == p)?.label.clone(),
+                other => hotkeys::label(other)?.to_string(),
+            };
+            let key = hotkeys::pretty(&b.shortcut);
+            (q.is_empty()
+                || label.to_ascii_lowercase().contains(q)
+                || key.to_ascii_lowercase().contains(q))
+            .then_some((key, label))
+        })
+        .collect()
+}
+
+/// The newest changelog section, heading and all. The release job already treats these sections
+/// as the release body, so whatever is good enough to publish is good enough to show here.
+fn whats_new(md: &str) -> String {
+    let mut out = String::new();
+    for line in md.lines().skip_while(|l| !l.starts_with("## ")) {
+        if line.starts_with("## ") {
+            if !out.is_empty() {
+                break;
+            }
+            out.push_str(line.strip_prefix("## ").unwrap_or(line));
+            out.push('\n');
+            continue;
+        }
+        out.push_str(line);
+        out.push('\n');
+    }
+    out.trim_end().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn whats_new_is_the_newest_section_only() {
+        let s = whats_new("# Changelog\n\nblurb\n\n## 1.1 - x\n- new thing\n\n## 1.0 - y\n- old\n");
+        assert!(s.starts_with("1.1 - x"), "{s}");
+        assert!(s.contains("new thing"));
+        assert!(!s.contains("old"));
+    }
+
+    #[test]
+    fn the_shipped_changelog_has_a_section_to_show() {
+        assert!(whats_new(CHANGELOG).contains('-'), "no release section");
+    }
+
+    #[test]
+    fn shortcuts_filter_by_label_and_by_key() {
+        let bindings = crate::hotkeys::defaults();
+        let all = shortcut_rows(&bindings, &[], "");
+        assert!(!all.is_empty(), "app-level bindings always label themselves");
+        // No registry passed, so every palette-bound row drops out and only `hotkeys::label` rows
+        // remain — which is exactly what a caller with no entries should see.
+        assert!(all.iter().any(|(_, l)| l == "Fullscreen"));
+        assert!(shortcut_rows(&bindings, &[], "fullscreen").len() == 1);
+        assert!(shortcut_rows(&bindings, &[], "zzzz").is_empty());
+    }
+}

--- a/crates/hookecho/src/ui/mod.rs
+++ b/crates/hookecho/src/ui/mod.rs
@@ -86,6 +86,7 @@ pub mod event_window;
 pub mod firstrun;
 pub mod forecast_window;
 pub mod glossary;
+pub mod help_hub;
 pub mod hodograph_window;
 pub mod layer_options;
 pub mod layer_window;


### PR DESCRIPTION
C2 of R18. Stacked on #91 (C1).

One searchable surface replaces three that didn't know about each other.

**New `ui/help_hub.rs`** — a drawer page (`"Help"`, wired into `window_for_page` so workspaces restore it) with one search box over:

- **Keyboard shortcuts** — built from the live binding table and labelled through the palette registry, so a rebind or a renamed action relabels the row without a second edit.
- **Glossary** — `ui/glossary.rs` is now data only. Its window is deleted; `ENTRIES` and the "every entry is filled in" test survive and are rendered here.
- **The tour** — a launcher button; the hub returns a bool rather than reaching into app state.
- **What's new** — the newest `CHANGELOG.md` section, `include_str!`'d. The release workflow already publishes those sections as the release body, so there is no second copy to drift.
- **A rotating tip** when the box is empty, cycling every 12 s of session time.

`AppWindow::Glossary` → `AppWindow::Help` with `#[serde(alias = "Glossary")]`, so saved workspaces and settings still resolve. Registry row is now "Help — shortcuts, glossary, tour…".

**F1** opens the hub. `?` stays the shortcut overlay (B7 invariant: cheatsheet unchanged); its footer now says F1 searches the shortcuts and the glossary together.

Skipped: no fuzzy matcher — a substring pass over ~15 entries and ~25 bindings costs nothing, and the fuzzy matcher exists for the command palette, where the user is typing an action name rather than reading.

## Gate

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — pass; 3 new tests (changelog excerpt is the newest section only, the shipped changelog has one, shortcut rows filter by label and by key)
- wasm check — 0 errors
- `shoot.sh check` — passed (no scene or label the harness stages changed)
- `web/build.sh` — 4,788,870 gzipped, budget 4,850,000

No screenshot reshoot: that is E3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)