### PR TITLE
feat(hail): pick the hail-swath window

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1308,7 +1308,7 @@ fn field_refresh_secs(layer: crate::render::FieldLayer) -> u64 {
         // Two global cycles behind it, so the same half hour.
         | FL::ModelDiff => 1800,
         FL::Smoke => 900,
-        // The 24-h hail-swath accumulation moves slowly.
+        // An accumulation moves slower than the grid it accumulates, whatever the window.
         FL::HailSwath => 300,
         // Environment (HRRR CAPE/SRH) refreshes slowly — 15 min.
         FL::Cape | FL::Srh => 900,
@@ -2109,6 +2109,8 @@ pub struct HookEchoApp {
     fields: std::collections::HashMap<crate::render::FieldLayer, FieldState>,
     /// Selected rotation-track accumulation window (minutes): 30, 60, or 120.
     rotation_minutes: u16,
+    /// Selected hail-swath accumulation window (minutes); see [`wxdata::mrms::hail_swath`].
+    hail_minutes: u16,
     /// Environment suite (HRRR CAPE/SRH): CAPE uses the mixed-layer (90-0 mb) parcel when true,
     /// else surface-based; SRH depth in km (1 = 0-1 km, 3 = 0-3 km). Changing either clears the
     /// layer's last_fetch so the next frame refetches.
@@ -2932,6 +2934,7 @@ impl HookEchoApp {
                 .map(|&l| (l, FieldState::default()))
                 .collect(),
             rotation_minutes: 30,
+            hail_minutes: 1440,
             env_cape_ml: false,
             env_srh_km: 3,
             l3grid_site: None,
@@ -8982,7 +8985,7 @@ impl HookEchoApp {
             FL::Qpe24h => wxdata::mrms::QPE_24H.to_string(),
             FL::PrecipType => wxdata::mrms::PRECIP_TYPE.to_string(),
             FL::FlashFlood => wxdata::mrms::FLASH_ARI30.to_string(),
-            FL::HailSwath => wxdata::mrms::MESH_1440.to_string(),
+            FL::HailSwath => wxdata::mrms::hail_swath(self.hail_minutes).to_string(),
             FL::Hrrr
             | FL::Cape
             | FL::Srh

--- a/crates/hookecho/src/app/chrome/overlay.rs
+++ b/crates/hookecho/src/app/chrome/overlay.rs
@@ -184,6 +184,7 @@ impl HookEchoApp {
                                         &mut self.filters,
                                         &mut self.fields,
                                         &mut self.rotation_minutes,
+                                        &mut self.hail_minutes,
                                         &mut self.hrrr_fcst_hour,
                                         self.hrrr_valid,
                                         tz,

--- a/crates/hookecho/src/app/chrome/registry.rs
+++ b/crates/hookecho/src/app/chrome/registry.rs
@@ -177,8 +177,8 @@ impl HookEchoApp {
             (
                 FL::HailSwath,
                 "National",
-                "Hail swaths (24 h)",
-                "Where hail has fallen over the past day",
+                "Hail swaths",
+                "Where hail has fallen — over the past day, or a window you pick",
                 false,
             ),
             (

--- a/crates/hookecho/src/ui/layer_options.rs
+++ b/crates/hookecho/src/ui/layer_options.rs
@@ -52,6 +52,7 @@ pub(crate) fn show(
     filters: &mut OverlayFilters,
     fields: &mut std::collections::HashMap<crate::render::FieldLayer, crate::app::FieldState>,
     rotation_minutes: &mut u16,
+    hail_minutes: &mut u16,
     hrrr_fcst_hour: &mut u8,
     hrrr_valid: Option<chrono::DateTime<chrono::Utc>>,
     tz: Option<wxdata::tz::Tz>,
@@ -312,6 +313,23 @@ pub(crate) fn show(
             // Duration change → force an immediate refetch of the rotation grid.
             if dur {
                 if let Some(s) = fields.get_mut(&FL::Rotation) {
+                    s.last_fetch = None;
+                }
+            }
+        });
+    }
+
+    if fields.get(&FL::HailSwath).is_some_and(|s| s.show) {
+        header(ui, "Hail swaths");
+        ui.horizontal(|ui| {
+            ui.label("Window:");
+            let mut dur = false;
+            for (m, label) in [(30u16, "30m"), (60, "1h"), (120, "2h"), (360, "6h"), (1440, "24h")]
+            {
+                dur |= ui.selectable_value(hail_minutes, m, label).changed();
+            }
+            if dur {
+                if let Some(s) = fields.get_mut(&FL::HailSwath) {
                     s.last_fetch = None;
                 }
             }

--- a/crates/wxdata/src/mrms.rs
+++ b/crates/wxdata/src/mrms.rs
@@ -28,6 +28,22 @@ pub fn lightning_density(minutes: u16) -> &'static str {
 pub const MESH: &str = "CONUS/MESH_00.50";
 /// 24-hour running max of MESH (mm) — hail swaths / damage tracks.
 pub const MESH_1440: &str = "CONUS/MESH_Max_1440min_00.50";
+
+/// Running-max MESH (hail swath) product for an accumulation window in minutes.
+///
+/// MRMS publishes the accumulation itself, so the swath is a fetch rather than a grid the client
+/// keeps a history of and maxes frame by frame. 30/60/120/240/360/1440 are published; 720 is not
+/// (checked against the bucket listing), and anything else falls back to the 24-hour swath.
+pub fn hail_swath(minutes: u16) -> &'static str {
+    match minutes {
+        30 => "CONUS/MESH_Max_30min_00.50",
+        60 => "CONUS/MESH_Max_60min_00.50",
+        120 => "CONUS/MESH_Max_120min_00.50",
+        240 => "CONUS/MESH_Max_240min_00.50",
+        360 => "CONUS/MESH_Max_360min_00.50",
+        _ => MESH_1440,
+    }
+}
 /// Instantaneous 0–2 km AGL azimuthal shear (s⁻¹).
 pub const AZSHEAR: &str = "CONUS/MergedAzShear_0-2kmAGL_00.50";
 /// Multi-sensor 1-hour QPE accumulation, Pass-2 gauge-corrected (mm).
@@ -530,5 +546,14 @@ mod tests {
         let passthrough = f.decimated(8192);
         assert_eq!(passthrough.nx, 4);
         assert_eq!(passthrough.values.as_ptr(), ptr);
+    }
+
+    #[test]
+    fn hail_swath_windows_map_to_published_products_and_fall_back_to_the_day() {
+        assert_eq!(hail_swath(60), "CONUS/MESH_Max_60min_00.50");
+        assert_eq!(hail_swath(360), "CONUS/MESH_Max_360min_00.50");
+        // 720 is not published, so it lands on the 24-hour swath rather than a 404.
+        assert_eq!(hail_swath(720), MESH_1440);
+        assert_eq!(hail_swath(1440), MESH_1440);
     }
 }


### PR DESCRIPTION
R18 wave F, item F3. Stacked on #104.

The swath was fixed at 24 h. Now 30 min / 1 h / 2 h / 6 h / 24 h, in the layer options beside the rotation-track window it copies.

**Cheaper than the plan said.** F3 was written as "client-side max-accum of MESH grids over a window" — keeping a grid history and maxing it frame by frame. MRMS already publishes `MESH_Max_{30,60,120,240,360,1440}min`, so the accumulation is a fetch. No history buffer, no accumulation code. `720min` is not in the bucket (probed), so it falls back to the 24-hour swath.

`FL::HailSwath` keeps its 300 s refresh throttle at every window; an accumulation moves slower than the grid it accumulates.

## Gate

- clippy `-D warnings`: clean
- `cargo test --workspace`: 572 passed, 29 ignored
- wasm check: clean
- `shoot.sh check`: passed
- web gzip: 4,795,326 / 4,850,000

🤖 Generated with [Claude Code](https://claude.com/claude-code)