### PR TITLE
feat(models): NAM 3 km nest and NBM

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -535,6 +535,20 @@ impl OverlaySource {
                         )
                         .await?
                     }
+                    // NBM's calibrated probability of thunder over the hour ending at `fh`. The
+                    // idx lists the trailing window first, so the plain var+level match already
+                    // picks that one over the run-total windows beside it.
+                    FL::ThunderProb => {
+                        wxdata::hrrr::fetch_field(
+                            http,
+                            wxdata::hrrr::Model::Nbm,
+                            "TSTM",
+                            "surface",
+                            fh.max(1),
+                            0.0,
+                        )
+                        .await?
+                    }
                     _ => {
                         wxdata::hrrr::fetch_field(
                             http,
@@ -1325,6 +1339,8 @@ fn field_refresh_secs(layer: crate::render::FieldLayer) -> u64 {
         // Two global cycles behind it, so the same half hour.
         | FL::ModelDiff => 1800,
         FL::Smoke => 900,
+        // NBM posts hourly; the blend moves no faster than that.
+        FL::ThunderProb => 900,
         // An accumulation moves slower than the grid it accumulates, whatever the window.
         FL::HailSwath => 300,
         // Environment (HRRR CAPE/SRH) refreshes slowly — 15 min.
@@ -9036,7 +9052,9 @@ impl HookEchoApp {
             | FL::ModelDiff
             | FL::GlmFed
             // Built from two grids at once, so it has a fetch block of its own.
-            | FL::SnowBands => return None,
+            | FL::SnowBands
+            // Model layers, fetched on the forecast-hour scrub rather than a product path.
+            | FL::ThunderProb => return None,
         })
     }
 
@@ -14420,7 +14438,12 @@ impl eframe::App for HookEchoApp {
             }
         }
         // HRRR rotation tracks + smoke: same forecast-hour scrub as future radar, own cadences.
