### PR TITLE
feat(cells): auto severity ranking

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -15433,10 +15433,17 @@ impl eframe::App for HookEchoApp {
         ) {
             self.settings.save();
         }
+        // One score per cell so the table can rank them; the join lives in wxdata.
+        let couplets: &[wxdata::rotation::CoupletHit] = match &self.couplet_cache {
+            Some((_, hits)) => hits,
+            None => &[],
+        };
+        let cell_scores = wxdata::cellscore::score_all(cells, &self.probsevere, couplets);
         if let Some(id) = ui::cells_window::show(
             &mut self.cells_window,
             ctx,
             cells,
+            &cell_scores,
             &zdr_cells,
             &self.cell_trends,
             crate::theme::accent(self.settings.theme),

--- a/crates/hookecho/src/ui/cells_window.rs
+++ b/crates/hookecho/src/ui/cells_window.rs
@@ -12,6 +12,10 @@ use wxdata::level3::Cell;
 /// Which column the table is ordered by.
 #[derive(Default, PartialEq, Clone, Copy)]
 pub enum SortCol {
+    /// The composite severity score — the default, because "which of these thirty" is the
+    /// question the table exists to answer.
+    #[default]
+    Rank,
     Id,
     Range,
     MaxDbz,
@@ -19,7 +23,6 @@ pub enum SortCol {
     Vil,
     Poh,
     Posh,
-    #[default]
     Hail,
 }
 
@@ -38,7 +41,7 @@ impl CellsWindow {
         self.open = !self.open;
         if self.open && !self.first_run {
             self.first_run = true;
-            self.sort = SortCol::Hail;
+            self.sort = SortCol::Rank;
             self.desc = true;
         }
     }
@@ -63,12 +66,24 @@ fn cmp_opt<T: PartialOrd>(a: Option<T>, b: Option<T>, desc: bool) -> std::cmp::O
     }
 }
 
+/// Green through amber to red across the score, so the top of the table reads at a glance.
+fn rank_color(score: u8) -> egui::Color32 {
+    let t = score as f32 / 100.0;
+    if t < 0.5 {
+        egui::Color32::from_rgb((60.0 + t * 2.0 * 195.0) as u8, 200, 60)
+    } else {
+        let k = (t - 0.5) * 2.0;
+        egui::Color32::from_rgb(255, (200.0 - k * 160.0) as u8, (60.0 - k * 20.0) as u8)
+    }
+}
+
 /// Order `cells` by `sort`, returning indices. Kept separate from the widget so it's testable.
