### PR TITLE
feat(motion): playful pass

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -14754,6 +14754,9 @@ impl eframe::App for HookEchoApp {
         let bare = self.obs_mode;
 
         self.chrome_rect = root.available_rect_before_wrap();
+        // Before any chrome: everything below asks `motion::reduced()`, and the answer has to be
+        // the same for every surface in a frame.
+        ui::motion::frame(ctx, self.settings.reduce_motion);
 
         // Chrome: touch-first on Android (top chips + bottom sheet + docked toolbar), desktop
         // otherwise (the floating map-first chrome below). Both funnel into the same `UiActions`
@@ -14781,6 +14784,16 @@ impl eframe::App for HookEchoApp {
                 self.info_chip(ctx);
                 self.error_chip(ctx);
             }
+        }
+
+        // The one decoration with no job. Costs nothing after the first second and a half, and
+        // never runs at all under OBS — a capture is not a place for a flourish.
+        if !bare {
+            ui::motion::intro(
+                ctx,
+                self.chrome_rect,
+                crate::theme::accent(self.settings.theme),
+            );
         }
 
         // Over everything, and only while a capture is pending.

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -117,6 +117,10 @@ pub struct Settings {
     pub density: Density,
     /// User accent override as RGB. `None` keeps the theme's own accent.
     pub accent: Option<[u8; 3]>,
+    /// Hold every animation at its endpoint. The app also sets this for itself when frames get
+    /// slow; this flag is only the user's half of that.
+    #[serde(default)]
+    pub reduce_motion: bool,
     /// Starred radar sites shown in the toolbox presets dropdown.
     pub presets: Vec<String>,
     /// Per-moment color-table override: moment short name (`REF`, `VEL`, …) -> `.pal` path.
@@ -976,6 +980,7 @@ impl Default for Settings {
             theme: Theme::Dark,
             density: Density::default(),
             accent: None,
+            reduce_motion: false,
             presets: Vec::new(),
             palettes: BTreeMap::new(),
             velocity_unit: VelocityUnit::default(),
@@ -1384,6 +1389,7 @@ mod tests {
     fn roundtrips() {
         let s = Settings {
             hints_seen: Vec::new(),
+            reduce_motion: true,
             precip_tint: false,
             custom_tile_url: String::new(),
             custom_tile_max_z: default_custom_tile_max_z(),

--- a/crates/hookecho/src/ui/drawer.rs
+++ b/crates/hookecho/src/ui/drawer.rs
@@ -32,6 +32,9 @@ pub struct Drawer {
     seen: Vec<String>,
     /// Which frame `seen` belongs to, so the stack can prune itself without the app calling us.
     frame: u64,
+    /// App time the drawer last went from empty to showing something, so the slide-in animates
+    /// from where the drawer actually came from rather than from wherever egui last latched it.
+    opened_at: f64,
     /// Is the top page's quick-settings row expanded? Per-page state would outlive the page it
     /// belongs to; a single flag reset on every page change is the honest scope.
     pub gear: bool,
@@ -93,6 +96,9 @@ impl Drawer {
             self.frame = frame;
         }
         self.seen.push(title.to_string());
+        if self.stack.is_empty() {
+            self.opened_at = ctx.input(|i| i.time);
+        }
         if !self.stack.iter().any(|t| t == title) {
             self.stack.push(title.to_string());
             self.gear = false;
@@ -102,6 +108,7 @@ impl Drawer {
         }
 
         let (head, body) = rects(ctx, width);
+        let (head, body) = self.slide(ctx, head, body);
         let depth = self.stack.len();
         let mut gear_on = self.gear;
         let mut close = false;
@@ -185,6 +192,22 @@ impl Drawer {
                 .vscroll(true)
                 .frame(frame),
         )
+    }
+
+    /// Walk the drawer in from the edge it lives on, overshooting a hair before it settles.
+    ///
+    /// ponytail: translation only — no fade, no scale. The drawer is opaque glass over a map, so
+    /// sliding is the only one of the three that reads at all, and it is the one that says where
+    /// the thing came from.
+    fn slide(&self, ctx: &egui::Context, head: Rect, body: Rect) -> (Rect, Rect) {
+        let dur = crate::ui::m3::DUR_MED as f64;
+        let t = (ctx.input(|i| i.time) - self.opened_at) / dur;
+        if crate::ui::motion::reduced() || t >= 1.0 {
+            return (head, body);
+        }
+        ctx.request_repaint();
+        let off = (1.0 - crate::ui::motion::ease_out_back(t as f32)) * (head.width() + X);
+        (head.translate(vec2(-off, 0.0)), body.translate(vec2(-off, 0.0)))
     }
 }
 

--- a/crates/hookecho/src/ui/mod.rs
+++ b/crates/hookecho/src/ui/mod.rs
@@ -111,6 +111,8 @@ pub mod legend;
 /// Material 3 design tokens for the mobile chrome.
 pub mod m3;
 pub mod marker_popup;
+/// Easing and the reduced-motion brake.
+pub mod motion;
 pub mod marker_window;
 pub mod palette_editor;
 pub mod placefile_window;

--- a/crates/hookecho/src/ui/motion.rs
+++ b/crates/hookecho/src/ui/motion.rs
@@ -1,0 +1,149 @@
+//! Easing, and the one brake that stops all of it.
+//!
+//! egui's `animate_bool_with_time` is a linear ramp. Linear is what "the panel moved" looks like;
+//! a slight overshoot at the end is what "the panel arrived" looks like, and that difference is
+//! most of what separates chrome that feels alive from chrome that feels like a slideshow. So the
+//! durations stay in [`crate::ui::m3`] as tokens and the shapes live here.
+//!
+//! Two things turn motion off, and they share one switch. The user's `reduce_motion` setting is
+//! the honest one. The other is the machine: a Pi drawing a 4-pane radar loop does not have the
+//! frames to spare for a springy drawer, and an animation that stutters reads worse than no
+//! animation at all. [`frame`] watches the frame time and latches the brake when the app is
+//! visibly struggling.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Set by [`frame`] from the user's setting; read by everything that animates.
+static USER_OFF: AtomicBool = AtomicBool::new(false);
+/// Latched when frames get slow. Never unlatches: a machine that fell behind once will do it
+/// again, and a brake that flickers on and off is worse than either state.
+static SLOW: AtomicBool = AtomicBool::new(false);
+
+/// Is motion off, for either reason?
+pub fn reduced() -> bool {
+    USER_OFF.load(Ordering::Relaxed) || SLOW.load(Ordering::Relaxed)
+}
+
+/// Call once per frame, before any chrome draws.
+///
+/// ponytail: the slow-frame test is a run of bad frames, not an average — a single 200 ms hitch is
+/// a tile decode, not a slow machine, and averaging in the startup frames would brake every cold
+/// start. Sustained badness is the thing worth reacting to.
+pub fn frame(ctx: &egui::Context, user_reduce: bool) {
+    USER_OFF.store(user_reduce, Ordering::Relaxed);
+    if SLOW.load(Ordering::Relaxed) {
+        return;
+    }
+    let dt = ctx.input(|i| i.unstable_dt);
+    // A frame budget of 33 ms is 30 fps: below that the springs stop reading as springs.
+    let run: u32 = ctx.data_mut(|d| {
+        let id = egui::Id::new("motion_slow_run");
+        let n: u32 = d.get_temp(id).unwrap_or(0);
+        let n = if dt > 1.0 / 30.0 { n + 1 } else { 0 };
+        d.insert_temp(id, n);
+        n
+    });
+    if run >= 30 {
+        SLOW.store(true, Ordering::Relaxed);
+        log::info!("motion: frames sustained under 30 fps, reducing animation");
+    }
+}
+
+/// Overshoot-and-settle. Standard cubic back-out; `t` outside 0..=1 is clamped.
+pub fn ease_out_back(t: f32) -> f32 {
+    const C1: f32 = 1.70158;
+    const C3: f32 = C1 + 1.0;
+    let t = t.clamp(0.0, 1.0) - 1.0;
+    1.0 + C3 * t * t * t + C1 * t * t
+}
+
+/// Decelerate into place, no overshoot. For anything that would look wrong bouncing — a fade, a
+/// scrim, anything already touching an edge.
+pub fn ease_out_cubic(t: f32) -> f32 {
+    let t = 1.0 - t.clamp(0.0, 1.0);
+    1.0 - t * t * t
+}
+
+/// A 0..1 progress for `on`, eased, or a hard 0/1 when motion is off.
+///
+/// `ease` is the shape; pass [`ease_out_back`] for arrivals and [`ease_out_cubic`] for the rest.
+pub fn rise(
+    ctx: &egui::Context,
+    id: egui::Id,
+    on: bool,
+    secs: f32,
+    ease: fn(f32) -> f32,
+) -> f32 {
+    if reduced() {
+        return if on { 1.0 } else { 0.0 };
+    }
+    ease(ctx.animate_bool_with_time(id, on, secs))
+}
+
+/// How long the opening sweep lasts, in seconds.
+const INTRO_SECS: f64 = 1.4;
+
+/// The radar sweep that greets a cold start.
+///
+/// One beam around the map, fading as it goes, over the first second and a half. It costs four
+/// draw calls and it is the only decoration in the app that has no job — that is the point of it.
+/// Skipped entirely under reduced motion, and after the first pass it never draws again.
+pub fn intro(ctx: &egui::Context, rect: egui::Rect, accent: egui::Color32) {
+    let t = ctx.input(|i| i.time);
+    if reduced() || t > INTRO_SECS {
+        return;
+    }
+    ctx.request_repaint();
+    let p = (t / INTRO_SECS) as f32;
+    // Fades out over the back half rather than the whole sweep, so the beam is actually visible
+    // while it crosses the screen.
+    let fade = (1.0 - (p - 0.5).max(0.0) * 2.0).clamp(0.0, 1.0);
+    let painter = ctx.layer_painter(egui::LayerId::new(
+        egui::Order::Foreground,
+        egui::Id::new("intro_sweep"),
+    ));
+    let c = rect.center();
+    let r = rect.size().length() * 0.5;
+    let a = std::f32::consts::TAU * ease_out_cubic(p) - std::f32::consts::FRAC_PI_2;
+    // The beam, plus a short trail behind it. Two segments read as a sweep; a full cone would
+    // need a mesh and would cover the map it is meant to reveal.
+    for (i, back) in [0.0_f32, 0.12, 0.24].iter().enumerate() {
+        let alpha = (fade * 150.0 / (1.0 + i as f32 * 1.6)) as u8;
+        let ang = a - back;
+        painter.line_segment(
+            [c, c + egui::vec2(ang.cos(), ang.sin()) * r],
+            egui::Stroke::new(2.0, accent.gamma_multiply(alpha as f32 / 255.0)),
+        );
+    }
+    // One range ring expanding with the sweep, so the beam has something to sweep over.
+    painter.circle_stroke(
+        c,
+        r * ease_out_cubic(p),
+        egui::Stroke::new(1.0, accent.gamma_multiply(fade * 0.25)),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn easings_start_at_zero_end_at_one_and_back_overshoots() {
+        for f in [ease_out_back as fn(f32) -> f32, ease_out_cubic] {
+            assert!(f(0.0).abs() < 1e-4);
+            assert!((f(1.0) - 1.0).abs() < 1e-4);
+            assert!((f(-3.0)).abs() < 1e-4, "clamped below");
+            assert!((f(9.0) - 1.0).abs() < 1e-4, "clamped above");
+        }
+        // The overshoot is the whole reason ease_out_back exists.
+        let peak = (0..100)
+            .map(|i| ease_out_back(i as f32 / 100.0))
+            .fold(0.0_f32, f32::max);
+        assert!(peak > 1.02, "no overshoot: {peak}");
+        // Cubic never does.
+        let peak = (0..100)
+            .map(|i| ease_out_cubic(i as f32 / 100.0))
+            .fold(0.0_f32, f32::max);
+        assert!(peak <= 1.0, "cubic overshot: {peak}");
+    }
+}

--- a/crates/hookecho/src/ui/popover.rs
+++ b/crates/hookecho/src/ui/popover.rs
@@ -23,11 +23,13 @@ const KEEPOUT_TOP: f32 = 58.0;
 const KEEPOUT_RIGHT: f32 = 74.0;
 const KEEPOUT_BOTTOM: f32 = 96.0;
 const KEEPOUT_SIDE: f32 = 10.0;
+/// How far a card rises into place when it opens.
+const RISE: f32 = 12.0;
 
 #[derive(Default)]
 pub struct Popovers {
-    /// Where each open card was summoned from, keyed by the id its caller passes.
-    at: Vec<(String, Pos2)>,
+    /// Where each open card was summoned from, and when, keyed by the id its caller passes.
+    at: Vec<(String, Pos2, f64)>,
     /// Ids that drew this frame; anything else has closed and loses its anchor.
     seen: Vec<String>,
     frame: u64,
@@ -48,14 +50,15 @@ impl Popovers {
         }
         let frame = ctx.cumulative_pass_nr();
         if frame != self.frame {
-            self.at.retain(|(k, _)| self.seen.iter().any(|s| s == k));
+            self.at.retain(|(k, ..)| self.seen.iter().any(|s| s == k));
             self.seen.clear();
             self.frame = frame;
         }
         self.seen.push(id.to_string());
         let field = field(ctx);
-        let anchor = match self.at.iter().find(|(k, _)| k == id) {
-            Some((_, p)) => *p,
+        let now = ctx.input(|i| i.time);
+        let (anchor, born) = match self.at.iter().find(|(k, ..)| k == id) {
+            Some((_, p, t)) => (*p, *t),
             None => {
                 // No pointer at all (a card opened by a hotkey, or a touch that already lifted):
                 // the middle of the map is the least wrong place left.
@@ -63,9 +66,18 @@ impl Popovers {
                     .pointer_interact_pos()
                     .map(|p| p + egui::vec2(OFFSET, OFFSET))
                     .unwrap_or_else(|| field.center());
-                self.at.push((id.to_string(), p));
-                p
+                self.at.push((id.to_string(), p, now));
+                (p, now)
             }
+        };
+        // A card that appears at full size looks like it was already there; one that rises the
+        // last few pixels into place looks like it came from the click. Two frames of work.
+        let t = ((now - born) / crate::ui::m3::DUR_SHORT as f64) as f32;
+        let anchor = if crate::ui::motion::reduced() || t >= 1.0 {
+            anchor
+        } else {
+            ctx.request_repaint();
+            anchor + egui::vec2(0.0, (1.0 - crate::ui::motion::ease_out_cubic(t)) * RISE)
         };
         w.fixed_pos(anchor).constrain_to(field)
     }

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -785,6 +785,14 @@ fn general_tab(
             .on_hover_text("Compact restores the denser spacing of earlier releases.");
             ui.end_row();
 
+            ui.label("Motion");
+            ui.checkbox(&mut settings.reduce_motion, "Reduce motion")
+                .on_hover_text(
+                    "Panels and cards appear where they belong instead of sliding in. The app \
+                     also turns this on for itself if frames get slow.",
+                );
+            ui.end_row();
+
             ui.label("UI scale");
             // Phones start denser: 0.5 × a 4.0 density factor ≈ a desktop-density canvas.
             let lo = if cfg!(target_os = "android") {

--- a/crates/hookecho/src/ui/volume3d_window.rs
+++ b/crates/hookecho/src/ui/volume3d_window.rs
@@ -53,6 +53,9 @@ fn axis_slice(ui: &mut egui::Ui, label: &str, lo: &mut f32, hi: &mut f32) {
 
 /// Show the 3D window. `pending` is a one-shot volume upload consumed by the first paint;
 /// `n`/`nz` are the grid dimensions and `range` the volume's `(value_min, value_max)` dBZ span.
+// ponytail: eight loose arguments rather than a params struct — every one of them is already a
+// field on the caller, and a struct here would just be that call site written twice.
+#[allow(clippy::too_many_arguments)]
 pub fn show(
     ctx: &egui::Context,
     open: &mut bool,


### PR DESCRIPTION
Wave E1. Motion tokens get shapes, and one brake that stops all of them.

## What moves
- **Drawer** slides in from its edge with an ease-out-back overshoot (`DUR_MED`).
- **Map-click popovers** rise 12 px into place on `DUR_SHORT`, so a card reads as coming from the click rather than having always been there.
- **Cold start** gets a radar sweep over the map for 1.4 s — three fading beams and one expanding range ring. Never under OBS.

## The brake
`motion::reduced()` is `Settings::reduce_motion` (new, `#[serde(default)]`, toggle in Settings → Motion) **or** a latched slow-frame flag. `motion::frame` counts consecutive frames over 33 ms and latches at 30 of them; it never unlatches, since a brake that flickers is worse than either state. Called once before any chrome draws so every surface in a frame gets the same answer.

## Why not `animate_bool_with_time`
It only advances on the frames it's called. A closed drawer/popover stops calling it, the value stays latched at 1.0, and the next open plays no animation at all. Both surfaces already latch state of their own (the drawer's stack, the popover's anchor), so the animation times off `input.time` from that latch instead.

## Unrelated fix
`volume3d_window::show` has failed `clippy::too_many_arguments` since B4b added its `drawer` parameter — the #99 gate report claimed clean and was wrong. Silenced with a `ponytail:` note (every argument is already a caller field; a params struct is that call site written twice).

## Gate
- clippy `-D warnings`: clean
- `cargo test`: 570 passed, 29 ignored
- wasm check: 0 errors
- `shoot.sh check`: passed
- web: 12,969,611 raw / **4,793,654 gzipped** (budget 4,850,000)

Not device-verified yet; the drawer slide and the intro sweep want a look on the S24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)