### PR TITLE
feat(android): haptics bridge

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -3927,6 +3927,7 @@ impl HookEchoApp {
             return;
         }
         crate::audio::play(sound, self.settings.alert_volume);
+        crate::platform::haptic(crate::platform::Haptic::Alert);
     }
 
     /// A sound quiet hours does not silence: the escalated warning tiers and the two detections
@@ -3937,6 +3938,7 @@ impl HookEchoApp {
             return;
         }
         crate::audio::play(sound, self.settings.alert_volume);
+        crate::platform::haptic(crate::platform::Haptic::Alert);
     }
 
     /// Everywhere the proximity alerts watch: the saved markers, plus your own live position when
@@ -9792,6 +9794,10 @@ impl HookEchoApp {
         // and arming Interrogate first to ask "what is that" is a step nobody discovers — so the
         // press that means "tell me about this" is the press people already try.
         let long_press = cfg!(target_os = "android") && response.long_touched();
+        if long_press {
+            // Before anything is drawn: the buzz is what says the press was heard.
+            crate::platform::haptic(crate::platform::Haptic::Press);
+        }
         if (response.clicked() || long_press) && quiet {
             self.active = idx;
             // What this press means. A long press is always an interrogation; anything else is

--- a/crates/hookecho/src/app/chrome/overlay.rs
+++ b/crates/hookecho/src/app/chrome/overlay.rs
@@ -531,6 +531,8 @@ impl HookEchoApp {
             });
         if let Some(i) = pick.filter(|i| *i != self.active) {
             self.active = i;
+            // A swipe walks several dots; each pane it lands on gets its own detent.
+            crate::platform::haptic(crate::platform::Haptic::Tick);
         }
     }
 

--- a/crates/hookecho/src/app/chrome/scrubber.rs
+++ b/crates/hookecho/src/app/chrome/scrubber.rs
@@ -384,6 +384,9 @@ fn track(
                 t.playhead = idx;
                 t.playing = false;
                 t.following = idx + 1 == observed;
+                // One detent per frame: the track has no ticks under a thumb that covers it, so
+                // the frames are felt instead.
+                crate::platform::haptic(crate::platform::Haptic::Tick);
             }
         }
     }

--- a/crates/hookecho/src/platform.rs
+++ b/crates/hookecho/src/platform.rs
@@ -918,6 +918,89 @@ mod android_browser {
     }
 }
 
+/// A short, physical acknowledgement. What the phone does when the screen says nothing.
+#[derive(Clone, Copy)]
+pub enum Haptic {
+    /// A detent: one scrubber frame, one pane. The lightest thing the OS offers.
+    Tick,
+    /// A press was recognised as a long press, before anything appears.
+    Press,
+    /// A warning fired. The one buzz that should be felt through a pocket.
+    Alert,
+}
+
+/// Play `h` on the device. No-op off Android.
+///
+/// ponytail: no app-level "enable haptics" setting — `performHapticFeedback` already obeys the
+/// system's own touch-feedback switch, and a second toggle that can disagree with it is a support
+/// question, not a feature.
+pub fn haptic(h: Haptic) {
+    #[cfg(target_os = "android")]
+    {
+        // HapticFeedbackConstants: CLOCK_TICK, LONG_PRESS, CONFIRM.
+        let effect = match h {
+            Haptic::Tick => 4,
+            Haptic::Press => 0,
+            Haptic::Alert => 16,
+        };
+        let _ = android_haptics::play(effect);
+    }
+    #[cfg(not(target_os = "android"))]
+    let _ = h;
+}
+
+/// `decorView.performHapticFeedback(effect)` — the Android half of [`haptic`].
+#[cfg(target_os = "android")]
+mod android_haptics {
+    use jni::objects::{GlobalRef, JObject};
+    use std::sync::OnceLock;
+
+    /// The decor view, held for the life of the process. Resolving it costs four JNI calls, and a
+    /// scrubber drag asks for a tick every frame.
+    static VIEW: OnceLock<Option<GlobalRef>> = OnceLock::new();
+
+    fn view() -> Option<&'static GlobalRef> {
+        VIEW.get_or_init(|| resolve().ok().flatten()).as_ref()
+    }
+
+    fn resolve() -> jni::errors::Result<Option<GlobalRef>> {
+        let Some(app) = super::android::app() else {
+            return Ok(None);
+        };
+        let vm = unsafe { jni::JavaVM::from_raw(app.vm_as_ptr() as *mut jni::sys::JavaVM) }?;
+        let mut env = vm.attach_current_thread()?;
+        let activity = unsafe { JObject::from_raw(app.activity_as_ptr() as jni::sys::jobject) };
+        let window = env
+            .call_method(&activity, "getWindow", "()Landroid/view/Window;", &[])?
+            .l()?;
+        let decor = env
+            .call_method(&window, "getDecorView", "()Landroid/view/View;", &[])?
+            .l()?;
+        Ok(Some(env.new_global_ref(&decor)?))
+    }
+
+    pub(super) fn play(effect: i32) -> jni::errors::Result<()> {
+        let Some(view) = view() else {
+            return Ok(());
+        };
+        let Some(app) = super::android::app() else {
+            return Ok(());
+        };
+        let vm = unsafe { jni::JavaVM::from_raw(app.vm_as_ptr() as *mut jni::sys::JavaVM) }?;
+        let mut env = vm.attach_current_thread()?;
+        let res = env.call_method(
+            view.as_obj(),
+            "performHapticFeedback",
+            "(I)Z",
+            &[effect.into()],
+        );
+        if res.is_err() {
+            let _ = env.exception_clear();
+        }
+        res.map(|_| ())
+    }
+}
+
 /// Hand a typeset text product to the Kotlin `TextViewActivity`, which puts it in a WebView.
 ///
 /// The document travels as a string extra rather than a file: it is generated fresh each time, it


### PR DESCRIPTION
R18 wave D, item D3. Stacked on #96 (D2) → #95 → #94 → #93 → #92 → #91.

`platform::haptic(Haptic::{Tick, Press, Alert})` → `decorView.performHapticFeedback(constant)` over JNI (`CLOCK_TICK` / `LONG_PRESS` / `CONFIRM`). The decor view is resolved once into a `GlobalRef` and kept: a scrubber drag asks for a tick every frame.

Hooks:

| Where | Effect |
|---|---|
| scrubbing past a frame | Tick — the track has no ticks under a thumb that covers it |
| landing on a pane in the pane strip | Tick |
| a long press being recognised | Press, before anything is drawn |
| `play_alert` / `play_alert_urgent` | Alert — both chokepoints, so mute and quiet hours still govern |

No app-level toggle: `performHapticFeedback` already obeys the system touch-feedback switch, and a second one that can disagree is a support question, not a feature. Noted as a `ponytail:` comment.

## Verification

- clippy `-D warnings` clean · 569 tests · wasm 0 errors · `shoot.sh check` passed · web 4,792,209 gz
- **On device** (S24 Ultra): dragging the scrubber logs `performHapticFeedback(constant=4): ViewRootImpl#performHapticFeedback` from `zip.batman.hookecho` and `SemHapticStep: Turning on vibrator 0 for 110ms`.
- The Alert hook is verified as code only — it needs a warning to fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)