### PR TITLE
feat(share): a share button, and an address bar that means something

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,6 +675,11 @@ instead of the configured default site. No third-party lookup and no browser
 permission prompt; a `#goto=` deep link still wins. A host without it just opens
 on the default.
 
+The address bar is a permalink: the `#goto=` fragment follows the active pane as
+you pan, zoom and scrub, so copying the URL sends someone to the frame you were
+looking at, archive time included. The share button in the control column does
+the same thing through the platform's share sheet where there is one.
+
 **Cloudflare Pages** — `web/_worker.js/`, deployed by
 `.github/workflows/demo.yml`. That's what `hookecho.pages.dev` is, and it is the
 only host this repo deploys to.

--- a/README.md
+++ b/README.md
@@ -643,11 +643,13 @@ sweep during a scan rather than waiting out the whole volume. Settings persist t
 own audio and `speechSynthesis`. It is also **installable**: a manifest and a
 service worker put it on the home screen or in its own window, and precache the
 app shell so a launch with no signal still opens the map instead of a browser
-error. Only the shell is cached — radar and everything through the proxy stay on
-the network, because a cached radar frame is a wrong radar frame.
+error. Basemap tiles are cached too, so a second visit draws the map without
+re-downloading geography that has not moved. Radar, satellite and everything else
+through the proxy stay on the network, because a cached radar frame is a wrong
+radar frame.
 
 This is a **core viewer**, though, not parity.
-There is no filesystem, so caches are memory-only and imports and exports are
+There is no filesystem, so volume caches are memory-only and imports and exports are
 out; there is no camera, plugin or GPS support; and any feed whose host refuses
 cross-origin requests simply doesn't load. Anything that needs those is on the
 desktop and Android builds.

--- a/README.md
+++ b/README.md
@@ -641,8 +641,9 @@ requests. **Live chunk streaming works too**, so a browser tab updates sweep by
 sweep during a scan rather than waiting out the whole volume. Settings persist to
 `localStorage`, and alert sounds and spoken warnings play through the browser's
 own audio and `speechSynthesis`. "Use my location" and chase follow-me work too,
-off the browser's own Geolocation — asked for when you press the button, never
-before. It is also **installable**: a manifest and a
+off the browser's own Geolocation, and "Post alerts to the desktop" posts real
+browser notifications. Both permissions are asked for at the moment you turn the
+thing on and never before. It is also **installable**: a manifest and a
 service worker put it on the home screen or in its own window, and precache the
 app shell so a launch with no signal still opens the map instead of a browser
 error. Basemap tiles are cached too, so a second visit draws the map without

--- a/README.md
+++ b/README.md
@@ -640,7 +640,9 @@ forecasts all work: the Level 2 buckets and `api.weather.gov` allow cross-origin
 requests. **Live chunk streaming works too**, so a browser tab updates sweep by
 sweep during a scan rather than waiting out the whole volume. Settings persist to
 `localStorage`, and alert sounds and spoken warnings play through the browser's
-own audio and `speechSynthesis`. It is also **installable**: a manifest and a
+own audio and `speechSynthesis`. "Use my location" and chase follow-me work too,
+off the browser's own Geolocation — asked for when you press the button, never
+before. It is also **installable**: a manifest and a
 service worker put it on the home screen or in its own window, and precache the
 app shell so a launch with no signal still opens the map instead of a browser
 error. Basemap tiles are cached too, so a second visit draws the map without
@@ -654,7 +656,7 @@ browser's own file picker and downloads — an imported `.pal` has no path to li
 at, so its content rides in the settings and survives a reload like everything
 else there. There is still no filesystem, though, so volume caches are
 memory-only and marker icons and custom alert sounds (both of which are files the
-app reopens later) stay off; there is no camera, plugin or GPS support; and any feed whose host refuses
+app reopens later) stay off; there is no camera or plugin support; and any feed whose host refuses
 cross-origin requests simply doesn't load. Anything that needs those is on the
 desktop and Android builds.
 

--- a/README.md
+++ b/README.md
@@ -649,8 +649,12 @@ through the proxy stay on the network, because a cached radar frame is a wrong
 radar frame.
 
 This is a **core viewer**, though, not parity.
-There is no filesystem, so volume caches are memory-only and imports and exports are
-out; there is no camera, plugin or GPS support; and any feed whose host refuses
+Settings bundles, color tables and CSV/GPX exports import and export through the
+browser's own file picker and downloads — an imported `.pal` has no path to live
+at, so its content rides in the settings and survives a reload like everything
+else there. There is still no filesystem, though, so volume caches are
+memory-only and marker icons and custom alert sounds (both of which are files the
+app reopens later) stay off; there is no camera, plugin or GPS support; and any feed whose host refuses
 cross-origin requests simply doesn't load. Anything that needs those is on the
 desktop and Android builds.
 

--- a/crates/hookecho/Cargo.toml
+++ b/crates/hookecho/Cargo.toml
@@ -115,7 +115,7 @@ console_error_panic_hook = "0.1"
 console_log = "1"
 # The file-dialog set (HtmlInputElement/FileList/File through Blob/Url/HtmlAnchorElement) is what
 # lets `dialog.rs` import and export in a browser — see its `web_open` and `web_save`.
-web-sys = { version = "0.3", features = ["Document", "Window", "HtmlCanvasElement", "Location", "Storage", "HtmlAudioElement", "SpeechSynthesis", "SpeechSynthesisUtterance", "HtmlInputElement", "HtmlAnchorElement", "HtmlElement", "CssStyleDeclaration", "Element", "FileList", "File", "Blob", "Url", "Navigator", "Geolocation", "Position", "Coordinates", "PositionError", "PositionOptions", "Notification", "NotificationOptions", "NotificationPermission"] }
+web-sys = { version = "0.3", features = ["Document", "Window", "HtmlCanvasElement", "Location", "Storage", "HtmlAudioElement", "SpeechSynthesis", "SpeechSynthesisUtterance", "HtmlInputElement", "HtmlAnchorElement", "HtmlElement", "CssStyleDeclaration", "Element", "FileList", "File", "Blob", "Url", "Navigator", "Geolocation", "Position", "Coordinates", "PositionError", "PositionOptions", "Notification", "NotificationOptions", "NotificationPermission", "History", "Performance"] }
 
 # Native file dialogs — desktop only. rfd has no Android backend, and Android replaces it with a
 # fixed exports dir + Storage-Access-Framework (deferred); see `dialog.rs`.

--- a/crates/hookecho/Cargo.toml
+++ b/crates/hookecho/Cargo.toml
@@ -115,7 +115,7 @@ console_error_panic_hook = "0.1"
 console_log = "1"
 # The file-dialog set (HtmlInputElement/FileList/File through Blob/Url/HtmlAnchorElement) is what
 # lets `dialog.rs` import and export in a browser — see its `web_open` and `web_save`.
-web-sys = { version = "0.3", features = ["Document", "Window", "HtmlCanvasElement", "Location", "Storage", "HtmlAudioElement", "SpeechSynthesis", "SpeechSynthesisUtterance", "HtmlInputElement", "HtmlAnchorElement", "HtmlElement", "CssStyleDeclaration", "Element", "FileList", "File", "Blob", "Url", "Navigator", "Geolocation", "Position", "Coordinates", "PositionError", "PositionOptions"] }
+web-sys = { version = "0.3", features = ["Document", "Window", "HtmlCanvasElement", "Location", "Storage", "HtmlAudioElement", "SpeechSynthesis", "SpeechSynthesisUtterance", "HtmlInputElement", "HtmlAnchorElement", "HtmlElement", "CssStyleDeclaration", "Element", "FileList", "File", "Blob", "Url", "Navigator", "Geolocation", "Position", "Coordinates", "PositionError", "PositionOptions", "Notification", "NotificationOptions", "NotificationPermission"] }
 
 # Native file dialogs — desktop only. rfd has no Android backend, and Android replaces it with a
 # fixed exports dir + Storage-Access-Framework (deferred); see `dialog.rs`.

