### PR TITLE
refactor(chrome): the rest of the windows become drawer pages

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -14816,7 +14816,7 @@ impl eframe::App for HookEchoApp {
         if self.about_open {
             let accent = crate::theme::accent(self.settings.theme);
             let mut open = self.about_open;
-            ui::about_window::show(ctx, &mut open, &self.update_state, accent);
+            ui::about_window::show(ctx, &mut open, &self.update_state, accent, &mut self.drawer);
             self.about_open = open;
         }
 
@@ -14860,6 +14860,7 @@ impl eframe::App for HookEchoApp {
                 dialog,
                 &mut self.views[self.active],
                 &mut self.settings,
+                &mut self.drawer,
             );
             if !keep {
                 self.site_dialog = None;
@@ -14911,7 +14912,7 @@ impl eframe::App for HookEchoApp {
             })
             .collect();
         self.placefile_window
-            .show(ctx, &mut self.settings, &pf_status);
+            .show(ctx, &mut self.settings, &pf_status, &mut self.drawer);
         // Names come from the action registry, so a layer reads the same here as in the layers
         // panel — the enum's Debug spelling ("Mrms") is not a label.
         let names: std::collections::HashMap<crate::render::FieldLayer, String> =
@@ -14940,6 +14941,7 @@ impl eframe::App for HookEchoApp {
             &mut self.layer_window_open,
             &mut self.settings,
             &active_fields,
+            &mut self.drawer,
         ) {
             self.overlay_gen += 1; // paint order / opacity changed — re-tessellate
         }
@@ -15000,7 +15002,7 @@ impl eframe::App for HookEchoApp {
         }
         let query = self
             .marker_window
-            .show(ctx, &mut self.settings, &self.marker_icon_tex);
+            .show(ctx, &mut self.settings, &self.marker_icon_tex, &mut self.drawer);
         // The map popup indexes into the same list: a delete above it leaves it describing the
         // wrong marker, which is the one way this UI can lie about which place you are editing.
         if let (Some(gone), Some(open)) = (self.marker_window.removed, self.marker_popup) {
@@ -15037,7 +15039,7 @@ impl eframe::App for HookEchoApp {
             }
         }
         self.palette_editor
-            .show(ctx, &mut self.settings, &self.palettes);
+            .show(ctx, &mut self.settings, &self.palettes, &mut self.drawer);
         // Storm digest: poll a pending Claude result, then render + handle Generate.
         if let Some(rx) = &self.digest_rx {
             if let Ok(res) = rx.try_recv() {
@@ -15052,7 +15054,7 @@ impl eframe::App for HookEchoApp {
                 }
             }
         }
-        if let Some(ui::digest_window::DigestAction::Generate) = self.digest_window.show(ctx) {
+        if let Some(ui::digest_window::DigestAction::Generate) = self.digest_window.show(ctx, &mut self.drawer) {
             self.generate_digest();
         }
         // Live station cards. Video keeps arriving between input events, so a playing card asks
@@ -15084,6 +15086,7 @@ impl eframe::App for HookEchoApp {
                 self.afd.as_ref(),
                 self.afd_busy,
                 self.afd_error.as_deref(),
+                &mut self.drawer,
             );
             if refresh {
                 self.fetch_afd();
@@ -15113,7 +15116,7 @@ impl eframe::App for HookEchoApp {
                 .map(|t| t.storms.clone())
                 .unwrap_or_default();
             if let Some((id, product)) =
-                ui::tropical_window::show(&mut self.tropical_window, ctx, &storms)
+                ui::tropical_window::show(&mut self.tropical_window, ctx, &storms, &mut self.drawer)
             {
                 self.fetch_tropical_text(&id, product);
             }
@@ -15140,7 +15143,8 @@ impl eframe::App for HookEchoApp {
                 }
             }
         }
-        self.sounding_window.show(ctx, self.active_tz());
+        let tz = self.active_tz();
+        self.sounding_window.show(ctx, tz, &mut self.drawer);
         if std::mem::take(&mut self.sounding_window.refetch) {
             self.refetch_sounding();
         }
@@ -15157,7 +15161,8 @@ impl eframe::App for HookEchoApp {
                 }
             }
         }
