### PR TITLE
feat(winter): snow bands and snow-squall emphasis

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -305,6 +305,8 @@ enum OverlaySource {
     FreezingLevels(f64, f64),
     /// NOHRSC observed snowfall analysis over an accumulation window (hours).
     Snow(u16),
+    /// Banded snow: the MRMS mosaic cut to elongated echo and masked to snow.
+    SnowBands,
     /// Nearest-station observations for `site` at `(lat, lon)`.
     Obs {
         site: String,
@@ -406,6 +408,19 @@ impl OverlaySource {
             }
             OverlaySource::Field(layer, product) => {
                 OverlayMsg::Field(layer, wxdata::mrms::fetch_latest(http, &product).await?)
+            }
+            OverlaySource::SnowBands => {
+                // Both grids at once: the mask is useless without the echo and vice versa.
+                let (mosaic, flags) = futures_util::future::try_join(
+                    wxdata::mrms::fetch_latest(http, wxdata::mrms::REFLECTIVITY),
+                    wxdata::mrms::fetch_latest(http, wxdata::mrms::PRECIP_TYPE),
+                )
+                .await?;
+                // MRMS PrecipFlag: 3 is snow, 4 is wet snow. Everything else is rain, ice or
+                // nothing, and a snow-squall layer that lit up over warm rain would be a liar.
+                let bands = wxdata::banding::bands(&mosaic, 20.0, Some((&flags, &[3, 4])))
+                    .ok_or_else(|| anyhow::anyhow!("the mosaic came back empty"))?;
+                OverlayMsg::Field(crate::render::FieldLayer::SnowBands, bands)
             }
             OverlaySource::Global(layer, model, field, fh) => {
                 let fc = wxdata::global::fetch(http, model, field, fh).await?;
@@ -1294,6 +1309,8 @@ fn field_refresh_secs(layer: crate::render::FieldLayer) -> u64 {
         FL::Qpe1h | FL::Qpe24h => 120,
         // MRMS precip type / flash-flood ARI on the ~2-min cadence; L3 grids on the 120 s L3 cadence.
         FL::PrecipType | FL::FlashFlood | FL::Vil | FL::EchoTops | FL::Hca => 120,
+        // Bands are cut from the ~2-min mosaic, so they are as fresh as it is.
+        FL::SnowBands => 120,
         FL::UpdraftHelicity => 600,
         // Snowfall accumulates over a whole model run; it moves as slowly as the run does.
         FL::Snowfall => 600,
@@ -9017,7 +9034,9 @@ impl HookEchoApp {
             | FL::GlobalWind10m
             | FL::GlobalPrecip
             | FL::ModelDiff
-            | FL::GlmFed => return None,
+            | FL::GlmFed
+            // Built from two grids at once, so it has a fetch block of its own.
+            | FL::SnowBands => return None,
         })
     }
 
@@ -14321,6 +14340,21 @@ impl eframe::App for HookEchoApp {
             if stale {
                 self.fields.entry(layer).or_default().last_fetch = Some(Instant::now());
                 self.spawn_overlay(ctx, OverlaySource::Field(layer, product));
+            }
+        }
+        // Snow bands: the mosaic and the precipitation-type grid, cut to the banded snow.
+        {
+            let layer = FL::SnowBands;
+            let stale = self.fields.get(&layer).is_some_and(|s| {
+                s.show
+                    && s.last_fetch
+                        .is_none_or(|t| t.elapsed().as_secs() >= field_refresh_secs(layer))
+            });
+            if stale {
+                if let Some(s) = self.fields.get_mut(&layer) {
+                    s.last_fetch = Some(Instant::now());
+                }
+                self.spawn_overlay(ctx, OverlaySource::SnowBands);
             }
         }
         // Environment suite (HRRR CAPE/SRH): fetch each enabled layer at f00, refresh ~15 min.

--- a/crates/hookecho/src/app/chrome/registry.rs
+++ b/crates/hookecho/src/app/chrome/registry.rs
@@ -182,6 +182,14 @@ impl HookEchoApp {
                 false,
             ),
             (
+                FL::SnowBands,
+                "National",
+                "Snow bands",
+                "Snow organised into a line — the squall that whites out a road in two minutes, \
+                 cut out of the national mosaic",
+                false,
+            ),
+            (
                 FL::Vil,
                 "National",
                 "Water aloft (VIL, L3)",

--- a/crates/hookecho/src/render/field_ramps.rs
+++ b/crates/hookecho/src/render/field_ramps.rs
@@ -474,6 +474,23 @@ static SNOW_ANALYSIS: FieldRamp = FieldRamp {
     )
 };
 
+/// Banded snow. The values are reflectivity, but the scale is not the reflectivity palette: what
+/// the layer says is "this echo is organised into a line", and it has to read as that against the
+/// mosaic it was cut out of.
+static SNOW_BANDS: FieldRamp = ramp!(
+    "Snow bands",
+    "dBZ",
+    10.0,
+    45.0,
+    RampScale::Linear,
+    230,
+    &[
+        (0.0, [120, 160, 210]),
+        (0.5, [180, 215, 250]),
+        (1.0, [255, 255, 255]),
+    ]
+);
+
 static PRECIP_TYPE: FieldRamp = FieldRamp {
     label: "Precip type",
     units: "",
@@ -618,6 +635,7 @@ pub fn ramp_for(layer: FieldLayer) -> Option<&'static FieldRamp> {
         FL::GlobalPrecip => &GLOBAL_PRECIP,
         FL::Hca => &HCA,
         FL::GlmFed => &GLM_FED,
+        FL::SnowBands => &SNOW_BANDS,
         // Composite is reflectivity in dBZ, so like the mosaic it follows the user's own
         // reflectivity `.pal` rather than a fixed ramp of its own.
         FL::Mrms | FL::Mosaic | FL::CompositeLocal | FL::Hrrr | FL::Lightning | FL::ModelDiff => {

--- a/crates/hookecho/src/render/mod.rs
+++ b/crates/hookecho/src/render/mod.rs
@@ -124,6 +124,8 @@ pub enum FieldLayer {
     GlobalWind10m,
     /// Global model precipitable water / total precipitation.
     GlobalPrecip,
+    /// Banded precipitation from the MRMS mosaic, narrowed to snow — the snow-squall layer.
+    SnowBands,
     /// GLM flash-extent density — the recent satellite flashes gridded into a density field.
     GlmFed,
     /// One model minus another — which field, and therefore which pair, is `app.diff_field`.
@@ -154,7 +156,7 @@ impl FieldLayer {
     }
 
     /// Fixed bottom-to-top paint order within each band.
-    pub const DRAW_ORDER: [FieldLayer; 35] = [
+    pub const DRAW_ORDER: [FieldLayer; 36] = [
         // Below-radar context band (bottom to top). The global models sit at the very bottom:
         // they are the synoptic backdrop everything else is drawn against.
         FieldLayer::GlobalMslp,
@@ -173,6 +175,7 @@ impl FieldLayer {
         FieldLayer::SnowAnalysis,
         FieldLayer::PrecipType,
         // Above-radar severe-signal band.
+        FieldLayer::SnowBands,
         FieldLayer::PrecipRate,
         FieldLayer::Qpe1h,
         FieldLayer::Qpe24h,
@@ -215,6 +218,7 @@ impl FieldLayer {
             FieldLayer::Vil => "vil",
             FieldLayer::EchoTops => "echotops",
             FieldLayer::HailSwath => "hailswath",
+            FieldLayer::SnowBands => "snowbands",
             FieldLayer::Hca => "hca",
             FieldLayer::UpdraftHelicity => "updrafthelicity",
             FieldLayer::Smoke => "smoke",

--- a/crates/wxdata/src/alerts.rs
+++ b/crates/wxdata/src/alerts.rs
@@ -127,7 +127,8 @@ pub fn escalation(a: &AlertInfo) -> u8 {
     if threat.contains("DESTRUCTIVE") || threat.contains("CATASTROPHIC") || observed {
         return 2;
     }
-    if threat.contains("CONSIDERABLE") {
+    // SIGNIFICANT is the snow squall's own escalation tag — the one that sends a phone alert.
+    if threat.contains("CONSIDERABLE") || threat.contains("SIGNIFICANT") {
         return 1;
     }
     0
@@ -150,6 +151,10 @@ pub(crate) fn event_style(event: &str) -> (FeatureKind, [u8; 3]) {
         "Severe Thunderstorm Warning" => [255, 165, 0],
         "Flash Flood Warning" => [0, 200, 0],
         "Flood Warning" => [0, 160, 90],
+        // NWS's own color for the product. A snow squall is a short-fuse life-threatening
+        // warning and used to draw in the same generic red as everything else with "warning" in
+        // its name, which is the one thing it must not look like on a winter map.
+        "Snow Squall Warning" => [199, 21, 133],
         "Tornado Watch" => [255, 255, 0],
         "Severe Thunderstorm Watch" => [219, 112, 147],
         "Special Weather Statement" => [255, 228, 181],
@@ -211,7 +216,10 @@ fn build_alert(
         max_wind: param(props, "maxWindGust"),
         tornado_detection: param(props, "tornadoDetection"),
         damage_threat: param(props, "thunderstormDamageThreat")
-            .or_else(|| param(props, "tornadoDamageThreat")),
+            .or_else(|| param(props, "tornadoDamageThreat"))
+            // A snow squall's tag rides in the same field: it is the same kind of statement about
+            // the same kind of warning, and everything downstream already reads this one.
+            .or_else(|| param(props, "snowSquallImpact")),
         vtec: param(props, "VTEC"),
         source: param(props, "eventMotionDescription").or_else(|| Some("Radar indicated".into())),
         motion: param(props, "eventMotionDescription")
@@ -551,5 +559,32 @@ mod tests {
         let client = reqwest::Client::new();
         let feats = fetch_active(&client, &[(32.57, -97.30)]).await.unwrap();
         eprintln!("fetched {} alert polygons", feats.len());
+    }
+
+    #[test]
+    fn a_snow_squall_gets_its_own_color_and_its_impact_tag_escalates() {
+        let (kind, rgb) = event_style("Snow Squall Warning");
+        assert_eq!(kind, FeatureKind::Warning);
+        assert_ne!(rgb, event_style("Winter Storm Warning").1, "not generic red");
+
+        let mut a = AlertInfo {
+            id: "urn:x".into(),
+            event: "Snow Squall Warning".into(),
+            headline: String::new(),
+            area: String::new(),
+            description: String::new(),
+            instruction: String::new(),
+            expires: None,
+            max_hail_in: None,
+            max_wind: None,
+            tornado_detection: None,
+            damage_threat: Some("SIGNIFICANT".into()),
+            source: None,
+            motion: None,
+            vtec: None,
+        };
+        assert_eq!(escalation(&a), 1, "a tagged squall sorts above plain warnings");
+        a.damage_threat = None;
+        assert_eq!(escalation(&a), 0);
     }
 }

--- a/crates/wxdata/src/banding.rs
+++ b/crates/wxdata/src/banding.rs
@@ -1,0 +1,222 @@
+//! Banded precipitation: which echoes are organised into a line, and which are just area.
+//!
+//! A snow squall is a narrow, fast, intense band — the thing that whites out an interstate in two
+//! minutes — and on a national mosaic it looks much like any other patch of moderate reflectivity
+//! until you notice its shape. Shape is the whole signal, so this is a geometry pass: threshold
+//! the grid, find connected echo, and keep only the components that are long and thin.
+//!
+//! Output is an [`MrmsField`] of the same reflectivity values with everything unbanded set to
+//! `NaN`, so it draws through the existing warp/upload path with no new pipeline and reads as
+//! emphasis rather than as a separate scale.
+
+use crate::mrms::MrmsField;
+
+/// A component has to be at least this many grid cells before its shape means anything. Below it,
+/// two cells in a row look infinitely elongated.
+const MIN_CELLS: usize = 40;
+
+/// Long-axis over short-axis, from the component's second moments. Three is about where a human
+/// stops calling it a blob.
+const MIN_ELONGATION: f64 = 3.0;
+
+/// Keep the parts of `field` that belong to an elongated echo, and blank the rest.
+///
+/// `min_dbz` is what counts as echo at all. `mask` is an optional MRMS categorical grid on the
+/// same lattice (`PrecipFlag`); when given, only cells whose flag is in `keep_flags` survive,
+/// which is how "bands" narrows to "snow bands". `None` when the grid is empty.
+pub fn bands(
+    field: &MrmsField,
+    min_dbz: f32,
+    mask: Option<(&MrmsField, &[i32])>,
+) -> Option<MrmsField> {
+    if field.nx == 0 || field.ny == 0 {
+        return None;
+    }
+    let (nx, ny) = (field.nx, field.ny);
+    let masked = |i: usize| -> bool {
+        let Some((m, keep)) = mask else { return true };
+        match sample(m, field, i) {
+            Some(v) if v.is_finite() => keep.contains(&(v.round() as i32)),
+            // No flag under the cell: the categorical grid is coarser or older than the echo, and
+            // dropping the echo for that would blank the band the layer exists to show.
+            _ => true,
+        }
+    };
+    let hot: Vec<bool> = (0..nx * ny)
+        .map(|i| {
+            let v = field.values[i];
+            v.is_finite() && v >= min_dbz && masked(i)
+        })
+        .collect();
+
+    let mut values = vec![f32::NAN; nx * ny];
+    let mut seen = vec![false; nx * ny];
+    let mut stack: Vec<usize> = Vec::new();
+    let mut comp: Vec<usize> = Vec::new();
+    for start in 0..nx * ny {
+        if seen[start] || !hot[start] {
+            continue;
+        }
+        // Flood fill, iteratively: a CONUS mosaic component can be tens of thousands of cells
+        // deep, which is a stack overflow if this recurses.
+        comp.clear();
+        stack.push(start);
+        seen[start] = true;
+        while let Some(i) = stack.pop() {
+            comp.push(i);
+            let (x, y) = (i % nx, i / nx);
+            let push = |x: usize, y: usize, stack: &mut Vec<usize>, seen: &mut Vec<bool>| {
+                let j = y * nx + x;
+                if hot[j] && !seen[j] {
+                    seen[j] = true;
+                    stack.push(j);
+                }
+            };
+            if x > 0 {
+                push(x - 1, y, &mut stack, &mut seen);
+            }
+            if x + 1 < nx {
+                push(x + 1, y, &mut stack, &mut seen);
+            }
+            if y > 0 {
+                push(x, y - 1, &mut stack, &mut seen);
+            }
+            if y + 1 < ny {
+                push(x, y + 1, &mut stack, &mut seen);
+            }
+        }
+        if comp.len() < MIN_CELLS || elongation(&comp, nx) < MIN_ELONGATION {
+            continue;
+        }
+        for &i in &comp {
+            values[i] = field.values[i];
+        }
+    }
+
+    Some(MrmsField {
+        values,
+        nx,
+        ny,
+        lon_west: field.lon_west,
+        lon_east: field.lon_east,
+        lat_north: field.lat_north,
+        lat_south: field.lat_south,
+        time: field.time,
+    })
+}
+
+/// The value of `mask` under cell `i` of `field`, by lattice offset. `None` off the edge.
+fn sample(mask: &MrmsField, field: &MrmsField, i: usize) -> Option<f32> {
+    if mask.nx == 0 || mask.ny == 0 {
+        return None;
+    }
+    let (mdx, mdy) = (
+        (mask.lon_east - mask.lon_west) / mask.nx as f64,
+        (mask.lat_north - mask.lat_south) / mask.ny as f64,
+    );
+    let (dx, dy) = (
+        (field.lon_east - field.lon_west) / field.nx as f64,
+        (field.lat_north - field.lat_south) / field.ny as f64,
+    );
+    let (x, y) = (i % field.nx, i / field.nx);
+    let lon = field.lon_west + (x as f64 + 0.5) * dx;
+    let lat = field.lat_north - (y as f64 + 0.5) * dy;
+    let mx = ((lon - mask.lon_west) / mdx).floor();
+    let my = ((mask.lat_north - lat) / mdy).floor();
+    if mx < 0.0 || my < 0.0 || mx >= mask.nx as f64 || my >= mask.ny as f64 {
+        return None;
+    }
+    Some(mask.values[my as usize * mask.nx + mx as usize])
+}
+
+/// Long-axis over short-axis of a component, from its second moments. A perfect line is infinite;
+/// a disc is 1.
+fn elongation(comp: &[usize], nx: usize) -> f64 {
+    let n = comp.len() as f64;
+    let (mut sx, mut sy) = (0.0, 0.0);
+    for &i in comp {
+        sx += (i % nx) as f64;
+        sy += (i / nx) as f64;
+    }
+    let (cx, cy) = (sx / n, sy / n);
+    let (mut xx, mut yy, mut xy) = (0.0, 0.0, 0.0);
+    for &i in comp {
+        let (dx, dy) = ((i % nx) as f64 - cx, (i / nx) as f64 - cy);
+        xx += dx * dx;
+        yy += dy * dy;
+        xy += dx * dy;
+    }
+    let (xx, yy, xy) = (xx / n, yy / n, xy / n);
+    // Eigenvalues of the 2×2 covariance matrix.
+    let tr = xx + yy;
+    let det = xx * yy - xy * xy;
+    let disc = (tr * tr / 4.0 - det).max(0.0).sqrt();
+    let (l1, l2) = (tr / 2.0 + disc, tr / 2.0 - disc);
+    if l2 <= 1e-9 {
+        return f64::INFINITY;
+    }
+    (l1 / l2).sqrt()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn field(nx: usize, ny: usize, f: impl Fn(usize, usize) -> f32) -> MrmsField {
+        let mut values = Vec::with_capacity(nx * ny);
+        for y in 0..ny {
+            for x in 0..nx {
+                values.push(f(x, y));
+            }
+        }
+        MrmsField {
+            values,
+            nx,
+            ny,
+            lon_west: 0.0,
+            lon_east: nx as f64 * 0.01,
+            lat_north: 40.0,
+            lat_south: 40.0 - ny as f64 * 0.01,
+            time: chrono::Utc::now(),
+        }
+    }
+
+    #[test]
+    fn a_line_survives_and_a_blob_of_the_same_area_does_not() {
+        // A 2×40 band and, well clear of it, a 9×9 blob.
+        let f = field(60, 20, |x, y| {
+            let band = y < 2 && x < 40;
+            let blob = (5..14).contains(&y) && (48..57).contains(&x);
+            if band || blob {
+                30.0
+            } else {
+                f32::NAN
+            }
+        });
+        let b = bands(&f, 20.0, None).unwrap();
+        assert!(b.values[5].is_finite(), "the band is kept");
+        assert!(b.values[9 * 60 + 52].is_nan(), "the blob is not a band");
+    }
+
+    #[test]
+    fn echo_below_the_threshold_and_specks_are_dropped() {
+        let weak = field(60, 20, |x, y| if y < 2 && x < 40 { 10.0 } else { f32::NAN });
+        let b = bands(&weak, 20.0, None).unwrap();
+        assert!(b.values.iter().all(|v| v.is_nan()), "10 dBZ is not echo");
+
+        // Three cells in a row are infinitely elongated and still not a band.
+        let speck = field(60, 20, |x, y| if y == 0 && x < 3 { 30.0 } else { f32::NAN });
+        let b = bands(&speck, 20.0, None).unwrap();
+        assert!(b.values.iter().all(|v| v.is_nan()));
+    }
+
+    #[test]
+    fn the_categorical_mask_narrows_a_band_to_the_snow_half() {
+        let f = field(60, 20, |x, y| if y < 2 && x < 40 { 30.0 } else { f32::NAN });
+        // Flag 3 (snow) over the western half, flag 1 (rain) over the east.
+        let mask = field(60, 20, |x, _| if x < 20 { 3.0 } else { 1.0 });
+        let b = bands(&f, 20.0, Some((&mask, &[3, 4]))).unwrap();
+        assert!(b.values[5].is_finite(), "snow half kept");
+        assert!(b.values[30].is_nan(), "rain half masked out");
+    }
+}

--- a/crates/wxdata/src/lib.rs
+++ b/crates/wxdata/src/lib.rs
@@ -5,6 +5,7 @@ pub mod airnow;
 pub mod alerts;
 pub mod archive_warnings;
 pub mod aviation;
+pub mod banding;
 pub mod clock;
 pub mod contour;
 pub mod dat;


### PR DESCRIPTION
R18 wave F, item F4. Stacked on #106.

## Banding — `wxdata::banding::bands`

Pure geometry over an `MrmsField`: threshold → iterative flood fill (a CONUS component is tens of thousands of cells deep; recursion overflows) → keep components with ≥40 cells and second-moment elongation ≥3. Elongation from the covariance eigenvalues rather than a bounding box, so a diagonal band is not scored as a square.

Optional categorical mask on the same lattice (PrecipFlag 3 = snow, 4 = wet snow), sampled by lattice offset. **A cell with no flag under it is kept**, not dropped — a coarser or staler flag grid must not blank the band the layer exists to show.

Wired as `FieldLayer::SnowBands`: masked reflectivity out, existing warp/upload path, its own blue-to-white ramp so it reads as emphasis against the mosaic it was cut from. Fetches the mosaic and the flag grid together, on the 2-min MRMS cadence, only while the layer is on.

Three tests: line kept / equal-area blob rejected, weak echo and 3-cell specks rejected, mask narrows a band to its snow half.

## Emphasis

- `Snow Squall Warning` gets NWS's own product color instead of the generic warning red it shared with everything else
- `snowSquallImpact` parses into `damage_threat`, and `SIGNIFICANT` escalates to tier 1 — sorts above plain warnings, no emergency sound (tier 2+ is where that lives)

## Gate

- clippy `-D warnings`: clean
- `cargo test --workspace`: 579 passed, 29 ignored
- wasm check: clean
- `shoot.sh check`: passed
- web gzip: 4,800,645 / 4,850,000

Not field-verified: it is August, there is no snow band on the mosaic to point this at. Geometry is unit-tested; the thresholds (20 dBZ, elongation 3, 40 cells) are first estimates and want a winter event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)