-        for layer in [FL::UpdraftHelicity, FL::Smoke, FL::Snowfall] {
+        for layer in [
+            FL::UpdraftHelicity,
+            FL::Smoke,
+            FL::Snowfall,
+            FL::ThunderProb,
+        ] {
             let fh = self.hrrr_fcst_hour;
             let stale = self.fields.get(&layer).is_some_and(|s| {
                 s.show

--- a/crates/hookecho/src/app/chrome/registry.rs
+++ b/crates/hookecho/src/app/chrome/registry.rs
@@ -182,6 +182,14 @@ impl HookEchoApp {
                 false,
             ),
             (
+                FL::ThunderProb,
+                "Models",
+                "Chance of thunder (NBM)",
+                "The National Blend's calibrated probability of a thunderstorm in the hour you \
+                 have scrubbed to — a forecast, not a detection",
+                false,
+            ),
+            (
                 FL::SnowBands,
                 "National",
                 "Snow bands",

--- a/crates/hookecho/src/render/field_ramps.rs
+++ b/crates/hookecho/src/render/field_ramps.rs
@@ -491,6 +491,23 @@ static SNOW_BANDS: FieldRamp = ramp!(
     ]
 );
 
+/// Calibrated chance of a thunderstorm. A probability, so the scale is linear and the numbers on
+/// the legend are the forecast: 30 means thirty percent.
+static THUNDER_PROB: FieldRamp = ramp!(
+    "Chance of thunder",
+    "%",
+    5.0,
+    100.0,
+    RampScale::Linear,
+    150,
+    &[
+        (0.0, [70, 100, 140]),
+        (0.35, [90, 180, 190]),
+        (0.7, [240, 200, 90]),
+        (1.0, [235, 90, 70]),
+    ]
+);
+
 static PRECIP_TYPE: FieldRamp = FieldRamp {
     label: "Precip type",
     units: "",
@@ -636,6 +653,7 @@ pub fn ramp_for(layer: FieldLayer) -> Option<&'static FieldRamp> {
         FL::Hca => &HCA,
         FL::GlmFed => &GLM_FED,
         FL::SnowBands => &SNOW_BANDS,
+        FL::ThunderProb => &THUNDER_PROB,
         // Composite is reflectivity in dBZ, so like the mosaic it follows the user's own
         // reflectivity `.pal` rather than a fixed ramp of its own.
         FL::Mrms | FL::Mosaic | FL::CompositeLocal | FL::Hrrr | FL::Lightning | FL::ModelDiff => {

--- a/crates/hookecho/src/render/mod.rs
+++ b/crates/hookecho/src/render/mod.rs
@@ -126,6 +126,8 @@ pub enum FieldLayer {
     GlobalPrecip,
     /// Banded precipitation from the MRMS mosaic, narrowed to snow — the snow-squall layer.
     SnowBands,
+    /// NBM calibrated probability of thunder over the hour ending at the scrubbed forecast hour.
+    ThunderProb,
     /// GLM flash-extent density — the recent satellite flashes gridded into a density field.
     GlmFed,
     /// One model minus another — which field, and therefore which pair, is `app.diff_field`.
@@ -143,6 +145,7 @@ impl FieldLayer {
                 | FieldLayer::Cape
                 | FieldLayer::Srh
                 | FieldLayer::PrecipType
+                | FieldLayer::ThunderProb
                 | FieldLayer::Smoke
                 | FieldLayer::Snowfall
                 | FieldLayer::SnowAnalysis
@@ -156,7 +159,7 @@ impl FieldLayer {
     }
 
     /// Fixed bottom-to-top paint order within each band.
-    pub const DRAW_ORDER: [FieldLayer; 36] = [
+    pub const DRAW_ORDER: [FieldLayer; 37] = [
         // Below-radar context band (bottom to top). The global models sit at the very bottom:
         // they are the synoptic backdrop everything else is drawn against.
         FieldLayer::GlobalMslp,
@@ -174,6 +177,7 @@ impl FieldLayer {
         FieldLayer::Snowfall,
         FieldLayer::SnowAnalysis,
         FieldLayer::PrecipType,
+        FieldLayer::ThunderProb,
         // Above-radar severe-signal band.
         FieldLayer::SnowBands,
         FieldLayer::PrecipRate,
@@ -219,6 +223,7 @@ impl FieldLayer {
             FieldLayer::EchoTops => "echotops",
             FieldLayer::HailSwath => "hailswath",
             FieldLayer::SnowBands => "snowbands",
+            FieldLayer::ThunderProb => "thunderprob",
             FieldLayer::Hca => "hca",
             FieldLayer::UpdraftHelicity => "updrafthelicity",
             FieldLayer::Smoke => "smoke",

--- a/crates/hookecho/src/serve.rs
+++ b/crates/hookecho/src/serve.rs
@@ -592,6 +592,8 @@ const ALLOWED_HOSTS: &[&str] = &[
     "noaa-mrms-pds.s3.amazonaws.com",
     "noaa-hrrr-bdp-pds.s3.amazonaws.com",
     "noaa-rap-pds.s3.amazonaws.com",
+    "noaa-nam-pds.s3.amazonaws.com",
+    "noaa-nbm-grib2-pds.s3.amazonaws.com",
     "noaa-goes19.s3.amazonaws.com",
     "noaa-goes18.s3.amazonaws.com",
     "noaa-gfs-bdp-pds.s3.amazonaws.com",

--- a/crates/hookecho/src/ui/layer_options.rs
+++ b/crates/hookecho/src/ui/layer_options.rs
@@ -46,6 +46,12 @@ pub struct ChasePackUi {
     pub progress: Option<(u64, u64, u64, f64)>,
 }
 
+/// Can STP be computed from this source? It needs an LCL height, which only the HRRR surface
+/// file publishes — the RAP analysis and the NAM nest both leave it out.
+fn stp_source(model: wxdata::hrrr::Model) -> bool {
+    matches!(model, wxdata::hrrr::Model::Hrrr)
+}
+
 #[allow(clippy::too_many_arguments)] // one flat call per frame; a params struct adds churn for no reader gain
 pub(crate) fn show(
     ui: &mut egui::Ui,
@@ -265,6 +271,11 @@ pub(crate) fn show(
             .on_hover_text(
                 "RAP f00 observed analysis, 13 km grid — coarser, but what is, not what's forecast",
             );
+        ui.selectable_value(env_model, wxdata::hrrr::Model::NamNest, "NAM 3 km nest")
+            .on_hover_text(
+                "The NAM's 3 km CONUS nest — a second convection-allowing opinion on its own \
+                 dynamical core, run every six hours",
+            );
     });
     if *env_model != env_before {
         // Both sources feed CAPE/SRH and the contours; drop their clocks so the next frame refetches.
@@ -274,7 +285,7 @@ pub(crate) fn show(
             }
         }
         // STP needs an LCL height the RAP file doesn't carry (see wxdata::severe::fetch_grid).
-        if *env_model == wxdata::hrrr::Model::Rap && *contour_kind == crate::app::ContourKind::Stp {
+        if !stp_source(*env_model) && *contour_kind == crate::app::ContourKind::Stp {
             *contour_kind = crate::app::ContourKind::Off;
         }
         changed = true;
@@ -285,8 +296,8 @@ pub(crate) fn show(
         .selected_text(contour_kind.label())
         .show_ui(ui, |ui| {
             for k in crate::app::ContourKind::ALL {
-                if k == crate::app::ContourKind::Stp && *env_model == wxdata::hrrr::Model::Rap {
-                    continue; // no LCL height in the RAP analysis file
+                if k == crate::app::ContourKind::Stp && !stp_source(*env_model) {
+                    continue; // no LCL height in these files
                 }
                 ui.selectable_value(contour_kind, k, k.label());
             }

--- a/crates/wxdata/src/hrrr.rs
+++ b/crates/wxdata/src/hrrr.rs
@@ -12,6 +12,10 @@ use futures_util::StreamExt;
 
 const BUCKET: &str = "https://noaa-hrrr-bdp-pds.s3.amazonaws.com";
 const RAP_BUCKET: &str = "https://noaa-rap-pds.s3.amazonaws.com";
+const NAM_BUCKET: &str = "https://noaa-nam-pds.s3.amazonaws.com";
+/// The National Blend of Models, in GRIB2 with `.idx` sidecars. Not `noaa-nbm-pds`: that bucket
+/// republished as per-element GeoTIFF, which would need a TIFF decoder to read one field.
+const NBM_BUCKET: &str = "https://noaa-nbm-grib2-pds.s3.amazonaws.com";
 
 /// Which model to pull a field from.
 ///
@@ -27,6 +31,12 @@ pub enum Model {
     /// HRRR's pressure-level file. Not offered as a user-facing source — it exists for the
     /// effective-layer parameters, which need real columns.
     HrrrPressure,
+    /// NAM 3 km CONUS nest. A second convection-allowing opinion at HRRR's resolution, on its own
+    /// dynamical core and its own 6-hourly cycle — which is the point of having it.
+    NamNest,
+    /// National Blend of Models, CONUS domain. Statistically post-processed guidance rather than
+    /// a raw model: no updraft helicity, but the calibrated probabilities nobody else publishes.
+    Nbm,
 }
 
 impl Model {
@@ -45,6 +55,22 @@ impl Model {
             Model::Rap => {
                 format!("{RAP_BUCKET}/rap.{date}/rap.t{cycle_hour:02}z.awp130pgrbf{fh:02}.grib2")
             }
+            Model::NamNest => format!(
+                "{NAM_BUCKET}/nam.{date}/nam.t{cycle_hour:02}z.conusnest.hiresf{fh:02}.tm00.grib2"
+            ),
+            // `co` is the CONUS domain; the forecast hour is three digits here, not two.
+            Model::Nbm => format!(
+                "{NBM_BUCKET}/blend.{date}/{cycle_hour:02}/core/blend.t{cycle_hour:02}z.core.f{fh:03}.co.grib2"
+            ),
+        }
+    }
+
+    /// Hours between cycles. Walking back an hour at a time past a model that runs every six only
+    /// ever finds 404s.
+    fn cycle_hours(self) -> u32 {
+        match self {
+            Model::NamNest => 6,
+            _ => 1,
         }
     }
 
@@ -55,6 +81,9 @@ impl Model {
         match self {
             Model::Hrrr | Model::HrrrPressure => 0.04,
             Model::Rap => 0.15,
+            // The NAM nest is 3 km like the HRRR; the NBM CONUS grid is 2.5 km.
+            Model::NamNest => 0.04,
+            Model::Nbm => 0.035,
         }
     }
 
@@ -63,6 +92,8 @@ impl Model {
             Model::Hrrr => "HRRR",
             Model::HrrrPressure => "HRRR pressure",
             Model::Rap => "RAP",
+            Model::NamNest => "NAM 3 km nest",
+            Model::Nbm => "NBM",
         }
     }
 }
@@ -111,14 +142,7 @@ pub async fn fetch_field(
     let fh = fcst_hour.min(18);
     let now = Utc::now();
     let mut last_err = None;
-    for back in 1..=6 {
-        let run = (now - chrono::Duration::hours(back))
-            .with_minute(0)
-            .unwrap()
-            .with_second(0)
-            .unwrap()
-            .with_nanosecond(0)
-            .unwrap();
+    for run in recent_cycles(model, now) {
         match fetch_run_field(http, model, run, fh, var, level, min_valid).await {
             Ok(field) => {
                 return Ok(HrrrForecast {
@@ -131,6 +155,28 @@ pub async fn fetch_field(
         }
     }
     Err(last_err.unwrap_or_else(|| anyhow::anyhow!("no HRRR run found")))
+}
+
+/// The six most recent cycles of `model` that could plausibly be posted, newest first.
+///
+/// Stepping back an hour at a time is right for the hourly models and useless for the NAM nest,
+/// which runs every six: the run hour is floored onto the model's own cycle lattice first.
+pub(crate) fn recent_cycles(model: Model, now: DateTime<Utc>) -> Vec<DateTime<Utc>> {
+    let step = model.cycle_hours();
+    // One step back before the first candidate: a cycle is not on the wire the moment it is named.
+    let base = now - chrono::Duration::hours(step as i64);
+    let floored = base
+        .with_hour(base.hour() / step * step)
+        .unwrap_or(base)
+        .with_minute(0)
+        .unwrap()
+        .with_second(0)
+        .unwrap()
+        .with_nanosecond(0)
+        .unwrap();
+    (0..6)
+        .map(|i| floored - chrono::Duration::hours((i * step) as i64))
+        .collect()
 }
 
 /// How many HRRR field fetches run at once. NOMADS is a shared public service; six is brisk
@@ -171,14 +217,7 @@ pub async fn fetch_fields_one_run_capped(
         .collect();
     let now = Utc::now();
     let mut last_err = None;
-    for back in 1..=6 {
-        let run = (now - chrono::Duration::hours(back))
-            .with_minute(0)
-            .unwrap()
-            .with_second(0)
-            .unwrap()
-            .with_nanosecond(0)
-            .unwrap();
+    for run in recent_cycles(model, now) {
         let results: Vec<_> = futures_util::stream::iter(owned_specs.clone().into_iter().map(
             |(var, level, mv): (String, String, f64)| {
                 let http = http.clone();
@@ -787,5 +826,34 @@ mod tests {
         );
         let dropped = regrid(&lats, &lons, &data, Utc::now(), 0.04, -30.0).unwrap();
         assert!(dropped.values[0].is_nan(), "below-threshold dropped");
+    }
+
+    #[test]
+    fn cycle_walks_follow_each_model_s_own_run_schedule() {
+        let now = "2026-08-25T14:37:00Z".parse::<DateTime<Utc>>().unwrap();
+
+        let hrrr = recent_cycles(Model::Hrrr, now);
+        assert_eq!(hrrr[0].hour(), 13, "one hour back, on the hour");
+        assert_eq!(hrrr[1].hour(), 12);
+        assert_eq!(hrrr.len(), 6);
+
+        // The nest runs 00/06/12/18: 14:37 minus a cycle is 08:37, which floors to 06z.
+        let nam = recent_cycles(Model::NamNest, now);
+        assert_eq!(nam[0].hour(), 6);
+        assert_eq!(nam[1].hour(), 0);
+        assert_eq!(nam[2].hour(), 18, "and back into yesterday");
+        assert_eq!(nam[2].day(), 24);
+        assert!(nam.iter().all(|c| c.hour() % 6 == 0));
+    }
+
+    #[test]
+    fn the_new_sources_point_at_their_own_buckets() {
+        let nam = Model::NamNest.url("20260825", 12, 6);
+        assert!(nam.contains("noaa-nam-pds"));
+        assert!(nam.ends_with("nam.t12z.conusnest.hiresf06.tm00.grib2"));
+        // NBM forecast hours are three digits, and CONUS is the `co` domain.
+        let nbm = Model::Nbm.url("20260825", 12, 6);
+        assert!(nbm.contains("noaa-nbm-grib2-pds"));
+        assert!(nbm.ends_with("blend.t12z.core.f006.co.grib2"));
     }
 }

--- a/crates/wxdata/src/severe.rs
+++ b/crates/wxdata/src/severe.rs
@@ -91,8 +91,8 @@ pub async fn fetch_grid(
     // STP needs an LCL height, and the RAP analysis file doesn't carry the adiabatic-condensation
     // level HRRR does. Say so rather than quietly serving a different parameter.
     anyhow::ensure!(
-        !(model == hrrr::Model::Rap && kind == SevereKind::Stp),
-        "STP needs an LCL height the RAP analysis doesn't publish — use the HRRR source"
+        !(model != hrrr::Model::Hrrr && kind == SevereKind::Stp),
+        "STP needs an LCL height only the HRRR surface file publishes — use the HRRR source"
     );
     if let SevereKind::Lapse700500 | SevereKind::Lapse850500 = kind {
         return fetch_lapse_grid(http, model, kind).await;

--- a/web/_worker.js/proxy-core.js
+++ b/web/_worker.js/proxy-core.js
@@ -22,6 +22,8 @@ export const ALLOWED_HOSTS = [
   "noaa-mrms-pds.s3.amazonaws.com",
   "noaa-hrrr-bdp-pds.s3.amazonaws.com",
   "noaa-rap-pds.s3.amazonaws.com",
+  "noaa-nam-pds.s3.amazonaws.com",
+  "noaa-nbm-grib2-pds.s3.amazonaws.com",
   "noaa-goes19.s3.amazonaws.com",
   "noaa-goes18.s3.amazonaws.com",
   "noaa-gfs-bdp-pds.s3.amazonaws.com",


### PR DESCRIPTION
R18 wave G, item G1.

## NAM 3 km nest

Joins the environment-model picker beside HRRR and RAP: CAPE, SRH, contours, future radar. Different dynamical core, same resolution — a second opinion rather than more of the same.

It runs 00/06/12/18, and the old cycle walk stepped back one hour at a time, so it would have found nothing but 404s. `recent_cycles(model, now)` floors onto each model's own cycle lattice; for the hourly models the behaviour is unchanged.

## NBM

Ships as a layer, not a source: **Chance of thunder (NBM)** — the calibrated probability of a thunderstorm in the hour you have scrubbed to. Raw models do not publish that; it is what the blend is for.

Bucket note: `noaa-nbm-pds` republished as per-element **GeoTIFF**, so the plan's ".idx sidecar" assumption fails there. `noaa-nbm-grib2-pds` carries GRIB2 with `.idx` and the same hourly cycles — verified against live listings. Using the TIFF bucket would mean a TIFF decoder for one field.

The idx lists TSTM's trailing window first (`0-1`, then `2-3` before `0-3` at f003), so plain var+level matching already picks the per-hour probability over the run-total beside it. No idx-matching change needed.

## STP guard fixed

`severe::fetch_grid` refused STP for "not HRRR"… by testing `== Rap`. Adding a third source would have walked the nest into a parameter it has no LCL height for. Now it names the requirement.

## Security

`noaa-nam-pds.s3.amazonaws.com` and `noaa-nbm-grib2-pds.s3.amazonaws.com` added to **both** allowlists in the same commit; ran the CI drift check locally — allowlists match. Both keyless, GET-only, unchanged proxy semantics.

## Not in this PR: G2 (RRFS)

Gated on plan check #7, and the check says no. `noaa-rrfs-pds` holds `retro_output_final/` and `rrfs_retro_maps/` only — no operational cycles under any `rrfs*` prefix — and NOMADS returned 403 for the equivalent path from here. There is no keyless operational RRFS feed to point the existing pattern at. G4 stays fenced per the plan.

## Gate

- clippy `-D warnings`: clean
- `cargo test --workspace`: 581 passed, 29 ignored
- wasm check: clean
- `shoot.sh check`: passed
- web gzip: 4,801,128 / 4,850,000
- live URL shapes: 12z NAM nest idx and NBM core idx both 200

Not verified: no decoded grid on screen yet — today's 00z cycles were not posted when I checked (~1 h latency, which the six-cycle walk covers). The URL shapes and cycle arithmetic are tested; the first real draw is unwatched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)