### PR TITLE
feat(workspace): per-pane thresholds and field layers

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1389,7 +1389,6 @@ type ZdrCache = (
 /// Per-field-layer UI + fetch state (toggle, pending upload, refresh clock).
 #[derive(Default)]
 pub(crate) struct FieldState {
-    pub show: bool,
     pub pending: Option<crate::render::MrmsUpload>,
     pub last_fetch: Option<Instant>,
 }
@@ -3487,7 +3486,7 @@ impl HookEchoApp {
         /// Bit positions in the mask for the two hail grids.
         const HAIL_BITS: u8 = 0b11000;
         let mask = LAYERS.iter().enumerate().fold(0u8, |m, (i, l)| {
-            m | u8::from(self.fields.get(l).is_some_and(|s| s.show)) << i
+            m | u8::from(self.field_wanted(*l)) << i
         });
         if mask == 0 {
             self.derived_key = None;
@@ -4696,16 +4695,12 @@ impl HookEchoApp {
         match self.views[self.active].timeline.forecast_hour() {
             Some(h) => {
                 self.hrrr_fcst_hour = h;
-                if let Some(s) = self.fields.get_mut(&FL::Hrrr) {
-                    s.show = true;
-                }
+                self.views[self.active].fields_on.insert(FL::Hrrr);
                 self.hrrr_by_timeline = true;
             }
             None => {
                 if self.hrrr_by_timeline {
-                    if let Some(s) = self.fields.get_mut(&FL::Hrrr) {
-                        s.show = false;
-                    }
+                    self.views[self.active].fields_on.remove(&FL::Hrrr);
                     self.hrrr_by_timeline = false;
                 }
             }
@@ -6940,6 +6935,22 @@ impl HookEchoApp {
 
     /// The boolean behind an [`OverlayToggle`]. One place to resolve a named toggle so the
     /// layers panel, command palette, and mobile sheet never drift apart.
+    /// Does any pane want this field layer? The grids are fetched once and shared, so one pane
+    /// asking is enough to keep the download alive.
+    fn field_wanted(&self, layer: crate::render::FieldLayer) -> bool {
+        self.views.iter().any(|v| v.fields_on.contains(&layer))
+    }
+
+    /// Turn a field layer on or off in the active pane.
+    fn set_field(&mut self, layer: crate::render::FieldLayer, on: bool) {
+        let set = &mut self.views[self.active].fields_on;
+        if on {
+            set.insert(layer);
+        } else {
+            set.remove(&layer);
+        }
+    }
+
     fn overlay_flag(&mut self, t: OverlayToggle) -> &mut bool {
         use OverlayToggle as T;
         match t {
@@ -6995,9 +7006,10 @@ impl HookEchoApp {
                 }
             }
             PaletteAction::ToggleField(layer) => {
-                if let Some(s) = self.fields.get_mut(&layer) {
-                    s.show = !s.show;
-                }
+                // The active pane's choice, not the app's: that is what makes two panes able to
+                // show two fields.
+                let on = self.views[self.active].fields_on.contains(&layer);
+                self.set_field(layer, !on);
             }
             PaletteAction::ToggleOverlay(t) => {
                 let f = self.overlay_flag(t);
@@ -7107,11 +7119,7 @@ impl HookEchoApp {
                 // branch dead code and always land people on the same Windy page.
                 let overlay = if self.show_wind {
                     "wind"
-                } else if self
-                    .fields
-                    .get(&crate::render::FieldLayer::Cape)
-                    .is_some_and(|s| s.show)
-                {
+                } else if self.field_wanted(crate::render::FieldLayer::Cape) {
                     "cape"
                 } else if v.basemap.slug().starts_with("goes") {
                     "satellite"
@@ -7674,7 +7682,7 @@ impl HookEchoApp {
 
     fn sync_mosaic(&mut self, ctx: &egui::Context) {
         use crate::render::FieldLayer as FL;
-        if !self.fields.get(&FL::Mosaic).is_some_and(|s| s.show) {
+        if !self.field_wanted(FL::Mosaic) {
             return;
         }
         if !self.views[self.active].timeline.following {
@@ -10360,11 +10368,10 @@ impl HookEchoApp {
         } else {
             Vec::new()
         };
-        let field_draws: Vec<(crate::render::FieldLayer, f32)> = self
-            .fields
+        let field_draws: Vec<(crate::render::FieldLayer, f32)> = self.views[idx]
+            .fields_on
             .iter()
-            .filter(|(_, s)| s.show)
-            .map(|(k, _)| {
+            .map(|k| {
                 (
                     *k,
                     self.settings.field_opacity.get(k).copied().unwrap_or(1.0),
@@ -11990,12 +11997,7 @@ impl HookEchoApp {
         }
 
         // HRRR "future radar" banner — unmistakable that this is model forecast, not observation.
-        if idx == self.active
-            && self
-                .fields
-                .get(&crate::render::FieldLayer::Hrrr)
-                .is_some_and(|s| s.show)
-        {
+        if idx == self.active && view.fields_on.contains(&crate::render::FieldLayer::Hrrr) {
             let valid = self
                 .hrrr_valid
                 .map(|v| crate::timefmt::fmt_date_clock(v, self.active_tz()))
@@ -12076,11 +12078,7 @@ impl HookEchoApp {
 
         // The difference layer reads as "they disagree here" and nothing more without a number,
         // so the cursor samples the grid it was drawn from.
-        if self
-            .fields
-            .get(&crate::render::FieldLayer::ModelDiff)
-            .is_some_and(|s| s.show)
-        {
+        if view.fields_on.contains(&crate::render::FieldLayer::ModelDiff) {
             if let (Some(grid), Some(hp)) = (self.diff_grid.as_ref(), response.hover_pos()) {
                 let w = cam.screen_to_world((hp.x - prect.left(), hp.y - prect.top()), vp);
                 let (lon, lat) = crate::render::mercator::world_to_lonlat(w.0, w.1);
@@ -12537,7 +12535,7 @@ impl HookEchoApp {
             if let Some(top) = crate::render::FieldLayer::DRAW_ORDER
                 .iter()
                 .rev()
-                .find(|l| self.fields.get(l).is_some_and(|s| s.show))
+                .find(|l| view.fields_on.contains(l))
             {
                 y += if *top == crate::render::FieldLayer::ModelDiff {
                     ui::legend::draw_diff(&painter, prect, self.diff_field, y)
@@ -12676,11 +12674,12 @@ impl HookEchoApp {
             // A workspace you saved records the sites you had open; only the shipped starters
             // adopt whatever is on screen.
             adopt_site: false,
-            fields_on: self
-                .fields
+            // The workspace-wide list stays as the union across panes: it is what an older build
+            // reads, and what a pane snapshot written before per-pane layers falls back to.
+            fields_on: crate::render::FieldLayer::DRAW_ORDER
                 .iter()
-                .filter(|(_, st)| st.show)
-                .map(|(l, _)| l.slug().to_string())
+                .filter(|l| self.field_wanted(**l))
+                .map(|l| l.slug().to_string())
                 .collect(),
             chrome: Some(self.capture_chrome()),
         }
@@ -12719,8 +12718,19 @@ impl HookEchoApp {
         }
         // Same rule for the national field layers: an unknown slug is a layer this build
         // doesn't have, which is a thing to skip rather than an error.
-        for (layer, st) in self.fields.iter_mut() {
-            st.show = ws.fields_on.iter().any(|s| s == layer.slug());
+        for (v, snap) in self.views.iter_mut().zip(&ws.panes) {
+            // A pane snapshot written before per-pane layers existed carries none, and falls back
+            // to the workspace-wide list so an old file still restores what it meant.
+            let list = if snap.fields_on.is_empty() {
+                &ws.fields_on
+            } else {
+                &snap.fields_on
+            };
+            v.fields_on = crate::render::FieldLayer::DRAW_ORDER
+                .iter()
+                .copied()
+                .filter(|l| list.iter().any(|s| s == l.slug()))
+                .collect();
         }
         if let Some(c) = &ws.chrome {
             self.apply_chrome(c, ctx);
@@ -14353,7 +14363,7 @@ impl eframe::App for HookEchoApp {
             };
             // The reflectivity tint reads the precipitation-type grid whether or not that
             // layer is being drawn, so wanting the tint counts as wanting the layer's data.
-            let wanted = self.fields.get(&layer).is_some_and(|s| s.show)
+            let wanted = self.field_wanted(layer)
                 || (layer == FL::PrecipType && self.settings.precip_tint);
             let stale = wanted
                 && self.fields.get(&layer).is_none_or(|s| {
@@ -14368,11 +14378,11 @@ impl eframe::App for HookEchoApp {
         // Snow bands: the mosaic and the precipitation-type grid, cut to the banded snow.
         {
             let layer = FL::SnowBands;
-            let stale = self.fields.get(&layer).is_some_and(|s| {
-                s.show
-                    && s.last_fetch
+            let stale = self.field_wanted(layer)
+                && self.fields.get(&layer).is_none_or(|s| {
+                    s.last_fetch
                         .is_none_or(|t| t.elapsed().as_secs() >= field_refresh_secs(layer))
-            });
+                });
             if stale {
                 if let Some(s) = self.fields.get_mut(&layer) {
                     s.last_fetch = Some(Instant::now());
@@ -14382,11 +14392,11 @@ impl eframe::App for HookEchoApp {
         }
         // Environment suite (HRRR CAPE/SRH): fetch each enabled layer at f00, refresh ~15 min.
         for layer in [FL::Cape, FL::Srh] {
-            let stale = self.fields.get(&layer).is_some_and(|s| {
-                s.show
-                    && s.last_fetch
+            let stale = self.field_wanted(layer)
+                && self.fields.get(&layer).is_none_or(|s| {
+                    s.last_fetch
                         .is_none_or(|t| t.elapsed().as_secs() >= field_refresh_secs(layer))
-            });
+                });
             if stale {
                 if let Some(s) = self.fields.get_mut(&layer) {
                     s.last_fetch = Some(Instant::now());
@@ -14407,7 +14417,7 @@ impl eframe::App for HookEchoApp {
         ] {
             let fh = self.global_fcst_hour;
             let model = self.global_model;
-            let on = self.fields.get(&layer).is_some_and(|s| s.show);
+            let on = self.field_wanted(layer);
             let stale = on
                 && self.fields.get(&layer).is_some_and(|s| {
                     s.last_fetch
@@ -14427,7 +14437,7 @@ impl eframe::App for HookEchoApp {
         {
             let layer = FL::ModelDiff;
             let fh = self.global_fcst_hour;
-            let on = self.fields.get(&layer).is_some_and(|s| s.show);
+            let on = self.field_wanted(layer);
             let stale = on
                 && self.fields.get(&layer).is_some_and(|s| {
                     s.last_fetch
@@ -14450,14 +14460,14 @@ impl eframe::App for HookEchoApp {
             FL::ThunderProb,
         ] {
             let fh = self.hrrr_fcst_hour;
-            let stale = self.fields.get(&layer).is_some_and(|s| {
-                s.show
-                    && s.last_fetch
+            let stale = self.field_wanted(layer)
+                && self.fields.get(&layer).is_none_or(|s| {
+                    s.last_fetch
                         .is_none_or(|t| t.elapsed().as_secs() >= field_refresh_secs(layer))
-            });
+                });
             // Scrubbing the forecast tail must refetch immediately, not wait out the cadence.
-            let hour_changed = self.fields.get(&layer).is_some_and(|s| s.show)
-                && self.hrrr_layer_hour.get(&layer) != Some(&fh);
+            let hour_changed =
+                self.field_wanted(layer) && self.hrrr_layer_hour.get(&layer) != Some(&fh);
             if stale || hour_changed {
                 if let Some(s) = self.fields.get_mut(&layer) {
                     s.last_fetch = Some(Instant::now());
@@ -14483,7 +14493,7 @@ impl eframe::App for HookEchoApp {
 
         // GOES lightning: granules land every 20 s, so poll about that often. One in flight at a
         // time — a slow fetch must not queue up behind itself.
-        let glm_fed_on = self.fields.get(&FL::GlmFed).is_some_and(|s| s.show);
+        let glm_fed_on = self.field_wanted(FL::GlmFed);
         // A lightning-density rule needs the flashes polled and the grid built even with the
         // layer off, exactly like the scan signatures.
         let glm_rule_armed = self.settings.alert_rules.iter().any(|r| {
@@ -14622,7 +14632,7 @@ impl eframe::App for HookEchoApp {
         // Observed snowfall analysis: its own block because the accumulation window is a knob,
         // and changing it must refetch at once rather than wait out the cadence.
         {
-            let on = self.fields.get(&FL::SnowAnalysis).is_some_and(|s| s.show);
+            let on = self.field_wanted(FL::SnowAnalysis);
             let stale = self.fields.get(&FL::SnowAnalysis).is_some_and(|s| {
                 s.last_fetch
                     .is_none_or(|t| t.elapsed().as_secs() >= field_refresh_secs(FL::SnowAnalysis))
@@ -14665,7 +14675,7 @@ impl eframe::App for HookEchoApp {
         let l3_site = self.views[self.active].site.clone();
         let site_changed = self.l3grid_site != l3_site;
         for layer in [FL::Vil, FL::EchoTops, FL::Hca] {
-            let on = self.fields.get(&layer).is_some_and(|s| s.show);
+            let on = self.field_wanted(layer);
             if !on {
                 continue;
             }
@@ -14685,13 +14695,13 @@ impl eframe::App for HookEchoApp {
         if site_changed
             && [FL::Vil, FL::EchoTops, FL::Hca]
                 .iter()
-                .any(|l| self.fields.get(l).is_some_and(|s| s.show))
+                .any(|l| self.field_wanted(*l))
         {
             self.l3grid_site = l3_site;
         }
         // HRRR future radar: fetch when enabled and the forecast hour changed or the run refreshed
         // (~10-min throttle; a new run posts hourly).
-        let hrrr_on = self.fields.get(&FL::Hrrr).is_some_and(|s| s.show);
+        let hrrr_on = self.field_wanted(FL::Hrrr);
         if hrrr_on {
             let hour_changed = self.hrrr_fetched_hour != Some(self.hrrr_fcst_hour);
             let stale = self
@@ -15038,7 +15048,7 @@ impl eframe::App for HookEchoApp {
         let active_fields: Vec<(crate::render::FieldLayer, String)> =
             crate::render::FieldLayer::DRAW_ORDER
                 .into_iter()
-                .filter(|l| self.fields.get(l).is_some_and(|s| s.show))
+                .filter(|l| self.field_wanted(*l))
                 .map(|l| {
                     let name = names.get(&l).cloned().unwrap_or_else(|| format!("{l:?}"));
                     (l, name)

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -15461,6 +15461,7 @@ impl eframe::App for HookEchoApp {
                 self.cell_popup = Some(c);
             }
         }
+        let mut open_3d: Option<[f32; 6]> = None;
         if let Some(cell) = &self.cell_popup {
             let trend = self
                 .cell_trends
@@ -15471,8 +15472,26 @@ impl eframe::App for HookEchoApp {
                 .follow_cell
                 .as_ref()
                 .is_some_and(|(_, c, _)| c.id == cell.id);
-            let (open, toggled) =
+            let (open, toggled, to_3d) =
                 ui::cell_window::show(ctx, cell, trend, following, &mut self.popovers);
+            // Crop the volume to this storm before opening it: the full 300 km box is a wall of
+            // echo you would then have to hunt through by hand. The clip is computed here, where
+            // the cell is still borrowed, and applied below.
+            if to_3d {
+                open_3d = Some(
+                    self.views[self.active]
+                        .site
+                        .as_deref()
+                        .and_then(wxdata::sites::site_by_id)
+                        .map(|site| {
+                            let (slat, slon) = (site.latitude as f64, site.longitude as f64);
+                            let dy = ((cell.lat - slat) * 111.0) as f32;
+                            let dx = ((cell.lon - slon) * 111.0 * slat.to_radians().cos()) as f32;
+                            wxdata::volume3d::clip_around(150.0, dx, dy, 30.0)
+                        })
+                        .unwrap_or([0.0, 1.0, 0.0, 1.0, 0.0, 1.0]),
+                );
+            }
             if toggled {
                 if following {
                     self.follow_cell = None;
@@ -15484,6 +15503,10 @@ impl eframe::App for HookEchoApp {
             if !open {
                 self.cell_popup = None;
             }
+        }
+        if let Some(clip) = open_3d {
+            self.vol3d.clip = clip;
+            self.build_volume3d();
         }
         if let Some(i) = self.marker_popup {
             match self.settings.markers.get_mut(i) {

--- a/crates/hookecho/src/app/chrome/overlay.rs
+++ b/crates/hookecho/src/app/chrome/overlay.rs
@@ -175,14 +175,14 @@ impl HookEchoApp {
                                 .default_open(false)
                                 .show(ui, |ui| {
                                     let glm_options = self.show_glm
-                                        || self
-                                            .fields
-                                            .get(&crate::render::FieldLayer::GlmFed)
-                                            .is_some_and(|s| s.show);
+                                        || self.views[self.active]
+                                            .fields_on
+                                            .contains(&crate::render::FieldLayer::GlmFed);
                                     crate::ui::layer_options::show(
                                         ui,
                                         &mut self.filters,
                                         &mut self.fields,
+                                        &self.views[self.active].fields_on.clone(),
                                         &mut self.rotation_minutes,
                                         &mut self.hail_minutes,
                                         &mut self.hrrr_fcst_hour,

--- a/crates/hookecho/src/app/chrome/registry.rs
+++ b/crates/hookecho/src/app/chrome/registry.rs
@@ -359,7 +359,7 @@ impl HookEchoApp {
                 false,
             ),
         ] {
-            let on = self.fields.get(&layer).is_some_and(|s| s.show);
+            let on = self.views[self.active].fields_on.contains(&layer);
             push(
                 label,
                 category,

--- a/crates/hookecho/src/app/mobile/mod.rs
+++ b/crates/hookecho/src/app/mobile/mod.rs
@@ -279,7 +279,7 @@ impl super::HookEchoApp {
             if let Some(top) = crate::render::FieldLayer::DRAW_ORDER
                 .iter()
                 .rev()
-                .find(|l| self.fields.get(l).is_some_and(|s| s.show))
+                .find(|l| self.views[self.active].fields_on.contains(l))
             {
                 paint_field_strip(&painter, strip.translate(vec2(0.0, 11.0)), *top);
             }

--- a/crates/hookecho/src/render/mod.rs
+++ b/crates/hookecho/src/render/mod.rs
@@ -411,6 +411,9 @@ struct PaneGpu {
     vector_over_raster: bool,
     frame_draw_radar: bool,
     frame_draw_overlay: bool,
+    /// Field layers this pane draws this frame. Per-pane, not shared: two panes are how you look
+    /// at two fields at once.
+    field_draws: Vec<FieldLayer>,
 }
 
 /// Long-lived GPU resources, stored in egui's `CallbackResources` type-map.
@@ -434,7 +437,6 @@ pub struct RenderResources {
     vector_tiles: HashMap<TileId, OverlayGpu>,
     overlay: Option<OverlayGpu>,
     fields: HashMap<FieldLayer, MrmsGpu>,
-    field_draws: Vec<FieldLayer>,
     // One entry per live pane.
     panes: HashMap<u32, PaneGpu>,
     /// GPU wind particles, built on first use. `None` when the CPU path is in charge.
@@ -692,7 +694,6 @@ impl RenderResources {
             vector_tiles: HashMap::new(),
             overlay: None,
             fields: HashMap::new(),
-            field_draws: Vec::new(),
             panes: HashMap::new(),
             wind: None,
             target_format,
@@ -740,6 +741,7 @@ impl RenderResources {
                 vector_over_raster: false,
                 frame_draw_radar: false,
                 frame_draw_overlay: false,
+                field_draws: Vec::new(),
             }
         })
     }
@@ -1055,11 +1057,11 @@ impl RenderResources {
         }
         // Draw only the requested layers that actually have GPU data. Opacity rides in the grid
         // uniform's first pad word, so it costs one 4-byte write per drawn layer — no LUT re-bake.
-        self.field_draws.clear();
+        let mut field_draws = Vec::new();
         for (layer, opacity) in &cb.field_draws {
             if let Some(f) = self.fields.get(layer) {
                 queue.write_buffer(&f.uni, 24, &opacity.to_le_bytes());
-                self.field_draws.push(*layer);
+                field_draws.push(*layer);
             }
         }
 
@@ -1143,6 +1145,7 @@ impl RenderResources {
         pane.vector_over_raster = cb.vector_over_raster;
         pane.frame_draw_radar = cb.draw_radar && pane.radar.is_some();
         pane.frame_draw_overlay = cb.draw_overlay && overlay_present;
+        pane.field_draws = field_draws;
     }
 
     fn upload_overlay(&mut self, device: &wgpu::Device, o: &OverlayUpload) {
@@ -1311,9 +1314,10 @@ impl RenderResources {
 
     /// Paint the active field layers in the requested band (below/above the radar), in the fixed
     /// bottom-to-top order, using this pane's camera.
-    fn draw_fields(&self, cam: &wgpu::BindGroup, pass: &mut wgpu::RenderPass<'_>, below: bool) {
+    fn draw_fields(&self, pane: &PaneGpu, pass: &mut wgpu::RenderPass<'_>, below: bool) {
+        let cam = &pane.camera_bg;
         for layer in FieldLayer::DRAW_ORDER {
-            if layer.below_radar() != below || !self.field_draws.contains(&layer) {
+            if layer.below_radar() != below || !pane.field_draws.contains(&layer) {
                 continue;
             }
             if let Some(f) = self.fields.get(&layer) {
@@ -1352,7 +1356,7 @@ impl RenderResources {
             self.draw_vector_basemap(pane, cam, pass);
         }
         // Field layers under the radar (national mosaic context).
-        self.draw_fields(cam, pass, true);
+        self.draw_fields(pane, pass, true);
         if pane.frame_draw_radar {
             if let Some(radar) = &pane.radar {
                 pass.set_pipeline(&self.radar_pipeline);
@@ -1363,7 +1367,7 @@ impl RenderResources {
             }
         }
         // Field layers over the radar (rotation/hail/shear/lightning signals).
-        self.draw_fields(cam, pass, false);
+        self.draw_fields(pane, pass, false);
         // Wind particles under the overlay, not over it: the CPU path paints in egui's own layer,
         // which is above everything, and a warning polygon disappearing under a particle trail
         // was the one complaint that layer ever attracted.

--- a/crates/hookecho/src/ui/cell_window.rs
+++ b/crates/hookecho/src/ui/cell_window.rs
@@ -16,16 +16,18 @@ pub struct CellSample {
 
 /// Show the storm-attributes window. `trend` is the cell's per-volume history (oldest→newest);
 /// `following` reflects whether the camera is currently tracking this cell. Returns
-/// `(still_open, follow_toggled)` — `follow_toggled` is `true` the frame the Follow button is hit.
+/// `(still_open, follow_toggled, to_3d)` — the two flags are `true` for the one frame their
+/// button is hit.
 pub fn show(
     ctx: &egui::Context,
     cell: &Cell,
     trend: &[CellSample],
     following: bool,
     popovers: &mut crate::ui::popover::Popovers,
-) -> (bool, bool) {
+) -> (bool, bool, bool) {
     let mut open = true;
     let mut follow_toggled = false;
+    let mut to_3d = false;
     popovers
         .card(
             ctx,
@@ -49,6 +51,19 @@ pub fn show(
                     .clicked()
                 {
                     follow_toggled = true;
+                }
+                if ui
+                    .add(
+                        egui::Button::new("\u{25A6} See in 3D")
+                            .min_size(egui::vec2(ui.available_width(), 0.0)),
+                    )
+                    .on_hover_text(
+                        "Open the raymarched volume cropped to this storm \u{2014} the whole box \
+                         at once is a wall of echo you then have to hunt through",
+                    )
+                    .clicked()
+                {
+                    to_3d = true;
                 }
                 theme::section(ui, "Current Position", |ui| {
                     grid(
@@ -154,7 +169,7 @@ pub fn show(
                 }
             });
         });
-    (open, follow_toggled)
+    (open, follow_toggled, to_3d)
 }
 
 /// A labelled trend sparkline over the samples that carry the selected field.

--- a/crates/hookecho/src/ui/layer_options.rs
+++ b/crates/hookecho/src/ui/layer_options.rs
@@ -57,6 +57,9 @@ pub(crate) fn show(
     ui: &mut egui::Ui,
     filters: &mut OverlayFilters,
     fields: &mut std::collections::HashMap<crate::render::FieldLayer, crate::app::FieldState>,
+    // Which layers the active pane draws. Visibility is per-pane now; the map above is the shared
+    // fetch state, which is what `fields` is still needed for (clearing a refetch clock).
+    on: &std::collections::HashSet<crate::render::FieldLayer>,
     rotation_minutes: &mut u16,
     hail_minutes: &mut u16,
     hrrr_fcst_hour: &mut u8,
@@ -104,7 +107,7 @@ pub(crate) fn show(
         FL::GlobalPrecip,
     ]
     .iter()
-    .any(|l| fields.get(l).is_some_and(|s| s.show));
+    .any(|l| on.contains(l));
     if global_on {
         ui.horizontal(|ui| {
             ui.label("Global model:");
@@ -128,7 +131,7 @@ pub(crate) fn show(
         });
     }
 
-    if fields.get(&FL::ModelDiff).is_some_and(|s| s.show) {
+    if on.contains(&FL::ModelDiff) {
         let (a, b) = diff_field.pair();
         ui.horizontal_wrapped(|ui| {
             ui.label("Difference:");
@@ -153,7 +156,7 @@ pub(crate) fn show(
         }
     }
 
-    if fields.get(&FL::Lightning).is_some_and(|s| s.show) {
+    if on.contains(&FL::Lightning) {
         ui.horizontal(|ui| {
             ui.label("CG density window:");
             for m in [1u16, 5, 15, 30] {
@@ -311,7 +314,7 @@ pub(crate) fn show(
         ui.label(egui::RichText::new(text).small().strong());
     };
 
-    if fields.get(&FL::Rotation).is_some_and(|s| s.show) {
+    if on.contains(&FL::Rotation) {
         header(ui, "Rotation tracks");
         ui.horizontal(|ui| {
             ui.label("Window:");
@@ -330,7 +333,7 @@ pub(crate) fn show(
         });
     }
 
-    if fields.get(&FL::HailSwath).is_some_and(|s| s.show) {
+    if on.contains(&FL::HailSwath) {
         header(ui, "Hail swaths");
         ui.horizontal(|ui| {
             ui.label("Window:");
@@ -347,14 +350,14 @@ pub(crate) fn show(
         });
     }
 
-    if fields.get(&FL::Mosaic).is_some_and(|s| s.show) {
+    if on.contains(&FL::Mosaic) {
         header(ui, "Radar mosaic");
         if let Some(m) = mosaic {
             ui.weak(m);
         }
     }
 
-    if fields.get(&FL::Hrrr).is_some_and(|s| s.show) {
+    if on.contains(&FL::Hrrr) {
         header(ui, "Future radar");
         ui.add(egui::Slider::new(hrrr_fcst_hour, 0..=18).text("F+ hr"));
         match hrrr_valid {
@@ -374,7 +377,7 @@ pub(crate) fn show(
         }
     }
 
-    if fields.get(&FL::Cape).is_some_and(|s| s.show) {
+    if on.contains(&FL::Cape) {
         header(ui, "CAPE");
         ui.horizontal(|ui| {
             ui.label("Parcel:");
@@ -388,7 +391,7 @@ pub(crate) fn show(
         });
     }
 
-    if fields.get(&FL::Srh).is_some_and(|s| s.show) {
+    if on.contains(&FL::Srh) {
         header(ui, "Storm-relative helicity");
         ui.horizontal(|ui| {
             ui.label("Depth:");
@@ -456,7 +459,7 @@ pub(crate) fn show(
             .changed();
     }
 
-    if fields.get(&FL::SnowAnalysis).is_some_and(|s| s.show) {
+    if on.contains(&FL::SnowAnalysis) {
         header(ui, "Snowfall analysis");
         ui.horizontal(|ui| {
             ui.label("Window:");
@@ -470,7 +473,7 @@ pub(crate) fn show(
 
     if [FL::VilLocal, FL::VilDensity, FL::EtopLocal]
         .iter()
-        .any(|l| fields.get(l).is_some_and(|s| s.show))
+        .any(|l| on.contains(l))
     {
         header(ui, "Derived products");
         ui.horizontal(|ui| {
@@ -530,7 +533,7 @@ pub(crate) fn show(
 
     if [FL::Vil, FL::EchoTops, FL::Hca]
         .iter()
-        .any(|l| fields.get(l).is_some_and(|s| s.show))
+        .any(|l| on.contains(l))
     {
         header(ui, "Level 3 grids");
         ui.weak(format!("Site: {}", l3grid_site.unwrap_or("—")));

--- a/crates/hookecho/src/view.rs
+++ b/crates/hookecho/src/view.rs
@@ -150,6 +150,11 @@ pub struct MapView {
     pub loading: bool,
     pub last_poll: Option<Instant>,
     pub error: Option<String>,
+    /// National field layers drawn in this pane. Per-pane rather than app-wide: two panes is how
+    /// you compare two fields, and the model-difference layer would rather be a pair of panes
+    /// than a subtraction. The grids themselves stay in one shared cache — only the choice of
+    /// what to draw lives here.
+    pub fields_on: std::collections::HashSet<crate::render::FieldLayer>,
     /// Every moment seen in any volume from `loaded_site`, cleared when the site changes.
     ///
     /// A single live volume is only as complete as the tilts that have arrived: early in a scan
@@ -182,6 +187,7 @@ impl MapView {
             loading: false,
             last_poll: None,
             error: None,
+            fields_on: Default::default(),
             moments_seen: [false; Moment::ALL.len()],
         }
     }

--- a/crates/hookecho/src/workspace.rs
+++ b/crates/hookecho/src/workspace.rs
@@ -9,7 +9,8 @@
 //! doesn't capture is anything tied to the moment rather than the arrangement — the archive
 //! playhead, open windows, per-moment thresholds.
 //!
-//! `ponytail: no per-pane thresholds; add them if someone asks for a saved threshold set.`
+//! Per-pane display thresholds and field layers ride along, since a pane that shows one field
+//! above 50 dBZ beside another that shows a different one is exactly the arrangement worth saving.
 
 use crate::view::MapView;
 
@@ -75,6 +76,15 @@ pub struct PaneSnap {
     pub lon: f64,
     pub lat: f64,
     pub zoom: f64,
+    /// Field layers this pane drew, by slug. Same forward-compatibility rule as the overlays: a
+    /// slug this build does not have is skipped. Empty on a snapshot written before per-pane
+    /// layers existed, which is read as "fall back to the workspace-wide list".
+    #[serde(default)]
+    pub fields_on: Vec<String>,
+    /// Enabled display thresholds, as `(moment, physical value)`. Only the enabled ones are
+    /// stored: a threshold that was set but switched off is not part of the arrangement.
+    #[serde(default)]
+    pub thresholds: Vec<(wxdata::level2::Moment, f32)>,
 }
 
 impl PaneSnap {
@@ -90,6 +100,17 @@ impl PaneSnap {
             lon,
             lat,
             zoom: v.camera.zoom,
+            fields_on: crate::render::FieldLayer::DRAW_ORDER
+                .iter()
+                .filter(|l| v.fields_on.contains(l))
+                .map(|l| l.slug().to_string())
+                .collect(),
+            thresholds: wxdata::level2::Moment::ALL
+                .iter()
+                .enumerate()
+                .filter(|&(i, _)| v.threshold_enabled[i])
+                .filter_map(|(i, m)| v.thresholds[i].map(|t| (*m, t)))
+                .collect(),
         }
     }
 
@@ -105,6 +126,14 @@ impl PaneSnap {
         // The camera came from the saved layout, not from a site recenter — hold it through the
         // site change the restore just triggered.
         v.camera_placed = true;
+        // Thresholds are a per-moment array; clear it first so restoring an arrangement without
+        // one does not leave the previous pane's filter in place.
+        v.thresholds = Default::default();
+        v.threshold_enabled = Default::default();
+        for (m, t) in &self.thresholds {
+            v.thresholds[m.index()] = Some(*t);
+            v.threshold_enabled[m.index()] = true;
+        }
     }
 }
 
@@ -122,6 +151,8 @@ fn pane(moment: wxdata::level2::Moment, tilt: usize, srv: bool) -> PaneSnap {
         lon: -97.5,
         lat: 35.5,
         zoom: 7.5,
+        fields_on: Vec::new(),
+        thresholds: Vec::new(),
     }
 }
 
@@ -163,6 +194,8 @@ pub fn starters() -> Vec<Workspace> {
                 lon: -97.0,
                 lat: 38.5,
                 zoom: 4.0,
+                fields_on: vec!["mrms".into()],
+                thresholds: Vec::new(),
             }],
             active: 0,
             link_cameras: false,
@@ -217,6 +250,42 @@ mod tests {
     }
 
     #[test]
+    fn per_pane_thresholds_and_layers_survive_the_round_trip() {
+        use wxdata::level2::Moment;
+        let mut v = MapView::new(None, crate::render::mercator::Camera::at_lonlat(0.0, 0.0, 3.0));
+        v.fields_on.insert(crate::render::FieldLayer::Mrms);
+        v.thresholds[Moment::Reflectivity.index()] = Some(35.0);
+        v.threshold_enabled[Moment::Reflectivity.index()] = true;
+        // Set but switched off: part of the session, not part of the arrangement.
+        v.thresholds[Moment::Velocity.index()] = Some(20.0);
+
+        let snap = PaneSnap::capture(&v);
+        assert_eq!(snap.fields_on, vec!["mrms"]);
+        assert_eq!(snap.thresholds, vec![(Moment::Reflectivity, 35.0)]);
+
+        let mut fresh = MapView::new(None, crate::render::mercator::Camera::at_lonlat(0.0, 0.0, 3.0));
+        // A leftover filter from whatever this pane was showing before must not survive a restore.
+        fresh.thresholds[Moment::SpectrumWidth.index()] = Some(4.0);
+        fresh.threshold_enabled[Moment::SpectrumWidth.index()] = true;
+        snap.apply(&mut fresh);
+        assert_eq!(fresh.thresholds[Moment::Reflectivity.index()], Some(35.0));
+        assert!(fresh.threshold_enabled[Moment::Reflectivity.index()]);
+        assert!(!fresh.threshold_enabled[Moment::SpectrumWidth.index()]);
+        assert_eq!(fresh.thresholds[Moment::Velocity.index()], None);
+    }
+
+    #[test]
+    fn a_pane_written_before_per_pane_layers_still_loads() {
+        // No `fields_on`, no `thresholds` — exactly what an older build wrote.
+        let snap: PaneSnap = serde_json::from_str(
+            r#"{"site":"KTLX","moment":"Reflectivity","tilt":0,"basemap":"dark",
+                "lon":-97.3,"lat":35.3,"zoom":8.0}"#,
+        )
+        .expect("old pane snapshots still parse");
+        assert!(snap.fields_on.is_empty() && snap.thresholds.is_empty());
+    }
+
+    #[test]
     fn workspace_roundtrips_through_json() {
         let ws = Workspace {
             name: "Two-site chase".into(),
@@ -229,6 +298,8 @@ mod tests {
                 lon: -93.72,
                 lat: 41.73,
                 zoom: 7.25,
+                fields_on: Vec::new(),
+                thresholds: Vec::new(),
             }],
             active: 0,
             link_cameras: true,

--- a/crates/wxdata/src/volume3d.rs
+++ b/crates/wxdata/src/volume3d.rs
@@ -157,6 +157,31 @@ pub fn cappi(sweeps: &[BinnedSweep], alt_km: f32, n: usize, half_km: f32) -> Opt
     })
 }
 
+/// Clip slab that isolates one storm inside the volume box, in the `[x0, x1, y0, y1, z0, z1]`
+/// fractions [`crate::volume3d`]'s consumers use.
+///
+/// `dx_km`/`dy_km` are the storm's offset east and north of the radar, `pad_km` the half-width to
+/// keep around it. The vertical span is left alone: the whole point of looking at a storm in 3D is
+/// its depth, so cropping height would throw away the answer.
+pub fn clip_around(half_km: f32, dx_km: f32, dy_km: f32, pad_km: f32) -> [f32; 6] {
+    // The box spans [-half_km, +half_km] in x and y, mapped onto 0..1.
+    let frac = |km: f32| ((km + half_km) / (2.0 * half_km)).clamp(0.0, 1.0);
+    let pad = (pad_km / (2.0 * half_km)).clamp(0.0, 0.5);
+    let span = |c: f32| {
+        let (mut lo, mut hi) = (c - pad, c + pad);
+        // A storm near the edge of the box slides its window inward rather than shrinking it.
+        if lo < 0.0 {
+            (lo, hi) = (0.0, (2.0 * pad).min(1.0));
+        } else if hi > 1.0 {
+            (lo, hi) = ((1.0 - 2.0 * pad).max(0.0), 1.0);
+        }
+        (lo, hi)
+    };
+    let (x0, x1) = span(frac(dx_km));
+    let (y0, y1) = span(frac(dy_km));
+    [x0, x1, y0, y1, 0.0, 1.0]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -229,5 +254,27 @@ mod tests {
             0,
             "14 km empty"
         );
+    }
+}
+
+#[cfg(test)]
+mod clip_tests {
+    use super::clip_around;
+
+    #[test]
+    fn the_slab_brackets_the_storm_and_slides_in_at_the_edge() {
+        // Dead center of a 150 km box, 25 km of padding: an eighth of the box either side.
+        let c = clip_around(150.0, 0.0, 0.0, 25.0);
+        assert!((c[0] - 0.4167).abs() < 1e-3 && (c[1] - 0.5833).abs() < 1e-3);
+        // Height is never cropped.
+        assert_eq!([c[4], c[5]], [0.0, 1.0]);
+        // Hard against the west wall: the window slides inward instead of collapsing.
+        let w = clip_around(150.0, -150.0, 0.0, 25.0);
+        assert_eq!(w[0], 0.0);
+        assert!((w[1] - w[0] - (c[1] - c[0])).abs() < 1e-3);
+        // And against the north wall.
+        let n = clip_around(150.0, 0.0, 150.0, 25.0);
+        assert_eq!(n[3], 1.0);
+        assert!((n[3] - n[2] - (c[1] - c[0])).abs() < 1e-3);
     }
 }


### PR DESCRIPTION
H3 of wave H. Closes #14. Stacked on #111.

## What

Field-layer visibility moves off the app and onto `MapView` as `fields_on`; `PaneSnap` learns to carry it and the per-pane display thresholds.

- **`MapView::fields_on`** — a per-pane set of `FieldLayer`. Toggling from the palette, the panel, or the mobile chrome hits the active pane.
- **Grids stay shared.** `FieldState` keeps `pending` and `last_fetch` and loses `show`; every fetch gate now asks `field_wanted(layer)` — "does *any* pane want this" — so a layer on in two panes still downloads once.
- **Renderer fix along the way.** `field_draws` lived on `RenderResources`, but all `prepare`s run before any `paint`, so the last pane to prepare decided what every pane drew. It now lives on `PaneGpu` beside the other frame draw lists, which is what makes per-pane layers actually render per-pane.
- **`PaneSnap`** gains `fields_on: Vec<String>` (slugs, unknown ones skipped) and `thresholds: Vec<(Moment, f32)>`. Only *enabled* thresholds are stored — one that was set and then switched off is session state, not part of the arrangement. `apply` clears the threshold arrays first, so restoring an arrangement without one does not leave the previous pane's filter in place.

## Compatibility

Both fields are `#[serde(default)]`. A pane snapshot written before they existed reads as empty, and empty `fields_on` falls back to the workspace-wide list — so an old workspace restores what it meant instead of restoring nothing. The workspace-wide `fields_on` is still written, as the union across panes, so an older build reading a new file still gets its layers.

Two tests cover it: a capture/apply round trip that checks the disabled threshold is dropped and a stale one is cleared, and a parse of an old pane snapshot with neither field present.

## Gate

- clippy `-D warnings` clean
- 590 passed / 30 ignored / 0 failed
- wasm check clean
- `shoot.sh check` passed
- web gzip 4,811,439 / 4,850,000

Not device-verified: two panes with different layers have not been on a screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)