-pub fn sorted_indices(cells: &[Cell], sort: SortCol, desc: bool) -> Vec<usize> {
+pub fn sorted_indices(cells: &[Cell], scores: &[u8], sort: SortCol, desc: bool) -> Vec<usize> {
     let mut idx: Vec<usize> = (0..cells.len()).collect();
     idx.sort_by(|&a, &b| {
         let (x, y) = (&cells[a], &cells[b]);
         match sort {
+            SortCol::Rank => cmp_opt(scores.get(a), scores.get(b), desc),
             SortCol::Id => {
                 let o = x.id.cmp(&y.id);
                 if desc {
@@ -91,17 +106,18 @@ pub fn sorted_indices(cells: &[Cell], sort: SortCol, desc: bool) -> Vec<usize> {
 
 /// The table as CSV, in `order` — what's on screen, in the order it's on screen. Unknowns are
 /// empty fields rather than the em dash the table draws, so a spreadsheet reads them as blanks.
-pub fn to_csv(cells: &[Cell], order: &[usize]) -> String {
+pub fn to_csv(cells: &[Cell], scores: &[u8], order: &[usize]) -> String {
     fn c<T: std::fmt::Display>(v: Option<T>) -> String {
         v.map(|x| x.to_string()).unwrap_or_default()
     }
     let mut s = String::from(
-        "id,azimuth_deg,range_nm,movement_deg,movement_kt,max_dbz,top_kft,vil,poh,posh,hail_in,tvs,meso\n",
+        "severity,id,azimuth_deg,range_nm,movement_deg,movement_kt,max_dbz,top_kft,vil,poh,posh,hail_in,tvs,meso\n",
     );
     for &i in order {
         let x = &cells[i];
         s.push_str(&format!(
-            "{},{},{},{},{},{},{},{},{},{},{},{},{}\n",
+            "{},{},{},{},{},{},{},{},{},{},{},{},{},{}\n",
+            scores.get(i).copied().unwrap_or(0),
             x.title,
             c(x.az_deg),
             c(x.range_nm),
@@ -148,10 +164,13 @@ fn position(c: &Cell) -> String {
 }
 
 /// Show the table. Returns the id of a clicked cell, if any.
+#[allow(clippy::too_many_arguments)] // one call site, flat; a params struct buys nothing
 pub fn show(
     w: &mut CellsWindow,
     ctx: &egui::Context,
     cells: &[Cell],
+    // Composite severity 0-100 per cell, parallel to `cells` (see [`wxdata::cellscore`]).
+    scores: &[u8],
     // Cell ids with a ZDR column detected near them — an updraft the storm table cannot see on
     // its own, badged next to the rotation flags it already carries.
     zdr_cells: &std::collections::HashSet<String>,
@@ -166,7 +185,7 @@ pub fn show(
     }
     let mut chosen = None;
     let mut open = w.open;
-    let order = sorted_indices(cells, w.sort, w.desc);
+    let order = sorted_indices(cells, scores, w.sort, w.desc);
     let Some(window) = drawer.page_sized(
         ctx,
         "Storm attributes",
@@ -193,7 +212,7 @@ pub fn show(
                 ui.weak("· click a row to fly there");
                 ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
                     crate::ui::csv_buttons(ui, "cells.csv", "Every row, current sort", || {
-                        to_csv(cells, &order)
+                        to_csv(cells, scores, &order)
                     });
                 });
             });
@@ -206,7 +225,8 @@ pub fn show(
                     for &i in &order {
                         let c = &cells[i];
                         let line = format!(
-                            "{}   {}   {} dBZ   hail {}\"\n{}   top {} kft   VIL {}",
+                            "{}  {}   {}   {} dBZ   hail {}\"\n{}   top {} kft   VIL {}",
+                            scores.get(i).copied().unwrap_or(0),
                             c.title,
                             position(c),
                             f0(c.max_dbz),
@@ -251,6 +271,7 @@ pub fn show(
                 TableBuilder::new(ui)
                     .striped(true)
                     .sense(egui::Sense::click())
+                    .column(Column::exact(46.0)) // rank
                     .column(Column::exact(52.0)) // id
                     .column(Column::exact(92.0)) // az/range
                     .column(Column::exact(86.0)) // movement
@@ -264,6 +285,7 @@ pub fn show(
                     .column(Column::remainder()) // flags
                     .min_scrolled_height(0.0)
                     .header(22.0, |mut h| {
+                        h.col(|ui| header(ui, "Sev", SortCol::Rank, w));
                         h.col(|ui| header(ui, "ID", SortCol::Id, w));
                         h.col(|ui| header(ui, "Pos", SortCol::Range, w));
                         h.col(|ui| {
@@ -287,7 +309,16 @@ pub fn show(
                     })
                     .body(|body| {
                         body.rows(20.0, order.len(), |mut row| {
-                            let c = &cells[order[row.index()]];
+                            let i = order[row.index()];
+                            let c = &cells[i];
+                            let score = scores.get(i).copied().unwrap_or(0);
+                            row.col(|ui| {
+                                ui.label(RichText::new(score.to_string()).strong().color(rank_color(score)))
+                                    .on_hover_text(
+                                        "Severity 0\u{2013}100: ProbSevere, rotation (Vrot) and \
+                                         hail size blended, nudged by the radar's TVS/MESO flags",
+                                    );
+                            });
                             row.col(|ui| {
                                 ui.label(RichText::new(&c.title).strong());
                             });
@@ -427,19 +458,31 @@ mod tests {
             cell("B", None, None),
             cell("C", Some(2.5), None),
         ];
-        let order = sorted_indices(&cells, SortCol::Hail, true);
+        let order = sorted_indices(&cells, &[], SortCol::Hail, true);
         assert_eq!(order, vec![2, 0, 1], "biggest hail first, unknown last");
+    }
+
+    #[test]
+    fn severity_sorts_the_table_and_a_missing_score_sinks() {
+        let cells = [
+            cell("A", Some(2.0), Some(60.0)),
+            cell("B", Some(0.2), Some(45.0)),
+            cell("C", None, None),
+        ];
+        // Only two scores for three cells: the third is unknown, and unknown sorts last either way.
+        assert_eq!(sorted_indices(&cells, &[30, 88], SortCol::Rank, true), vec![1, 0, 2]);
+        assert_eq!(sorted_indices(&cells, &[30, 88], SortCol::Rank, false), vec![0, 1, 2]);
     }
 
     #[test]
     fn csv_follows_the_table() {
         let cells = [cell("A", Some(0.5), Some(60.0)), cell("B", None, None)];
-        let order = sorted_indices(&cells, SortCol::Hail, true);
-        let csv = to_csv(&cells, &order);
+        let order = sorted_indices(&cells, &[], SortCol::Hail, true);
+        let csv = to_csv(&cells, &[71, 12], &order);
         let lines: Vec<&str> = csv.lines().collect();
-        assert!(lines[0].starts_with("id,azimuth_deg"), "header first");
-        assert!(lines[1].starts_with("A,"), "sorted order, not input order");
-        assert_eq!(lines[2], "B,,,,,,,,,,,0,0", "unknowns are empty fields");
+        assert!(lines[0].starts_with("severity,id,azimuth_deg"), "header first");
+        assert!(lines[1].starts_with("71,A,"), "sorted order, not input order");
+        assert_eq!(lines[2], "12,B,,,,,,,,,,,0,0", "unknowns are empty fields");
     }
 
     #[test]
@@ -449,14 +492,14 @@ mod tests {
             cell("B", None, None),
             cell("C", Some(2.5), None),
         ];
-        let order = sorted_indices(&cells, SortCol::Hail, false);
+        let order = sorted_indices(&cells, &[], SortCol::Hail, false);
         assert_eq!(order, vec![0, 2, 1], "smallest first, unknown still last");
     }
 
     #[test]
     fn sorts_by_id_alphabetically() {
         let cells = [cell("Q7", None, None), cell("B3", None, None)];
-        assert_eq!(sorted_indices(&cells, SortCol::Id, false), vec![1, 0]);
-        assert_eq!(sorted_indices(&cells, SortCol::Id, true), vec![0, 1]);
+        assert_eq!(sorted_indices(&cells, &[], SortCol::Id, false), vec![1, 0]);
+        assert_eq!(sorted_indices(&cells, &[], SortCol::Id, true), vec![0, 1]);
     }
 }

--- a/crates/wxdata/src/cellscore.rs
+++ b/crates/wxdata/src/cellscore.rs
@@ -1,0 +1,154 @@
+//! One number for "how bad is this storm", so a busy day sorts itself.
+//!
+//! The attributes table already lists everything the radar knows about a cell, but on a day with
+//! thirty cells on screen the question is which row to click first, and no single column answers
+//! it: the biggest hail is not always the rotating one, and the tallest top is often neither.
+//!
+//! The score blends the three things a warning decision actually rests on — the machine-learning
+//! probability of severe (ProbSevere), how hard the storm is rotating (Vrot from the client-side
+//! couplet detector), and how big the hail estimate is (MESH, which the Level 3 cell table
+//! publishes as `hail_in`) — then nudges for the radar's own TVS/MESO flags.
+//!
+//! Components that are missing are dropped and the rest renormalized, rather than counted as
+//! zero: a cell outside the ProbSevere feed's coverage is unknown there, not benign.
+
+use crate::level3::Cell;
+use crate::overlay::GeoFeature;
+use crate::rotation::CoupletHit;
+
+/// A couplet or a storm object belongs to the cell it is nearest, within this radius. Same 15 km
+/// the ZDR-column badge uses — a storm's circulation is not 15 km from its centroid.
+const CLAIM_KM: f64 = 15.0;
+
+/// Linear ramp from `lo` (0) to `hi` (100), clamped.
+fn ramp(v: f32, lo: f32, hi: f32) -> f32 {
+    (((v - lo) / (hi - lo)) * 100.0).clamp(0.0, 100.0)
+}
+
+/// Flat-earth kilometres. Distances here are tens of km, where the error is well under a percent.
+fn km(a_lon: f64, a_lat: f64, b_lon: f64, b_lat: f64) -> f64 {
+    let dy = (a_lat - b_lat) * 111.0;
+    let dx = (a_lon - b_lon) * 111.0 * b_lat.to_radians().cos();
+    (dx * dx + dy * dy).sqrt()
+}
+
+/// Composite severity 0–100 for one cell.
+///
+/// `prob_pct` is ProbSevere's dominant probability and `vrot_ms` the rotational velocity of the
+/// couplet claimed by this cell; both `None` when nothing covers the storm.
+pub fn severity(cell: &Cell, prob_pct: Option<u8>, vrot_ms: Option<f32>) -> u8 {
+    // Weights: the probability is the most informative single input, rotation and hail split the
+    // rest. Thresholds are the operational ones — 10 m/s of Vrot is noise, 40 is a strong
+    // mesocyclone; half-inch hail is the severe criterion, three inches is a destructive day.
+    let parts = [
+        (0.4, prob_pct.map(|p| p as f32)),
+        (0.3, vrot_ms.map(|v| ramp(v, 10.0, 40.0))),
+        (0.3, cell.hail_in.map(|h| ramp(h, 0.5, 3.0))),
+    ];
+    let (sum, weight) = parts
+        .iter()
+        .filter_map(|&(w, v)| v.map(|v| (w * v, w)))
+        .fold((0.0, 0.0), |(s, w), (a, b)| (s + a, w + b));
+    // Nothing to blend: fall back to reflectivity, which every cell has, so the row still ranks
+    // above an empty one instead of tying at zero.
+    let base = if weight > 0.0 {
+        sum / weight
+    } else {
+        cell.max_dbz.map(|d| ramp(d, 40.0, 70.0)).unwrap_or(0.0)
+    };
+    // The radar's own algorithm flags are weak evidence on their own and strong confirmation on
+    // top of a score, so they add rather than blend.
+    let bump = if cell.tvs.is_some() {
+        15.0
+    } else if cell.meso.is_some() {
+        8.0
+    } else {
+        0.0
+    };
+    (base + bump).clamp(0.0, 100.0).round() as u8
+}
+
+/// Score every cell, claiming the ProbSevere polygon it sits inside and the nearest couplet.
+///
+/// Kept here rather than at the call site so the join is testable and the app wiring is one line.
+pub fn score_all(cells: &[Cell], probsevere: &[GeoFeature], couplets: &[CoupletHit]) -> Vec<u8> {
+    cells
+        .iter()
+        .map(|c| {
+            let prob = crate::overlay::hit(probsevere, c.lon, c.lat).and_then(dominant_pct);
+            let vrot = couplets
+                .iter()
+                .filter(|h| km(h.lon, h.lat, c.lon, c.lat) <= CLAIM_KM)
+                .map(|h| h.vrot_ms)
+                .fold(None::<f32>, |m, v| Some(m.map_or(v, |m| m.max(v))));
+            severity(c, prob, vrot)
+        })
+        .collect()
+}
+
+/// The percentage out of a ProbSevere badge title ("Svr 78%" → 78).
+pub fn dominant_pct(f: &GeoFeature) -> Option<u8> {
+    f.title
+        .rsplit(' ')
+        .next()?
+        .strip_suffix('%')?
+        .parse::<u8>()
+        .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::level3::CellKind;
+
+    fn cell(lon: f64, lat: f64) -> Cell {
+        let mut c = Cell::new(CellKind::Storm, lon, lat, "A1".into(), "A1".into());
+        c.max_dbz = Some(55.0);
+        c
+    }
+
+    #[test]
+    fn missing_inputs_are_unknown_rather_than_zero() {
+        let mut c = cell(-97.5, 35.0);
+        c.hail_in = Some(3.0);
+        // Hail alone maxes out; adding an unknown probability must not halve it.
+        assert_eq!(severity(&c, None, None), 100);
+        // A low probability alongside it does drag the blend down.
+        assert!(severity(&c, Some(10), None) < 60);
+    }
+
+    #[test]
+    fn a_bare_cell_still_ranks_on_reflectivity_and_flags() {
+        let c = cell(-97.5, 35.0);
+        let plain = severity(&c, None, None);
+        assert_eq!(plain, 50); // 55 dBZ, halfway up the 40–70 ramp.
+        let mut tvs = cell(-97.5, 35.0);
+        tvs.tvs = Some("TVS".into());
+        assert_eq!(severity(&tvs, None, None), plain + 15);
+    }
+
+    #[test]
+    fn the_join_claims_the_polygon_it_sits_in_and_the_couplet_beside_it() {
+        let cells = [cell(-97.45, 35.05), cell(-90.0, 40.0)];
+        let feats = crate::probsevere::parse_probsevere(
+            r#"{"type":"FeatureCollection","features":[
+                {"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[-97.5,35.0],[-97.4,35.0],[-97.4,35.1],[-97.5,35.1],[-97.5,35.0]]]},
+                 "properties":{"ID":"1","ProbSevere":"90","ProbTor":"5","ProbHail":"10","ProbWind":"20"}}]}"#,
+        )
+        .unwrap();
+        let couplets = [CoupletHit {
+            lon: -97.44,
+            lat: 35.06,
+            vrot_ms: 40.0,
+            g2g_ms: 80.0,
+            range_km: 30.0,
+            gates: 6,
+        }];
+        let s = score_all(&cells, &feats, &couplets);
+        // Inside the polygon and next to the couplet: 90% at weight 0.4 and a maxed Vrot ramp at
+        // 0.3, renormalized over the two present components.
+        assert_eq!(s[0], 94);
+        // Six hundred km away, neither claims it — reflectivity only.
+        assert_eq!(s[1], 50);
+    }
+}

--- a/crates/wxdata/src/level3.rs
+++ b/crates/wxdata/src/level3.rs
@@ -79,7 +79,7 @@ pub struct Cell {
 }
 
 impl Cell {
-    fn new(kind: CellKind, lon: f64, lat: f64, id: String, title: String) -> Self {
+    pub(crate) fn new(kind: CellKind, lon: f64, lat: f64, id: String, title: String) -> Self {
         Cell {
             kind,
             lon,

--- a/crates/wxdata/src/lib.rs
+++ b/crates/wxdata/src/lib.rs
@@ -6,6 +6,7 @@ pub mod alerts;
 pub mod archive_warnings;
 pub mod aviation;
 pub mod banding;
+pub mod cellscore;
 pub mod clock;
 pub mod contour;
 pub mod dat;


### PR DESCRIPTION
H1 of wave H.

## What

One composite score per storm cell, 0–100, so the attributes table answers "which of these thirty" instead of making you sort by each column in turn.

New `wxdata::cellscore`:

- `severity(cell, prob_pct, vrot_ms)` — weighted blend of ProbSevere's dominant probability (0.4), Vrot ramped 10→40 m/s (0.3), and MESH `hail_in` ramped 0.5→3.0 in (0.3). Missing components drop out and the remaining weights renormalize, so an unknown never reads as a zero. Nothing at all present falls back to reflectivity on a 40–70 dBZ ramp. TVS adds 15, MESO 8, clamped at 100.
- `score_all(cells, probsevere, couplets)` — the join: `overlay::hit` for the polygon the cell sits inside, strongest couplet within 15 km for Vrot (the same radius the ZDR-column badge already claims with). Kept in wxdata so it is testable and the app wiring stays one line.

Table changes: new leading **Sev** column, green→amber→red, the default sort on open, first field in the CSV export. Android's button-list rows lead with the score too.

## Notes

- ProbSevere's percentage is read back off the badge title (`"Svr 78%"`), which the parser already builds — no second parse of the feed.
- `Cell::new` became `pub(crate)` so the score tests can build fixtures.
- `show` picked up an `#[allow(clippy::too_many_arguments)]`, matching the note already on `layer_options` and `layers_panel`.

## Gate

- clippy `-D warnings` clean
- 587 passed / 30 ignored / 0 failed
- wasm check clean
- `shoot.sh check` passed
- web gzip 4,806,941 / 4,850,000

Not device-verified: no live ProbSevere/couplet pair has been on screen for this build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)