### PR TITLE
feat(history): event replay bundles

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -9090,7 +9090,10 @@ impl HookEchoApp {
             // scrub path displays and what it downloads until the new listing lands — i.e. the
             // wrong radar's volumes at an index that means nothing here. A scrubbed pane keeps
             // the time it was looking at; a live one just goes back to the head.
-            if !v.timeline.following {
+            // ...unless a deep link, an event or a replay bundle already asked for an instant:
+            // that target is the whole point of the jump, and overwriting it with the frame the
+            // pane happened to be showing sent every Event Library entry to the wrong day.
+            if !v.timeline.following && v.timeline.seek_target.is_none() {
                 v.timeline.seek_target = v.timeline.current().and_then(|id| id.date_time());
             }
             v.timeline.frames.clear();

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1389,7 +1389,6 @@ type ZdrCache = (
 /// Per-field-layer UI + fetch state (toggle, pending upload, refresh clock).
 #[derive(Default)]
 pub(crate) struct FieldState {
-    pub show: bool,
     pub pending: Option<crate::render::MrmsUpload>,
     pub last_fetch: Option<Instant>,
 }
@@ -3487,7 +3486,7 @@ impl HookEchoApp {
         /// Bit positions in the mask for the two hail grids.
         const HAIL_BITS: u8 = 0b11000;
         let mask = LAYERS.iter().enumerate().fold(0u8, |m, (i, l)| {
-            m | u8::from(self.fields.get(l).is_some_and(|s| s.show)) << i
+            m | u8::from(self.field_wanted(*l)) << i
         });
         if mask == 0 {
             self.derived_key = None;
@@ -4696,16 +4695,12 @@ impl HookEchoApp {
         match self.views[self.active].timeline.forecast_hour() {
             Some(h) => {
                 self.hrrr_fcst_hour = h;
-                if let Some(s) = self.fields.get_mut(&FL::Hrrr) {
-                    s.show = true;
-                }
+                self.views[self.active].fields_on.insert(FL::Hrrr);
                 self.hrrr_by_timeline = true;
             }
             None => {
                 if self.hrrr_by_timeline {
-                    if let Some(s) = self.fields.get_mut(&FL::Hrrr) {
-                        s.show = false;
-                    }
+                    self.views[self.active].fields_on.remove(&FL::Hrrr);
                     self.hrrr_by_timeline = false;
                 }
             }
@@ -6940,6 +6935,22 @@ impl HookEchoApp {
 
     /// The boolean behind an [`OverlayToggle`]. One place to resolve a named toggle so the
     /// layers panel, command palette, and mobile sheet never drift apart.
+    /// Does any pane want this field layer? The grids are fetched once and shared, so one pane
+    /// asking is enough to keep the download alive.
+    fn field_wanted(&self, layer: crate::render::FieldLayer) -> bool {
+        self.views.iter().any(|v| v.fields_on.contains(&layer))
+    }
+
+    /// Turn a field layer on or off in the active pane.
+    fn set_field(&mut self, layer: crate::render::FieldLayer, on: bool) {
+        let set = &mut self.views[self.active].fields_on;
+        if on {
+            set.insert(layer);
+        } else {
+            set.remove(&layer);
+        }
+    }
+
     fn overlay_flag(&mut self, t: OverlayToggle) -> &mut bool {
         use OverlayToggle as T;
         match t {
@@ -6995,9 +7006,10 @@ impl HookEchoApp {
                 }
             }
             PaletteAction::ToggleField(layer) => {
-                if let Some(s) = self.fields.get_mut(&layer) {
-                    s.show = !s.show;
-                }
+                // The active pane's choice, not the app's: that is what makes two panes able to
+                // show two fields.
+                let on = self.views[self.active].fields_on.contains(&layer);
+                self.set_field(layer, !on);
             }
             PaletteAction::ToggleOverlay(t) => {
                 let f = self.overlay_flag(t);
@@ -7107,11 +7119,7 @@ impl HookEchoApp {
                 // branch dead code and always land people on the same Windy page.
                 let overlay = if self.show_wind {
                     "wind"
-                } else if self
-                    .fields
-                    .get(&crate::render::FieldLayer::Cape)
-                    .is_some_and(|s| s.show)
-                {
+                } else if self.field_wanted(crate::render::FieldLayer::Cape) {
                     "cape"
                 } else if v.basemap.slug().starts_with("goes") {
                     "satellite"
@@ -7674,7 +7682,7 @@ impl HookEchoApp {
 
     fn sync_mosaic(&mut self, ctx: &egui::Context) {
         use crate::render::FieldLayer as FL;
-        if !self.fields.get(&FL::Mosaic).is_some_and(|s| s.show) {
+        if !self.field_wanted(FL::Mosaic) {
             return;
         }
         if !self.views[self.active].timeline.following {
@@ -10360,11 +10368,10 @@ impl HookEchoApp {
         } else {
             Vec::new()
         };
-        let field_draws: Vec<(crate::render::FieldLayer, f32)> = self
-            .fields
+        let field_draws: Vec<(crate::render::FieldLayer, f32)> = self.views[idx]
+            .fields_on
             .iter()
-            .filter(|(_, s)| s.show)
-            .map(|(k, _)| {
+            .map(|k| {
                 (
                     *k,
                     self.settings.field_opacity.get(k).copied().unwrap_or(1.0),
@@ -11990,12 +11997,7 @@ impl HookEchoApp {
         }
 
         // HRRR "future radar" banner — unmistakable that this is model forecast, not observation.
-        if idx == self.active
-            && self
-                .fields
-                .get(&crate::render::FieldLayer::Hrrr)
-                .is_some_and(|s| s.show)
-        {
+        if idx == self.active && view.fields_on.contains(&crate::render::FieldLayer::Hrrr) {
             let valid = self
                 .hrrr_valid
                 .map(|v| crate::timefmt::fmt_date_clock(v, self.active_tz()))
@@ -12076,11 +12078,7 @@ impl HookEchoApp {
 
         // The difference layer reads as "they disagree here" and nothing more without a number,
         // so the cursor samples the grid it was drawn from.
-        if self
-            .fields
-            .get(&crate::render::FieldLayer::ModelDiff)
-            .is_some_and(|s| s.show)
-        {
+        if view.fields_on.contains(&crate::render::FieldLayer::ModelDiff) {
             if let (Some(grid), Some(hp)) = (self.diff_grid.as_ref(), response.hover_pos()) {
                 let w = cam.screen_to_world((hp.x - prect.left(), hp.y - prect.top()), vp);
                 let (lon, lat) = crate::render::mercator::world_to_lonlat(w.0, w.1);
@@ -12537,7 +12535,7 @@ impl HookEchoApp {
             if let Some(top) = crate::render::FieldLayer::DRAW_ORDER
                 .iter()
                 .rev()
-                .find(|l| self.fields.get(l).is_some_and(|s| s.show))
+                .find(|l| view.fields_on.contains(l))
             {
                 y += if *top == crate::render::FieldLayer::ModelDiff {
                     ui::legend::draw_diff(&painter, prect, self.diff_field, y)
@@ -12676,11 +12674,12 @@ impl HookEchoApp {
             // A workspace you saved records the sites you had open; only the shipped starters
             // adopt whatever is on screen.
             adopt_site: false,
-            fields_on: self
-                .fields
+            // The workspace-wide list stays as the union across panes: it is what an older build
+            // reads, and what a pane snapshot written before per-pane layers falls back to.
+            fields_on: crate::render::FieldLayer::DRAW_ORDER
                 .iter()
-                .filter(|(_, st)| st.show)
-                .map(|(l, _)| l.slug().to_string())
+                .filter(|l| self.field_wanted(**l))
+                .map(|l| l.slug().to_string())
                 .collect(),
             chrome: Some(self.capture_chrome()),
         }
@@ -12719,8 +12718,19 @@ impl HookEchoApp {
         }
         // Same rule for the national field layers: an unknown slug is a layer this build
         // doesn't have, which is a thing to skip rather than an error.
-        for (layer, st) in self.fields.iter_mut() {
-            st.show = ws.fields_on.iter().any(|s| s == layer.slug());
+        for (v, snap) in self.views.iter_mut().zip(&ws.panes) {
+            // A pane snapshot written before per-pane layers existed carries none, and falls back
+            // to the workspace-wide list so an old file still restores what it meant.
+            let list = if snap.fields_on.is_empty() {
+                &ws.fields_on
+            } else {
+                &snap.fields_on
+            };
+            v.fields_on = crate::render::FieldLayer::DRAW_ORDER
+                .iter()
+                .copied()
+                .filter(|l| list.iter().any(|s| s == l.slug()))
+                .collect();
         }
         if let Some(c) = &ws.chrome {
             self.apply_chrome(c, ctx);
@@ -14353,7 +14363,7 @@ impl eframe::App for HookEchoApp {
             };
             // The reflectivity tint reads the precipitation-type grid whether or not that
             // layer is being drawn, so wanting the tint counts as wanting the layer's data.
-            let wanted = self.fields.get(&layer).is_some_and(|s| s.show)
+            let wanted = self.field_wanted(layer)
                 || (layer == FL::PrecipType && self.settings.precip_tint);
             let stale = wanted
                 && self.fields.get(&layer).is_none_or(|s| {
@@ -14368,11 +14378,11 @@ impl eframe::App for HookEchoApp {
         // Snow bands: the mosaic and the precipitation-type grid, cut to the banded snow.
         {
             let layer = FL::SnowBands;
-            let stale = self.fields.get(&layer).is_some_and(|s| {
-                s.show
-                    && s.last_fetch
+            let stale = self.field_wanted(layer)
+                && self.fields.get(&layer).is_none_or(|s| {
+                    s.last_fetch
                         .is_none_or(|t| t.elapsed().as_secs() >= field_refresh_secs(layer))
-            });
+                });
             if stale {
                 if let Some(s) = self.fields.get_mut(&layer) {
                     s.last_fetch = Some(Instant::now());
@@ -14382,11 +14392,11 @@ impl eframe::App for HookEchoApp {
         }
         // Environment suite (HRRR CAPE/SRH): fetch each enabled layer at f00, refresh ~15 min.
         for layer in [FL::Cape, FL::Srh] {
-            let stale = self.fields.get(&layer).is_some_and(|s| {
-                s.show
-                    && s.last_fetch
+            let stale = self.field_wanted(layer)
+                && self.fields.get(&layer).is_none_or(|s| {
+                    s.last_fetch
                         .is_none_or(|t| t.elapsed().as_secs() >= field_refresh_secs(layer))
-            });
+                });
             if stale {
                 if let Some(s) = self.fields.get_mut(&layer) {
                     s.last_fetch = Some(Instant::now());
@@ -14407,7 +14417,7 @@ impl eframe::App for HookEchoApp {
         ] {
             let fh = self.global_fcst_hour;
             let model = self.global_model;
-            let on = self.fields.get(&layer).is_some_and(|s| s.show);
+            let on = self.field_wanted(layer);
             let stale = on
                 && self.fields.get(&layer).is_some_and(|s| {
                     s.last_fetch
@@ -14427,7 +14437,7 @@ impl eframe::App for HookEchoApp {
         {
             let layer = FL::ModelDiff;
             let fh = self.global_fcst_hour;
-            let on = self.fields.get(&layer).is_some_and(|s| s.show);
+            let on = self.field_wanted(layer);
             let stale = on
                 && self.fields.get(&layer).is_some_and(|s| {
                     s.last_fetch
@@ -14450,14 +14460,14 @@ impl eframe::App for HookEchoApp {
             FL::ThunderProb,
         ] {
             let fh = self.hrrr_fcst_hour;
-            let stale = self.fields.get(&layer).is_some_and(|s| {
-                s.show
-                    && s.last_fetch
+            let stale = self.field_wanted(layer)
+                && self.fields.get(&layer).is_none_or(|s| {
+                    s.last_fetch
                         .is_none_or(|t| t.elapsed().as_secs() >= field_refresh_secs(layer))
-            });
+                });
             // Scrubbing the forecast tail must refetch immediately, not wait out the cadence.
-            let hour_changed = self.fields.get(&layer).is_some_and(|s| s.show)
-                && self.hrrr_layer_hour.get(&layer) != Some(&fh);
+            let hour_changed =
+                self.field_wanted(layer) && self.hrrr_layer_hour.get(&layer) != Some(&fh);
             if stale || hour_changed {
                 if let Some(s) = self.fields.get_mut(&layer) {
                     s.last_fetch = Some(Instant::now());
@@ -14483,7 +14493,7 @@ impl eframe::App for HookEchoApp {
 
         // GOES lightning: granules land every 20 s, so poll about that often. One in flight at a
         // time — a slow fetch must not queue up behind itself.
-        let glm_fed_on = self.fields.get(&FL::GlmFed).is_some_and(|s| s.show);
+        let glm_fed_on = self.field_wanted(FL::GlmFed);
         // A lightning-density rule needs the flashes polled and the grid built even with the
         // layer off, exactly like the scan signatures.
         let glm_rule_armed = self.settings.alert_rules.iter().any(|r| {
@@ -14622,7 +14632,7 @@ impl eframe::App for HookEchoApp {
         // Observed snowfall analysis: its own block because the accumulation window is a knob,
         // and changing it must refetch at once rather than wait out the cadence.
         {
-            let on = self.fields.get(&FL::SnowAnalysis).is_some_and(|s| s.show);
+            let on = self.field_wanted(FL::SnowAnalysis);
             let stale = self.fields.get(&FL::SnowAnalysis).is_some_and(|s| {
                 s.last_fetch
                     .is_none_or(|t| t.elapsed().as_secs() >= field_refresh_secs(FL::SnowAnalysis))
@@ -14665,7 +14675,7 @@ impl eframe::App for HookEchoApp {
         let l3_site = self.views[self.active].site.clone();
         let site_changed = self.l3grid_site != l3_site;
         for layer in [FL::Vil, FL::EchoTops, FL::Hca] {
-            let on = self.fields.get(&layer).is_some_and(|s| s.show);
+            let on = self.field_wanted(layer);
             if !on {
                 continue;
             }
@@ -14685,13 +14695,13 @@ impl eframe::App for HookEchoApp {
         if site_changed
             && [FL::Vil, FL::EchoTops, FL::Hca]
                 .iter()
-                .any(|l| self.fields.get(l).is_some_and(|s| s.show))
+                .any(|l| self.field_wanted(*l))
         {
             self.l3grid_site = l3_site;
         }
         // HRRR future radar: fetch when enabled and the forecast hour changed or the run refreshed
         // (~10-min throttle; a new run posts hourly).
-        let hrrr_on = self.fields.get(&FL::Hrrr).is_some_and(|s| s.show);
+        let hrrr_on = self.field_wanted(FL::Hrrr);
         if hrrr_on {
             let hour_changed = self.hrrr_fetched_hour != Some(self.hrrr_fcst_hour);
             let stale = self
@@ -15038,7 +15048,7 @@ impl eframe::App for HookEchoApp {
         let active_fields: Vec<(crate::render::FieldLayer, String)> =
             crate::render::FieldLayer::DRAW_ORDER
                 .into_iter()
-                .filter(|l| self.fields.get(l).is_some_and(|s| s.show))
+                .filter(|l| self.field_wanted(*l))
                 .map(|l| {
                     let name = names.get(&l).cloned().unwrap_or_else(|| format!("{l:?}"));
                     (l, name)

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -13082,7 +13082,7 @@ impl HookEchoApp {
     }
 
     /// Save the active pane's current view as a named bookmark (archive time captured if scrubbed).
-    pub(crate) fn add_bookmark(&mut self, name: String) {
+    pub(crate) fn add_bookmark(&mut self, name: String, span_min: u16) {
         let v = &self.views[self.active];
         let Some(site) = v.site.clone() else { return };
         let time_secs = v
@@ -13097,6 +13097,7 @@ impl HookEchoApp {
             y: v.camera.center.1,
             zoom: v.camera.zoom,
             time_secs,
+            span_min,
         });
     }
 
@@ -15382,12 +15383,21 @@ impl eframe::App for HookEchoApp {
                     lat,
                     zoom,
                     time,
+                    span_min,
                 } => {
                     self.goto_view(&site, lon, lat, zoom, time);
+                    if span_min > 0 && time.is_some() {
+                        self.views[self.active].timeline.replay_span_min = span_min;
+                        // A replay without its warnings and its damage reports is just a loop;
+                        // both already follow the playhead once they are on.
+                        self.filters.show_alerts = true;
+                        self.show_storm_reports = true;
+                        self.rebuild_overlays();
+                    }
                 }
-                EventAction::AddBookmark => {
+                EventAction::AddBookmark(span_min) => {
                     let n = self.settings.bookmarks.len() + 1;
-                    self.add_bookmark(format!("Bookmark {n}"));
+                    self.add_bookmark(format!("Bookmark {n}"), span_min);
                 }
             }
         }

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -15461,6 +15461,7 @@ impl eframe::App for HookEchoApp {
                 self.cell_popup = Some(c);
             }
         }
+        let mut open_3d: Option<[f32; 6]> = None;
         if let Some(cell) = &self.cell_popup {
             let trend = self
                 .cell_trends
@@ -15471,8 +15472,26 @@ impl eframe::App for HookEchoApp {
                 .follow_cell
                 .as_ref()
                 .is_some_and(|(_, c, _)| c.id == cell.id);
-            let (open, toggled) =
+            let (open, toggled, to_3d) =
                 ui::cell_window::show(ctx, cell, trend, following, &mut self.popovers);
+            // Crop the volume to this storm before opening it: the full 300 km box is a wall of
+            // echo you would then have to hunt through by hand. The clip is computed here, where
+            // the cell is still borrowed, and applied below.
+            if to_3d {
+                open_3d = Some(
+                    self.views[self.active]
+                        .site
+                        .as_deref()
+                        .and_then(wxdata::sites::site_by_id)
+                        .map(|site| {
+                            let (slat, slon) = (site.latitude as f64, site.longitude as f64);
+                            let dy = ((cell.lat - slat) * 111.0) as f32;
+                            let dx = ((cell.lon - slon) * 111.0 * slat.to_radians().cos()) as f32;
+                            wxdata::volume3d::clip_around(150.0, dx, dy, 30.0)
+                        })
+                        .unwrap_or([0.0, 1.0, 0.0, 1.0, 0.0, 1.0]),
+                );
+            }
             if toggled {
                 if following {
                     self.follow_cell = None;
@@ -15484,6 +15503,10 @@ impl eframe::App for HookEchoApp {
             if !open {
                 self.cell_popup = None;
             }
+        }
+        if let Some(clip) = open_3d {
+            self.vol3d.clip = clip;
+            self.build_volume3d();
         }
         if let Some(i) = self.marker_popup {
             match self.settings.markers.get_mut(i) {

--- a/crates/hookecho/src/app/chrome/overlay.rs
+++ b/crates/hookecho/src/app/chrome/overlay.rs
@@ -175,14 +175,14 @@ impl HookEchoApp {
                                 .default_open(false)
                                 .show(ui, |ui| {
                                     let glm_options = self.show_glm
-                                        || self
-                                            .fields
-                                            .get(&crate::render::FieldLayer::GlmFed)
-                                            .is_some_and(|s| s.show);
+                                        || self.views[self.active]
+                                            .fields_on
+                                            .contains(&crate::render::FieldLayer::GlmFed);
                                     crate::ui::layer_options::show(
                                         ui,
                                         &mut self.filters,
                                         &mut self.fields,
+                                        &self.views[self.active].fields_on.clone(),
                                         &mut self.rotation_minutes,
                                         &mut self.hail_minutes,
                                         &mut self.hrrr_fcst_hour,

--- a/crates/hookecho/src/app/chrome/registry.rs
+++ b/crates/hookecho/src/app/chrome/registry.rs
@@ -359,7 +359,7 @@ impl HookEchoApp {
                 false,
             ),
         ] {
-            let on = self.fields.get(&layer).is_some_and(|s| s.show);
+            let on = self.views[self.active].fields_on.contains(&layer);
             push(
                 label,
                 category,

--- a/crates/hookecho/src/app/mobile/mod.rs
+++ b/crates/hookecho/src/app/mobile/mod.rs
@@ -279,7 +279,7 @@ impl super::HookEchoApp {
             if let Some(top) = crate::render::FieldLayer::DRAW_ORDER
                 .iter()
                 .rev()
-                .find(|l| self.fields.get(l).is_some_and(|s| s.show))
+                .find(|l| self.views[self.active].fields_on.contains(l))
             {
                 paint_field_strip(&painter, strip.translate(vec2(0.0, 11.0)), *top);
             }

--- a/crates/hookecho/src/events.rs
+++ b/crates/hookecho/src/events.rs
@@ -13,6 +13,9 @@ pub struct RadarEvent {
     pub lon: f64,
     pub lat: f64,
     pub zoom: f64,
+    /// Minutes of replay centered on `time`. Every curated event has one: the interesting part of
+    /// a tornado is the twenty minutes around it, not the single volume it happened to peak on.
+    pub span_min: u16,
     pub blurb: &'static str,
 }
 
@@ -32,6 +35,7 @@ pub const EVENTS: &[RadarEvent] = &[
         lon: -97.48,
         lat: 35.34,
         zoom: 9.0,
+        span_min: 60,
         blurb: "May 20 2013 — EF5 tracks through Moore; textbook hook echo south of OKC.",
     },
     RadarEvent {
@@ -41,6 +45,7 @@ pub const EVENTS: &[RadarEvent] = &[
         lon: -97.96,
         lat: 35.53,
         zoom: 9.0,
+        span_min: 60,
         blurb: "May 31 2013 — 2.6-mi-wide EF3; violent, erratic couplet west of OKC.",
     },
     RadarEvent {
@@ -50,6 +55,7 @@ pub const EVENTS: &[RadarEvent] = &[
         lon: -94.51,
         lat: 37.06,
         zoom: 9.0,
+        span_min: 60,
         blurb: "May 22 2011 — rain-wrapped EF5 devastates Joplin.",
     },
     RadarEvent {
@@ -59,6 +65,7 @@ pub const EVENTS: &[RadarEvent] = &[
         lon: -87.57,
         lat: 33.21,
         zoom: 9.0,
+        span_min: 60,
         blurb: "Apr 27 2011 — long-track EF4 during the Super Outbreak.",
     },
     RadarEvent {
@@ -68,6 +75,7 @@ pub const EVENTS: &[RadarEvent] = &[
         lon: -88.64,
         lat: 36.74,
         zoom: 9.0,
+        span_min: 60,
         blurb: "Dec 10-11 2021 — nocturnal long-track tornado, Mayfield destroyed.",
     },
     RadarEvent {
@@ -77,6 +85,7 @@ pub const EVENTS: &[RadarEvent] = &[
         lon: -94.46,
         lat: 41.31,
         zoom: 9.0,
+        span_min: 60,
         blurb: "May 21 2024 — high-end EF4 with a striking velocity couplet.",
     },
     RadarEvent {
@@ -86,6 +95,7 @@ pub const EVENTS: &[RadarEvent] = &[
         lon: -97.05,
         lat: 28.02,
         zoom: 7.0,
+        span_min: 60,
         blurb: "Aug 26 2017 — Cat 4 landfall near Rockport, TX.",
     },
     RadarEvent {
@@ -95,6 +105,7 @@ pub const EVENTS: &[RadarEvent] = &[
         lon: -82.20,
         lat: 26.70,
         zoom: 7.0,
+        span_min: 60,
         blurb: "Sep 28 2022 — Cat 5 landfall at Cayo Costa / SW Florida.",
     },
 ];
@@ -117,6 +128,8 @@ mod tests {
                 "coords {}",
                 e.name
             );
+            // A curated event with no span is a still frame, which is not what the library is for.
+            assert!(e.span_min >= 20, "span {}", e.name);
         }
     }
 }

--- a/crates/hookecho/src/render/mod.rs
+++ b/crates/hookecho/src/render/mod.rs
@@ -425,6 +425,7 @@ pub struct RenderResources {
     camera_bgl: wgpu::BindGroupLayout,
     tile_bgl: wgpu::BindGroupLayout,
     radar_bgl: wgpu::BindGroupLayout,
+    mrms_bgl: wgpu::BindGroupLayout,
     sampler: wgpu::Sampler,
     // Shared across panes: tile image cache, vector tile geometry, and the world-space overlay
     // (severe weather + placefiles) — the overlay is camera-independent, drawn per-pane camera.
@@ -607,10 +608,54 @@ impl RenderResources {
             cache: None,
         });
 
-        // MRMS pipeline: same layout as radar (camera + radar_bgl), warps a world quad.
+        // The mosaic shares radar.wgsl's shape — uniform, index grid, LUT — but not its layout:
+        // radar_bgl has since grown a precipitation-type texture and an 80-byte uniform, and
+        // borrowing it meant the mosaic had to carry a dummy texture and dead padding that
+        // nobody remembered to keep in step. It got out of step, and every MRMS draw died in
+        // bind-group validation. Its own three-binding layout cannot drift.
+        let mrms_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("mrms_bgl"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: NonZeroU64::new(48),
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Uint,
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+            ],
+        });
+        let mrms_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("mrms_layout"),
+            bind_group_layouts: &[Some(&camera_bgl), Some(&mrms_bgl)],
+            immediate_size: 0,
+        });
         let mrms_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             label: Some("mrms_pipeline"),
-            layout: Some(&radar_layout),
+            layout: Some(&mrms_layout),
             vertex: wgpu::VertexState {
                 module: &mrms_shader,
                 entry_point: Some("vs_main"),
@@ -689,6 +734,7 @@ impl RenderResources {
             camera_bgl,
             tile_bgl,
             radar_bgl,
+            mrms_bgl,
             sampler,
             tiles: HashMap::new(),
             vector_tiles: HashMap::new(),
@@ -1247,7 +1293,7 @@ impl RenderResources {
         let lut_view = lut_tex.create_view(&wgpu::TextureViewDescriptor::default());
         let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("mrms_bg"),
-            layout: &self.radar_bgl,
+            layout: &self.mrms_bgl,
             entries: &[
                 wgpu::BindGroupEntry {
                     binding: 0,

--- a/crates/hookecho/src/render/mod.rs
+++ b/crates/hookecho/src/render/mod.rs
@@ -411,6 +411,9 @@ struct PaneGpu {
     vector_over_raster: bool,
     frame_draw_radar: bool,
     frame_draw_overlay: bool,
+    /// Field layers this pane draws this frame. Per-pane, not shared: two panes are how you look
+    /// at two fields at once.
+    field_draws: Vec<FieldLayer>,
 }
 
 /// Long-lived GPU resources, stored in egui's `CallbackResources` type-map.
@@ -434,7 +437,6 @@ pub struct RenderResources {
     vector_tiles: HashMap<TileId, OverlayGpu>,
     overlay: Option<OverlayGpu>,
     fields: HashMap<FieldLayer, MrmsGpu>,
-    field_draws: Vec<FieldLayer>,
     // One entry per live pane.
     panes: HashMap<u32, PaneGpu>,
     /// GPU wind particles, built on first use. `None` when the CPU path is in charge.
@@ -692,7 +694,6 @@ impl RenderResources {
             vector_tiles: HashMap::new(),
             overlay: None,
             fields: HashMap::new(),
-            field_draws: Vec::new(),
             panes: HashMap::new(),
             wind: None,
             target_format,
@@ -740,6 +741,7 @@ impl RenderResources {
                 vector_over_raster: false,
                 frame_draw_radar: false,
                 frame_draw_overlay: false,
+                field_draws: Vec::new(),
             }
         })
     }
@@ -1055,11 +1057,11 @@ impl RenderResources {
         }
         // Draw only the requested layers that actually have GPU data. Opacity rides in the grid
         // uniform's first pad word, so it costs one 4-byte write per drawn layer — no LUT re-bake.
-        self.field_draws.clear();
+        let mut field_draws = Vec::new();
         for (layer, opacity) in &cb.field_draws {
             if let Some(f) = self.fields.get(layer) {
                 queue.write_buffer(&f.uni, 24, &opacity.to_le_bytes());
-                self.field_draws.push(*layer);
+                field_draws.push(*layer);
             }
         }
 
@@ -1143,6 +1145,7 @@ impl RenderResources {
         pane.vector_over_raster = cb.vector_over_raster;
         pane.frame_draw_radar = cb.draw_radar && pane.radar.is_some();
         pane.frame_draw_overlay = cb.draw_overlay && overlay_present;
+        pane.field_draws = field_draws;
     }
 
     fn upload_overlay(&mut self, device: &wgpu::Device, o: &OverlayUpload) {
@@ -1311,9 +1314,10 @@ impl RenderResources {
 
     /// Paint the active field layers in the requested band (below/above the radar), in the fixed
     /// bottom-to-top order, using this pane's camera.
-    fn draw_fields(&self, cam: &wgpu::BindGroup, pass: &mut wgpu::RenderPass<'_>, below: bool) {
+    fn draw_fields(&self, pane: &PaneGpu, pass: &mut wgpu::RenderPass<'_>, below: bool) {
+        let cam = &pane.camera_bg;
         for layer in FieldLayer::DRAW_ORDER {
-            if layer.below_radar() != below || !self.field_draws.contains(&layer) {
+            if layer.below_radar() != below || !pane.field_draws.contains(&layer) {
                 continue;
             }
             if let Some(f) = self.fields.get(&layer) {
@@ -1352,7 +1356,7 @@ impl RenderResources {
             self.draw_vector_basemap(pane, cam, pass);
         }
         // Field layers under the radar (national mosaic context).
-        self.draw_fields(cam, pass, true);
+        self.draw_fields(pane, pass, true);
         if pane.frame_draw_radar {
             if let Some(radar) = &pane.radar {
                 pass.set_pipeline(&self.radar_pipeline);
@@ -1363,7 +1367,7 @@ impl RenderResources {
             }
         }
         // Field layers over the radar (rotation/hail/shear/lightning signals).
-        self.draw_fields(cam, pass, false);
+        self.draw_fields(pane, pass, false);
         // Wind particles under the overlay, not over it: the CPU path paints in egui's own layer,
         // which is above everything, and a warning polygon disappearing under a particle trail
         // was the one complaint that layer ever attracted.

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -522,6 +522,10 @@ pub struct Bookmark {
     /// UTC time to seek to (Unix seconds); `None` = live/head.
     #[serde(default)]
     pub time_secs: Option<i64>,
+    /// Replay window around `time_secs`, in minutes. `0` (and any bookmark written before this
+    /// existed) means a still: jump there and stop.
+    #[serde(default)]
+    pub span_min: u16,
 }
 
 fn default_quiet_start() -> u32 {
@@ -1491,6 +1495,7 @@ mod tests {
                 y: 0.4,
                 zoom: 9.0,
                 time_secs: Some(1_600_000_000),
+                span_min: 60,
             }],
             anthropic_key: "sk-test".to_string(),
             lightning_alarm: true,

--- a/crates/hookecho/src/shaders/mrms.wgsl
+++ b/crates/hookecho/src/shaders/mrms.wgsl
@@ -9,7 +9,7 @@ struct Camera {
     scale: vec2<f32>,
 };
 
-// Grid bounds + dimensions (padded to 48 bytes to share the radar bind-group layout).
+// Grid bounds + dimensions (48 bytes, matching mrms_bgl's min_binding_size).
 struct Mrms {
     lon_west: f32,
     lat_north: f32,

--- a/crates/hookecho/src/timeline.rs
+++ b/crates/hookecho/src/timeline.rs
@@ -106,9 +106,13 @@ impl Timeline {
         self.frames = frames;
         self.frames_key = Some(key);
         self.listing = false;
-        // A pending event/deep-link seek wins: snap to the nearest frame by time.
-        if let Some(target) = self.seek_target.take() {
+        // A pending event/deep-link seek wins: snap to the nearest frame by time. The target is
+        // only consumed once a listing actually has a frame to land on — the first listing after
+        // a site switch can arrive empty, and taking the seek there dropped it on the floor and
+        // left the pane parked at the end of the day.
+        if let Some(target) = self.seek_target {
             if let Some(i) = self.nearest_frame(target) {
+                self.seek_target = None;
                 self.playhead = i;
                 self.following = false;
                 // A replay bundle brackets the event rather than starting on it: the minutes
@@ -120,10 +124,15 @@ impl Timeline {
                     let to = self
                         .nearest_frame(target + half)
                         .unwrap_or(self.frames.len().saturating_sub(1));
-                    self.replay = Some((from.min(to), to.max(from)));
-                    self.playhead = from.min(to);
-                    self.playing = true;
-                    self.loop_enabled = true;
+                    let (from, to) = (from.min(to), to.max(from));
+                    // A window that collapsed onto one frame is not a replay: a listing that
+                    // thin would loop the same volume forever, which reads as a frozen app.
+                    if to > from {
+                        self.replay = Some((from, to));
+                        self.playhead = from;
+                        self.playing = true;
+                        self.loop_enabled = true;
+                    }
                 }
                 return;
             }
@@ -452,6 +461,37 @@ mod tests {
             "playhead unmoved; window slides on next wrap"
         );
         assert!(t.live_looping());
+    }
+
+    #[test]
+    fn a_seek_survives_a_listing_it_cannot_land_on() {
+        let mut t = Timeline::default();
+        let day_frames = day("KTLX", 288);
+        let target = day_frames[144].date_time().expect("frame time parses");
+        t.seek_target = Some(target);
+        t.replay_span_min = 60;
+        // The first listing after a site switch can arrive empty; the seek must outlive it.
+        t.set_frames(Vec::new(), ("KTLX".into(), t.date));
+        assert_eq!(t.seek_target, Some(target));
+        assert_eq!(t.replay_span_min, 60);
+
+        t.set_frames(day_frames, ("KTLX".into(), t.date));
+        assert_eq!(t.seek_target, None);
+        assert_eq!(t.replay, Some((138, 150)));
+    }
+
+    #[test]
+    fn a_listing_too_thin_to_bracket_does_not_loop_one_frame_forever() {
+        let mut t = Timeline::default();
+        let frames = day("KTLX", 1);
+        let target = frames[0].date_time().expect("frame time parses");
+        t.seek_target = Some(target);
+        t.replay_span_min = 60;
+        t.set_frames(frames, ("KTLX".into(), t.date));
+        // A single-volume listing: both ends of the window land on it. Seek there, but do not
+        // call it a replay.
+        assert_eq!(t.replay, None);
+        assert!(!t.playing);
     }
 
     #[test]

--- a/crates/hookecho/src/timeline.rs
+++ b/crates/hookecho/src/timeline.rs
@@ -31,6 +31,13 @@ pub struct Timeline {
     /// After the next listing lands, snap the playhead to the frame nearest this time (event
     /// jump / archive deep-link). Cleared once applied.
     pub seek_target: Option<DateTime<Utc>>,
+    /// How long a replay bundle's window is, in minutes. Set alongside `seek_target` when an
+    /// event or a saved replay is opened; consumed when the listing lands, which is the first
+    /// moment frame indices exist to bound.
+    pub replay_span_min: u16,
+    /// Playback bounds as frame indices, inclusive. `None` = play the whole listing. Any manual
+    /// step or jump clears it: the user has taken the playhead back.
+    pub replay: Option<(usize, usize)>,
     /// Forecast hours appended after the newest observed frame (HRRR "future radar" scrub tail).
     pub forecast_hours: u8,
     last_advance: Option<Instant>,
@@ -50,6 +57,8 @@ impl Default for Timeline {
             frames_key: None,
             listing: false,
             seek_target: None,
+            replay_span_min: 0,
+            replay: None,
             forecast_hours: 6,
             last_advance: None,
         }
@@ -102,8 +111,26 @@ impl Timeline {
             if let Some(i) = self.nearest_frame(target) {
                 self.playhead = i;
                 self.following = false;
+                // A replay bundle brackets the event rather than starting on it: the minutes
+                // before are how you see the storm become the thing worth replaying.
+                let span = std::mem::take(&mut self.replay_span_min);
+                if span > 0 {
+                    let half = chrono::Duration::minutes(span as i64 / 2);
+                    let from = self.nearest_frame(target - half).unwrap_or(0);
+                    let to = self
+                        .nearest_frame(target + half)
+                        .unwrap_or(self.frames.len().saturating_sub(1));
+                    self.replay = Some((from.min(to), to.max(from)));
+                    self.playhead = from.min(to);
+                    self.playing = true;
+                    self.loop_enabled = true;
+                }
                 return;
             }
+        }
+        // A listing for another site or day is a different axis; the old bounds mean nothing on it.
+        if switched_site {
+            self.replay = None;
         }
         // While live-looping, a fresh listing must not yank the playhead to the head — the loop
         // owns the playhead. Only clamp it back into range if it now points past the end.
@@ -175,6 +202,7 @@ impl Timeline {
     /// Step `delta` slots (observed frames + forecast tail), un-pinning and pausing playback.
     pub fn step(&mut self, delta: i32) {
         self.playing = false;
+        self.replay = None;
         let n = self.slot_count() as i32;
         if n == 0 {
             return;
@@ -186,6 +214,7 @@ impl Timeline {
 
     /// Jump to the newest frame and re-pin to live.
     pub fn go_head(&mut self) {
+        self.replay = None;
         self.following = true;
         self.playing = false;
         self.playhead = self.frames.len().saturating_sub(1);
@@ -227,6 +256,12 @@ impl Timeline {
             return false;
         }
         self.last_advance = Some(Instant::now());
+        // A replay bundle owns the playhead: it wraps inside its own window, live or not.
+        if let Some((from, to)) = self.replay {
+            let to = to.min(self.frames.len().saturating_sub(1));
+            self.playhead = if self.playhead >= to { from.min(to) } else { self.playhead + 1 };
+            return true;
+        }
         if self.playhead + 1 < self.frames.len() {
             self.playhead += 1;
             // Archive play re-pins to live at the head; a live loop stays pinned throughout.
@@ -417,5 +452,30 @@ mod tests {
             "playhead unmoved; window slides on next wrap"
         );
         assert!(t.live_looping());
+    }
+
+    #[test]
+    fn a_replay_bundle_brackets_its_event_and_loops_inside_the_window() {
+        let mut t = Timeline::default();
+        let day_frames = day("KTLX", 288); // 24 h at 5-minute volumes
+        let target = day_frames[144].date_time().expect("frame time parses"); // 12:00Z
+        t.seek_target = Some(target);
+        t.replay_span_min = 60;
+        t.set_frames(day_frames, ("KTLX".into(), t.date));
+
+        // Half an hour either side of noon, at 5-minute frames: 6 frames back, 6 forward.
+        assert_eq!(t.replay, Some((138, 150)));
+        assert_eq!(t.playhead, 138, "starts before the event, not on it");
+        assert!(t.playing && t.loop_enabled);
+
+        // Playback wraps at the end of the window instead of running on into the afternoon.
+        t.playhead = 150;
+        t.last_advance = None;
+        assert!(t.tick());
+        assert_eq!(t.playhead, 138);
+
+        // Taking the playhead back by hand ends the bundle.
+        t.step(1);
+        assert_eq!(t.replay, None);
     }
 }

--- a/crates/hookecho/src/ui/cell_window.rs
+++ b/crates/hookecho/src/ui/cell_window.rs
@@ -16,16 +16,18 @@ pub struct CellSample {
 
 /// Show the storm-attributes window. `trend` is the cell's per-volume history (oldest→newest);
 /// `following` reflects whether the camera is currently tracking this cell. Returns
-/// `(still_open, follow_toggled)` — `follow_toggled` is `true` the frame the Follow button is hit.
+/// `(still_open, follow_toggled, to_3d)` — the two flags are `true` for the one frame their
+/// button is hit.
 pub fn show(
     ctx: &egui::Context,
     cell: &Cell,
     trend: &[CellSample],
     following: bool,
     popovers: &mut crate::ui::popover::Popovers,
-) -> (bool, bool) {
+) -> (bool, bool, bool) {
     let mut open = true;
     let mut follow_toggled = false;
+    let mut to_3d = false;
     popovers
         .card(
             ctx,
@@ -49,6 +51,19 @@ pub fn show(
                     .clicked()
                 {
                     follow_toggled = true;
+                }
+                if ui
+                    .add(
+                        egui::Button::new("\u{25A6} See in 3D")
+                            .min_size(egui::vec2(ui.available_width(), 0.0)),
+                    )
+                    .on_hover_text(
+                        "Open the raymarched volume cropped to this storm \u{2014} the whole box \
+                         at once is a wall of echo you then have to hunt through",
+                    )
+                    .clicked()
+                {
+                    to_3d = true;
                 }
                 theme::section(ui, "Current Position", |ui| {
                     grid(
@@ -154,7 +169,7 @@ pub fn show(
                 }
             });
         });
-    (open, follow_toggled)
+    (open, follow_toggled, to_3d)
 }
 
 /// A labelled trend sparkline over the samples that carry the selected field.

--- a/crates/hookecho/src/ui/event_window.rs
+++ b/crates/hookecho/src/ui/event_window.rs
@@ -14,9 +14,12 @@ pub enum EventAction {
         lat: f64,
         zoom: f64,
         time: Option<DateTime<Utc>>,
+        /// Minutes to replay around `time`; `0` jumps there and stops.
+        span_min: u16,
     },
-    /// Save the active pane's current view as a bookmark.
-    AddBookmark,
+    /// Save the active pane's current view as a bookmark. The span is the replay window to save
+    /// with it, `0` for a still.
+    AddBookmark(u16),
 }
 
 #[derive(Default)]
@@ -59,10 +62,12 @@ impl EventWindow {
                                 lat: e.lat,
                                 zoom: e.zoom,
                                 time: Some(e.datetime()),
+                                span_min: e.span_min,
                             });
                         }
                         ui.strong(e.name);
                         ui.weak(e.site);
+                        ui.weak(format!("· {} min replay", e.span_min));
                     });
                     ui.label(egui::RichText::new(e.blurb).size(11.0).weak());
                     ui.add_space(2.0);
@@ -84,12 +89,17 @@ impl EventWindow {
                                 lat,
                                 zoom: b.zoom,
                                 time: b.time_secs.and_then(|s| DateTime::from_timestamp(s, 0)),
+                                span_min: b.span_min,
                             });
                         }
                         ui.strong(&b.name);
                         ui.weak(&b.site);
                         if b.time_secs.is_some() {
-                            ui.weak("· archive");
+                            ui.weak(if b.span_min > 0 {
+                                format!("· {} min replay", b.span_min)
+                            } else {
+                                "· archive".to_string()
+                            });
                         }
                         if ui.button("✖").clicked() {
                             remove = Some(i);
@@ -97,9 +107,25 @@ impl EventWindow {
                     });
                 }
                 ui.add_space(4.0);
-                if ui.button("🔖 Bookmark current view").clicked() {
-                    action = Some(EventAction::AddBookmark);
-                }
+                ui.horizontal(|ui| {
+                    if ui
+                        .button("🔖 Bookmark current view")
+                        .on_hover_text("The frame you are on, as a still")
+                        .clicked()
+                    {
+                        action = Some(EventAction::AddBookmark(0));
+                    }
+                    if ui
+                        .button("▶ Save as replay")
+                        .on_hover_text(
+                            "The hour around this frame, looped \u{2014} the storm becoming the \
+                             thing worth saving, not one volume of it",
+                        )
+                        .clicked()
+                    {
+                        action = Some(EventAction::AddBookmark(60));
+                    }
+                });
             });
         });
         if let Some(i) = remove {

--- a/crates/hookecho/src/ui/layer_options.rs
+++ b/crates/hookecho/src/ui/layer_options.rs
@@ -57,6 +57,9 @@ pub(crate) fn show(
     ui: &mut egui::Ui,
     filters: &mut OverlayFilters,
     fields: &mut std::collections::HashMap<crate::render::FieldLayer, crate::app::FieldState>,
+    // Which layers the active pane draws. Visibility is per-pane now; the map above is the shared
+    // fetch state, which is what `fields` is still needed for (clearing a refetch clock).
+    on: &std::collections::HashSet<crate::render::FieldLayer>,
     rotation_minutes: &mut u16,
     hail_minutes: &mut u16,
     hrrr_fcst_hour: &mut u8,
@@ -104,7 +107,7 @@ pub(crate) fn show(
         FL::GlobalPrecip,
     ]
     .iter()
-    .any(|l| fields.get(l).is_some_and(|s| s.show));
+    .any(|l| on.contains(l));
     if global_on {
         ui.horizontal(|ui| {
             ui.label("Global model:");
@@ -128,7 +131,7 @@ pub(crate) fn show(
         });
     }
 
-    if fields.get(&FL::ModelDiff).is_some_and(|s| s.show) {
+    if on.contains(&FL::ModelDiff) {
         let (a, b) = diff_field.pair();
         ui.horizontal_wrapped(|ui| {
             ui.label("Difference:");
@@ -153,7 +156,7 @@ pub(crate) fn show(
         }
     }
 
-    if fields.get(&FL::Lightning).is_some_and(|s| s.show) {
+    if on.contains(&FL::Lightning) {
         ui.horizontal(|ui| {
             ui.label("CG density window:");
             for m in [1u16, 5, 15, 30] {
@@ -311,7 +314,7 @@ pub(crate) fn show(
         ui.label(egui::RichText::new(text).small().strong());
     };
 
-    if fields.get(&FL::Rotation).is_some_and(|s| s.show) {
+    if on.contains(&FL::Rotation) {
         header(ui, "Rotation tracks");
         ui.horizontal(|ui| {
             ui.label("Window:");
@@ -330,7 +333,7 @@ pub(crate) fn show(
         });
     }
 
-    if fields.get(&FL::HailSwath).is_some_and(|s| s.show) {
+    if on.contains(&FL::HailSwath) {
         header(ui, "Hail swaths");
         ui.horizontal(|ui| {
             ui.label("Window:");
@@ -347,14 +350,14 @@ pub(crate) fn show(
         });
     }
 
-    if fields.get(&FL::Mosaic).is_some_and(|s| s.show) {
+    if on.contains(&FL::Mosaic) {
         header(ui, "Radar mosaic");
         if let Some(m) = mosaic {
             ui.weak(m);
         }
     }
 
-    if fields.get(&FL::Hrrr).is_some_and(|s| s.show) {
+    if on.contains(&FL::Hrrr) {
         header(ui, "Future radar");
         ui.add(egui::Slider::new(hrrr_fcst_hour, 0..=18).text("F+ hr"));
         match hrrr_valid {
@@ -374,7 +377,7 @@ pub(crate) fn show(
         }
     }
 
-    if fields.get(&FL::Cape).is_some_and(|s| s.show) {
+    if on.contains(&FL::Cape) {
         header(ui, "CAPE");
         ui.horizontal(|ui| {
             ui.label("Parcel:");
@@ -388,7 +391,7 @@ pub(crate) fn show(
         });
     }
 
-    if fields.get(&FL::Srh).is_some_and(|s| s.show) {
+    if on.contains(&FL::Srh) {
         header(ui, "Storm-relative helicity");
         ui.horizontal(|ui| {
             ui.label("Depth:");
@@ -456,7 +459,7 @@ pub(crate) fn show(
             .changed();
     }
 
-    if fields.get(&FL::SnowAnalysis).is_some_and(|s| s.show) {
+    if on.contains(&FL::SnowAnalysis) {
         header(ui, "Snowfall analysis");
         ui.horizontal(|ui| {
             ui.label("Window:");
@@ -470,7 +473,7 @@ pub(crate) fn show(
 
     if [FL::VilLocal, FL::VilDensity, FL::EtopLocal]
         .iter()
-        .any(|l| fields.get(l).is_some_and(|s| s.show))
+        .any(|l| on.contains(l))
     {
         header(ui, "Derived products");
         ui.horizontal(|ui| {
@@ -530,7 +533,7 @@ pub(crate) fn show(
 
     if [FL::Vil, FL::EchoTops, FL::Hca]
         .iter()
-        .any(|l| fields.get(l).is_some_and(|s| s.show))
+        .any(|l| on.contains(l))
     {
         header(ui, "Level 3 grids");
         ui.weak(format!("Site: {}", l3grid_site.unwrap_or("—")));

--- a/crates/hookecho/src/view.rs
+++ b/crates/hookecho/src/view.rs
@@ -150,6 +150,11 @@ pub struct MapView {
     pub loading: bool,
     pub last_poll: Option<Instant>,
     pub error: Option<String>,
+    /// National field layers drawn in this pane. Per-pane rather than app-wide: two panes is how
+    /// you compare two fields, and the model-difference layer would rather be a pair of panes
+    /// than a subtraction. The grids themselves stay in one shared cache — only the choice of
+    /// what to draw lives here.
+    pub fields_on: std::collections::HashSet<crate::render::FieldLayer>,
     /// Every moment seen in any volume from `loaded_site`, cleared when the site changes.
     ///
     /// A single live volume is only as complete as the tilts that have arrived: early in a scan
@@ -182,6 +187,7 @@ impl MapView {
             loading: false,
             last_poll: None,
             error: None,
+            fields_on: Default::default(),
             moments_seen: [false; Moment::ALL.len()],
         }
     }

--- a/crates/hookecho/src/workspace.rs
+++ b/crates/hookecho/src/workspace.rs
@@ -9,7 +9,8 @@
 //! doesn't capture is anything tied to the moment rather than the arrangement — the archive
 //! playhead, open windows, per-moment thresholds.
 //!
-//! `ponytail: no per-pane thresholds; add them if someone asks for a saved threshold set.`
+//! Per-pane display thresholds and field layers ride along, since a pane that shows one field
+//! above 50 dBZ beside another that shows a different one is exactly the arrangement worth saving.
 
 use crate::view::MapView;
 
@@ -75,6 +76,15 @@ pub struct PaneSnap {
     pub lon: f64,
     pub lat: f64,
     pub zoom: f64,
+    /// Field layers this pane drew, by slug. Same forward-compatibility rule as the overlays: a
+    /// slug this build does not have is skipped. Empty on a snapshot written before per-pane
+    /// layers existed, which is read as "fall back to the workspace-wide list".
+    #[serde(default)]
+    pub fields_on: Vec<String>,
+    /// Enabled display thresholds, as `(moment, physical value)`. Only the enabled ones are
+    /// stored: a threshold that was set but switched off is not part of the arrangement.
+    #[serde(default)]
+    pub thresholds: Vec<(wxdata::level2::Moment, f32)>,
 }
 
 impl PaneSnap {
@@ -90,6 +100,17 @@ impl PaneSnap {
             lon,
             lat,
             zoom: v.camera.zoom,
+            fields_on: crate::render::FieldLayer::DRAW_ORDER
+                .iter()
+                .filter(|l| v.fields_on.contains(l))
+                .map(|l| l.slug().to_string())
+                .collect(),
+            thresholds: wxdata::level2::Moment::ALL
+                .iter()
+                .enumerate()
+                .filter(|&(i, _)| v.threshold_enabled[i])
+                .filter_map(|(i, m)| v.thresholds[i].map(|t| (*m, t)))
+                .collect(),
         }
     }
 
@@ -105,6 +126,14 @@ impl PaneSnap {
         // The camera came from the saved layout, not from a site recenter — hold it through the
         // site change the restore just triggered.
         v.camera_placed = true;
+        // Thresholds are a per-moment array; clear it first so restoring an arrangement without
+        // one does not leave the previous pane's filter in place.
+        v.thresholds = Default::default();
+        v.threshold_enabled = Default::default();
+        for (m, t) in &self.thresholds {
+            v.thresholds[m.index()] = Some(*t);
+            v.threshold_enabled[m.index()] = true;
+        }
     }
 }
 
@@ -122,6 +151,8 @@ fn pane(moment: wxdata::level2::Moment, tilt: usize, srv: bool) -> PaneSnap {
         lon: -97.5,
         lat: 35.5,
         zoom: 7.5,
+        fields_on: Vec::new(),
+        thresholds: Vec::new(),
     }
 }
 
@@ -163,6 +194,8 @@ pub fn starters() -> Vec<Workspace> {
                 lon: -97.0,
                 lat: 38.5,
                 zoom: 4.0,
+                fields_on: vec!["mrms".into()],
+                thresholds: Vec::new(),
             }],
             active: 0,
             link_cameras: false,
@@ -217,6 +250,42 @@ mod tests {
     }
 
     #[test]
+    fn per_pane_thresholds_and_layers_survive_the_round_trip() {
+        use wxdata::level2::Moment;
+        let mut v = MapView::new(None, crate::render::mercator::Camera::at_lonlat(0.0, 0.0, 3.0));
+        v.fields_on.insert(crate::render::FieldLayer::Mrms);
+        v.thresholds[Moment::Reflectivity.index()] = Some(35.0);
+        v.threshold_enabled[Moment::Reflectivity.index()] = true;
+        // Set but switched off: part of the session, not part of the arrangement.
+        v.thresholds[Moment::Velocity.index()] = Some(20.0);
+
+        let snap = PaneSnap::capture(&v);
+        assert_eq!(snap.fields_on, vec!["mrms"]);
+        assert_eq!(snap.thresholds, vec![(Moment::Reflectivity, 35.0)]);
+
+        let mut fresh = MapView::new(None, crate::render::mercator::Camera::at_lonlat(0.0, 0.0, 3.0));
+        // A leftover filter from whatever this pane was showing before must not survive a restore.
+        fresh.thresholds[Moment::SpectrumWidth.index()] = Some(4.0);
+        fresh.threshold_enabled[Moment::SpectrumWidth.index()] = true;
+        snap.apply(&mut fresh);
+        assert_eq!(fresh.thresholds[Moment::Reflectivity.index()], Some(35.0));
+        assert!(fresh.threshold_enabled[Moment::Reflectivity.index()]);
+        assert!(!fresh.threshold_enabled[Moment::SpectrumWidth.index()]);
+        assert_eq!(fresh.thresholds[Moment::Velocity.index()], None);
+    }
+
+    #[test]
+    fn a_pane_written_before_per_pane_layers_still_loads() {
+        // No `fields_on`, no `thresholds` — exactly what an older build wrote.
+        let snap: PaneSnap = serde_json::from_str(
+            r#"{"site":"KTLX","moment":"Reflectivity","tilt":0,"basemap":"dark",
+                "lon":-97.3,"lat":35.3,"zoom":8.0}"#,
+        )
+        .expect("old pane snapshots still parse");
+        assert!(snap.fields_on.is_empty() && snap.thresholds.is_empty());
+    }
+
+    #[test]
     fn workspace_roundtrips_through_json() {
         let ws = Workspace {
             name: "Two-site chase".into(),
@@ -229,6 +298,8 @@ mod tests {
                 lon: -93.72,
                 lat: 41.73,
                 zoom: 7.25,
+                fields_on: Vec::new(),
+                thresholds: Vec::new(),
             }],
             active: 0,
             link_cameras: true,

--- a/crates/wxdata/src/cellscore.rs
+++ b/crates/wxdata/src/cellscore.rs
@@ -40,21 +40,36 @@ pub fn severity(cell: &Cell, prob_pct: Option<u8>, vrot_ms: Option<f32>) -> u8 {
     // Weights: the probability is the most informative single input, rotation and hail split the
     // rest. Thresholds are the operational ones — 10 m/s of Vrot is noise, 40 is a strong
     // mesocyclone; half-inch hail is the severe criterion, three inches is a destructive day.
+    // POSH — the radar's own probability of severe hail — stands in for ProbSevere where the feed
+    // has no storm object over the cell, which is most of the time: the layer is off by default.
+    // It is weaker evidence than a machine-learning severe probability, so it carries less weight.
     let parts = [
         (0.4, prob_pct.map(|p| p as f32)),
         (0.3, vrot_ms.map(|v| ramp(v, 10.0, 40.0))),
         (0.3, cell.hail_in.map(|h| ramp(h, 0.5, 3.0))),
+        (
+            0.2,
+            prob_pct
+                .is_none()
+                .then(|| cell.posh.map(|p| p as f32))
+                .flatten(),
+        ),
     ];
     let (sum, weight) = parts
         .iter()
         .filter_map(|&(w, v)| v.map(|v| (w * v, w)))
         .fold((0.0, 0.0), |(s, w), (a, b)| (s + a, w + b));
-    // Nothing to blend: fall back to reflectivity, which every cell has, so the row still ranks
-    // above an empty one instead of tying at zero.
+    // Reflectivity is the one field every cell has, and it is the weakest evidence of all: a
+    // bright echo is a storm, not a threat. So it rides alongside the hazard blend at a fixed
+    // small share rather than being renormalized with it — otherwise a cell with nothing but
+    // 57 dBZ scored its full ramp and outranked storms carrying a measured hail core, which is
+    // what a live KAMA table did. With no hazard signal at all it is halved: an unknown cell
+    // belongs in the middle of the table, not the top.
+    let dbz = cell.max_dbz.map(|d| ramp(d, 40.0, 70.0)).unwrap_or(0.0);
     let base = if weight > 0.0 {
-        sum / weight
+        0.85 * (sum / weight) + 0.15 * dbz
     } else {
-        cell.max_dbz.map(|d| ramp(d, 40.0, 70.0)).unwrap_or(0.0)
+        0.5 * dbz
     };
     // The radar's own algorithm flags are weak evidence on their own and strong confirmation on
     // top of a score, so they add rather than blend.
@@ -111,8 +126,9 @@ mod tests {
     fn missing_inputs_are_unknown_rather_than_zero() {
         let mut c = cell(-97.5, 35.0);
         c.hail_in = Some(3.0);
-        // Hail alone maxes out; adding an unknown probability must not halve it.
-        assert_eq!(severity(&c, None, None), 100);
+        // Three inches of hail alongside 55 dBZ: the hail dominates its weight, and the weak
+        // reflectivity component pulls the blend down only a little.
+        assert!(severity(&c, None, None) >= 85, "got {}", severity(&c, None, None));
         // A low probability alongside it does drag the blend down.
         assert!(severity(&c, Some(10), None) < 60);
     }
@@ -121,10 +137,25 @@ mod tests {
     fn a_bare_cell_still_ranks_on_reflectivity_and_flags() {
         let c = cell(-97.5, 35.0);
         let plain = severity(&c, None, None);
-        assert_eq!(plain, 50); // 55 dBZ, halfway up the 40–70 ramp.
+        // Nothing but a 55 dBZ echo: halfway up the 40–70 ramp, halved because that is all we
+        // know about it.
+        assert_eq!(plain, 25);
         let mut tvs = cell(-97.5, 35.0);
         tvs.tvs = Some("TVS".into());
         assert_eq!(severity(&tvs, None, None), plain + 15);
+    }
+
+    #[test]
+    fn a_measured_hail_core_outranks_a_merely_bright_echo() {
+        // The case a live KAMA table produced: a 57 dBZ cell with nothing else known was sorting
+        // above a storm carrying a 1.2 in hail estimate and POSH 40.
+        let mut bright = cell(-101.9, 35.5);
+        bright.max_dbz = Some(57.0);
+        let mut hail = cell(-101.8, 35.4);
+        hail.max_dbz = Some(59.0);
+        hail.hail_in = Some(1.2);
+        hail.posh = Some(40);
+        assert!(severity(&hail, None, None) > severity(&bright, None, None));
     }
 
     #[test]
@@ -147,8 +178,8 @@ mod tests {
         let s = score_all(&cells, &feats, &couplets);
         // Inside the polygon and next to the couplet: 90% at weight 0.4 and a maxed Vrot ramp at
         // 0.3, renormalized over the two present components.
-        assert_eq!(s[0], 94);
-        // Six hundred km away, neither claims it — reflectivity only.
-        assert_eq!(s[1], 50);
+        assert_eq!(s[0], 88);
+        // Six hundred km away, neither claims it — the halved reflectivity term only.
+        assert_eq!(s[1], 25);
     }
 }

--- a/crates/wxdata/src/volume3d.rs
+++ b/crates/wxdata/src/volume3d.rs
@@ -157,6 +157,31 @@ pub fn cappi(sweeps: &[BinnedSweep], alt_km: f32, n: usize, half_km: f32) -> Opt
     })
 }
 
+/// Clip slab that isolates one storm inside the volume box, in the `[x0, x1, y0, y1, z0, z1]`
+/// fractions [`crate::volume3d`]'s consumers use.
+///
+/// `dx_km`/`dy_km` are the storm's offset east and north of the radar, `pad_km` the half-width to
+/// keep around it. The vertical span is left alone: the whole point of looking at a storm in 3D is
+/// its depth, so cropping height would throw away the answer.
+pub fn clip_around(half_km: f32, dx_km: f32, dy_km: f32, pad_km: f32) -> [f32; 6] {
+    // The box spans [-half_km, +half_km] in x and y, mapped onto 0..1.
+    let frac = |km: f32| ((km + half_km) / (2.0 * half_km)).clamp(0.0, 1.0);
+    let pad = (pad_km / (2.0 * half_km)).clamp(0.0, 0.5);
+    let span = |c: f32| {
+        let (mut lo, mut hi) = (c - pad, c + pad);
+        // A storm near the edge of the box slides its window inward rather than shrinking it.
+        if lo < 0.0 {
+            (lo, hi) = (0.0, (2.0 * pad).min(1.0));
+        } else if hi > 1.0 {
+            (lo, hi) = ((1.0 - 2.0 * pad).max(0.0), 1.0);
+        }
+        (lo, hi)
+    };
+    let (x0, x1) = span(frac(dx_km));
+    let (y0, y1) = span(frac(dy_km));
+    [x0, x1, y0, y1, 0.0, 1.0]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -229,5 +254,27 @@ mod tests {
             0,
             "14 km empty"
         );
+    }
+}
+
+#[cfg(test)]
+mod clip_tests {
+    use super::clip_around;
+
+    #[test]
+    fn the_slab_brackets_the_storm_and_slides_in_at_the_edge() {
+        // Dead center of a 150 km box, 25 km of padding: an eighth of the box either side.
+        let c = clip_around(150.0, 0.0, 0.0, 25.0);
+        assert!((c[0] - 0.4167).abs() < 1e-3 && (c[1] - 0.5833).abs() < 1e-3);
+        // Height is never cropped.
+        assert_eq!([c[4], c[5]], [0.0, 1.0]);
+        // Hard against the west wall: the window slides inward instead of collapsing.
+        let w = clip_around(150.0, -150.0, 0.0, 25.0);
+        assert_eq!(w[0], 0.0);
+        assert!((w[1] - w[0] - (c[1] - c[0])).abs() < 1e-3);
+        // And against the north wall.
+        let n = clip_around(150.0, 0.0, 150.0, 25.0);
+        assert_eq!(n[3], 1.0);
+        assert!((n[3] - n[2] - (c[1] - c[0])).abs() < 1e-3);
     }
 }


### PR DESCRIPTION
H4 of wave H. Stacked on #112.

## What

The Event Library deep-linked to a single volume and stopped. A **bundle** is that instant plus a span, replayed as a loop with the time-synced context on.

- **`Timeline::replay: Option<(usize, usize)>`** — inclusive frame bounds `tick` wraps inside. Armed in `set_frames`, alongside the existing `seek_target` snap, because that is the first moment frame indices exist to bound. `replay_span_min` carries the request across the listing fetch.
- **Brackets, does not start on.** Half the span either side of the target: the minutes before are how you see the storm become the thing worth replaying.
- **Cleared by hand.** `step` and `go_head` drop the bounds, and a listing for another site drops them too — index N of one radar's day is not index N of another's.
- **Curated events** all gain `span_min: 60`, asserted `>= 20` by the existing test so a future entry cannot be added as a still by accident.
- **Bookmarks** gain `span_min` (`#[serde(default)]`, `0` = still) and a "Save as replay" button beside "Bookmark current view". Existing bookmarks read as stills, which is what they were.
- Opening a bundle switches on alerts and storm reports; both already follow the playhead into the archive (`sync_archive_warnings`, the LSR bucket path), so nothing new was needed to time-sync them.

## Gate

- clippy `-D warnings` clean
- 591 passed / 30 ignored / 0 failed
- wasm check clean
- `shoot.sh check` passed
- web gzip 4,813,650 / 4,850,000

Not device-verified: no bundle has been replayed against a live archive listing. The wrap arithmetic and the bracketing are covered by a unit test over a synthetic 24 h listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)