### PR TITLE
chore(brand): About art, share-card mark, pre-31 splash

### DIFF
--- a/android/app/src/main/res/drawable/splash_screen.xml
+++ b/android/app/src/main/res/drawable/splash_screen.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  The cold-start window on Android 10 and 11, which have no SplashScreen API to configure (see
+  values-v31/themes.xml for the 12+ half). It is a window background, not a layout: the platform
+  draws it the moment the window exists and throws it away on our first frame.
+-->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@color/hookecho_navy" />
+    <item>
+        <bitmap
+            android:gravity="center"
+            android:src="@mipmap/ic_launcher_foreground" />
+    </item>
+</layer-list>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -11,7 +11,10 @@
 -->
 <resources>
     <style name="Theme.HookEcho" parent="Theme.AppCompat.NoActionBar">
-        <item name="android:windowBackground">@android:color/black</item>
+        <!-- The mark on the app's navy while the renderer starts, rather than a black flash.
+             Android 12+ overrides this with the SplashScreen API (values-v31/themes.xml); the
+             extra overdraw is one pre-first-frame window, not a per-frame cost. -->
+        <item name="android:windowBackground">@drawable/splash_screen</item>
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowFullscreen">false</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -13370,6 +13370,7 @@ impl HookEchoApp {
             .map(|vol| crate::timefmt::fmt_date_clock(vol.time, self.active_tz()))
             .unwrap_or_default();
         let accent = crate::theme::accent(self.settings.theme);
+        let logo = crate::icon::texture(ctx, 64);
         egui::Area::new(egui::Id::new("share_card"))
             .order(egui::Order::Foreground)
             .constrain_to(self.chrome_rect)
@@ -13392,6 +13393,11 @@ impl HookEchoApp {
                             egui::RichText::new(line)
                                 .size(crate::ui::style::FONT_BASE)
                                 .color(egui::Color32::from_gray(238)),
+                        );
+                        // The mark rides with the caption: a shared loop travels without the app
+                        // around it, and the wordmark alone is not what anyone recognises.
+                        ui.add(
+                            egui::Image::new(&logo).fit_to_exact_size(egui::vec2(16.0, 16.0)),
                         );
                         ui.label(
                             egui::RichText::new("Hook Echo-WX · data: NOAA/NWS")

--- a/crates/hookecho/src/icon.rs
+++ b/crates/hookecho/src/icon.rs
@@ -95,6 +95,22 @@ pub fn icon_data() -> egui::IconData {
     }
 }
 
+/// The logo as a texture, drawn once and kept for the session.
+///
+/// `rgba` is a per-pixel distance field over six blobs — cheap at 64 px, not something to redo
+/// every frame for a window that is open while somebody reads it. The handle lives in egui's own
+/// temp store keyed by size, which is already the right lifetime: it dies with the context.
+pub fn texture(ctx: &egui::Context, size: usize) -> egui::TextureHandle {
+    let id = egui::Id::new(("app_logo_tex", size));
+    if let Some(t) = ctx.data(|d| d.get_temp::<egui::TextureHandle>(id)) {
+        return t;
+    }
+    let img = egui::ColorImage::from_rgba_unmultiplied([size, size], &rgba(size));
+    let t = ctx.load_texture("app_logo", img, egui::TextureOptions::LINEAR);
+    ctx.data_mut(|d| d.insert_temp(id, t.clone()));
+    t
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/hookecho/src/ui/about_window.rs
+++ b/crates/hookecho/src/ui/about_window.rs
@@ -31,14 +31,22 @@ pub fn show(
     else {
         return;
     };
+    let logo = crate::icon::texture(ctx, 128);
     window.show(ctx, |ui| {
-            ui.label(
-                egui::RichText::new("Hook Echo-WX")
-                    .size(style::FONT_TITLE)
-                    .color(accent)
-                    .strong(),
-            );
-            ui.label(egui::RichText::new(format!("Version {VERSION}")).weak());
+            // The mark beside the name, which is the one place in the app the logo is looked at
+            // rather than glanced at in a taskbar.
+            ui.horizontal(|ui| {
+                ui.add(egui::Image::new(&logo).fit_to_exact_size(egui::vec2(64.0, 64.0)));
+                ui.vertical(|ui| {
+                    ui.label(
+                        egui::RichText::new("Hook Echo-WX")
+                            .size(style::FONT_TITLE)
+                            .color(accent)
+                            .strong(),
+                    );
+                    ui.label(egui::RichText::new(format!("Version {VERSION}")).weak());
+                });
+            });
             ui.add_space(8.0);
             ui.label("An advanced NEXRAD weather radar viewer. Free and MIT licensed.");
             ui.add_space(8.0);


### PR DESCRIPTION
Wave E3, stacked on #101.

Most of the brand pass turned out to already exist: the logo is procedural (`icon.rs`), the Android adaptive icon has a monochrome layer for themed home screens, and `values-v31/themes.xml` already styles the SplashScreen API. What was missing:

- **`icon::texture`** — caches the logo as an egui texture keyed by size. `rgba()` is a per-pixel distance field over six blobs; fine once, wasteful per frame.
- **About page art** — the mark beside the name and version. Verified on the S24 Ultra (screenshot below in comments if wanted).
- **Share-card mark** — 16 px, riding with the caption. A shared loop travels without the app around it, and the wordmark alone isn't what anyone recognises.
- **Pre-31 splash** — Android 10/11 have no SplashScreen API to configure and were getting a black window background. `drawable/splash_screen.xml` is navy plus the launcher foreground. Costs one pre-first-frame window of overdraw.

## Deliberately not here
Store screenshots, `hero.gif`, README imagery. The plan puts the single reshoot at **beta**, and the chrome still moves under waves F–L. The `ARCHIVE_SCENES` xdotool coordinate audit belongs with it.

## Gate
clippy clean · 570 passed, 29 ignored · wasm 0 errors · `shoot.sh check` passed · `cargo ndk` check clean · 4,794,877 gz (budget 4,850,000) · APK built, installed and exercised on the S24 Ultra

🤖 Generated with [Claude Code](https://claude.com/claude-code)