--- a/crates/hookecho/Cargo.toml
+++ b/crates/hookecho/Cargo.toml
@@ -115,7 +115,7 @@ console_error_panic_hook = "0.1"
 console_log = "1"
 # The file-dialog set (HtmlInputElement/FileList/File through Blob/Url/HtmlAnchorElement) is what
 # lets `dialog.rs` import and export in a browser — see its `web_open` and `web_save`.
-web-sys = { version = "0.3", features = ["Document", "Window", "HtmlCanvasElement", "Location", "Storage", "HtmlAudioElement", "SpeechSynthesis", "SpeechSynthesisUtterance", "HtmlInputElement", "HtmlAnchorElement", "HtmlElement", "CssStyleDeclaration", "Element", "FileList", "File", "Blob", "Url"] }
+web-sys = { version = "0.3", features = ["Document", "Window", "HtmlCanvasElement", "Location", "Storage", "HtmlAudioElement", "SpeechSynthesis", "SpeechSynthesisUtterance", "HtmlInputElement", "HtmlAnchorElement", "HtmlElement", "CssStyleDeclaration", "Element", "FileList", "File", "Blob", "Url", "Navigator", "Geolocation", "Position", "Coordinates", "PositionError", "PositionOptions"] }
 
 # Native file dialogs — desktop only. rfd has no Android backend, and Android replaces it with a
 # fixed exports dir + Storage-Access-Framework (deferred); see `dialog.rs`.

--- a/crates/hookecho/Cargo.toml
+++ b/crates/hookecho/Cargo.toml
@@ -113,7 +113,9 @@ getrandom = { version = "0.3", features = ["wasm_js"] }
 # app's own logs in the devtools console, which is the only debugger a wasm build has.
 console_error_panic_hook = "0.1"
 console_log = "1"
-web-sys = { version = "0.3", features = ["Document", "Window", "HtmlCanvasElement", "Location", "Storage", "HtmlAudioElement", "SpeechSynthesis", "SpeechSynthesisUtterance"] }
+# The file-dialog set (HtmlInputElement/FileList/File through Blob/Url/HtmlAnchorElement) is what
+# lets `dialog.rs` import and export in a browser — see its `web_open` and `web_save`.
+web-sys = { version = "0.3", features = ["Document", "Window", "HtmlCanvasElement", "Location", "Storage", "HtmlAudioElement", "SpeechSynthesis", "SpeechSynthesisUtterance", "HtmlInputElement", "HtmlAnchorElement", "HtmlElement", "CssStyleDeclaration", "Element", "FileList", "File", "Blob", "Url"] }
 
 # Native file dialogs — desktop only. rfd has no Android backend, and Android replaces it with a
 # fixed exports dir + Storage-Access-Framework (deferred); see `dialog.rs`.

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -12875,13 +12875,19 @@ impl HookEchoApp {
                     }
                 });
             }
