### PR TITLE
feat(obs): Synoptic mesonets

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -342,6 +342,7 @@ enum OverlaySource {
         center: (f64, f64),
         tempest: String,
         wu: String,
+        synoptic: String,
     },
     /// NOAA's PPEF electric-field table.
     Ppef,
@@ -718,14 +719,17 @@ impl OverlaySource {
                 center,
                 tempest,
                 wu,
+                synoptic,
             } => {
                 // METARs come first and cost one request; the keyed networks add themselves.
                 let metars = wxdata::metar::fetch_bbox(http, bbox.0, bbox.1, bbox.2, bbox.3)
                     .await
                     .unwrap_or_default();
                 OverlayMsg::Stations(
-                    wxdata::stations::fetch_all(http, &metars, &tempest, &wu, center.0, center.1)
-                        .await,
+                    wxdata::stations::fetch_all(
+                        http, &metars, &tempest, &wu, &synoptic, center.0, center.1,
+                    )
+                    .await,
                 )
             }
             OverlaySource::Ppef => OverlayMsg::Ppef(wxdata::efield::fetch_ppef(http).await?),
@@ -7829,6 +7833,7 @@ impl HookEchoApp {
                     center: ((min_lat + max_lat) * 0.5, (min_lon + max_lon) * 0.5),
                     tempest: self.settings.tempest_token.clone(),
                     wu: self.settings.wu_key.clone(),
+                    synoptic: self.settings.synoptic_token.clone(),
                 },
             );
             if !self.settings.field_mill_url.is_empty() {

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -170,6 +170,10 @@ pub struct Settings {
     /// Weather Underground API key — adds nearby PWS stations to the live station cards.
     #[serde(default)]
     pub wu_key: String,
+    /// Synoptic Data token — adds the mesonets (state, university, DOT) to the station cards.
+    /// Held locally only, and never sent through the web build's proxy.
+    #[serde(default)]
+    pub synoptic_token: String,
     /// AirNow API key — turns on the AQI station layer. Held locally, same as the other keys.
     #[serde(default)]
     pub airnow_key: String,
@@ -1004,6 +1008,7 @@ impl Default for Settings {
             maptiler_key: String::new(),
             tempest_token: String::new(),
             wu_key: String::new(),
+            synoptic_token: String::new(),
             field_opacity: Default::default(),
             airnow_key: String::new(),
             windy_key: String::new(),
@@ -1450,6 +1455,7 @@ mod tests {
             mapbox_key: "pk.test".to_string(),
             tempest_token: String::new(),
             wu_key: String::new(),
+            synoptic_token: String::new(),
             field_opacity: Default::default(),
             airnow_key: String::new(),
             windy_key: String::new(),

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -584,6 +584,12 @@ fn basemaps_tab(ui: &mut egui::Ui, settings: &mut Settings) {
     key_field(ui, "WeatherFlow Tempest token", &mut settings.tempest_token);
     ui.add_space(8.0);
     key_field(ui, "Weather Underground API key", &mut settings.wu_key);
+    ui.add_space(8.0);
+    key_field(ui, "Synoptic Data token", &mut settings.synoptic_token);
+    ui.weak(
+        "Synoptic aggregates the mesonets \u{2014} state, university and highway-department \
+         networks. The stations actually inside the storm, rather than at the airport.",
+    );
     ui.add_space(12.0);
     ui.separator();
     ui.label("Crowd reports");

--- a/crates/wxdata/src/lib.rs
+++ b/crates/wxdata/src/lib.rs
@@ -50,6 +50,7 @@ pub mod spc;
 pub mod spoken;
 pub mod spotters;
 pub mod stations;
+pub mod synoptic;
 pub mod task;
 pub mod tds;
 pub mod tfr;

--- a/crates/wxdata/src/net.rs
+++ b/crates/wxdata/src/net.rs
@@ -26,6 +26,9 @@ pub const CORS_OK: &[&str] = &[
     "api.open-meteo.com",
     "api.mapbox.com",
     "api.maptiler.com",
+    // Same reason as the tile providers: the request carries the user's Synoptic token, and the
+    // proxy is a shared cache. Synoptic sends `Access-Control-Allow-Origin: *`, so this works.
+    "api.synopticdata.com",
     "unidata-nexrad-level2-chunks.s3.amazonaws.com",
 ];
 

--- a/crates/wxdata/src/stations.rs
+++ b/crates/wxdata/src/stations.rs
@@ -26,6 +26,8 @@ pub enum Network {
     Metar,
     Tempest,
     WeatherUnderground,
+    /// Synoptic Data's mesonet aggregation — state, university and DOT networks.
+    Synoptic,
 }
 
 impl Network {
@@ -34,6 +36,7 @@ impl Network {
             Network::Metar => "METAR",
             Network::Tempest => "Tempest",
             Network::WeatherUnderground => "Weather Underground",
+            Network::Synoptic => "Mesonet",
         }
     }
 }
@@ -364,6 +367,7 @@ pub async fn fetch_all(
     metars: &[crate::metar::SurfaceOb],
     tempest: &str,
     wu: &str,
+    synoptic: &str,
     lat: f64,
     lon: f64,
 ) -> Vec<StationOb> {
@@ -397,6 +401,14 @@ pub async fn fetch_all(
                 }
             }
             Err(e) => log::warn!("wu stations near {lat},{lon}: {e}"),
+        }
+    }
+
+    if !synoptic.is_empty() {
+        // One request for the whole circle, unlike the per-station networks above.
+        match crate::synoptic::fetch_near(client, synoptic, lat, lon, 60, 60).await {
+            Ok(obs) => out.extend(obs),
+            Err(e) => log::warn!("synoptic stations near {lat},{lon}: {e}"),
         }
     }
 
@@ -491,7 +503,7 @@ mod tests {
     async fn live_tempest_stations_report() {
         let token = std::env::var("HOOKECHO_TEMPEST_TOKEN").expect("set HOOKECHO_TEMPEST_TOKEN");
         let client = reqwest::Client::new();
-        let obs = fetch_all(&client, &[], &token, "", 33.0, -96.0).await;
+        let obs = fetch_all(&client, &[], &token, "", "", 33.0, -96.0).await;
         for o in &obs {
             println!(
                 "{} {} {:.4},{:.4} temp={:?}",
@@ -503,5 +515,21 @@ mod tests {
             );
         }
         assert!(!obs.is_empty(), "token saw no stations");
+    }
+
+    /// Live Synoptic check. `HOOKECHO_SYNOPTIC_TOKEN=... cargo test -p wxdata live_synoptic -- --ignored --nocapture`
+    #[tokio::test]
+    #[ignore]
+    async fn live_synoptic_mesonets_report() {
+        let token = std::env::var("HOOKECHO_SYNOPTIC_TOKEN").expect("set HOOKECHO_SYNOPTIC_TOKEN");
+        let client = reqwest::Client::new();
+        // Norman: as dense a mesonet as the country has.
+        let obs = crate::synoptic::fetch_near(&client, &token, 35.22, -97.44, 60, 60)
+            .await
+            .expect("synoptic answered");
+        assert!(!obs.is_empty(), "no stations came back");
+        for o in obs.iter().take(10) {
+            println!("{} {} temp={:?} gust={:?}", o.id, o.name, o.temp_c, o.gust_kt);
+        }
     }
 }

--- a/crates/wxdata/src/synoptic.rs
+++ b/crates/wxdata/src/synoptic.rs
@@ -1,0 +1,174 @@
+//! Synoptic Data's mesonet aggregation — every state, university and DOT network at once.
+//!
+//! METAR covers airports and the personal-weather networks cover back gardens; between them sit
+//! the mesonets — Oklahoma's, West Texas's, every state DOT's roadside kit — which are the
+//! stations actually inside the storm. Synoptic aggregates about thirty thousand of them behind
+//! one query.
+//!
+//! Opt-in and keyed, like Tempest and Weather Underground: empty token, no requests. The token is
+//! a user secret, so this talks to `api.synopticdata.com` **directly** on every target — the web
+//! build's CORS proxy is a shared edge cache, and a key in a cacheable URL is a key stored on
+//! someone else's disk. Synoptic sends `Access-Control-Allow-Origin: *`, so direct works.
+
+use crate::alerts::USER_AGENT;
+use crate::stations::{Network, StationOb};
+use chrono::{DateTime, Utc};
+
+const API: &str = "https://api.synopticdata.com/v2/stations/latest";
+
+/// Feet to metres — `ELEVATION` is in feet whatever the unit system asked for.
+const FT_TO_M: f32 = 0.3048;
+
+/// Parse a `/stations/latest` response into station observations.
+///
+/// Every observation lives under `OBSERVATIONS` as `{var}_value_1: {date_time, value}`, and any
+/// of them may be missing on any station — a roadside sensor that reports only temperature and
+/// wind is normal, not an error.
+pub fn parse_latest(json: &str) -> Vec<StationOb> {
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(json) else {
+        return Vec::new();
+    };
+    let Some(stations) = v.get("STATION").and_then(|s| s.as_array()) else {
+        return Vec::new();
+    };
+    stations.iter().filter_map(station).collect()
+}
+
+fn station(s: &serde_json::Value) -> Option<StationOb> {
+    let obs = s.get("OBSERVATIONS");
+    // Values arrive as numbers, but a few networks report them as strings; take either.
+    let num = |key: &str| -> Option<f32> {
+        let v = obs?.get(format!("{key}_value_1"))?.get("value")?;
+        v.as_f64()
+            .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+            .map(|x| x as f32)
+    };
+    let str_num = |key: &str| -> Option<f64> {
+        let v = s.get(key)?;
+        v.as_f64().or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+    };
+    let temp_c = num("air_temp");
+    let dewp_c = num("dew_point_temperature");
+    let time = obs
+        .and_then(|o| o.get("air_temp_value_1"))
+        .or_else(|| obs.and_then(|o| o.get("wind_speed_value_1")))
+        .and_then(|o| o.get("date_time"))
+        .and_then(|t| t.as_str())
+        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+        .map(|d| d.with_timezone(&Utc));
+    Some(StationOb {
+        id: s.get("STID")?.as_str()?.to_string(),
+        name: s
+            .get("NAME")
+            .and_then(|n| n.as_str())
+            .filter(|n| !n.is_empty())
+            .unwrap_or_else(|| s.get("STID").and_then(|x| x.as_str()).unwrap_or("Mesonet"))
+            .to_string(),
+        network: Network::Synoptic,
+        lat: str_num("LATITUDE")?,
+        lon: str_num("LONGITUDE")?,
+        time,
+        temp_c,
+        dewp_c,
+        rh_pct: num("relative_humidity").or(match (temp_c, dewp_c) {
+            (Some(t), Some(d)) => Some(crate::stations::rh_from_dewpoint(t, d)),
+            _ => None,
+        }),
+        wdir_deg: num("wind_direction"),
+        wspd_kt: num("wind_speed"),
+        gust_kt: num("wind_gust"),
+        pressure_mb: num("sea_level_pressure").or_else(|| num("pressure")),
+        precip_rate_mmh: None,
+        elev_m: str_num("ELEVATION").map(|f| f as f32 * FT_TO_M),
+    })
+}
+
+/// Stations reporting within `radius_miles` of a point, most recent observation each.
+///
+/// `limit` caps what comes back: a thirty-mile circle over the Front Range is hundreds of
+/// stations, and the cards can only show so many before they stop being readable.
+pub async fn fetch_near(
+    client: &reqwest::Client,
+    token: &str,
+    lat: f64,
+    lon: f64,
+    radius_miles: u32,
+    limit: usize,
+) -> anyhow::Result<Vec<StationOb>> {
+    anyhow::ensure!(!token.is_empty(), "no Synoptic token");
+    let radius = format!("{lat:.4},{lon:.4},{radius_miles}");
+    let body = client
+        // Deliberately not `net::fetch_url`: the token must never enter the shared proxy cache.
+        .get(API)
+        .query(&[
+            ("token", token),
+            ("radius", radius.as_str()),
+            // Anything older than half an hour is not "live" on a station card.
+            ("within", "30"),
+            ("status", "active"),
+            ("limit", &limit.to_string()),
+            (
+                "vars",
+                "air_temp,dew_point_temperature,relative_humidity,wind_speed,wind_direction,\
+                 wind_gust,sea_level_pressure",
+            ),
+            // Knots and millibars, so nothing downstream has to convert.
+            ("units", "metric,speed|kts,pres|mb"),
+        ])
+        .header("User-Agent", USER_AGENT)
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+    Ok(parse_latest(&body))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"{"STATION":[
+      {"STID":"NRMN","NAME":"Norman Mesonet","LATITUDE":"35.2362","LONGITUDE":"-97.4643",
+       "ELEVATION":"1180",
+       "OBSERVATIONS":{
+         "air_temp_value_1":{"date_time":"2026-08-25T18:05:00Z","value":31.5},
+         "dew_point_temperature_value_1":{"date_time":"2026-08-25T18:05:00Z","value":21.0},
+         "wind_speed_value_1":{"date_time":"2026-08-25T18:05:00Z","value":14.0},
+         "wind_gust_value_1":{"date_time":"2026-08-25T18:05:00Z","value":25.0},
+         "wind_direction_value_1":{"date_time":"2026-08-25T18:05:00Z","value":170}}},
+      {"STID":"ROAD","NAME":"","LATITUDE":"36.0","LONGITUDE":"-98.0","ELEVATION":"1000",
+       "OBSERVATIONS":{"wind_speed_value_1":{"date_time":"2026-08-25T18:00:00Z","value":8}}},
+      {"NAME":"no id, dropped","LATITUDE":"36.0","LONGITUDE":"-98.0"}
+    ]}"#;
+
+    #[test]
+    fn a_mesonet_station_parses_with_what_it_reports_and_nothing_it_does_not() {
+        let obs = parse_latest(SAMPLE);
+        assert_eq!(obs.len(), 2, "the station with no id is dropped");
+
+        let n = &obs[0];
+        assert_eq!(n.id, "NRMN");
+        assert_eq!(n.network, Network::Synoptic);
+        assert_eq!(n.temp_c, Some(31.5));
+        assert_eq!(n.gust_kt, Some(25.0));
+        // No humidity reported, so it comes from temperature and dewpoint.
+        assert!(n.rh_pct.is_some_and(|r| (50.0..60.0).contains(&r)));
+        // Elevation is feet on the wire whatever units were asked for.
+        assert!(n.elev_m.is_some_and(|m| (355.0..362.0).contains(&m)));
+        assert!(n.time.is_some());
+
+        // A wind-only roadside sensor is a normal station, not a parse failure.
+        let r = &obs[1];
+        assert_eq!(r.name, "ROAD", "an empty name falls back to the id");
+        assert_eq!(r.temp_c, None);
+        assert_eq!(r.wspd_kt, Some(8.0));
+        assert!(r.time.is_some(), "the timestamp can come off any variable");
+    }
+
+    #[test]
+    fn junk_and_error_responses_come_back_empty_rather_than_panicking() {
+        assert!(parse_latest("").is_empty());
+        assert!(parse_latest(r#"{"SUMMARY":{"RESPONSE_MESSAGE":"Invalid token"}}"#).is_empty());
+    }
+}


### PR DESCRIPTION
R18 wave G, item G3. Stacked on #108.

New `wxdata::synoptic` — `/v2/stations/latest` within a 60-mile circle, joining METAR/Tempest/WU in `fetch_all` as `Network::Synoptic` ("Mesonet"). One request for the whole circle, unlike the per-station keyed networks beside it.

Parsing is defensive by design: values arrive as numbers or strings depending on the network, any variable may be absent, and a station with no `STID` is dropped rather than guessed at. Humidity falls back to temperature+dewpoint; elevation is feet on the wire whatever unit system is asked for. Junk and error payloads come back empty, not panicking — two unit tests cover both, plus an `#[ignore]`d live check (`HOOKECHO_SYNOPTIC_TOKEN=… cargo test -p wxdata live_synoptic -- --ignored`).

## Security — the keyed-host rule

The token is a user secret:

- **Not** in `scripts/shots/settings.template.json` (`shoot.sh check` passes; grepped for `synoptic` — 0 hits)
- **Never proxied**: `fetch_near` skips `net::fetch_url` and hits the API directly on every target. The web proxy is a shared edge cache; a key in a cacheable URL is a key stored on someone else's disk.
- `api.synopticdata.com` added to `CORS_OK` only — grepped `serve.rs` and `proxy-core.js` for `synopticdata`: 0 hits in both. Same shape as Mapbox/MapTiler.
- Verified live: Synoptic answers `Access-Control-Allow-Origin: *`, so the browser build can go direct.
- Allowlist drift check still passes (unchanged from #108's additions).

Free tier requires a token (plan check #8): confirmed — a bogus token gets `RESPONSE_CODE 2, "Invalid request per token rules"`.

## Gate

- clippy `-D warnings`: clean
- `cargo test --workspace`: 583 passed, 30 ignored
- wasm check: clean
- `shoot.sh check`: passed
- web gzip: 4,805,959 / 4,850,000

Not verified: I have no Synoptic token, so no live payload has been through the parser. The fixture matches the documented v2 shape; the live test is written and waiting for a token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)