### PR TITLE
feat(a11y): labels, roles, focus order

### DIFF
--- a/crates/hookecho/src/app/chrome/overlay.rs
+++ b/crates/hookecho/src/app/chrome/overlay.rs
@@ -5,6 +5,7 @@
 //! costs the map nothing.
 
 use super::*;
+use crate::ui::a11y::Named as _;
 
 /// The floating panel's geometry: left margin, top offset (clear of the search pill), width.
 const PANEL_X: f32 = 10.0;
@@ -136,7 +137,7 @@ impl HookEchoApp {
                                     .fill(egui::Color32::TRANSPARENT)
                                     .stroke(egui::Stroke::NONE),
                                 )
-                                .on_hover_text("Close this panel")
+                                .named("Close this panel")
                                 .clicked()
                             {
                                 hide = true;
@@ -234,7 +235,7 @@ impl HookEchoApp {
                                 .min_size(egui::vec2(w, 34.0))
                                 .corner_radius(10.0),
                             )
-                            .on_hover_text("Search the place name and move the map there")
+                            .named("Search the place name and move the map there")
                             .clicked()
                         {
                             fly_to = Some(query.trim().to_string());
@@ -380,7 +381,7 @@ impl HookEchoApp {
                         // The tour's "everything else" stop points here: the pill is always on
                         // screen, where the panel it opens is not.
                         anchor = Some(menu.rect);
-                        if menu.on_hover_text("Show or hide the panel").clicked() {
+                        if menu.named_toggle("Show or hide the panel", self.panel_open).clicked() {
                             self.panel_open = !self.panel_open;
                         }
                         if phone() {
@@ -393,7 +394,7 @@ impl HookEchoApp {
                                     .fill(egui::Color32::TRANSPARENT)
                                     .stroke(egui::Stroke::NONE),
                                 )
-                                .on_hover_text("Change radar site");
+                                .named("Change radar site");
                             if label.clicked() && self.site_dialog.is_none() {
                                 self.site_dialog = Some(Default::default());
                             }
@@ -452,7 +453,7 @@ impl HookEchoApp {
             .show(ctx, |ui| {
                 ui.vertical(|ui| {
                     if square_btn(ui, egui_phosphor::regular::STACK, layers_on, accent)
-                        .on_hover_text("Layers, products and tools")
+                        .named_toggle("Layers, products and tools", layers_on)
                         .clicked()
                     {
                         self.panel_open = !layers_on;
@@ -464,13 +465,13 @@ impl HookEchoApp {
                         self.basemap_open,
                         accent,
                     )
-                    .on_hover_text("Background map")
+                    .named_toggle("Background map", self.basemap_open)
                     .clicked()
                     {
                         self.basemap_open = !self.basemap_open;
                     }
                     let bell = square_btn(ui, egui_phosphor::regular::BELL, alerts_on, accent)
-                        .on_hover_text("Active alerts in view");
+                        .named_toggle("Active alerts in view", alerts_on);
                     alerts_anchor = Some(bell.rect);
                     if bell.clicked() {
                         self.panel_open = !alerts_on;

--- a/crates/hookecho/src/app/chrome/scrubber.rs
+++ b/crates/hookecho/src/app/chrome/scrubber.rs
@@ -6,6 +6,7 @@
 //! same axis.
 
 use super::*;
+use crate::ui::a11y::Named as _;
 
 impl HookEchoApp {
     pub(crate) fn scrubber(&mut self, ctx: &egui::Context) {
@@ -76,7 +77,7 @@ impl HookEchoApp {
                                 .color(egui::Color32::from_gray(238)),
                         );
                     }
-                    let btn = |ui: &mut egui::Ui, glyph: &str, on: bool| {
+                    let btn = |ui: &mut egui::Ui, glyph: &str, on: bool, name: &str| {
                         let fg = if on {
                             accent
                         } else {
@@ -88,16 +89,22 @@ impl HookEchoApp {
                                 .fill(egui::Color32::TRANSPARENT)
                                 .stroke(egui::Stroke::NONE),
                         )
+                        .named_toggle(name, on)
                         .clicked()
                     };
-                    if btn(ui, ph::SKIP_BACK, false) {
+                    if btn(ui, ph::SKIP_BACK, false, "Previous frame") {
                         t.step(-1);
                     }
                     let playing = t.playing;
-                    if btn(ui, if playing { ph::PAUSE } else { ph::PLAY }, playing) {
+                    if btn(
+                        ui,
+                        if playing { ph::PAUSE } else { ph::PLAY },
+                        playing,
+                        if playing { "Pause" } else { "Play" },
+                    ) {
                         t.toggle_play();
                     }
-                    if btn(ui, ph::SKIP_FORWARD, false) {
+                    if btn(ui, ph::SKIP_FORWARD, false, "Next frame") {
                         t.step(1);
                     }
                     // Live / archive badge: click to re-pin to the newest volume.
@@ -136,7 +143,7 @@ impl HookEchoApp {
                         .fill(col)
                         .corner_radius(9.0),
                     )
-                    .on_hover_text(hint);
+                    .named(hint);
                     if badge.clicked() {
                         go_head = true;
                     }
@@ -390,6 +397,12 @@ fn track(
             }
         }
     }
+    // The track is painted rather than built from widgets, so its accessibility node is empty
+    // unless we fill it in. Where the playhead sits is the whole of what it says.
+    let (at, of) = (t.playhead + 1, slots.max(1));
+    resp.widget_info(|| {
+        egui::WidgetInfo::slider(true, at as f64, format!("Timeline, frame {at} of {of}"))
+    });
     rect
 }
 

--- a/crates/hookecho/src/app/chrome/window_frame.rs
+++ b/crates/hookecho/src/app/chrome/window_frame.rs
@@ -65,6 +65,7 @@ impl HookEchoApp {
 
 /// One small glassy chrome button, sized for a row of three rather than the 44 px column.
 fn btn(ui: &mut egui::Ui, glyph: &str, hint: &str) -> bool {
+    use crate::ui::a11y::Named as _;
     let (r, g, b) = crate::ui::style::CARD_FILL;
     ui.add(
         egui::Button::new(
@@ -80,7 +81,7 @@ fn btn(ui: &mut egui::Ui, glyph: &str, hint: &str) -> bool {
         ))
         .corner_radius(crate::ui::style::RADIUS_SM),
     )
-    .on_hover_text(hint)
+    .named(hint)
     .clicked()
 }
 

--- a/crates/hookecho/src/ui/a11y.rs
+++ b/crates/hookecho/src/ui/a11y.rs
@@ -1,0 +1,38 @@
+//! Names for the chrome that has none.
+//!
+//! The floating chrome is icon-first by design: a stack glyph for the panel, a bell for alerts, a
+//! caret for back. A screen reader handed that button reads out the private-use codepoint the
+//! icon font happens to sit at, which is worse than silence. egui already carries an AccessKit
+//! node per widget — it just has nothing to put in it unless the app says so.
+//!
+//! Every one of these buttons already has the words: they are in the tooltip. So the fix is one
+//! call that spends the tooltip text twice, once for the pointer and once for the accessibility
+//! tree, and the mechanical change is `.on_hover_text(x)` becoming `.named(x)`.
+//!
+//! ponytail: an extension trait on `Response` rather than wrappers around `Button`, because the
+//! chrome builds its buttons half a dozen different ways (`square_btn`, bare `egui::Button`,
+//! `selectable_label`) and they all end at a `Response`.
+
+use egui::{Response, WidgetInfo, WidgetType};
+
+pub trait Named {
+    /// Name this control, for the pointer and for assistive technology alike.
+    fn named(self, name: &str) -> Response;
+
+    /// Same, for a control that is also on or off — a toggle in a control column, a tab.
+    fn named_toggle(self, name: &str, on: bool) -> Response;
+}
+
+impl Named for Response {
+    fn named(self, name: &str) -> Response {
+        let enabled = self.enabled();
+        self.widget_info(|| WidgetInfo::labeled(WidgetType::Button, enabled, name));
+        self.on_hover_text(name.to_owned())
+    }
+
+    fn named_toggle(self, name: &str, on: bool) -> Response {
+        let enabled = self.enabled();
+        self.widget_info(|| WidgetInfo::selected(WidgetType::Button, enabled, on, name));
+        self.on_hover_text(name.to_owned())
+    }
+}

--- a/crates/hookecho/src/ui/drawer.rs
+++ b/crates/hookecho/src/ui/drawer.rs
@@ -13,6 +13,7 @@
 //! scrolling body and the frame — the drawer only takes over the chrome and the ordering. If
 //! pages ever need transitions of their own, that's the seam to cut at.
 
+use crate::ui::a11y::Named as _;
 use egui::{pos2, vec2, Rect};
 
 /// The drawer's geometry on a desktop-sized screen. On a phone it takes the whole content rect,
@@ -133,7 +134,7 @@ impl Drawer {
                                 .fill(egui::Color32::TRANSPARENT)
                                 .stroke(egui::Stroke::NONE),
                             )
-                            .on_hover_text(hint)
+                            .named(hint)
                             .clicked()
                         {
                             close = true;
@@ -156,7 +157,7 @@ impl Drawer {
                                             .fill(egui::Color32::TRANSPARENT)
                                             .stroke(egui::Stroke::NONE),
                                         )
-                                        .on_hover_text("Quick settings for this page")
+                                        .named_toggle("Quick settings for this page", gear_on)
                                         .clicked()
                                     {
                                         gear_on = !gear_on;

--- a/crates/hookecho/src/ui/mod.rs
+++ b/crates/hookecho/src/ui/mod.rs
@@ -86,6 +86,8 @@ pub(crate) fn csv_buttons(
     }
 }
 
+/// Accessible names for icon-only chrome.
+pub mod a11y;
 pub mod about_window;
 pub mod afd_window;
 pub mod tropical_window;


### PR DESCRIPTION
Wave E2, stacked on #100.

The new chrome is icon-first, and every icon button's AccessKit node was empty — a screen reader reads the phosphor font's private-use codepoint, which is worse than silence. The words already existed, in the tooltips.

## New: `ui/a11y.rs`
A `Named` extension trait on `Response`:
- `.named(name)` — tooltip **and** `WidgetInfo::labeled`
- `.named_toggle(name, on)` — same plus selected state

An extension trait rather than button wrappers, because the chrome builds buttons via `square_btn`, bare `egui::Button` and `selectable_label`, and they all end at a `Response`.

## Named
Window-frame buttons · drawer back/close + gear · panel close · place search · panel toggle · site label · layers/basemap/alerts control column · scrubber transport (play/pause reads its current state) · LIVE/ARCHIVE badge.

The scrubber **track** is painted, not composed of widgets, so it gets an explicit slider role: "Timeline, frame N of M".

## Focus order
Already matches the plan (pill → controls → scrubber → drawer) because that is the draw order in `app.rs`. Everything remains reachable by hotkey and through the registry.

AccessKit stays native-only — eframe 0.35's web runner drops the updates.

## Gate
clippy clean · 570 passed, 29 ignored · wasm 0 errors · `shoot.sh check` passed · 4,793,926 gz (budget 4,850,000)

Not verified with a live screen reader (Orca) yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)