### PR TITLE
feat(cells): tap a cell, see it in 3D

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -15461,6 +15461,7 @@ impl eframe::App for HookEchoApp {
                 self.cell_popup = Some(c);
             }
         }
+        let mut open_3d: Option<[f32; 6]> = None;
         if let Some(cell) = &self.cell_popup {
             let trend = self
                 .cell_trends
@@ -15471,8 +15472,26 @@ impl eframe::App for HookEchoApp {
                 .follow_cell
                 .as_ref()
                 .is_some_and(|(_, c, _)| c.id == cell.id);
-            let (open, toggled) =
+            let (open, toggled, to_3d) =
                 ui::cell_window::show(ctx, cell, trend, following, &mut self.popovers);
+            // Crop the volume to this storm before opening it: the full 300 km box is a wall of
+            // echo you would then have to hunt through by hand. The clip is computed here, where
+            // the cell is still borrowed, and applied below.
+            if to_3d {
+                open_3d = Some(
+                    self.views[self.active]
+                        .site
+                        .as_deref()
+                        .and_then(wxdata::sites::site_by_id)
+                        .map(|site| {
+                            let (slat, slon) = (site.latitude as f64, site.longitude as f64);
+                            let dy = ((cell.lat - slat) * 111.0) as f32;
+                            let dx = ((cell.lon - slon) * 111.0 * slat.to_radians().cos()) as f32;
+                            wxdata::volume3d::clip_around(150.0, dx, dy, 30.0)
+                        })
+                        .unwrap_or([0.0, 1.0, 0.0, 1.0, 0.0, 1.0]),
+                );
+            }
             if toggled {
                 if following {
                     self.follow_cell = None;
@@ -15484,6 +15503,10 @@ impl eframe::App for HookEchoApp {
             if !open {
                 self.cell_popup = None;
             }
+        }
+        if let Some(clip) = open_3d {
+            self.vol3d.clip = clip;
+            self.build_volume3d();
         }
         if let Some(i) = self.marker_popup {
             match self.settings.markers.get_mut(i) {

--- a/crates/hookecho/src/ui/cell_window.rs
+++ b/crates/hookecho/src/ui/cell_window.rs
@@ -16,16 +16,18 @@ pub struct CellSample {
 
 /// Show the storm-attributes window. `trend` is the cell's per-volume history (oldest→newest);
 /// `following` reflects whether the camera is currently tracking this cell. Returns
-/// `(still_open, follow_toggled)` — `follow_toggled` is `true` the frame the Follow button is hit.
+/// `(still_open, follow_toggled, to_3d)` — the two flags are `true` for the one frame their
+/// button is hit.
 pub fn show(
     ctx: &egui::Context,
     cell: &Cell,
     trend: &[CellSample],
     following: bool,
     popovers: &mut crate::ui::popover::Popovers,
-) -> (bool, bool) {
+) -> (bool, bool, bool) {
     let mut open = true;
     let mut follow_toggled = false;
+    let mut to_3d = false;
     popovers
         .card(
             ctx,
@@ -49,6 +51,19 @@ pub fn show(
                     .clicked()
                 {
                     follow_toggled = true;
+                }
+                if ui
+                    .add(
+                        egui::Button::new("\u{25A6} See in 3D")
+                            .min_size(egui::vec2(ui.available_width(), 0.0)),
+                    )
+                    .on_hover_text(
+                        "Open the raymarched volume cropped to this storm \u{2014} the whole box \
+                         at once is a wall of echo you then have to hunt through",
+                    )
+                    .clicked()
+                {
+                    to_3d = true;
                 }
                 theme::section(ui, "Current Position", |ui| {
                     grid(
@@ -154,7 +169,7 @@ pub fn show(
                 }
             });
         });
-    (open, follow_toggled)
+    (open, follow_toggled, to_3d)
 }
 
 /// A labelled trend sparkline over the samples that carry the selected field.

--- a/crates/wxdata/src/volume3d.rs
+++ b/crates/wxdata/src/volume3d.rs
@@ -157,6 +157,31 @@ pub fn cappi(sweeps: &[BinnedSweep], alt_km: f32, n: usize, half_km: f32) -> Opt
     })
 }
 
+/// Clip slab that isolates one storm inside the volume box, in the `[x0, x1, y0, y1, z0, z1]`
+/// fractions [`crate::volume3d`]'s consumers use.
+///
+/// `dx_km`/`dy_km` are the storm's offset east and north of the radar, `pad_km` the half-width to
+/// keep around it. The vertical span is left alone: the whole point of looking at a storm in 3D is
+/// its depth, so cropping height would throw away the answer.
+pub fn clip_around(half_km: f32, dx_km: f32, dy_km: f32, pad_km: f32) -> [f32; 6] {
+    // The box spans [-half_km, +half_km] in x and y, mapped onto 0..1.
+    let frac = |km: f32| ((km + half_km) / (2.0 * half_km)).clamp(0.0, 1.0);
+    let pad = (pad_km / (2.0 * half_km)).clamp(0.0, 0.5);
+    let span = |c: f32| {
+        let (mut lo, mut hi) = (c - pad, c + pad);
+        // A storm near the edge of the box slides its window inward rather than shrinking it.
+        if lo < 0.0 {
+            (lo, hi) = (0.0, (2.0 * pad).min(1.0));
+        } else if hi > 1.0 {
+            (lo, hi) = ((1.0 - 2.0 * pad).max(0.0), 1.0);
+        }
+        (lo, hi)
+    };
+    let (x0, x1) = span(frac(dx_km));
+    let (y0, y1) = span(frac(dy_km));
+    [x0, x1, y0, y1, 0.0, 1.0]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -229,5 +254,27 @@ mod tests {
             0,
             "14 km empty"
         );
+    }
+}
+
+#[cfg(test)]
+mod clip_tests {
+    use super::clip_around;
+
+    #[test]
+    fn the_slab_brackets_the_storm_and_slides_in_at_the_edge() {
+        // Dead center of a 150 km box, 25 km of padding: an eighth of the box either side.
+        let c = clip_around(150.0, 0.0, 0.0, 25.0);
+        assert!((c[0] - 0.4167).abs() < 1e-3 && (c[1] - 0.5833).abs() < 1e-3);
+        // Height is never cropped.
+        assert_eq!([c[4], c[5]], [0.0, 1.0]);
+        // Hard against the west wall: the window slides inward instead of collapsing.
+        let w = clip_around(150.0, -150.0, 0.0, 25.0);
+        assert_eq!(w[0], 0.0);
+        assert!((w[1] - w[0] - (c[1] - c[0])).abs() < 1e-3);
+        // And against the north wall.
+        let n = clip_around(150.0, 0.0, 150.0, 25.0);
+        assert_eq!(n[3], 1.0);
+        assert!((n[3] - n[2] - (c[1] - c[0])).abs() < 1e-3);
     }
 }


### PR DESCRIPTION
H2 of wave H. Stacked on #110.

## What

The storm-attributes popup gains **See in 3D**: opens the raymarched volume already cropped to that cell.

New `wxdata::volume3d::clip_around(half_km, dx_km, dy_km, pad_km)` maps the storm's offset from the radar onto the `[x0, x1, y0, y1, z0, z1]` fractions the clip sliders already use. A storm against the edge of the box slides its window inward rather than shrinking it, so the crop is the same size wherever the storm is. The vertical span is left at full: depth is the reason to look at a storm in 3D.

The app computes the clip while the cell is still borrowed and applies it after the popup block — `build_volume3d` takes `&mut self`.

## Notes

- No new camera state: the existing `Volume3dState.clip` is what the sliders read, so the crop is visible and adjustable the moment the window opens.
- Falls back to the uncropped box when the pane has no resolvable site.

## Gate

- clippy `-D warnings` clean
- 588 passed / 30 ignored / 0 failed
- wasm check clean
- `shoot.sh check` passed
- web gzip 4,807,475 / 4,850,000

Not device-verified: the button has not been pressed against a live volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)