-        let vact = self.verify_window.show(ctx, self.active_tz());
+        let tz = self.active_tz();
+        let vact = self.verify_window.show(ctx, tz, &mut self.drawer);
         if vact.refresh {
             self.verify_window.data = None;
             self.fetch_verify();
@@ -15327,6 +15332,7 @@ impl eframe::App for HookEchoApp {
             &zdr_cells,
             &self.cell_trends,
             crate::theme::accent(self.settings.theme),
+            &mut self.drawer,
         ) {
             if let Some(c) = self
                 .active_storm_cells()
@@ -15394,7 +15400,7 @@ impl eframe::App for HookEchoApp {
             self.open_spotter(&sp);
         }
         if let Some(p) = &mut self.video_player {
-            if !p.show(ctx) {
+            if !p.show(ctx, &mut self.drawer) {
                 self.video_player = None; // dropping the player stops the download
             }
         }
@@ -15407,8 +15413,9 @@ impl eframe::App for HookEchoApp {
                 self.warning_popup = None;
             }
         }
+        let tz = self.active_tz();
         if self.show_sensors
-            && !ui::sensor_window::show(ctx, self.sensor_data.as_ref(), self.active_tz())
+            && !ui::sensor_window::show(ctx, self.sensor_data.as_ref(), tz, &mut self.drawer)
         {
             self.show_sensors = false;
         }
@@ -15420,13 +15427,14 @@ impl eframe::App for HookEchoApp {
                 self.hodo_history.make_contiguous(),
                 &mut self.hodo_tab,
                 self.settings.tz_for(self.hodo_site.as_deref()),
+                &mut self.drawer,
             )
         {
             self.show_hodo = false;
         }
         if let (Some(xs), Some(tex)) = (&self.xsection, &self.xsection_tex) {
             let mut moment = self.xsection_moment;
-            let open = ui::xsection_window::show(ctx, xs, tex, &mut moment);
+            let open = ui::xsection_window::show(ctx, xs, tex, &mut moment, &mut self.drawer);
             if !open {
                 self.xsection = None;
                 self.xsection_tex = None;
@@ -15448,14 +15456,17 @@ impl eframe::App for HookEchoApp {
                 VOL3D_N as u32,
                 VOL3D_NZ as u32,
                 self.vol3d_range,
+                &mut self.drawer,
             );
             self.show_3d = open;
         }
         if self.show_cappi {
             self.update_cappi(ctx);
             let open = match self.cappi_tex.clone() {
-                Some(tex) => ui::cappi_window::show(ctx, &tex, &mut self.cappi_alt_km, 300.0),
-                None => ui::cappi_window::show_empty(ctx),
+                Some(tex) => {
+                    ui::cappi_window::show(ctx, &tex, &mut self.cappi_alt_km, 300.0, &mut self.drawer)
+                }
+                None => ui::cappi_window::show_empty(ctx, &mut self.drawer),
             };
             self.show_cappi = open;
         }

--- a/crates/hookecho/src/app/chrome/state.rs
+++ b/crates/hookecho/src/app/chrome/state.rs
@@ -10,14 +10,29 @@ use super::*;
 /// Which window a drawer page belongs to, so a saved page can be reopened through the registry
 /// instead of through a second table of `open` flags.
 ///
-/// ponytail: one arm per converted page. B4b converts the rest of `ui/*_window.rs`; each one adds
-/// its line here, and a title this build doesn't know simply doesn't reopen.
+/// ponytail: one arm per page that has a registry action to reopen it. Pages opened by the map
+/// rather than by a menu — a cross-section, a hodograph, the sounding, the station sensors — have
+/// no such action and no meaningful thing to restore into, so they are absent on purpose: a title
+/// this build cannot reopen simply doesn't reopen.
 pub(crate) fn window_for_page(title: &str) -> Option<AppWindow> {
     Some(match title {
         "Settings" => AppWindow::Settings,
         "Event Library" => AppWindow::Events,
         "Alert rules" => AppWindow::AlertRules,
         "Help" => AppWindow::Help,
+        "About Hook Echo-WX" => AppWindow::About,
+        "Forecast Discussion" => AppWindow::Afd,
+        "CAPPI slice" => AppWindow::Cappi,
+        "Storm attributes" => AppWindow::StormTable,
+        "Storm Digest" => AppWindow::Digest,
+        "Layer Manager" => AppWindow::LayerManager,
+        "Location Markers" => AppWindow::Markers,
+        "Color-Table Editor" => AppWindow::Palettes,
+        "Placefile Manager" => AppWindow::Placefiles,
+        "Select Radar Site" => AppWindow::Site,
+        "Warning Verification" => AppWindow::Verify,
+        "3D Reflectivity" => AppWindow::Volume3d,
+        "Tornado climatology" => AppWindow::Climatology,
         _ => return None,
     })
 }
@@ -52,7 +67,13 @@ mod tests {
             super::window_for_page("Settings"),
             Some(super::AppWindow::Settings)
         );
+        assert_eq!(
+            super::window_for_page("Tornado climatology"),
+            Some(super::AppWindow::Climatology)
+        );
         // A page from a newer build, or one that isn't a window at all: skipped, not fatal.
         assert_eq!(super::window_for_page("Storm 42 Attributes"), None);
+        // Map-click pages are deliberately absent — nothing to restore them into.
+        assert_eq!(super::window_for_page("Cross-section"), None);
     }
 }

--- a/crates/hookecho/src/app/chrome/windows.rs
+++ b/crates/hookecho/src/app/chrome/windows.rs
@@ -10,10 +10,17 @@ impl HookEchoApp {
             return;
         }
         let mut open = self.climo_open;
-        crate::ui::phone_surface(ctx, egui::Window::new("Tornado climatology"))
-            .open(&mut open)
-            .default_width(360.0)
-            .show(ctx, |ui| {
+        let Some(window) = self.drawer.page(
+            ctx,
+            "Tornado climatology",
+            &mut open,
+            false,
+            egui::Window::new("Tornado climatology"),
+        ) else {
+            self.climo_open = open;
+            return;
+        };
+        window.show(ctx, |ui| {
                 if let Some((lon, lat)) = self.climo_center {
                     ui.label(format!("Within 25 mi of {lat:.3}, {lon:.3}"));
                 }

--- a/crates/hookecho/src/ui/about_window.rs
+++ b/crates/hookecho/src/ui/about_window.rs
@@ -20,11 +20,18 @@ pub enum UpdateState {
 }
 
 /// Draw the window. Returns false once the user closed it.
-pub fn show(ctx: &egui::Context, open: &mut bool, update: &UpdateState, accent: egui::Color32) {
-    crate::ui::phone_surface(ctx, egui::Window::new("About Hook Echo-WX"))
-        .open(open)
-        .default_size([380.0, 260.0])
-        .show(ctx, |ui| {
+pub fn show(
+    ctx: &egui::Context,
+    open: &mut bool,
+    update: &UpdateState,
+    accent: egui::Color32,
+    drawer: &mut crate::ui::drawer::Drawer,
+) {
+    let Some(window) = drawer.page(ctx, "About Hook Echo-WX", open, false, egui::Window::new("About Hook Echo-WX"))
+    else {
+        return;
+    };
+    window.show(ctx, |ui| {
             ui.label(
                 egui::RichText::new("Hook Echo-WX")
                     .size(style::FONT_TITLE)

--- a/crates/hookecho/src/ui/afd_window.rs
+++ b/crates/hookecho/src/ui/afd_window.rs
@@ -9,12 +9,20 @@ pub fn show(
     afd: Option<&Afd>,
     busy: bool,
     error: Option<&str>,
+    drawer: &mut crate::ui::drawer::Drawer,
 ) -> bool {
     let mut refresh = false;
-    crate::ui::phone_surface(ctx, egui::Window::new("Forecast Discussion"))
-        .open(open)
-        .default_size([560.0, 520.0])
-        .show(ctx, |ui| {
+    let Some(window) = drawer.page_sized(
+        ctx,
+        "Forecast Discussion",
+        open,
+        false,
+        560.0,
+        egui::Window::new("Forecast Discussion"),
+    ) else {
+        return false;
+    };
+    window.show(ctx, |ui| {
             ui.horizontal(|ui| {
                 match afd {
                     Some(a) => {

--- a/crates/hookecho/src/ui/cappi_window.rs
+++ b/crates/hookecho/src/ui/cappi_window.rs
@@ -18,12 +18,25 @@ pub fn to_image(c: &Cappi, table: &ColorTable) -> egui::ColorImage {
 
 /// Show the CAPPI window. `alt_km` is edited by the slider; `length` is the box width (km).
 /// Returns `false` when the window should close.
-pub fn show(ctx: &egui::Context, tex: &egui::TextureHandle, alt_km: &mut f32, length: f32) -> bool {
+pub fn show(
+    ctx: &egui::Context,
+    tex: &egui::TextureHandle,
+    alt_km: &mut f32,
+    length: f32,
+    drawer: &mut crate::ui::drawer::Drawer,
+) -> bool {
     let mut open = true;
-    crate::ui::phone_surface(ctx, egui::Window::new("CAPPI slice"))
-        .open(&mut open)
-        .default_size([420.0, 480.0])
-        .show(ctx, |ui| {
+    let Some(window) = drawer.page_sized(
+        ctx,
+        "CAPPI slice",
+        &mut open,
+        false,
+        420.0,
+        egui::Window::new("CAPPI slice"),
+    ) else {
+        return open;
+    };
+    window.show(ctx, |ui| {
             ui.horizontal(|ui| {
                 ui.label("Altitude");
                 ui.add(egui::Slider::new(alt_km, 0.5..=15.0).suffix(" km"));
@@ -41,11 +54,18 @@ pub fn show(ctx: &egui::Context, tex: &egui::TextureHandle, alt_km: &mut f32, le
 }
 
 /// The same window with nothing to slice yet. Its own function so `app` keeps no window bodies.
-pub fn show_empty(ctx: &egui::Context) -> bool {
+pub fn show_empty(ctx: &egui::Context, drawer: &mut crate::ui::drawer::Drawer) -> bool {
     let mut open = true;
-    crate::ui::phone_surface(ctx, egui::Window::new("CAPPI slice"))
-        .open(&mut open)
-        .show(ctx, |ui| {
+    let Some(window) = drawer.page(
+        ctx,
+        "CAPPI slice",
+        &mut open,
+        false,
+        egui::Window::new("CAPPI slice"),
+    ) else {
+        return open;
+    };
+    window.show(ctx, |ui| {
             ui.weak("No volume loaded in the active pane.");
         });
     open

--- a/crates/hookecho/src/ui/cells_window.rs
+++ b/crates/hookecho/src/ui/cells_window.rs
@@ -159,6 +159,7 @@ pub fn show(
     // draws its trend rows from.
     trends: &std::collections::HashMap<String, Vec<crate::ui::cell_window::CellSample>>,
     accent: egui::Color32,
+    drawer: &mut crate::ui::drawer::Drawer,
 ) -> Option<String> {
     if !w.open {
         return None;
@@ -166,10 +167,18 @@ pub fn show(
     let mut chosen = None;
     let mut open = w.open;
     let order = sorted_indices(cells, w.sort, w.desc);
-    crate::ui::phone_surface(ctx, egui::Window::new("Storm attributes"))
-        .open(&mut open)
-        .default_size([720.0, 420.0])
-        .show(ctx, |ui| {
+    let Some(window) = drawer.page_sized(
+        ctx,
+        "Storm attributes",
+        &mut open,
+        false,
+        720.0,
+        egui::Window::new("Storm attributes"),
+    ) else {
+        w.open = open;
+        return None;
+    };
+    window.show(ctx, |ui| {
             if cells.is_empty() {
                 ui.weak("No tracked storm cells for this site right now.");
                 ui.small("Cells come from the radar's own storm-tracking product (SCIT).");

--- a/crates/hookecho/src/ui/digest_window.rs
+++ b/crates/hookecho/src/ui/digest_window.rs
@@ -15,16 +15,27 @@ pub enum DigestAction {
 }
 
 impl DigestWindow {
-    pub fn show(&mut self, ctx: &egui::Context) -> Option<DigestAction> {
+    pub fn show(
+        &mut self,
+        ctx: &egui::Context,
+        drawer: &mut crate::ui::drawer::Drawer,
+    ) -> Option<DigestAction> {
         if !self.open {
             return None;
         }
         let mut open = self.open;
         let mut action = None;
-        crate::ui::phone_surface(ctx, egui::Window::new("Storm Digest"))
-            .open(&mut open)
-            .default_size([420.0, 240.0])
-            .show(ctx, |ui| {
+        let Some(window) = drawer.page(
+            ctx,
+            "Storm Digest",
+            &mut open,
+            false,
+            egui::Window::new("Storm Digest"),
+        ) else {
+            self.open = open;
+            return None;
+        };
+        window.show(ctx, |ui| {
                 ui.horizontal(|ui| {
                     if ui.add_enabled(!self.busy, egui::Button::new("↻ Generate")).clicked() {
                         action = Some(DigestAction::Generate);

--- a/crates/hookecho/src/ui/drawer.rs
+++ b/crates/hookecho/src/ui/drawer.rs
@@ -64,6 +64,21 @@ impl Drawer {
         gear: bool,
         w: egui::Window<'a>,
     ) -> Option<egui::Window<'a>> {
+        self.page_sized(ctx, title, open, gear, WIDTH, w)
+    }
+
+    /// Same, for a page that carries a drawing rather than a list — a hodograph, a cross-section,
+    /// a 3D volume. `width` is what the old floating window asked for; the drawer still clamps it
+    /// to the screen, and the phone still takes the whole thing.
+    pub fn page_sized<'a>(
+        &mut self,
+        ctx: &egui::Context,
+        title: &str,
+        open: &mut bool,
+        gear: bool,
+        width: f32,
+        w: egui::Window<'a>,
+    ) -> Option<egui::Window<'a>> {
         // A page that isn't open doesn't get a slot: several callers reach `page` before their
         // own `open` check, and a closed page silently holding the top of the stack would hide
         // the one the user actually asked for.
@@ -86,7 +101,7 @@ impl Drawer {
             return None;
         }
 
-        let (head, body) = rects(ctx);
+        let (head, body) = rects(ctx, width);
         let depth = self.stack.len();
         let mut gear_on = self.gear;
         let mut close = false;
@@ -174,14 +189,14 @@ impl Drawer {
 }
 
 /// Header and body rectangles for the current screen.
-fn rects(ctx: &egui::Context) -> (Rect, Rect) {
+fn rects(ctx: &egui::Context, width: f32) -> (Rect, Rect) {
     let full = ctx.content_rect();
     let (x, w, top, bottom) = if cfg!(target_os = "android") {
         (full.left(), full.width(), full.top(), full.bottom())
     } else {
         (
             full.left() + X,
-            WIDTH.min(full.width() - 2.0 * X),
+            width.min(full.width() - 2.0 * X),
             full.top() + TOP,
             (full.bottom() - BOTTOM_CLEARANCE).max(full.top() + TOP + 200.0),
         )

--- a/crates/hookecho/src/ui/hodograph_window.rs
+++ b/crates/hookecho/src/ui/hodograph_window.rs
@@ -27,12 +27,20 @@ pub fn show(
     history: &[(DateTime<Utc>, Vec<VwpLevel>)],
     tab: &mut Tab,
     tz: Option<wxdata::tz::Tz>,
+    drawer: &mut crate::ui::drawer::Drawer,
 ) -> bool {
     let mut open = true;
-    crate::ui::phone_surface(ctx, egui::Window::new("VAD wind profile"))
-        .open(&mut open)
-        .default_size([420.0, 460.0])
-        .show(ctx, |ui| {
+    let Some(window) = drawer.page_sized(
+        ctx,
+        "VAD wind profile",
+        &mut open,
+        false,
+        420.0,
+        egui::Window::new("VAD wind profile"),
+    ) else {
+        return open;
+    };
+    window.show(ctx, |ui| {
             ui.horizontal(|ui| {
                 ui.strong(site.unwrap_or("—"));
                 ui.weak(format!("{} levels", levels.len()));

--- a/crates/hookecho/src/ui/layer_window.rs
+++ b/crates/hookecho/src/ui/layer_window.rs
@@ -17,16 +17,25 @@ pub(crate) fn show(
     open: &mut bool,
     settings: &mut Settings,
     active: &[(FieldLayer, String)],
+    drawer: &mut crate::ui::drawer::Drawer,
 ) -> bool {
     if !*open {
         return false;
     }
     let mut changed = false;
     let mut win_open = *open;
-    crate::ui::phone_surface(ctx, egui::Window::new("Layer Manager"))
-        .open(&mut win_open)
-        .default_width(420.0)
-        .show(ctx, |ui| {
+    let Some(window) = drawer.page_sized(
+        ctx,
+        "Layer Manager",
+        &mut win_open,
+        false,
+        420.0,
+        egui::Window::new("Layer Manager"),
+    ) else {
+        *open = win_open;
+        return false;
+    };
+    window.show(ctx, |ui| {
             if !active.is_empty() {
                 ui.label(egui::RichText::new("Field layers").strong());
                 for (layer, name) in active {

--- a/crates/hookecho/src/ui/marker_window.rs
+++ b/crates/hookecho/src/ui/marker_window.rs
@@ -35,14 +35,23 @@ impl MarkerWindow {
         ctx: &egui::Context,
         settings: &mut Settings,
         icon_tex: &IconTextures,
+        drawer: &mut crate::ui::drawer::Drawer,
     ) -> Option<String> {
         let mut open = self.open;
         let mut go: Option<String> = None;
         self.removed = None;
-        crate::ui::phone_surface(ctx, egui::Window::new("Location Markers"))
-            .open(&mut open)
-            .default_size([520.0, 360.0])
-            .show(ctx, |ui| {
+        let Some(window) = drawer.page_sized(
+            ctx,
+            "Location Markers",
+            &mut open,
+            false,
+            520.0,
+            egui::Window::new("Location Markers"),
+        ) else {
+            self.open = open;
+            return None;
+        };
+        window.show(ctx, |ui| {
                 ui.strong("Add by address");
                 ui.horizontal(|ui| {
                     let field = ui.add(

--- a/crates/hookecho/src/ui/mod.rs
+++ b/crates/hookecho/src/ui/mod.rs
@@ -13,18 +13,14 @@ pub(crate) fn loading(ui: &mut egui::Ui, what: &str) {
 ///
 /// Material 3's rule for the compact width class is that a secondary screen takes the whole
 /// screen — no floating panel, no dialog margins, no dragging a window around a display it barely
-/// fits on. So on Android every one of these windows becomes a full-screen surface: pinned to the
-/// content rect (which already excludes the system bars and grows to clear the keyboard), not
-/// draggable, not resizable, not collapsible, scrolling its body, with square corners because
-/// there is nothing behind it to round against. The title bar stays: its ✕ is the surface's back
-/// affordance, and it is already wired to each caller's `open` flag.
+/// fits on. So on Android these become full-screen surfaces: pinned to the content rect (which
+/// already excludes the system bars and grows to clear the keyboard), not draggable, not
+/// resizable, not collapsible, scrolling their body, with square corners because there is nothing
+/// behind them to round against.
 ///
-/// One function, because there is exactly one right answer for all twenty-odd of these windows,
-/// and a per-window conversion would be twenty chances to get it slightly different.
-///
-/// ponytail: `Window` rather than a hand-rolled surface widget — it already does the title row,
-/// the close button, the open flag and the scroll body, and reusing it keeps the desktop and
-/// phone call sites identical.
+/// What is left after B4b is the handful of surfaces that are not drawer pages: the first-run
+/// card, the anchored map-click popovers, and the station cards. Every browsable tool now goes
+/// through [`drawer::Drawer::page`], which owns its own chrome.
 pub(crate) fn phone_surface<'a>(ctx: &egui::Context, w: egui::Window<'a>) -> egui::Window<'a> {
     if cfg!(target_os = "android") {
         let r = ctx.content_rect();

--- a/crates/hookecho/src/ui/palette_editor.rs
+++ b/crates/hookecho/src/ui/palette_editor.rs
@@ -30,6 +30,7 @@ impl PaletteEditor {
         ctx: &egui::Context,
         settings: &mut Settings,
         active: &crate::colormap::Palettes,
+        drawer: &mut crate::ui::drawer::Drawer,
     ) {
         if !self.open {
             return;
@@ -49,10 +50,18 @@ impl PaletteEditor {
         }
 
         let mut open = self.open;
-        crate::ui::phone_surface(ctx, egui::Window::new("Color-Table Editor"))
-            .open(&mut open)
-            .default_size([460.0, 520.0])
-            .show(ctx, |ui| {
+        let Some(window) = drawer.page_sized(
+            ctx,
+            "Color-Table Editor",
+            &mut open,
+            false,
+            460.0,
+            egui::Window::new("Color-Table Editor"),
+        ) else {
+            self.open = open;
+            return;
+        };
+        window.show(ctx, |ui| {
                 ui.horizontal(|ui| {
                     ui.label("Moment");
                     egui::ComboBox::from_id_salt("pal_moment")

--- a/crates/hookecho/src/ui/placefile_window.rs
+++ b/crates/hookecho/src/ui/placefile_window.rs
@@ -26,12 +26,21 @@ impl PlacefileWindow {
         ctx: &egui::Context,
         settings: &mut Settings,
         status: &[PlacefileStatus],
+        drawer: &mut crate::ui::drawer::Drawer,
     ) {
         let mut open = self.open;
-        crate::ui::phone_surface(ctx, egui::Window::new("Placefile Manager"))
-            .open(&mut open)
-            .default_size([520.0, 320.0])
-            .show(ctx, |ui| {
+        let Some(window) = drawer.page_sized(
+            ctx,
+            "Placefile Manager",
+            &mut open,
+            false,
+            520.0,
+            egui::Window::new("Placefile Manager"),
+        ) else {
+            self.open = open;
+            return;
+        };
+        window.show(ctx, |ui| {
                 ui.label("GRLevelX placefiles (lines, polygons, text, icons at lat/lon).");
                 ui.add_space(4.0);
 

--- a/crates/hookecho/src/ui/sensor_window.rs
+++ b/crates/hookecho/src/ui/sensor_window.rs
@@ -12,12 +12,14 @@ pub fn show(
     ctx: &egui::Context,
     data: Option<&Result<StationObs, String>>,
     tz: Option<wxdata::tz::Tz>,
+    drawer: &mut crate::ui::drawer::Drawer,
 ) -> bool {
     let mut open = true;
-    crate::ui::phone_surface(ctx, egui::Window::new("Sensors"))
-        .open(&mut open)
-        .default_size([340.0, 520.0])
-        .show(ctx, |ui| match data {
+    let Some(window) = drawer.page(ctx, "Sensors", &mut open, false, egui::Window::new("Sensors"))
+    else {
+        return open;
+    };
+    window.show(ctx, |ui| match data {
             None => {
                 ui.weak("Loading nearest station…");
             }

--- a/crates/hookecho/src/ui/site_dialog.rs
+++ b/crates/hookecho/src/ui/site_dialog.rs
@@ -46,6 +46,7 @@ pub fn show(
     dialog: &mut SiteDialog,
     view: &mut MapView,
     settings: &mut Settings,
+    drawer: &mut crate::ui::drawer::Drawer,
 ) -> bool {
     let center = world_to_lonlat(view.camera.center.0, view.camera.center.1);
 
@@ -95,10 +96,17 @@ pub fn show(
     let mut go_home = false;
     let mut toggle_star: Option<String> = None;
 
-    crate::ui::phone_surface(ctx, egui::Window::new("Select Radar Site"))
-        .open(&mut open)
-        .default_size([460.0, 520.0])
-        .show(ctx, |ui| {
+    let Some(window) = drawer.page_sized(
+        ctx,
+        "Select Radar Site",
+        &mut open,
+        false,
+        460.0,
+        egui::Window::new("Select Radar Site"),
+    ) else {
+        return open;
+    };
+    window.show(ctx, |ui| {
             // Selectable label text senses clicks and drags of its own, and a row is made of
             // nothing but labels — so every click on a row went into selecting the city name and
             // `row.response().clicked()` never fired. Clicking a site did nothing at all.

--- a/crates/hookecho/src/ui/sounding_window.rs
+++ b/crates/hookecho/src/ui/sounding_window.rs
@@ -47,15 +47,28 @@ impl Default for SoundingWindow {
 }
 
 impl SoundingWindow {
-    pub fn show(&mut self, ctx: &egui::Context, tz: Option<wxdata::tz::Tz>) {
+    pub fn show(
+        &mut self,
+        ctx: &egui::Context,
+        tz: Option<wxdata::tz::Tz>,
+        drawer: &mut crate::ui::drawer::Drawer,
+    ) {
         if !self.open {
             return;
         }
         let mut open = self.open;
-        crate::ui::phone_surface(ctx, egui::Window::new("Point Sounding"))
-            .open(&mut open)
-            .default_size([560.0, 460.0])
-            .show(ctx, |ui| {
+        let Some(window) = drawer.page_sized(
+            ctx,
+            "Point Sounding",
+            &mut open,
+            false,
+            560.0,
+            egui::Window::new("Point Sounding"),
+        ) else {
+            self.open = open;
+            return;
+        };
+        window.show(ctx, |ui| {
                 if self.busy {
                     ui.horizontal(|ui| {
                         ui.spinner();

--- a/crates/hookecho/src/ui/tropical_window.rs
+++ b/crates/hookecho/src/ui/tropical_window.rs
@@ -62,16 +62,25 @@ pub fn show(
     w: &mut TropicalWindow,
     ctx: &egui::Context,
     storms: &[TropicalStorm],
+    drawer: &mut crate::ui::drawer::Drawer,
 ) -> Option<(String, Product)> {
     if !w.open {
         return None;
     }
     let mut want: Option<(String, Product)> = None;
     let mut open = w.open;
-    crate::ui::phone_surface(ctx, egui::Window::new("Tropical products"))
-        .open(&mut open)
-        .default_size([600.0, 540.0])
-        .show(ctx, |ui| {
+    let Some(window) = drawer.page_sized(
+        ctx,
+        "Tropical products",
+        &mut open,
+        false,
+        600.0,
+        egui::Window::new("Tropical products"),
+    ) else {
+        w.open = open;
+        return None;
+    };
+    window.show(ctx, |ui| {
             if storms.is_empty() {
                 ui.weak("No active tropical cyclones.");
                 ui.small("The NHC publishes these only while a storm is being advised on.");

--- a/crates/hookecho/src/ui/verify_window.rs
+++ b/crates/hookecho/src/ui/verify_window.rs
@@ -31,17 +31,29 @@ pub struct VerifyWindow {
 }
 
 impl VerifyWindow {
-    pub fn show(&mut self, ctx: &egui::Context, tz: Option<wxdata::tz::Tz>) -> VerifyActions {
+    pub fn show(
+        &mut self,
+        ctx: &egui::Context,
+        tz: Option<wxdata::tz::Tz>,
+        drawer: &mut crate::ui::drawer::Drawer,
+    ) -> VerifyActions {
         let mut act = VerifyActions::default();
         if !self.open {
             return act;
         }
         let mut open = self.open;
-        crate::ui::phone_surface(ctx, egui::Window::new("Warning Verification"))
-            .open(&mut open)
-            .default_width(560.0)
-            .default_height(460.0)
-            .show(ctx, |ui| {
+        let Some(window) = drawer.page_sized(
+            ctx,
+            "Warning Verification",
+            &mut open,
+            false,
+            560.0,
+            egui::Window::new("Warning Verification"),
+        ) else {
+            self.open = open;
+            return act;
+        };
+        window.show(ctx, |ui| {
                 ui.horizontal_wrapped(|ui| {
                     ui.label("Office:");
                     ui.add(egui::TextEdit::singleline(&mut self.wfo).desired_width(56.0));

--- a/crates/hookecho/src/ui/video_window.rs
+++ b/crates/hookecho/src/ui/video_window.rs
@@ -56,7 +56,7 @@ impl VideoPlayer {
 
     /// Draw the window. Returns false once the user closes it (the caller drops the player,
     /// which stops the download).
-    pub fn show(&mut self, ctx: &egui::Context) -> bool {
+    pub fn show(&mut self, ctx: &egui::Context, drawer: &mut crate::ui::drawer::Drawer) -> bool {
         #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
         {
             if let Some(img) = self.stream.take_frame() {
@@ -72,12 +72,18 @@ impl VideoPlayer {
             }
         }
         let mut open = true;
-        crate::ui::phone_surface(ctx, egui::Window::new(format!("📹 {}", self.title)))
-            .id(egui::Id::new(("video-window", &self.url)))
-            .open(&mut open)
-            .vscroll(false)
-            .default_width(480.0)
-            .show(ctx, |ui| {
+        let title = format!("📹 {}", self.title);
+        let Some(window) = drawer.page_sized(
+            ctx,
+            &title,
+            &mut open,
+            false,
+            480.0,
+            egui::Window::new(title.clone()).id(egui::Id::new(("video-window", &self.url))),
+        ) else {
+            return open;
+        };
+        window.vscroll(false).show(ctx, |ui| {
                 let w = ui.available_width();
                 match &self.tex {
                     Some(tex) => {

--- a/crates/hookecho/src/ui/volume3d_window.rs
+++ b/crates/hookecho/src/ui/volume3d_window.rs
@@ -61,12 +61,21 @@ pub fn show(
     n: u32,
     nz: u32,
     range: (f32, f32),
+    drawer: &mut crate::ui::drawer::Drawer,
 ) {
     let mut keep = *open;
-    crate::ui::phone_surface(ctx, egui::Window::new("3D Reflectivity"))
-        .open(&mut keep)
-        .default_size([480.0, 480.0])
-        .show(ctx, |ui| {
+    let Some(window) = drawer.page_sized(
+        ctx,
+        "3D Reflectivity",
+        &mut keep,
+        false,
+        480.0,
+        egui::Window::new("3D Reflectivity"),
+    ) else {
+        *open = keep;
+        return;
+    };
+    window.show(ctx, |ui| {
             ui.weak("Drag to orbit · scroll to zoom · max-intensity projection");
             ui.horizontal(|ui| {
                 let mut on = st.threshold_dbz.is_finite();

--- a/crates/hookecho/src/ui/xsection_window.rs
+++ b/crates/hookecho/src/ui/xsection_window.rs
@@ -25,14 +25,22 @@ pub fn show(
     xs: &CrossSection,
     tex: &egui::TextureHandle,
     moment: &mut wxdata::level2::Moment,
+    drawer: &mut crate::ui::drawer::Drawer,
 ) -> bool {
     use wxdata::level2::Moment;
     let mut open = true;
     let mut changed = false;
-    crate::ui::phone_surface(ctx, egui::Window::new("Cross-section"))
-        .open(&mut open)
-        .default_size([560.0, 300.0])
-        .show(ctx, |ui| {
+    let Some(window) = drawer.page_sized(
+        ctx,
+        "Cross-section",
+        &mut open,
+        false,
+        560.0,
+        egui::Window::new("Cross-section"),
+    ) else {
+        return open;
+    };
+    window.show(ctx, |ui| {
             ui.horizontal(|ui| {
                 ui.label(format!(
                     "Length {:.0} km · top {:.0} km",


### PR DESCRIPTION
B4b — the mechanical half of B4, stacked on #98.

Nineteen `ui/*_window.rs` wrappers stop calling `phone_surface` and start calling `Drawer::page`. They stop being free-floating egui windows on the desktop and stop being full-screen imitations of windows on the phone: one surface, one back-stack, one header, one ✕.

Converted: about · afd · cappi (both bodies) · cells · digest · hodograph · layer manager · markers · palette editor · placefiles · sensors · site dialog · sounding · tropical · verify · video · volume3d · xsection · tornado climatology.

### `Drawer::page_sized`

The drawer's 380 pt is right for a list and wrong for a hodograph, a cross-section, or the 720 pt storm table. A page now passes the width its old floating window asked for; `page` keeps the default and delegates; `rects()` still clamps to the screen, and the phone still takes the whole content rect either way. No new geometry, one parameter.

### `window_for_page`

One arm per page that has a registry action to reopen it, so a workspace saved with the palette editor showing comes back to it. Pages the map opens — cross-section, hodograph, sounding, sensors — have no such action and are absent on purpose; the test asserts both directions.

### What `phone_surface` is still for

The first-run card, the anchored map-click popovers, and the station cards. Those are not browsable tools and were never going to be pages. Doc updated to say so rather than to keep promising a conversion that has now happened.

### Verified

Full gate green: clippy `-D warnings`, 569 tests, wasm check, `shoot.sh check`, web 4,790,681 gz (budget 4,850,000), plus `cargo ndk -t arm64-v8a check`.

On the S24 Ultra (release lib): About opens as a page with the drawer header over the map, the panel sheet steps aside for it, predictive back leaves it and the chrome comes back intact.

### Unrelated finding

`./android/build.sh debug` produces an APK that aborts on the first frame — `slice::from_raw_parts requires the pointer to be aligned and non-null` from `android-activity-0.6.1/src/game_activity/mod.rs:717`, reached through our `platform::android_ime::pump_ime`. It is a debug-assertion precondition check that the default release lib compiles out, so the shipped build is unaffected, but the debug lib is currently not runnable for a native crash hunt. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)