### PR TITLE
feat(rules): lightning-jump trigger

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -2069,6 +2069,8 @@ pub struct HookEchoApp {
     /// Scrubbing far enough back to cross into another hour refetches; staying inside one does
     /// not, which is what keeps an archive loop from asking GIBS a question per frame.
     goes_hour: Option<i64>,
+    /// The previous flash-extent grid, kept only so the lightning jump has something to subtract.
+    glm_fed_prev: Option<wxdata::mrms::MrmsField>,
     /// When the Android widget snapshot was last written.
     widget_shot_at: Option<Instant>,
     /// A warning that wants a radar picture pushed after it (see `settings.ntfy_snapshot`).
@@ -2909,6 +2911,7 @@ impl HookEchoApp {
             goes_follow_radar: true,
             goes_times_rx: None,
             goes_hour: None,
+            glm_fed_prev: None,
             widget_shot_at: None,
             snapshot_push: None,
             rotation_alerted: std::collections::HashMap::new(),
@@ -4274,17 +4277,22 @@ impl HookEchoApp {
         }
     }
 
-    /// Run the lightning-density rules over a freshly built flash-extent grid.
+    /// Run the rules on `trigger` over a freshly built lightning grid (density, or its rate of
+    /// rise).
     ///
     /// The grid's own cell is the detection: a cell whose flash count clears the rule's threshold
     /// is somewhere worth knowing about. Cooldowns are per rule and place, as everywhere else.
-    fn evaluate_grid_rules(&mut self, field: &wxdata::mrms::MrmsField) {
+    fn evaluate_grid_rules(
+        &mut self,
+        trigger: crate::settings::RuleTrigger,
+        field: &wxdata::mrms::MrmsField,
+    ) {
         use crate::rules::Detection;
         let rules: Vec<crate::settings::AlertRule> = self
             .settings
             .alert_rules
             .iter()
-            .filter(|r| r.enabled && r.trigger == crate::settings::RuleTrigger::GlmFed)
+            .filter(|r| r.enabled && r.trigger == trigger)
             .cloned()
             .collect();
         if rules.is_empty() || field.nx == 0 || field.ny == 0 {
@@ -4316,7 +4324,7 @@ impl HookEchoApp {
                         .total_cmp(&b.strength.unwrap_or(0.0))
                 });
             if let Some(hit) = best {
-                self.note_hits(&crate::settings::RuleTrigger::GlmFed, &[hit]);
+                self.note_hits(&trigger, &[hit]);
                 if crate::rules::compound_ok(&rule, &hit, &self.recent_for_rules()) {
                     self.fire_rule(&rule, &hit);
                 }
@@ -14416,11 +14424,13 @@ impl eframe::App for HookEchoApp {
         let glm_fed_on = self.fields.get(&FL::GlmFed).is_some_and(|s| s.show);
         // A lightning-density rule needs the flashes polled and the grid built even with the
         // layer off, exactly like the scan signatures.
-        let glm_rule_armed = self
-            .settings
-            .alert_rules
-            .iter()
-            .any(|r| r.enabled && r.trigger == crate::settings::RuleTrigger::GlmFed);
+        let glm_rule_armed = self.settings.alert_rules.iter().any(|r| {
+            r.enabled
+                && matches!(
+                    r.trigger,
+                    crate::settings::RuleTrigger::GlmFed | crate::settings::RuleTrigger::GlmJump
+                )
+        });
         if (self.show_glm || glm_fed_on || glm_rule_armed)
             && self
                 .glm_last_poll
@@ -14474,7 +14484,16 @@ impl eframe::App for HookEchoApp {
                 )
             });
             if let Some(field) = &field {
-                self.evaluate_grid_rules(field);
+                self.evaluate_grid_rules(crate::settings::RuleTrigger::GlmFed, field);
+                // The jump is the difference between this grid and the one before it, so it can
+                // only be asked for once there is a previous one — the first grid after launch
+                // has no rate.
+                if let Some(prev) = &self.glm_fed_prev {
+                    if let Some(jump) = wxdata::glm::flash_jump(prev, field) {
+                        self.evaluate_grid_rules(crate::settings::RuleTrigger::GlmJump, &jump);
+                    }
+                }
+                self.glm_fed_prev = Some(field.clone());
             }
             if let (Some(field), true) = (field, glm_fed_on) {
                 let cap = self.field_texture_cap();

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -642,6 +642,9 @@ pub enum RuleTrigger {
     ProbSevere,
     /// GLM flash-extent density; the threshold is minimum flashes per cell per window.
     GlmFed,
+    /// A lightning jump: how fast flash-extent density is *rising*, in flashes per cell per
+    /// minute. The threshold is that rate.
+    GlmJump,
     /// An NWS warning whose event name contains this text, case-insensitively. Empty matches
     /// every warning.
     Warning { event_contains: String },
@@ -649,13 +652,14 @@ pub enum RuleTrigger {
 
 impl RuleTrigger {
     /// Every trigger, with the defaults a fresh rule starts on — menu order.
-    pub const ALL: [RuleTrigger; 7] = [
+    pub const ALL: [RuleTrigger; 8] = [
         RuleTrigger::Tds,
         RuleTrigger::Tbss,
         RuleTrigger::ZdrColumn,
         RuleTrigger::Rotation,
         RuleTrigger::ProbSevere,
         RuleTrigger::GlmFed,
+        RuleTrigger::GlmJump,
         RuleTrigger::Warning {
             event_contains: String::new(),
         },
@@ -669,6 +673,7 @@ impl RuleTrigger {
             RuleTrigger::Rotation => "Rotation",
             RuleTrigger::ProbSevere => "ProbSevere",
             RuleTrigger::GlmFed => "Lightning density",
+            RuleTrigger::GlmJump => "Lightning jump",
             RuleTrigger::Warning { .. } => "NWS warning",
         }
     }
@@ -680,6 +685,7 @@ impl RuleTrigger {
             RuleTrigger::Rotation => Some(("kt Vrot", 40.0)),
             RuleTrigger::ProbSevere => Some(("% severe", 50.0)),
             RuleTrigger::GlmFed => Some(("flashes", 20.0)),
+            RuleTrigger::GlmJump => Some(("flashes/min rise", 4.0)),
             _ => None,
         }
     }

--- a/crates/wxdata/src/glm.rs
+++ b/crates/wxdata/src/glm.rs
@@ -314,6 +314,117 @@ pub fn flash_density(
     })
 }
 
+/// Rate of change of flash-extent density between two [`flash_density`] grids, in flashes per
+/// cell per minute — the lightning jump.
+///
+/// A storm that is about to do something usually electrifies first: total flash rate climbs
+/// sharply several minutes before the severe weather arrives. A high density on its own only says
+/// the storm is already big; the *rise* is the part with lead time in it.
+///
+/// Both grids snap to the same lattice, so cells line up by an integer offset and no interpolation
+/// is involved — but only if they were built with the same cell size, which is checked. Cells that
+/// fell (or held steady) come back `NaN`: a jump layer showing decay would bury the thing it is
+/// for. `None` when the grids do not line up or no time passed between them.
+pub fn flash_jump(
+    prev: &crate::mrms::MrmsField,
+    cur: &crate::mrms::MrmsField,
+) -> Option<crate::mrms::MrmsField> {
+    let dt_min = (cur.time - prev.time).num_seconds() as f32 / 60.0;
+    if dt_min <= 0.0 || cur.nx == 0 || cur.ny == 0 || prev.nx == 0 || prev.ny == 0 {
+        return None;
+    }
+    let cell = (cur.lon_east - cur.lon_west) / cur.nx as f64;
+    let prev_cell = (prev.lon_east - prev.lon_west) / prev.nx as f64;
+    if cell <= 0.0 || (cell - prev_cell).abs() > cell * 1e-6 {
+        return None;
+    }
+    // Where cur's origin sits in prev's index space. Rows run north to south.
+    let ox = ((cur.lon_west - prev.lon_west) / cell).round() as isize;
+    let oy = ((prev.lat_north - cur.lat_north) / cell).round() as isize;
+    let mut values = vec![f32::NAN; cur.nx * cur.ny];
+    for y in 0..cur.ny {
+        for x in 0..cur.nx {
+            let now = cur.values[y * cur.nx + x];
+            if !now.is_finite() {
+                continue;
+            }
+            let (px, py) = (x as isize + ox, y as isize + oy);
+            let before = if px >= 0 && py >= 0 && (px as usize) < prev.nx && (py as usize) < prev.ny
+            {
+                let v = prev.values[py as usize * prev.nx + px as usize];
+                if v.is_finite() {
+                    v
+                } else {
+                    0.0
+                }
+            } else {
+                // Off the edge of the older grid: the storm moved in, so all of it is new.
+                0.0
+            };
+            let rate = (now - before) / dt_min;
+            if rate > 0.0 {
+                values[y * cur.nx + x] = rate;
+            }
+        }
+    }
+    Some(crate::mrms::MrmsField {
+        values,
+        nx: cur.nx,
+        ny: cur.ny,
+        lon_west: cur.lon_west,
+        lon_east: cur.lon_east,
+        lat_north: cur.lat_north,
+        lat_south: cur.lat_south,
+        time: cur.time,
+    })
+}
+
+#[cfg(test)]
+mod jump_tests {
+    use super::*;
+
+    fn grid(vals: &[f32], lon_west: f64, lat_north: f64, min_ago: i64) -> crate::mrms::MrmsField {
+        crate::mrms::MrmsField {
+            values: vals.to_vec(),
+            nx: 2,
+            ny: 1,
+            lon_west,
+            lon_east: lon_west + 2.0,
+            lat_north,
+            lat_south: lat_north - 1.0,
+            time: Utc::now() - chrono::Duration::minutes(min_ago),
+        }
+    }
+
+    #[test]
+    fn a_rising_cell_reports_its_rate_and_a_falling_one_reports_nothing() {
+        let prev = grid(&[10.0, 30.0], 0.0, 10.0, 5);
+        let cur = grid(&[20.0, 12.0], 0.0, 10.0, 0);
+        let j = flash_jump(&prev, &cur).expect("same lattice, five minutes apart");
+        assert!((j.values[0] - 2.0).abs() < 1e-4, "10 flashes over 5 min");
+        assert!(j.values[1].is_nan(), "decay is not a jump");
+    }
+
+    #[test]
+    fn a_shifted_grid_lines_up_by_offset_and_new_ground_counts_as_all_new() {
+        // cur sits one cell east of prev: cur cell 0 is prev cell 1, cur cell 1 is off the edge.
+        let prev = grid(&[0.0, 5.0], 0.0, 10.0, 5);
+        let cur = grid(&[10.0, 10.0], 1.0, 10.0, 0);
+        let j = flash_jump(&prev, &cur).unwrap();
+        assert!((j.values[0] - 1.0).abs() < 1e-4, "(10 - 5) / 5 min");
+        assert!((j.values[1] - 2.0).abs() < 1e-4, "nothing there before");
+    }
+
+    #[test]
+    fn mismatched_cell_sizes_and_stopped_clocks_are_refused() {
+        let prev = grid(&[1.0, 1.0], 0.0, 10.0, 5);
+        let mut coarse = grid(&[2.0, 2.0], 0.0, 10.0, 0);
+        coarse.lon_east = coarse.lon_west + 4.0;
+        assert!(flash_jump(&prev, &coarse).is_none());
+        assert!(flash_jump(&prev, &grid(&[2.0, 2.0], 0.0, 10.0, 5)).is_none());
+    }
+}
+
 #[cfg(test)]
 mod density_tests {
     use super::*;


### PR DESCRIPTION
R18 wave F, item F5. Stacked on #105.

## What

`wxdata::glm::flash_jump(prev, cur)` → flashes per cell per minute, from the same `flash_density` grids the GLM layer already builds. New `RuleTrigger::GlmJump` ("Lightning jump", threshold in flashes/min, default 4).

- lattice-aligned integer offset, no interpolation; mismatched cell size or non-advancing clock returns `None`
- decay is `NaN`, not a negative rate
- ground outside the older grid counts as all new
- arming a jump rule polls GLM and builds the grid with the layer off, same as a density rule
- `evaluate_grid_rules` now takes the trigger, so density and jump share one evaluator

Three unit tests in `glm.rs` (rise/decay, shifted grid, refusals) rather than `rules.rs` as the plan sketched — the pure fn lives in wxdata, so its test does too.

## Gate

- clippy `-D warnings`: clean
- `cargo test --workspace`: 575 passed, 29 ignored
- wasm check: clean
- `shoot.sh check`: passed
- web gzip: 4,798,306 / 4,850,000

Not field-verified: no lightning jump has happened in front of me. The arithmetic is tested; the meteorology is Schultz et al.'s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)