### PR TITLE
feat(sat): GOES archive loops

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -2065,6 +2065,10 @@ pub struct HookEchoApp {
     /// Keep the GOES frame on the active pane's radar clock rather than on a hand-picked frame.
     goes_follow_radar: bool,
     goes_times_rx: Option<std::sync::mpsc::Receiver<Vec<chrono::DateTime<chrono::Utc>>>>,
+    /// The archive hour the loaded frame times cover (`None` = the live window ending now).
+    /// Scrubbing far enough back to cross into another hour refetches; staying inside one does
+    /// not, which is what keeps an archive loop from asking GIBS a question per frame.
+    goes_hour: Option<i64>,
     /// When the Android widget snapshot was last written.
     widget_shot_at: Option<Instant>,
     /// A warning that wants a radar picture pushed after it (see `settings.ntfy_snapshot`).
@@ -2902,6 +2906,7 @@ impl HookEchoApp {
             goes_time_idx: None,
             goes_follow_radar: true,
             goes_times_rx: None,
+            goes_hour: None,
             widget_shot_at: None,
             snapshot_push: None,
             rotation_alerted: std::collections::HashMap::new(),
@@ -15574,8 +15579,17 @@ impl eframe::App for HookEchoApp {
             // GOES sub-hourly scrub: fetch the available frame times when a GOES style becomes
             // active, and apply the selected frame (None = latest).
             if raster_style.goes_layer().is_some() {
-                if self.goes_times_style != Some(raster_style) {
+                // Which hour of imagery to ask for: the pane's own clock when it is replaying an
+                // archive, otherwise the live window ending now. GIBS keeps GeoColor about two
+                // weeks and Band 13 several months, so a replayed event usually has satellite.
+                let radar_time = self.views[self.active.min(n - 1)]
+                    .volume
+                    .as_ref()
+                    .map(|v| v.time);
+                let (hour, from, to) = crate::tiles::goes_window(chrono::Utc::now(), radar_time);
+                if self.goes_times_style != Some(raster_style) || self.goes_hour != hour {
                     self.goes_times_style = Some(raster_style);
+                    self.goes_hour = hour;
                     self.goes_times.clear();
                     self.goes_time_idx = None;
                     let (tx, rx) = std::sync::mpsc::channel();
@@ -15583,7 +15597,7 @@ impl eframe::App for HookEchoApp {
                     let http = self.http.clone();
                     self.spawner.spawn(async move {
                         let times =
-                            crate::tiles::fetch_goes_times(&http, raster_style, 8, 48).await;
+                            crate::tiles::fetch_goes_times(&http, raster_style, from, to, 48).await;
                         let _ = tx.send(times);
                     });
                 }
@@ -15600,9 +15614,17 @@ impl eframe::App for HookEchoApp {
                     self.goes_time_idx
                         .and_then(|i| self.goes_times.get(i).copied())
                 };
+                // `None` means GIBS's own default, which is the newest imagery there is — right
+                // for a live pane, three days wrong for one replaying an archive. In an archive
+                // window, fall back to the newest frame *in that window* instead.
+                let selected = match (selected, self.goes_hour) {
+                    (None, Some(_)) => self.goes_times.last().copied(),
+                    (s, _) => s,
+                };
                 clear_tiles |= self.tiles.set_goes_time(selected);
             } else if self.goes_times_style.is_some() {
                 self.goes_times_style = None;
+                self.goes_hour = None;
                 self.goes_times.clear();
                 clear_tiles |= self.tiles.set_goes_time(None);
             }

--- a/crates/hookecho/src/tiles.rs
+++ b/crates/hookecho/src/tiles.rs
@@ -860,20 +860,55 @@ fn parse_iso_minutes(p: &str) -> Option<i64> {
     }
 }
 
-/// Fetch the available GOES frame times for `style` over the last `hours` (best-effort; empty on
-/// any failure). Uses the GIBS REST DescribeDomains endpoint.
+/// Which GOES frame times to ask for, given the wall clock and the active pane's radar time.
+///
+/// Returns the archive hour the window covers (`None` while live) and the window itself. The hour
+/// is the refetch key: scrubbing within it reuses the frames already loaded, and only crossing
+/// into another hour asks GIBS again.
+pub fn goes_window(
+    now: chrono::DateTime<chrono::Utc>,
+    radar: Option<chrono::DateTime<chrono::Utc>>,
+) -> (
+    Option<i64>,
+    chrono::DateTime<chrono::Utc>,
+    chrono::DateTime<chrono::Utc>,
+) {
+    // Four hours back is well past the point where a pane is replaying rather than lagging.
+    let hour = radar
+        .filter(|t| now.signed_duration_since(*t) > chrono::Duration::hours(4))
+        .map(|t| t.timestamp().div_euclid(3600));
+    match hour {
+        // Brackets the hour so stepping either way stays inside what was loaded.
+        Some(h) => {
+            let c = chrono::DateTime::from_timestamp(h * 3600, 0).unwrap_or(now);
+            (
+                hour,
+                c - chrono::Duration::hours(1),
+                c + chrono::Duration::hours(2),
+            )
+        }
+        None => (None, now - chrono::Duration::hours(8), now),
+    }
+}
+
+/// Fetch the available GOES frame times for `style` between `from` and `to` (best-effort; empty
+/// on any failure). Uses the GIBS REST DescribeDomains endpoint.
+///
+/// The window is a parameter rather than "the last N hours" because the same call serves the live
+/// loop and archive replay: GIBS keeps GeoColor about two weeks back and Band 13 several months,
+/// so scrubbing the radar into last week's event can ask for that week's satellite frames.
 pub async fn fetch_goes_times(
     client: &reqwest::Client,
     style: BasemapStyle,
-    hours: i64,
+    from: chrono::DateTime<chrono::Utc>,
+    to: chrono::DateTime<chrono::Utc>,
     limit: usize,
 ) -> Vec<chrono::DateTime<chrono::Utc>> {
     let Some((layer, level)) = style.goes_layer() else {
         return Vec::new();
     };
-    let now = chrono::Utc::now();
-    let from = (now - chrono::Duration::hours(hours)).format("%Y-%m-%dT%H:%M:%SZ");
-    let to = now.format("%Y-%m-%dT%H:%M:%SZ");
+    let from = from.format("%Y-%m-%dT%H:%M:%SZ");
+    let to = to.format("%Y-%m-%dT%H:%M:%SZ");
     let url = format!(
         "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/1.0.0/{layer}/default/GoogleMapsCompatible_Level{level}/-180,-90,180,90/{from}--{to}.xml"
     );
@@ -1960,5 +1995,29 @@ mod tests {
                 assert_eq!(s.category(), Category::Satellite, "{s:?}");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod goes_window_tests {
+    use super::goes_window;
+
+    #[test]
+    fn live_asks_for_the_last_eight_hours_and_an_archive_brackets_its_hour() {
+        let now = chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+        let (hour, from, to) = goes_window(now, Some(now - chrono::Duration::minutes(6)));
+        assert_eq!(hour, None, "a lagging live pane is still live");
+        assert_eq!(to, now);
+        assert_eq!(now - from, chrono::Duration::hours(8));
+
+        let old = now - chrono::Duration::days(3);
+        let (hour, from, to) = goes_window(now, Some(old));
+        let h = hour.expect("three days back is an archive");
+        assert_eq!(h, old.timestamp().div_euclid(3600));
+        assert!(from <= old && old <= to, "the frame we are replaying is covered");
+        assert_eq!(to - from, chrono::Duration::hours(3));
+        // Scrubbing a few minutes inside the same hour must not change the refetch key.
+        let (again, ..) = goes_window(now, Some(old + chrono::Duration::minutes(5)));
+        assert_eq!(again, hour);
     }
 }


### PR DESCRIPTION
R18 wave F, item F1 (the archive half).

## What

The GOES frame-time fetch took "the last N hours". It now takes a window, and the window follows the active pane's clock:

- pane replaying something >4 h old: that hour, bracketed by an hour either side
- live pane: the last eight hours, as before

The archive hour is also the refetch key, so scrubbing inside one hour reuses the loaded frames instead of asking GIBS per frame.

Also fixes a mismatch that predates this: an unselected frame meant GIBS's own `default`, i.e. the newest imagery in existence. Live that is right; three days into a replay it is the wrong picture. In an archive window it now resolves to the newest frame *in that window*.

`goes_window` lives in `tiles.rs` rather than `app.rs` (collision doctrine) and carries the test.

## Verified against the live endpoint

DescribeDomains says GIBS keeps GeoColor back to 2026-08-10 and Band 13 back to 2026-04-30 — deep enough for the events people replay.

## What is NOT here: mid-level water vapour

GIBS publishes six ABI layers in both EPSG:3857 and EPSG:4326 — GeoColor, Band 13 Clean IR, Band 2 Red Visible, Air Mass, Dust, FireTemp. **No water-vapour band exists to point a style at.** The plan's contingency is decoding ABI L2 CMIP netCDF from `noaa-goes19` (already allowlisted, and `glm.rs` already reads netCDF through `hdf5lite`), but ABI is on a geostationary fixed grid and the field warp pipeline is plate-carrée only — that is a reprojection, not a style entry. Flagged rather than smuggled in.

## Gate

- clippy `-D warnings`: clean
- `cargo test --workspace`: 571 passed, 29 ignored
- wasm check: clean
- `shoot.sh check`: passed
- web gzip: 4,795,156 / 4,850,000

🤖 Generated with [Claude Code](https://claude.com/claude-code)