### PR TITLE
feat(android): tablet layout

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -15499,7 +15499,8 @@ impl eframe::App for HookEchoApp {
             let n = self.views.len();
             // A phone shows one pane at a time. Two 400x400 pt panes stacked is two views of
             // nothing; the pane strip above the scrubber is how you get to the others.
-            let solo = cfg!(target_os = "android") && n > 1;
+            // Only where one pane is all that fits: a tablet shows the split.
+            let solo = cfg!(target_os = "android") && n > 1 && chrome::compact(ctx);
             let rects = if solo {
                 vec![full; n]
             } else {

--- a/crates/hookecho/src/app/chrome/mod.rs
+++ b/crates/hookecho/src/app/chrome/mod.rs
@@ -4,6 +4,7 @@
 
 mod chips;
 mod overlay;
+pub(crate) use overlay::compact;
 mod registry;
 mod scrubber;
 mod state;

--- a/crates/hookecho/src/app/chrome/overlay.rs
+++ b/crates/hookecho/src/app/chrome/overlay.rs
@@ -26,6 +26,21 @@ fn phone() -> bool {
     cfg!(target_os = "android")
 }
 
+/// Is this a compact screen — a phone held in portrait?
+///
+/// The touch layout and the sheet layout are two different questions, and a tablet answers them
+/// differently: it wants the big targets and the top pill, and it has room to put the panel beside
+/// the map like a desktop does rather than over it. M3 calls the line 600 dp; the same line moves
+/// a phone in landscape onto the tablet layout, which is the right answer there too.
+pub(crate) fn compact(ctx: &egui::Context) -> bool {
+    crate::ui::m3::width_class(ctx.content_rect().width()) == crate::ui::m3::WidthClass::Compact
+}
+
+/// Does this screen get bottom sheets instead of a docked panel?
+fn sheets(ctx: &egui::Context) -> bool {
+    phone() && compact(ctx)
+}
+
 /// Where the phone's chrome starts: under the status bar and the color-scale strips.
 fn phone_top(ctx: &egui::Context) -> f32 {
     let content = ctx.content_rect();
@@ -80,6 +95,7 @@ impl HookEchoApp {
         // bottom sheet on a phone. The content is identical — that is the point of the wave, and
         // why the phone's own menu sheet could be deleted rather than kept in sync.
         let alerts_tab_was = alerts_tab;
+        let sheets_layout = sheets(ctx);
         let mut sheet_close = false;
         let mut body = |ui: &mut egui::Ui| {
                     // Title on the same line as the tabs: the name is branding, not a section, and
@@ -144,7 +160,7 @@ impl HookEchoApp {
                         // Leave room for the disclosures under the tree, whatever the window
                         // height. In the sheet there is no height to read yet — it scrolls — so
                         // the tree takes half the screen and the rest scrolls past it.
-                        if phone() {
+                        if sheets_layout {
                             chrome.height() * 0.5
                         } else {
                             (ui.available_height() - 110.0).max(120.0)
@@ -233,7 +249,7 @@ impl HookEchoApp {
                         .default_open(false)
                         .show(ui, |ui| self.app_rows(ui));
         };
-        if phone() {
+        if sheets(ctx) {
             let title = if alerts_tab_was {
                 format!("Alerts in view ({alert_count})")
             } else {
@@ -258,7 +274,12 @@ impl HookEchoApp {
                     // Denser than the chips: this one carries a wall of small text, and a basemap
                     // label showing through a list row is unreadable, not tasteful.
                     crate::ui::style::glass(ui, 250).show(ui, |ui| {
-                        ui.set_width(PANEL_W);
+                        // A tablet's docked panel is a rail: same card, thumb-width.
+                        ui.set_width(if phone() {
+                            crate::ui::m3::RAIL_W
+                        } else {
+                            PANEL_W
+                        });
                         ui.set_max_height(max_h);
                         body(ui);
                     });
@@ -489,7 +510,7 @@ impl HookEchoApp {
     /// which is exactly the cost showing one pane at a time was buying back.
     pub(crate) fn pane_strip(&mut self, ctx: &egui::Context) {
         let n = self.views.len();
-        if !phone() || n < 2 {
+        if !sheets(ctx) || n < 2 {
             return;
         }
         let accent = crate::theme::accent(self.settings.theme);
@@ -543,7 +564,7 @@ impl HookEchoApp {
         }
         let mut picked = None;
         let chrome = self.chrome_rect;
-        if phone() {
+        if sheets(ctx) {
             // The phone gets the chip row above the grid: the eight common styles are one tap
             // each, and the grid is for the other forty.
             let mut close = false;


### PR DESCRIPTION
R18 wave D, item D4 — closes wave D. Stacked on #97 (D3) → #96 → #95 → #94 → #93 → #92 → #91.

## What

`phone()` was doing two jobs: "is this touch" and "is this small". They split.

- **Touch sizing** (top pill with site/VCP, big control column, `phone_top` offsets) stays on every Android screen.
- **Sheet layout** (`sheets()` = Android **and** M3 compact, < 600 dp) now gates the bottom sheets, the one-pane-at-a-time map, and the pane strip.

Above the line: the panel and basemap picker dock as a left rail at `m3::RAIL_W` — the same card the desktop draws, thumb-width because it is still a touch target — the map keeps its split panes with the active-pane outline, and the pane strip disappears because there is nothing left for it to say. A phone in landscape crosses the same line and gets the same layout.

## Native pickers: not done, deliberately

The plan says "adopted where trivially cheap (intent-based)". The two this app would want are a date (archive day) and a time; Android has no intent-based system picker for either, so the only route is a Compose dialog hosted over the GameActivity surface — exactly the interop D1 stopped needing. Left out rather than half-built.

## Verification

- clippy `-D warnings` clean · 569 tests · wasm 0 errors · `shoot.sh check` passed · web 4,792,045 gz
- **On device** (S24 Ultra at a forced `wm size 2400x1080` = 640 dp wide, Medium class): the panel docks as a left rail instead of rising from the bottom edge, control column and pill unchanged. Display size reset to physical afterwards.
- The device is not a real tablet, so the Expanded class (≥ 840 dp) is covered by the same code path but not by a run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)