-            // Desktop streams from a local gpsd; Android polls the system LocationManager
-            // over JNI (see platform.rs). Both feed the same `gps_rx` channel.
+            // Desktop streams from a local gpsd; Android polls the system LocationManager over
+            // JNI (see platform.rs); the web watches the browser's own Geolocation. All three
+            // feed the same `gps_rx` channel.
             if self.gps_rx.is_none() {
                 let (label, tip) = if cfg!(target_os = "android") {
                     (
                         "Enable GPS (chase)",
                         "Follow your device's position (asks for the location permission)",
+                    )
+                } else if cfg!(target_arch = "wasm32") {
+                    (
+                        "Enable GPS (chase)",
+                        "Follow your position (asks the browser for the location permission)",
                     )
                 } else {
                     (

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -7089,8 +7089,12 @@ impl HookEchoApp {
                         .then(|| v.thresholds[v.moment.index()]),
                     srv: false,
                 });
-                ctx.copy_text(link.clone());
-                self.banner("Link copied".to_string(), link);
+                // A phone or a tablet has a share sheet, and pasting into a chat is what this is
+                // for; the clipboard is the fallback for everything that does not.
+                if !crate::platform::share_link("Hook Echo-WX", &link) {
+                    ctx.copy_text(link.clone());
+                    self.banner("Link copied".to_string(), link);
+                }
             }
             PaletteAction::SaveWorkspace => {
                 let ws = self.capture_workspace();
@@ -14909,6 +14913,7 @@ impl eframe::App for HookEchoApp {
                 true
             };
             if chrome {
+                self.sync_permalink();
                 self.search_pill(ctx);
                 self.control_column(ctx);
                 self.scrubber(ctx);

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -12854,17 +12854,16 @@ impl HookEchoApp {
                         let n = self.chase_track.waypoints.len() + 1;
                         self.chase_track.mark(format!("Mark {n}"));
                     }
-                    if !cfg!(target_arch = "wasm32") && ui.button("Save GPX…").clicked() {
-                        if let Some(path) = crate::dialog::save_path("chase.gpx", "gpx") {
-                            match std::fs::write(&path, self.chase_track.to_gpx()) {
-                                Ok(()) => {
-                                    let msg = format!("Saved {}", path.display());
-                                    self.toast(ToastKind::Success, msg);
-                                }
-                                Err(e) => {
-                                    self.toast(ToastKind::Error, format!("GPX save failed: {e}"))
-                                }
+                    if ui.button("Save GPX…").clicked() {
+                        let gpx = self.chase_track.to_gpx();
+                        match crate::dialog::save_bytes("chase.gpx", "gpx", gpx.as_bytes()) {
+                            crate::dialog::Saved::Where(w) => {
+                                self.toast(ToastKind::Success, format!("Saved to {w}"))
                             }
+                            crate::dialog::Saved::Failed(e) => {
+                                self.toast(ToastKind::Error, format!("GPX save failed: {e}"))
+                            }
+                            crate::dialog::Saved::Cancelled => {}
                         }
                     }
                     if ui
@@ -13104,24 +13103,26 @@ impl HookEchoApp {
         });
     }
 
-    /// Export settings + referenced color tables to a portable JSON bundle (rfd save dialog).
+    /// Export settings + referenced color tables to a portable JSON bundle (a save dialog on
+    /// desktop, a download in a browser).
     fn export_settings_bundle(&mut self) {
-        let Some(path) = crate::dialog::save_path("hookecho-settings.json", "json") else {
-            return;
-        };
-        match self
-            .settings
-            .export_bundle()
-            .and_then(|json| std::fs::write(&path, json).map_err(|e| e.to_string()))
-        {
-            Ok(()) => self.toast(
-                ToastKind::Success,
-                format!("Settings saved to {}", path.display()),
-            ),
+        let json = match self.settings.export_bundle() {
+            Ok(json) => json,
             Err(e) => {
                 log::warn!("settings export failed: {e}");
                 self.toast(ToastKind::Error, format!("Settings export failed: {e}"));
+                return;
             }
+        };
+        match crate::dialog::save_bytes("hookecho-settings.json", "json", json.as_bytes()) {
+            crate::dialog::Saved::Where(w) => {
+                self.toast(ToastKind::Success, format!("Settings saved to {w}"))
+            }
+            crate::dialog::Saved::Failed(e) => {
+                log::warn!("settings export failed: {e}");
+                self.toast(ToastKind::Error, format!("Settings export failed: {e}"));
+            }
+            crate::dialog::Saved::Cancelled => {}
         }
     }
 
@@ -13135,15 +13136,33 @@ impl HookEchoApp {
     fn apply_import(&mut self, import: crate::dialog::Import) {
         use crate::dialog::ImportKind as K;
         match import.kind {
-            K::SettingsBundle => self.apply_settings_bundle(&import.path),
+            K::SettingsBundle => self.apply_settings_bundle(&import),
             K::Palette if import.tag == crate::ui::palette_editor::EDITOR_TAG => {
-                self.palette_editor.pending_import = Some(import.path);
+                match import.text() {
+                    Ok(text) => self.palette_editor.pending_import = Some(text),
+                    Err(e) => self.toast(ToastKind::Error, format!("Palette import failed: {e}")),
+                }
             }
             K::Palette => {
+                // A platform that handed over content rather than a path (the browser) has no
+                // path worth storing — the content goes into the settings and the override names
+                // it, which is what `palette_paths` resolves back to a table.
+                let value = match &import.bytes {
+                    None => import.path.to_string_lossy().into_owned(),
+                    Some(_) => match import.text() {
+                        Ok(text) => {
+                            let name = import.name();
+                            self.settings.web_files.insert(name.clone(), text);
+                            name
+                        }
+                        Err(e) => {
+                            self.toast(ToastKind::Error, format!("Palette import failed: {e}"));
+                            return;
+                        }
+                    },
+                };
                 // Setting the override triggers the next-frame dirty-diff palette reload.
-                self.settings
-                    .palettes
-                    .insert(import.tag, import.path.to_string_lossy().into_owned());
+                self.settings.palettes.insert(import.tag, value);
             }
             K::MarkerIcon => {
                 let idx = import.tag.parse::<usize>().ok();
@@ -13172,9 +13191,9 @@ impl HookEchoApp {
     }
 
     /// Apply a settings bundle the user picked.
-    fn apply_settings_bundle(&mut self, path: &std::path::Path) {
-        match std::fs::read_to_string(path)
-            .map_err(|e| e.to_string())
+    fn apply_settings_bundle(&mut self, import: &crate::dialog::Import) {
+        match import
+            .text()
             .and_then(|s| crate::settings::Settings::import_bundle(&s))
         {
             Ok(settings) => {

--- a/crates/hookecho/src/app/chrome/mod.rs
+++ b/crates/hookecho/src/app/chrome/mod.rs
@@ -4,6 +4,7 @@
 
 mod chips;
 mod overlay;
+mod permalink;
 pub(crate) use overlay::compact;
 mod registry;
 mod scrubber;

--- a/crates/hookecho/src/app/chrome/overlay.rs
+++ b/crates/hookecho/src/app/chrome/overlay.rs
@@ -478,6 +478,14 @@ impl HookEchoApp {
                         self.panel_open = !alerts_on;
                         self.show_alert_panel = true;
                     }
+                    // Sharing where you are looking is the thing people do with a radar and had
+                    // no button for — only Ctrl+K knew about it.
+                    if square_btn(ui, egui_phosphor::regular::SHARE_NETWORK, false, accent)
+                        .named("Share this view")
+                        .clicked()
+                    {
+                        self.apply_palette(crate::app::PaletteAction::CopyViewLink, ctx);
+                    }
                     // Count over the bell's top-right corner, coloured by the worst alert in
                     // view — the same escalation the alert panel sorts by.
                     if alert_count > 0 {

--- a/crates/hookecho/src/app/chrome/permalink.rs
+++ b/crates/hookecho/src/app/chrome/permalink.rs
@@ -1,0 +1,100 @@
+//! The address bar as a permalink.
+//!
+//! `#goto=` has been a link you could be sent since PR #76, and one the app read exactly once, at
+//! boot. Nothing ever wrote it back — so the URL of a browser tab said where the session started,
+//! never where it had got to, and copying out of the address bar sent someone to the wrong place
+//! and the wrong hour.
+//!
+//! This keeps it honest: the fragment tracks the active pane, including the archive time when the
+//! timeline is scrubbed off live. `replaceState`, not `pushState` — panning a map is not
+//! navigation, and forty history entries per drag would make the back button useless.
+
+use super::*;
+
+/// The last fragment written, so an unchanged view costs nothing.
+///
+/// A static rather than a field on the app: the browser owns this, there is exactly one address
+/// bar, and threading it through `HookEchoApp` would be state nobody else can use.
+#[cfg(target_arch = "wasm32")]
+static LAST: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
+
+/// How often the URL may be rewritten. A pan is a hundred frames and one destination; the number
+/// is low enough that the address bar is never stale in any way a person would notice.
+#[cfg(target_arch = "wasm32")]
+const MIN_INTERVAL: std::time::Duration = std::time::Duration::from_millis(750);
+
+impl HookEchoApp {
+    /// Point the address bar at what is on screen. No-op off the web, where there is no address
+    /// bar to point.
+    pub(crate) fn sync_permalink(&mut self) {
+        #[cfg(target_arch = "wasm32")]
+        {
+            let Some(frag) = self.permalink_fragment() else {
+                return;
+            };
+            let mut last = LAST.lock().unwrap_or_else(|e| e.into_inner());
+            if last.as_deref() == Some(frag.as_str()) {
+                return;
+            }
+            if !self.permalink_due() {
+                return;
+            }
+            let Some(win) = web_sys::window() else { return };
+            // The rest of the URL is left exactly as it is — the recovery reload's `?relaunched`
+            // lives in the query, and stamping over it would spend the retry it is tracking.
+            if let Ok(h) = win.history() {
+                let _ = h.replace_state_with_url(&wasm_bindgen::JsValue::NULL, "", Some(&frag));
+                *last = Some(frag);
+            }
+        }
+    }
+
+    /// The `#goto=…` for the active pane, built from the same [`goto_link`] the share button uses
+    /// so a copied address and a shared link are the same string.
+    #[cfg(target_arch = "wasm32")]
+    fn permalink_fragment(&self) -> Option<String> {
+        let v = self.views.get(self.active)?;
+        let site = v.site.clone()?;
+        let c = v.camera.center;
+        let (lon, lat) = crate::render::mercator::world_to_lonlat(c.0, c.1);
+        // Live stays live: a permalink that pinned the current minute would turn "share what I am
+        // watching" into "share the moment I happened to copy it".
+        let time = (!v.timeline.following)
+            .then(|| v.timeline.current().and_then(|id| id.date_time()))
+            .flatten();
+        let link = goto_link(&Goto {
+            site,
+            lon,
+            lat,
+            zoom: v.camera.zoom,
+            time,
+            moment: Some(v.moment),
+            tilt: Some(v.tilt),
+            basemap: None,
+            threshold: v.threshold_enabled[v.moment.index()].then(|| v.thresholds[v.moment.index()]),
+            srv: false,
+        });
+        link.find('#').map(|i| link[i..].to_string())
+    }
+
+    /// Has enough time passed since the last rewrite? Safari throttles `replaceState` and starts
+    /// throwing past roughly a hundred calls a minute, so this is a correctness guard, not a
+    /// politeness one.
+    #[cfg(target_arch = "wasm32")]
+    fn permalink_due(&self) -> bool {
+        use std::sync::Mutex;
+        static WHEN: Mutex<Option<f64>> = Mutex::new(None);
+        let Some(now) = web_sys::window()
+            .and_then(|w| w.performance())
+            .map(|p| p.now())
+        else {
+            return false;
+        };
+        let mut when = WHEN.lock().unwrap_or_else(|e| e.into_inner());
+        if when.is_some_and(|t| now - t < MIN_INTERVAL.as_millis() as f64) {
+            return false;
+        }
+        *when = Some(now);
+        true
+    }
+}

--- a/crates/hookecho/src/colormap.rs
+++ b/crates/hookecho/src/colormap.rs
@@ -304,6 +304,11 @@ const ALT_SRC: [(&str, usize, &str); 2] = [
 /// The `settings.palettes` value that selects built-in alternate `name`.
 pub const BUILTIN_PREFIX: &str = "builtin:";
 
+/// A "path" that is really the file's own content. The browser has nowhere to put an imported
+/// `.pal`, so `Settings::palette_paths` inlines it behind this and the loader parses it directly.
+/// The marker is a prefix no real path starts with, same trick as [`BUILTIN_PREFIX`].
+pub const INLINE_PREFIX: &str = "inline:";
+
 /// Names of the built-in alternates offered for `moment`, in menu order.
 pub fn alt_names(moment: Moment) -> impl Iterator<Item = &'static str> {
     ALT_SRC
@@ -369,6 +374,13 @@ impl Palettes {
                         ),
                     }
                 }
+                Some(path) if path.to_string_lossy().starts_with(INLINE_PREFIX) => {
+                    let text = path.to_string_lossy()[INLINE_PREFIX.len()..].to_string();
+                    match parse_pal(&text) {
+                        Ok(t) => (t, None),
+                        Err(e) => (default_table(moment).clone(), Some(e.to_string())),
+                    }
+                }
                 Some(path) => match std::fs::read_to_string(path)
                     .map_err(|e| e.to_string())
                     .and_then(|s| parse_pal(&s).map_err(|e| e.to_string()))
@@ -387,6 +399,18 @@ impl Palettes {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn an_inline_table_loads_without_a_file() {
+        let mut p = Palettes::default();
+        let mut paths: [Option<std::path::PathBuf>; Moment::ALL.len()] = Default::default();
+        paths[0] = Some(format!("{INLINE_PREFIX}Color: 5 255 0 0\nColor: 70 255 255 255").into());
+        paths[1] = Some(format!("{INLINE_PREFIX}not a palette").into());
+        p.reload(&paths);
+        assert_eq!(p.tables[0].stops.len(), 2);
+        assert!(p.errors[0].is_none());
+        assert!(p.errors[1].is_some(), "bad inline content reports, not panics");
+    }
 
     #[test]
     fn all_builtins_parse() {

--- a/crates/hookecho/src/dialog.rs
+++ b/crates/hookecho/src/dialog.rs
@@ -1,9 +1,50 @@
-//! Native file-dialog shim. Desktop uses `rfd`; Android goes through the Storage Access
-//! Framework, which is asynchronous, so opening a file is a request now and a result later on
-//! both platforms. Keeping both behind this shim lets the call sites stay platform-agnostic and
-//! `rfd` stay off the Android build.
+//! File-dialog shim. Desktop uses `rfd`; Android goes through the Storage Access Framework; the
+//! browser uses a hidden `<input type="file">` and a download link. All three are asynchronous —
+//! opening a file is a request now and a result later — so the call sites stay platform-agnostic
+//! and `rfd` stays off the Android and wasm builds.
+//!
+//! The browser has no filesystem, so a picked file arrives as bytes rather than a path and a
+//! saved file leaves as a download. [`Import::text`] and [`save_bytes`] are the two call-site
+//! shapes that work on every platform; a raw `path` is native-only by construction.
 
 use std::path::PathBuf;
+
+/// Where a save went, for the caller's toast. Cancelling is not a failure and gets no message.
+pub enum Saved {
+    /// The user dismissed the dialog.
+    Cancelled,
+    /// Written. The string is where, in whatever terms that platform has — a path, or "Downloads".
+    Where(String),
+    /// It did not get written. The string is why.
+    Failed(String),
+}
+
+/// Save `bytes` under `default_name`. The whole-file form: the caller has the content in hand, so
+/// the browser can hand it to the user as a download and no call site needs a path at all.
+///
+/// ponytail: byte-sized exports only. A screenshot or a loop export picks its destination before
+/// it has any content to write and streams into it, which is why those still go through
+/// [`save_path`] and stay native-only.
+pub fn save_bytes(default_name: &str, ext: &str, bytes: &[u8]) -> Saved {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let _ = ext;
+        return match web_save::download(default_name, bytes) {
+            Ok(()) => Saved::Where("your downloads".to_string()),
+            Err(e) => Saved::Failed(e),
+        };
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let Some(path) = save_path(default_name, ext) else {
+            return Saved::Cancelled;
+        };
+        match std::fs::write(&path, bytes) {
+            Ok(()) => Saved::Where(path.display().to_string()),
+            Err(e) => Saved::Failed(e.to_string()),
+        }
+    }
+}
 
 /// Choose a save path for `default_name` (a `<label>.<ext>` filename). Desktop pops a native save
 /// dialog; Android returns `<data>/exports/<timestamp>-<default_name>` (creating the folder), so
@@ -85,7 +126,30 @@ pub struct Import {
     /// Caller-chosen: a moment name, a marker index, an alert-sound row. Empty when the kind
     /// alone says everything.
     pub tag: String,
+    /// Where it landed. In a browser there is nowhere for it to land, so this is the file's own
+    /// name and nothing will ever open it — read the content through [`Import::text`] instead.
     pub path: PathBuf,
+    /// The content, when the platform handed it over instead of a path (the browser always does).
+    pub bytes: Option<Vec<u8>>,
+}
+
+impl Import {
+    /// The file's content as text. The one read that works everywhere: native and Android reopen
+    /// the path, the browser already has the bytes.
+    pub fn text(&self) -> Result<String, String> {
+        match &self.bytes {
+            Some(b) => String::from_utf8(b.clone()).map_err(|e| e.to_string()),
+            None => std::fs::read_to_string(&self.path).map_err(|e| e.to_string()),
+        }
+    }
+
+    /// The name to show, and on the web the only handle there is.
+    pub fn name(&self) -> String {
+        self.path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default()
+    }
 }
 
 /// Ask the user for a file. Returns immediately on every platform; the answer arrives through
@@ -101,7 +165,12 @@ pub fn request_open(kind: ImportKind, tag: impl Into<String>) {
             .add_filter(kind.label(), kind.extensions())
             .pick_file()
         {
-            deliver(Import { kind, tag, path });
+            deliver(Import {
+                kind,
+                tag,
+                path,
+                bytes: None,
+            });
         }
     }
     #[cfg(target_os = "android")]
@@ -112,8 +181,7 @@ pub fn request_open(kind: ImportKind, tag: impl Into<String>) {
     }
     #[cfg(target_arch = "wasm32")]
     {
-        // No filesystem to import into. The buttons are hidden on the web anyway.
-        let _ = (kind, tag);
+        web_open::pick(kind, tag);
     }
 }
 
@@ -201,8 +269,103 @@ mod android_open {
                 kind,
                 tag: tag.to_string(),
                 path: std::path::PathBuf::from(file),
+                bytes: None,
             }),
             None => log::warn!("import.txt names an unknown kind '{kind}'"),
         }
+    }
+}
+
+/// The browser's own file picker: a hidden `<input type="file">`, clicked from here.
+///
+/// It has to be an element in the document — a detached input's `click()` is ignored by every
+/// browser's popup blocker unless it is reachable — and it has to survive the call, because the
+/// `change` event fires long after `pick` returns. So it is appended, hidden, and removes itself
+/// once it has answered.
+#[cfg(target_arch = "wasm32")]
+mod web_open {
+    use super::{deliver, Import, ImportKind};
+    use wasm_bindgen::prelude::*;
+    use wasm_bindgen::JsCast;
+
+    pub fn pick(kind: ImportKind, tag: String) {
+        if let Err(e) = try_pick(kind, tag) {
+            log::warn!("file picker failed: {e:?}");
+        }
+    }
+
+    fn try_pick(kind: ImportKind, tag: String) -> Result<(), JsValue> {
+        let doc = web_sys::window()
+            .and_then(|w| w.document())
+            .ok_or_else(|| JsValue::from_str("no document"))?;
+        let input: web_sys::HtmlInputElement = doc.create_element("input")?.unchecked_into();
+        input.set_type("file");
+        // Extensions, not MIME: a `.pal` has no registered type, and every browser accepts a
+        // dotted-extension accept list.
+        let accept: Vec<String> = kind.extensions().iter().map(|e| format!(".{e}")).collect();
+        input.set_accept(&accept.join(","));
+        input.style().set_property("display", "none")?;
+        doc.body()
+            .ok_or_else(|| JsValue::from_str("no body"))?
+            .append_child(&input)?;
+
+        let el = input.clone();
+        let on_change = Closure::once(Box::new(move || {
+            let file = el.files().and_then(|f| f.get(0));
+            el.remove();
+            let Some(file) = file else { return };
+            let name = file.name();
+            wasm_bindgen_futures::spawn_local(async move {
+                match wasm_bindgen_futures::JsFuture::from(file.array_buffer()).await {
+                    Ok(buf) => {
+                        let bytes = js_sys::Uint8Array::new(&buf).to_vec();
+                        deliver(Import {
+                            kind,
+                            tag,
+                            path: std::path::PathBuf::from(&name),
+                            bytes: Some(bytes),
+                        });
+                    }
+                    Err(e) => log::warn!("could not read {name}: {e:?}"),
+                }
+            });
+        }) as Box<dyn FnOnce()>);
+        input.set_onchange(Some(on_change.as_ref().unchecked_ref()));
+        // The closure outlives this function by design — it fires when the user picks, which may
+        // be a minute from now. `forget` is the honest way to say "the DOM owns this".
+        on_change.forget();
+        input.click();
+        Ok(())
+    }
+}
+
+/// Saving in a browser: a Blob, an object URL, and a synthetic click on a download link. There is
+/// no dialog to cancel — the browser either takes it or the user's download settings intervene.
+#[cfg(target_arch = "wasm32")]
+mod web_save {
+    use wasm_bindgen::prelude::*;
+    use wasm_bindgen::JsCast;
+
+    pub fn download(name: &str, bytes: &[u8]) -> Result<(), String> {
+        inner(name, bytes).map_err(|e| format!("{e:?}"))
+    }
+
+    fn inner(name: &str, bytes: &[u8]) -> Result<(), JsValue> {
+        let doc = web_sys::window()
+            .and_then(|w| w.document())
+            .ok_or_else(|| JsValue::from_str("no document"))?;
+        // `Uint8Array::from` copies into the JS heap, which the Blob then owns — the Rust slice is
+        // free to go the moment this returns.
+        let array = js_sys::Array::of1(&js_sys::Uint8Array::from(bytes));
+        let blob = web_sys::Blob::new_with_u8_array_sequence(&array)?;
+        let url = web_sys::Url::create_object_url_with_blob(&blob)?;
+        let a: web_sys::HtmlAnchorElement = doc.create_element("a")?.unchecked_into();
+        a.set_href(&url);
+        a.set_download(name);
+        a.click();
+        // The click is synchronous, so by here the browser has taken what it needs. Holding the
+        // URL any longer pins the whole blob in memory for the life of the document.
+        web_sys::Url::revoke_object_url(&url)?;
+        Ok(())
     }
 }

--- a/crates/hookecho/src/gps.rs
+++ b/crates/hookecho/src/gps.rs
@@ -1,11 +1,18 @@
-//! Optional GPS position source via `gpsd` (localhost:2947). Connects, enables JSON watch, and
-//! streams the latest fix `(lon, lat)` to the app over a channel for chase-mode follow-me.
-//! Best-effort: if `gpsd` isn't running, `spawn` returns `None` and chase mode stays manual.
+//! Optional GPS position source, streaming the latest fix `(lon, lat)` to the app over a channel
+//! for chase-mode follow-me. Two implementations behind one `spawn`: `gpsd` on localhost:2947 for
+//! desktop, and the browser's Geolocation API on the web. Best-effort on both — no daemon, or a
+//! refused permission, means `spawn` returns `None` (or the channel simply stays quiet) and chase
+//! mode stays manual.
+//!
+//! (Android is neither: it polls the system LocationManager over JNI in `platform.rs`, and feeds
+//! the same channel shape.)
 
+#[cfg(not(target_arch = "wasm32"))]
 use std::io::{BufRead, BufReader, Write};
 use std::sync::mpsc::{self, Receiver};
 
 /// Parse a gpsd JSON line, returning `(lon, lat)` for a TPV report with a 2D+ fix.
+#[cfg(not(target_arch = "wasm32"))]
 fn parse_tpv(line: &str) -> Option<(f64, f64)> {
     let v: serde_json::Value = serde_json::from_str(line).ok()?;
     if v.get("class")?.as_str()? != "TPV" {
@@ -22,6 +29,7 @@ fn parse_tpv(line: &str) -> Option<(f64, f64)> {
 
 /// Connect to `gpsd` and stream position fixes. Returns `None` if the daemon isn't reachable.
 /// The reader thread runs for the process lifetime.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn spawn() -> Option<Receiver<(f64, f64)>> {
     let stream = std::net::TcpStream::connect(("127.0.0.1", 2947)).ok()?;
     stream.set_read_timeout(None).ok()?;
@@ -48,7 +56,61 @@ pub fn spawn() -> Option<Receiver<(f64, f64)>> {
     Some(rx)
 }
 
-#[cfg(test)]
+/// Watch the browser's own position. There is no daemon to be missing here — the thing that can
+/// go wrong is the user saying no, which arrives as an error on the callback rather than as a
+/// failure to start. So this returns a live receiver either way and the channel just stays empty,
+/// which is the same thing chase mode already does while waiting for a first fix.
+///
+/// Calling `watchPosition` is what raises the permission prompt, and it is only ever called from a
+/// button the user pressed — the app never asks for a location out of nowhere.
+///
+/// ponytail: no `clearWatch`. The watch ends with the page, and a browser tab that has the
+/// permission is not spending anything meaningful to keep an idle GPS callback registered.
+#[cfg(target_arch = "wasm32")]
+pub fn spawn() -> Option<Receiver<(f64, f64)>> {
+    use wasm_bindgen::prelude::*;
+    use wasm_bindgen::JsCast;
+
+    let geo = web_sys::window()?.navigator().geolocation().ok()?;
+    let (tx, rx) = mpsc::channel();
+
+    let on_fix = Closure::wrap(Box::new(move |pos: JsValue| {
+        // `unchecked_into`, not `dyn_into`: web-sys still calls this interface `Position`, while
+        // every current browser exposes it as `GeolocationPosition`, so an `instanceof Position`
+        // check fails against a perfectly good fix. The getters underneath are plain property
+        // reads and do not care what the constructor is called.
+        let pos: web_sys::Position = pos.unchecked_into();
+        let c = pos.coords();
+        // Dropped receiver means the user disconnected GPS; nothing to do but stop sending.
+        let _ = tx.send((c.longitude(), c.latitude()));
+    }) as Box<dyn FnMut(JsValue)>);
+
+    let on_err = Closure::wrap(Box::new(move |e: JsValue| {
+        // Same renaming story as the fix callback (`GeolocationPositionError` now).
+        let msg: web_sys::PositionError = e.unchecked_into();
+        log::warn!("geolocation: {}", msg.message());
+    }) as Box<dyn FnMut(JsValue)>);
+
+    // High accuracy: this is chase follow-me, where the difference between a cell-tower fix and a
+    // GPS fix is the difference between the right side of a storm and the wrong one.
+    let opts = web_sys::PositionOptions::new();
+    opts.set_enable_high_accuracy(true);
+    let started = geo.watch_position_with_error_callback_and_options(
+        on_fix.as_ref().unchecked_ref(),
+        Some(on_err.as_ref().unchecked_ref()),
+        &opts,
+    );
+    if let Err(e) = started {
+        log::warn!("geolocation unavailable: {e:?}");
+        return None;
+    }
+    // The callbacks outlive this function by design — they fire for as long as the watch runs.
+    on_fix.forget();
+    on_err.forget();
+    Some(rx)
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
 

--- a/crates/hookecho/src/notify.rs
+++ b/crates/hookecho/src/notify.rs
@@ -82,9 +82,59 @@ pub fn desktop(title: &str, body: &str) {
     }
 }
 
-/// No-op on Android (the alert service posts its own) and on the web.
-#[cfg(any(target_os = "android", target_arch = "wasm32"))]
+/// No-op on Android — the alert service posts its own, through the system channel.
+#[cfg(target_os = "android")]
 pub fn desktop(_title: &str, _body: &str) {}
+
+/// Post a browser notification, so an alert reaches someone whose tab is behind something else.
+///
+/// Best effort in the same way the desktop one is: no permission, or a browser that refuses,
+/// logs and carries on. The in-app banner and the alert list never depended on this.
+#[cfg(target_arch = "wasm32")]
+pub fn desktop(title: &str, body: &str) {
+    use web_sys::NotificationPermission as P;
+    match web_sys::Notification::permission() {
+        P::Granted => {
+            let opts = web_sys::NotificationOptions::new();
+            opts.set_body(body);
+            opts.set_icon("/icon-192.png");
+            // One notification per event, replacing rather than stacking: an outbreak should not
+            // leave forty cards in the tray.
+            opts.set_tag("hookecho-alert");
+            if let Err(e) = web_sys::Notification::new_with_options(title, &opts) {
+                log::warn!("browser notification failed: {e:?}");
+            }
+        }
+        // Never prompt from here. An alert firing is not a moment to interrupt someone with a
+        // permission dialog, and the ask already happened when they turned the setting on.
+        _ => log::debug!("browser notification skipped: no permission"),
+    }
+}
+
+/// Ask the browser for notification permission, if it has not already been answered.
+///
+/// Called from the one place that makes it contextual — the moment the user turns alert
+/// notifications on — never at load. A denial is final and is not asked about again; the browser
+/// enforces that anyway.
+#[cfg(target_arch = "wasm32")]
+pub fn ask_permission() {
+    if web_sys::Notification::permission() != web_sys::NotificationPermission::Default {
+        return;
+    }
+    match web_sys::Notification::request_permission() {
+        Ok(p) => wasm_bindgen_futures::spawn_local(async move {
+            match wasm_bindgen_futures::JsFuture::from(p).await {
+                Ok(v) => log::info!("notification permission: {v:?}"),
+                Err(e) => log::warn!("notification permission request failed: {e:?}"),
+            }
+        }),
+        Err(e) => log::warn!("cannot ask for notification permission: {e:?}"),
+    }
+}
+
+/// Nothing to ask for: desktop notifications need no permission, and Android's are the service's.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn ask_permission() {}
 
 /// Waits before each retry. A webhook that fails is usually failing for seconds (a Discord blip,
 /// a laptop's wifi coming back after a lid open), so the first retry is quick and the last one is

--- a/crates/hookecho/src/platform.rs
+++ b/crates/hookecho/src/platform.rs
@@ -175,6 +175,53 @@ pub fn open_url(url: &str) -> Result<(), String> {
     }
 }
 
+/// Hand `link` to the platform's own share sheet, if it has one. Returns whether it took it —
+/// `false` means the caller should fall back to the clipboard.
+///
+/// Only the browser has one today, and only some of them: `navigator.share` is missing on desktop
+/// Firefox and outside a secure context, so the presence check is the whole design here. It also
+/// requires a user gesture, which is satisfied because this is only ever reached from a click.
+pub fn share_link(title: &str, link: &str) -> bool {
+    #[cfg(target_arch = "wasm32")]
+    {
+        use wasm_bindgen::{JsCast, JsValue};
+        let Some(nav) = web_sys::window().map(|w| w.navigator()) else {
+            return false;
+        };
+        let key = JsValue::from_str("share");
+        let Ok(f) = js_sys::Reflect::get(&nav, &key) else {
+            return false;
+        };
+        let Ok(f) = f.dyn_into::<js_sys::Function>() else {
+            return false;
+        };
+        let data = js_sys::Object::new();
+        let _ = js_sys::Reflect::set(&data, &JsValue::from_str("title"), &JsValue::from_str(title));
+        let _ = js_sys::Reflect::set(&data, &JsValue::from_str("url"), &JsValue::from_str(link));
+        match f.call1(&nav, &data) {
+            // The promise rejects when the user dismisses the sheet, which is not our problem and
+            // certainly not a reason to paste something into their clipboard after the fact.
+            Ok(p) => {
+                if let Ok(p) = p.dyn_into::<js_sys::Promise>() {
+                    wasm_bindgen_futures::spawn_local(async move {
+                        let _ = wasm_bindgen_futures::JsFuture::from(p).await;
+                    });
+                }
+                true
+            }
+            Err(e) => {
+                log::warn!("share sheet refused: {e:?}");
+                false
+            }
+        }
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let _ = (title, link);
+        false
+    }
+}
+
 /// Keep a child process from flashing its own console window on Windows.
 ///
 /// Every helper we shell out to (the PowerShell speech synthesizer, ffmpeg, the URL opener) is a

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -126,6 +126,12 @@ pub struct Settings {
     /// Per-moment color-table override: moment short name (`REF`, `VEL`, …) -> `.pal` path.
     /// A missing key uses the built-in default table.
     pub palettes: BTreeMap<String, String>,
+    /// File name -> file content, for platforms with nowhere to put a file. A browser hands an
+    /// imported `.pal` over as bytes and there is no path that would survive the next reload, so
+    /// the content rides along in the settings — which already persist, and already export with
+    /// the settings bundle. Empty everywhere else.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub web_files: BTreeMap<String, String>,
     /// Velocity/spectrum-width display unit (internal data stays m/s).
     pub velocity_unit: VelocityUnit,
     /// Temperature display unit for the surface station plots (internal data stays Celsius).
@@ -977,6 +983,7 @@ impl Default for Settings {
     fn default() -> Self {
         Self {
             default_site: "KTLX".to_string(),
+            web_files: BTreeMap::new(),
             detectors: DetectorTuning::default(),
             alert_rules: Vec::new(),
             serve_token: String::new(),
@@ -1115,7 +1122,12 @@ impl Settings {
             if p.is_none() && m == Moment::CorrelationCoefficient {
                 p = self.palettes.get("RHO"); // legacy key, pre-CC rename
             }
-            p.map(PathBuf::from)
+            // A name that is in `web_files` names content, not a file. Resolved here rather than
+            // in the loader so the loader keeps taking one kind of thing.
+            p.map(|v| match self.web_files.get(v) {
+                Some(text) => PathBuf::from(format!("{}{text}", crate::colormap::INLINE_PREFIX)),
+                None => PathBuf::from(v),
+            })
         })
     }
 
@@ -1401,9 +1413,28 @@ mod tests {
     }
 
     #[test]
+    fn a_web_file_name_resolves_to_its_content() {
+        let mut s = Settings::default();
+        s.palettes.insert("REF".to_string(), "mine.pal".to_string());
+        // Not in web_files yet: it is an ordinary path, whatever the platform makes of it.
+        assert_eq!(
+            s.palette_paths()[0].as_deref(),
+            Some(std::path::Path::new("mine.pal"))
+        );
+        s.web_files
+            .insert("mine.pal".to_string(), "Color: 5 255 0 0".to_string());
+        let p = s.palette_paths()[0].clone().unwrap();
+        assert_eq!(
+            p.to_string_lossy(),
+            format!("{}Color: 5 255 0 0", crate::colormap::INLINE_PREFIX)
+        );
+    }
+
+    #[test]
     fn roundtrips() {
         let s = Settings {
             hints_seen: Vec::new(),
+            web_files: BTreeMap::new(),
             reduce_motion: true,
             precip_tint: false,
             custom_tile_url: String::new(),

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -337,8 +337,8 @@ pub struct Settings {
     /// First-run setup completed (or dismissed). `false` shows the first-run card at startup.
     #[serde(default)]
     pub setup_done: bool,
-    /// Post alerts to the desktop's own notification centre, so they arrive with the window
-    /// behind something else. Ignored on Android (the alert service posts its own) and the web.
+    /// Post alerts to the platform's own notification centre, so they arrive with the window
+    /// behind something else. Ignored on Android, where the alert service posts its own.
     #[serde(default)]
     pub desktop_notify: bool,
     /// Record a breadcrumb track of the session's GPS fixes, exportable as GPX. Off by default:

--- a/crates/hookecho/src/ui/firstrun.rs
+++ b/crates/hookecho/src/ui/firstrun.rs
@@ -41,11 +41,10 @@ impl FirstRun {
         self.refused = false;
     }
 
-    /// Ask the platform where we are. Same two sources chase mode uses — Android polls the system
-    /// LocationManager over JNI, desktop streams from a local gpsd.
+    /// Ask the platform where we are. The same sources chase mode uses — Android polls the system
+    /// LocationManager over JNI, desktop streams from a local gpsd, the web watches the browser's
+    /// own Geolocation.
     fn locate(&mut self) {
-        // ponytail: no web arm — the browser's Geolocation API is I5's job, and `gps::spawn`'s
-        // TcpStream can't work there. The button isn't drawn on wasm until it does.
         self.rx = if cfg!(target_os = "android") {
             crate::platform::start_location()
         } else {
@@ -94,9 +93,7 @@ pub fn show(ctx: &egui::Context, fr: &mut FirstRun, settings: &mut Settings) -> 
             ui.add_space(8.0);
 
             ui.horizontal(|ui| {
-                if cfg!(target_arch = "wasm32") {
-                    // Nothing to ask: the web build has no position source yet.
-                } else if fr.rx.is_some() {
+                if fr.rx.is_some() {
                     // getLastKnownLocation is null until the first fix lands, and gpsd can take a
                     // few seconds to see a satellite. Say so rather than look stuck.
                     ui.spinner();
@@ -107,7 +104,7 @@ pub fn show(ctx: &egui::Context, fr: &mut FirstRun, settings: &mut Settings) -> 
                         "{} Use my location",
                         egui_phosphor::regular::CROSSHAIR
                     ))
-                    .on_hover_text(if cfg!(target_os = "android") {
+                    .on_hover_text(if cfg!(any(target_os = "android", target_arch = "wasm32")) {
                         "Asks for the location permission, picks the nearest radar, and gets out of the way"
                     } else {
                         "Reads a local gpsd on :2947 and picks the nearest radar"
@@ -118,7 +115,7 @@ pub fn show(ctx: &egui::Context, fr: &mut FirstRun, settings: &mut Settings) -> 
                 }
             });
             if fr.refused {
-                ui.small(if cfg!(target_os = "android") {
+                ui.small(if cfg!(any(target_os = "android", target_arch = "wasm32")) {
                     "No position yet \u{2014} pick a radar below instead."
                 } else {
                     "No gpsd on this machine \u{2014} pick a radar below instead."

--- a/crates/hookecho/src/ui/marker_window.rs
+++ b/crates/hookecho/src/ui/marker_window.rs
@@ -174,7 +174,9 @@ pub fn marker_grid(
                                 .corner_radius(10.0),
                         );
                     }
-                    if ui.button("Browse…").clicked() {
+                    // Icons are copied into the data dir and referenced by name from then on;
+                    // in a browser there is no data dir, so there is nothing to browse to.
+                    if !cfg!(target_arch = "wasm32") && ui.button("Browse…").clicked() {
                         crate::dialog::request_open(
                             crate::dialog::ImportKind::MarkerIcon,
                             i.to_string(),

--- a/crates/hookecho/src/ui/mod.rs
+++ b/crates/hookecho/src/ui/mod.rs
@@ -65,20 +65,17 @@ pub(crate) fn reader_button(ui: &mut egui::Ui, title: &str, issued: &str, text: 
 
 /// The "Copy CSV" / "Save CSV…" pair every table window ends up wanting. `csv` is only called
 /// when a button is clicked, so building the text stays off the per-frame path.
-///
-/// ponytail: no file dialog on the web — there is no filesystem behind `save_path` there, and the
-/// clipboard already covers that platform.
 pub(crate) fn csv_buttons(
     ui: &mut egui::Ui,
     default_name: &str,
     hover: &str,
     csv: impl Fn() -> String,
 ) {
-    if !cfg!(target_arch = "wasm32") && ui.button("Save CSV…").on_hover_text(hover).clicked() {
-        if let Some(path) = crate::dialog::save_path(default_name, "csv") {
-            if let Err(e) = std::fs::write(&path, csv()) {
-                log::warn!("CSV export failed: {e}");
-            }
+    if ui.button("Save CSV…").on_hover_text(hover).clicked() {
+        if let crate::dialog::Saved::Failed(e) =
+            crate::dialog::save_bytes(default_name, "csv", csv().as_bytes())
+        {
+            log::warn!("CSV export failed: {e}");
         }
     }
     if ui.button("Copy CSV").on_hover_text(hover).clicked() {

--- a/crates/hookecho/src/ui/palette_editor.rs
+++ b/crates/hookecho/src/ui/palette_editor.rs
@@ -16,7 +16,8 @@ pub struct PaletteEditor {
     /// A `.pal` the user picked, waiting to become the working copy. The picker answers a frame
     /// or more later — on Android, after a whole activity round trip — so the file arrives here
     /// through the app rather than as a return value.
-    pub pending_import: Option<std::path::PathBuf>,
+    /// A picked `.pal`, as its text — the browser never has a path to hand over.
+    pub pending_import: Option<String>,
 }
 
 /// Tag for the editor's own import, so a `.pal` picked here becomes the working copy instead of
@@ -42,10 +43,13 @@ impl PaletteEditor {
             self.loaded_for = Some(self.moment_idx);
         }
         // A `.pal` the user picked since the last frame becomes the working copy.
-        if let Some(path) = self.pending_import.take() {
-            if let Some(t) = read_pal(&path) {
-                self.table = Some(t);
-                self.loaded_for = Some(self.moment_idx);
+        if let Some(text) = self.pending_import.take() {
+            match crate::colormap::parse_pal(&text) {
+                Ok(t) => {
+                    self.table = Some(t);
+                    self.loaded_for = Some(self.moment_idx);
+                }
+                Err(e) => log::warn!("could not parse the picked palette: {e}"),
             }
         }
 
@@ -206,10 +210,17 @@ fn color_edit(ui: &mut egui::Ui, rgba: &mut [u8; 4]) {
 
 /// Write the working table into the colortables dir and set it as the moment's override.
 fn save_and_apply(table: &ColorTable, moment: Moment, settings: &mut Settings) {
+    let name = format!("{}.pal", moment.short_name());
     let Some(dir) = Settings::colortables_dir() else {
+        // No colortables dir means no filesystem (the browser). The table rides in the settings
+        // instead, which is the same place an imported one goes — see `Settings::web_files`.
+        settings
+            .web_files
+            .insert(name.clone(), crate::colormap::to_pal_string(table));
+        settings.palettes.insert(moment.short_name().to_string(), name);
         return;
     };
-    let path = dir.join(format!("{}.pal", moment.short_name()));
+    let path = dir.join(&name);
     if let Err(e) = std::fs::write(&path, crate::colormap::to_pal_string(table)) {
         log::warn!("palette save failed: {e}");
         return;
@@ -221,25 +232,10 @@ fn save_and_apply(table: &ColorTable, moment: Moment, settings: &mut Settings) {
     );
 }
 
-/// Parse a picked `.pal` into a table, or complain in the log and change nothing.
-pub(crate) fn read_pal(path: &std::path::Path) -> Option<ColorTable> {
-    match std::fs::read_to_string(path)
-        .ok()
-        .and_then(|t| crate::colormap::parse_pal(&t).ok())
-    {
-        Some(t) => Some(t),
-        None => {
-            log::warn!("could not parse {}", path.display());
-            None
-        }
-    }
-}
-
 fn export_pal(table: &ColorTable) {
-    let Some(path) = crate::dialog::save_path("palette.pal", "pal") else {
-        return;
-    };
-    if let Err(e) = std::fs::write(&path, crate::colormap::to_pal_string(table)) {
+    let pal = crate::colormap::to_pal_string(table);
+    if let crate::dialog::Saved::Failed(e) = crate::dialog::save_bytes("palette.pal", "pal", pal.as_bytes())
+    {
         log::warn!("palette export failed: {e}");
     }
 }

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -398,6 +398,8 @@ impl SettingsWindow {
     }
 
     fn palettes_tab(&mut self, ui: &mut egui::Ui, settings: &mut Settings, palettes: &Palettes) {
+        // Collected up front: the combo below writes to `settings` while this is being read.
+        let imported: Vec<String> = settings.web_files.keys().cloned().collect();
         if !self.scanned {
             self.rescan();
         }
@@ -463,6 +465,15 @@ impl SettingsWindow {
                                             path.to_string_lossy().into_owned(),
                                         );
                                     }
+                                }
+                            }
+                            // Tables that live in the settings rather than on disk (the browser
+                            // has nowhere to put a file). Named, not pathed — the name is the
+                            // whole handle.
+                            for name in &imported {
+                                let is_sel = current.as_deref() == Some(name.as_str());
+                                if ui.selectable_label(is_sel, name).clicked() {
+                                    settings.palettes.insert(key.to_string(), name.clone());
                                 }
                             }
                         });
@@ -935,7 +946,11 @@ pub fn sound_picker(ui: &mut egui::Ui, settings: &mut Settings) {
                             }
                         }
                         let is_custom = matches!(sound, AlertSound::Custom(_));
-                        if ui.selectable_label(is_custom, "Custom…").clicked() {
+                        // A custom sound is a file the mixer reopens on every alert, and a
+                        // browser has no path that outlives the picker. Built-ins only there.
+                        if !cfg!(target_arch = "wasm32")
+                            && ui.selectable_label(is_custom, "Custom…").clicked()
+                        {
                             crate::dialog::request_open(
                                 crate::dialog::ImportKind::AlertSound,
                                 label,

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -978,11 +978,17 @@ fn alerts_tab(ui: &mut egui::Ui, settings: &mut Settings) {
     ui.separator();
     ui.strong("When to interrupt");
     ui.add_enabled_ui(!cfg!(target_os = "android"), |ui| {
-        ui.checkbox(&mut settings.desktop_notify, "Post alerts to the desktop")
+        let r = ui
+            .checkbox(&mut settings.desktop_notify, "Post alerts to the desktop")
             .on_hover_text(
                 "Use the system notification centre, so an alert arrives with the window \
                  behind something else",
             );
+        // Turning it on is the moment to ask, and the only one — a browser that is asked at load,
+        // or when a warning fires, gets a permission dialog nobody was expecting. No-op natively.
+        if r.changed() && settings.desktop_notify {
+            crate::notify::ask_permission();
+        }
     });
     ui.checkbox(&mut settings.alert_follow_gps, "Alert where I am, too")
         .on_hover_text(

--- a/web/sw.src.js
+++ b/web/sw.src.js
@@ -4,9 +4,13 @@
 // content-hashed asset list of the build that produced it. That list is the version: a new build
 // is a new script body, which is what makes the browser install a new worker at all.
 //
-// ponytail: precache only. Radar, tiles and everything that goes through /proxy stay on the
-// network — a cached radar frame is a wrong radar frame, and the wasm is the only thing here big
-// enough for caching to be worth a stale-content risk.
+// Basemap tiles get a second, persistent cache. They are the one thing the app fetches over and
+// over that never changes — a road at z9 is the same road next week — and without a filesystem
+// behind `paths::cache_dir()` the web build otherwise re-downloads the entire visible map on
+// every cold start.
+//
+// ponytail: radar, satellite and everything through /proxy stay on the network. A cached radar
+// frame is a wrong radar frame, and the win here is geography, which is static by definition.
 
 // Replaced at build time. Every entry is either a content-hashed bundle file or the page
 // itself, which is revalidated on every navigation.
@@ -15,6 +19,47 @@ const SHELL = __SHELL__;
 // Named for the shell it holds, so installing a new worker never collides with the old cache and
 // the activate step can delete every cache that is not this one.
 const CACHE = "shell-" + __VERSION__;
+
+// Survives deploys — the tiles in it are not versioned by our build, and throwing them away
+// because the wasm changed would be pure waste.
+const TILES = "tiles-v1";
+
+// Roughly a few hundred MB of raster at worst, which is well inside a normal origin quota and
+// small enough that trimming stays cheap. Cache.keys() is insertion-ordered, so the oldest
+// entries are the first ones — evicting from the front is FIFO with no bookkeeping to store.
+const TILE_MAX = 1500;
+const TILE_TRIM = 300;
+
+// Is this an XYZ tile (or the glyphs and sprites a vector basemap needs to draw one)? Matched on
+// URL shape rather than a host list: the app ships a dozen basemaps and lets the user paste their
+// own template, most of them arrive rewritten as `/proxy/<host>/…` rather than cross-origin, and a
+// host allowlist here would silently fall out of step with tiles.rs and proxy-core.js both.
+//
+// Shape is also what keeps radar out. A volume through the same proxy is
+// `/proxy/…/KTLX/KTLX20260825_…`, which has no tile coordinate and no tile extension, so it never
+// matches — the rule that keeps live data on the network is structural, not a host check.
+//
+// Keyed hosts (Mapbox, MapTiler) carry the user's key in the query, which becomes part of the
+// cache key. That is the same place the browser's own HTTP cache already keeps it — origin-private
+// storage on the user's machine — and nothing is ever sent anywhere new.
+function isTile(url) {
+  const p = url.pathname;
+  return (
+    /\/\d+\/\d+\/\d+(@\dx)?(\.[a-z0-9]+)?$/.test(p) ||
+    /\.(pbf|mvt)$/.test(p) ||
+    /\/fonts?\//.test(p) ||
+    /sprite(@\dx)?\.(png|json)$/.test(p)
+  );
+}
+
+// Drop the oldest entries once the cache has grown past its cap. Fire-and-forget: a trim that
+// loses a race just runs again on the next tile.
+async function trim() {
+  const c = await caches.open(TILES);
+  const keys = await c.keys();
+  if (keys.length <= TILE_MAX) return;
+  await Promise.all(keys.slice(0, TILE_TRIM).map((k) => c.delete(k)));
+}
 
 self.addEventListener("install", (e) => {
   // The new worker takes over on the next navigation, not this one — the running page is already
@@ -26,7 +71,11 @@ self.addEventListener("activate", (e) => {
   e.waitUntil(
     caches
       .keys()
-      .then((keys) => Promise.all(keys.filter((k) => k !== CACHE).map((k) => caches.delete(k))))
+      .then((keys) =>
+        Promise.all(
+          keys.filter((k) => k !== CACHE && k !== TILES).map((k) => caches.delete(k)),
+        ),
+      )
       .then(() => self.clients.claim()),
   );
 });
@@ -35,9 +84,40 @@ self.addEventListener("fetch", (e) => {
   const req = e.request;
   if (req.method !== "GET") return;
   const url = new URL(req.url);
+
+  if (isTile(url)) {
+    // Cache-first, no revalidation: these URLs address fixed content (a tile coordinate, a glyph
+    // range, a satellite timestamp), so a hit is the right answer and a conditional request would
+    // only spend a round trip to be told so.
+    e.respondWith(
+      caches.match(req).then(
+        (hit) =>
+          hit ||
+          fetch(req).then((res) => {
+            // Opaque responses (a tile host with no CORS headers) are cacheable and replayable,
+            // which is all the renderer needs. An error is not: caching a 404 tile would make a
+            // transient outage permanent.
+            if (res.ok || res.type === "opaque") {
+              const copy = res.clone();
+              // Not waitUntil: by the time this runs the response has usually already been
+              // handed to the page, and a settled event rejects it. The worker stays alive for
+              // the fetch anyway, and a store that loses the race costs one re-download.
+              caches
+                .open(TILES)
+                .then((c) => c.put(req, copy))
+                .then(trim)
+                .catch(() => {});
+            }
+            return res;
+          }),
+      ),
+    );
+    return;
+  }
+  // Anything else off-origin is live data going straight to its host — let the browser have it.
   if (url.origin !== self.location.origin) return;
-  // /proxy and /geo.json are per-request answers: the proxy streams live data, and /geo.json is a
-  // different answer for every visitor. Neither is ever served from here.
+  // What is left under /proxy is live data too, and /geo.json is a different answer for every
+  // visitor. Neither is ever served from here.
   if (url.pathname.startsWith("/proxy/") || url.pathname === "/geo.json") return;
 
   // A navigation asks for index.html, which names the hashed assets — serving a stale one would


### PR DESCRIPTION
Stacked on #118. Closes the wave.

Two halves of the same gap. `#goto=` has been a link you could be sent since #76 and one the app read exactly once, at boot — nothing ever wrote it back. A browser tab's URL said where the session started rather than where it had got to. And the only way to get a link at all was Ctrl+K, which is not where anyone looks for one.

The control column gets a **share button**, handing the link to the platform's own share sheet where there is one. Desktop Firefox and insecure origins have no `navigator.share`, so the presence check is the whole design and the clipboard is the fallback.

`sync_permalink` keeps the fragment pointed at the active pane, **archive time included** when the timeline is off live. `replaceState`, not `pushState`: panning a map is not navigation, and forty history entries per drag would make the back button useless. Throttled to 750 ms — a correctness guard, since Safari starts throwing past roughly a hundred rewrites a minute. Live stays live in the link.

**Verified** in headless Chrome: the fragment tracks a pan (`#goto=KTLX,-96.2341,34.9063,8.0`), grows the timestamp when scrubbed (`…,2026-08-26T02:14:45+00:00`), and the share button with `navigator.share` deleted falls back to the clipboard with the same string the address bar holds.

Gate: clippy clean · 596 tests pass · wasm check clean · `shoot.sh check` passed · wasm 4,823,984 gzipped (budget 4,850,000).

🤖 Generated with [Claude Code](https://claude.com/claude-code)