### PR TITLE
feat(mqtt): the house can subscribe to the weather

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,6 +621,28 @@ Remember the server has to be reachable from Home Assistant — that means
 `--bind 0.0.0.0` (or the container), and a network you're willing to expose your
 saved locations on. Set `serve_token` if that network is not one you control.
 
+### Over MQTT
+
+If the rest of the house already talks to a broker, hookecho can talk to it too.
+Set the broker under **Settings → Alerts → MQTT** (host, port, optional TLS and
+credentials, and a topic prefix), restart, and three topics appear:
+
+| Topic | Retained | What it carries |
+|---|---|---|
+| `<prefix>/status` | yes | the whole `--status` report as JSON, every five minutes |
+| `<prefix>/nearest` | yes | the closest tracked cell to your home location, or `null` |
+| `<prefix>/alerts` | no | one message per alert as it is delivered — title, body, urgency, time |
+
+Alerts are not retained on purpose: a warning is an event, and a subscriber that
+connects tomorrow must not be handed yesterday's tornado. `null` on `nearest` is
+the honest answer for "nothing is being tracked" — a retained topic that simply
+stopped updating looks the same as a dead app.
+
+Publishing only; nothing subscribes, so a compromised broker cannot drive the
+app. The password is a secret like the rest — it stays in your settings file.
+`hookecho --serve` publishes too, which is usually the process you want doing it:
+it is the one that is always up.
+
 ### In a browser
 
 A hosted build of `main` runs at **<https://hookecho.pages.dev/>** if you only

--- a/crates/hookecho/Cargo.toml
+++ b/crates/hookecho/Cargo.toml
@@ -124,6 +124,10 @@ web-sys = { version = "0.3", features = ["Document", "Window", "HtmlCanvasElemen
 # both have their own notification story.
 notify-rust = "4"
 rfd = "0.15"
+# MQTT publishing (`mqtt.rs`). No Android (its alerts go through the foreground service) and no
+# wasm (no TCP socket). Its default `use-rustls` is kept: a broker password must not cross a
+# network in the clear, and rustls is already in the graph via reqwest.
+rumqttc = "0.25"
 
 # One wgpu backend set per platform, feature-unioned onto the base wgpu above.
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -3194,6 +3194,10 @@ impl HookEchoApp {
             app.locate_by_ip(&cc.egui_ctx.clone());
         }
         crate::platform::set_background_alerts(app.settings.background_alerts);
+        // The broker is publish-only and reconnects on its own, so it starts here and is never
+        // stopped; changing the setting takes a restart, same as the tray.
+        #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
+        crate::mqtt::spawn(&app.settings);
         // Point the speech path at Piper before anything can speak.
         #[cfg(not(target_arch = "wasm32"))]
         crate::speech::set_piper(&app.settings.piper_path, &app.settings.piper_voice);
@@ -4986,6 +4990,9 @@ impl HookEchoApp {
         if self.settings.desktop_notify {
             crate::notify::desktop(&title, &body);
         }
+
+        #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
+        crate::mqtt::publish_alert(&self.settings, &title, &body, urgent);
 
         let topic = self.settings.ntfy_topic.trim().to_string();
         if !topic.is_empty() {

--- a/crates/hookecho/src/lib.rs
+++ b/crates/hookecho/src/lib.rs
@@ -38,6 +38,9 @@ pub mod labelplace;
 pub mod icon;
 pub mod loopexport;
 pub mod notify;
+/// MQTT publishing for home automation; native only (no TCP socket in a browser).
+#[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
+pub mod mqtt;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod nwr;
 pub mod overlay_build;

--- a/crates/hookecho/src/main.rs
+++ b/crates/hookecho/src/main.rs
@@ -90,6 +90,9 @@ fn main() -> eframe::Result<()> {
             .map(str::to_string)
             .unwrap_or_else(|| saved.serve_token.clone());
         let spots = hookecho::status::spots(&saved, None);
+        // A headless box on a shelf is exactly where MQTT earns its keep — this is the process
+        // that is always up.
+        hookecho::mqtt::spawn(&saved);
         if let Err(e) = hookecho::serve::run(spots, bind, port, web_root, token) {
             eprintln!("serve failed: {e}");
             std::process::exit(1);

--- a/crates/hookecho/src/mqtt.rs
+++ b/crates/hookecho/src/mqtt.rs
@@ -1,0 +1,192 @@
+//! MQTT publishing: what this app knows, pushed onto the broker the rest of the house listens to.
+//!
+//! `--serve` answers questions; nothing there pushes. Home Assistant, Node-RED and a shelf of
+//! ESPHome things are all already subscribed to a broker, and an automation that waits for a
+//! tornado warning cannot poll for it. Three topics, under a prefix the user picks:
+//!
+//! - `<prefix>/status` — the whole [`crate::status`] report as JSON, retained.
+//! - `<prefix>/nearest` — the closest tracked storm cell to the home spot, retained.
+//! - `<prefix>/alerts` — one message per delivered alert, not retained (an alert is an event; a
+//!   subscriber that connects tomorrow must not be handed yesterday's tornado).
+//!
+//! Native only: a browser has no TCP socket, and the Android alert path is its own service.
+//!
+//! Credentials are a user secret — settings.json only, never the shots template, never logged.
+//
+// ponytail: one broker, one publisher thread, publish-only — no subscribe side and no Home
+// Assistant discovery config. The ceiling is "a house automates on this"; if someone wants
+// commands back (change site, start a loop) that is a subscribe loop on the same client.
+
+use crate::settings::Settings;
+use crate::status::Spot;
+use rumqttc::{Client, MqttOptions, QoS, Transport};
+use std::sync::OnceLock;
+use std::time::Duration;
+
+/// How often the retained status/nearest topics are refreshed. A volume is ~5 minutes wide and
+/// the observation feeds update slower than that, so anything quicker only spends network.
+const POLL: Duration = Duration::from_secs(300);
+
+/// The connected client, once [`spawn`] has one. `None` until then, and permanently absent when
+/// no broker is configured — [`publish_alert`] is a no-op in both cases.
+static CLIENT: OnceLock<Client> = OnceLock::new();
+
+/// A topic prefix the user typed, made safe to concatenate onto.
+///
+/// **Trust boundary**: `#` and `+` are MQTT wildcards and are illegal in a topic being published
+/// to; a broker drops the whole publish (or the connection) rather than guessing. Empty segments
+/// from a stray `/` are legal but publish to a topic nobody can type back, so they go too.
+fn clean_prefix(raw: &str) -> String {
+    let cleaned: Vec<&str> = raw
+        .split('/')
+        .map(str::trim)
+        .filter(|s| !s.is_empty() && !s.contains(['#', '+']))
+        .collect();
+    if cleaned.is_empty() {
+        "hookecho".to_string()
+    } else {
+        cleaned.join("/")
+    }
+}
+
+/// The JSON one alert is published as. A subscriber wants the fields apart, not a sentence to
+/// parse back out — `title` is the warning, `body` is where and until when.
+fn alert_payload(title: &str, body: &str, urgent: bool) -> String {
+    serde_json::json!({
+        "title": title,
+        "body": body,
+        "urgent": urgent,
+        "time": chrono::Utc::now().to_rfc3339(),
+    })
+    .to_string()
+}
+
+/// Start publishing, if a broker is configured and one is not running already.
+///
+/// Two threads: rumqttc's event loop must be driven by someone, and the status poll blocks on
+/// feeds for seconds at a time, so it cannot be the same one.
+pub fn spawn(settings: &Settings) {
+    let host = settings.mqtt_host.trim().to_string();
+    if host.is_empty() || CLIENT.get().is_some() {
+        return;
+    }
+    let prefix = clean_prefix(&settings.mqtt_prefix);
+    // A fixed client id would fight itself if the app and a `--serve` container both published;
+    // the pid keeps two on one machine apart without asking the user for a name.
+    let mut opts = MqttOptions::new(
+        format!("hookecho-{}", std::process::id()),
+        host,
+        settings.mqtt_port,
+    );
+    opts.set_keep_alive(Duration::from_secs(30));
+    if settings.mqtt_tls {
+        opts.set_transport(Transport::tls_with_default_config());
+    }
+    let (user, pass) = (settings.mqtt_user.trim(), settings.mqtt_pass.trim());
+    if !user.is_empty() {
+        opts.set_credentials(user, pass);
+    }
+    // Capacity is the publish queue, not a message history: an outbreak is a few dozen alerts.
+    let (client, mut conn) = Client::new(opts, 64);
+    if CLIENT.set(client.clone()).is_err() {
+        return;
+    }
+    log::info!("mqtt: publishing under {prefix}/");
+
+    std::thread::spawn(move || {
+        // Iterating the connection *is* the reconnect loop — rumqttc yields the error and then
+        // tries again, so this only ends when the process does.
+        for event in conn.iter() {
+            if let Err(e) = event {
+                log::debug!("mqtt: {e}");
+                std::thread::sleep(Duration::from_secs(5));
+            }
+        }
+    });
+
+    let spots = crate::status::spots(settings, None);
+    std::thread::spawn(move || status_loop(client, prefix, spots));
+}
+
+/// Publish the retained topics forever. Builds its own runtime: the callers are the GUI (whose
+/// runtime is busy drawing) and `--serve` (whose runtime answers requests).
+fn status_loop(client: Client, prefix: String, spots: Vec<Spot>) {
+    let Ok(rt) = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    else {
+        log::warn!("mqtt: no runtime for the status poll");
+        return;
+    };
+    let http = reqwest::Client::new();
+    loop {
+        match rt.block_on(crate::status::collect(&http, &spots)) {
+            Ok(report) => {
+                if let Ok(json) = serde_json::to_string(&report) {
+                    publish(&client, &format!("{prefix}/status"), json, true);
+                }
+                // The home spot's cell is the one an automation acts on ("is anything coming
+                // here"); the rest of the report is in `/status` for whoever wants it.
+                let home = report.iter().find(|s| s.home).or_else(|| report.first());
+                let nearest = home.and_then(|s| s.nearest_cell.as_ref());
+                let payload = match nearest {
+                    Some(c) => serde_json::to_string(c).unwrap_or_else(|_| "null".to_string()),
+                    // Explicitly null, not silence: "nothing is being tracked" is an answer, and a
+                    // retained topic that stops updating looks the same as a dead app otherwise.
+                    None => "null".to_string(),
+                };
+                publish(&client, &format!("{prefix}/nearest"), payload, true);
+            }
+            Err(e) => log::warn!("mqtt: status collect failed: {e}"),
+        }
+        std::thread::sleep(POLL);
+    }
+}
+
+/// One publish, with the failure logged and swallowed — a broker being down is not a reason for
+/// the app to stop drawing radar.
+fn publish(client: &Client, topic: &str, payload: String, retain: bool) {
+    if let Err(e) = client.publish(topic, QoS::AtLeastOnce, retain, payload) {
+        log::debug!("mqtt: publish to {topic} failed: {e}");
+    }
+}
+
+/// Push one alert, if a broker is connected. Called from the same place the webhooks are, so
+/// quiet hours and outbreak rollup have already had their say.
+pub fn publish_alert(settings: &Settings, title: &str, body: &str, urgent: bool) {
+    let Some(client) = CLIENT.get() else {
+        return;
+    };
+    let topic = format!("{}/alerts", clean_prefix(&settings.mqtt_prefix));
+    publish(client, &topic, alert_payload(title, body, urgent), false);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_prefix_cannot_carry_a_wildcard_into_a_publish() {
+        assert_eq!(clean_prefix("home/weather"), "home/weather");
+        assert_eq!(clean_prefix("/home//weather/"), "home/weather");
+        assert_eq!(clean_prefix("  spaced  "), "spaced");
+        // Wildcards are illegal in a published topic; a broker drops the publish rather than
+        // interpreting it, so the segment goes instead of the whole message.
+        assert_eq!(clean_prefix("home/#"), "home");
+        assert_eq!(clean_prefix("home/+/x"), "home/x");
+        // Nothing usable left means the default, not a publish to "".
+        assert_eq!(clean_prefix(""), "hookecho");
+        assert_eq!(clean_prefix("#"), "hookecho");
+    }
+
+    #[test]
+    fn an_alert_publishes_its_fields_apart() {
+        let v: serde_json::Value =
+            serde_json::from_str(&alert_payload("Tornado Warning", "Norman until 21:15", true))
+                .unwrap();
+        assert_eq!(v["title"], "Tornado Warning");
+        assert_eq!(v["body"], "Norman until 21:15");
+        assert_eq!(v["urgent"], true);
+        assert!(v["time"].as_str().unwrap().contains('T'));
+    }
+}

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -264,6 +264,24 @@ pub struct Settings {
     /// Matrix access token. User secret, as above.
     #[serde(default)]
     pub matrix_token: String,
+    /// MQTT broker hostname for publishing alerts and status (empty = off).
+    #[serde(default)]
+    pub mqtt_host: String,
+    /// Broker port. 1883 is the plain default, 8883 the TLS one.
+    #[serde(default = "default_mqtt_port")]
+    pub mqtt_port: u16,
+    /// Connect over TLS. Off by default: a house broker on the same LAN usually is not.
+    #[serde(default)]
+    pub mqtt_tls: bool,
+    /// Broker username (empty = anonymous).
+    #[serde(default)]
+    pub mqtt_user: String,
+    /// Broker password. A user secret: settings.json only, never committed.
+    #[serde(default)]
+    pub mqtt_pass: String,
+    /// Topic prefix everything is published under, e.g. `home/weather`.
+    #[serde(default = "default_mqtt_prefix")]
+    pub mqtt_prefix: String,
     /// Fetch terrain at z12 (~40 m/px) instead of z10. Sixteen times the tiles, so it is off by
     /// default and meant for chase packs you download deliberately.
     #[serde(default)]
@@ -844,6 +862,14 @@ pub fn default_lightning_minutes() -> u16 {
     5
 }
 
+fn default_mqtt_port() -> u16 {
+    1883
+}
+
+fn default_mqtt_prefix() -> String {
+    "hookecho".to_string()
+}
+
 pub fn default_spotter_range_km() -> f64 {
     230.0
 }
@@ -1043,6 +1069,12 @@ impl Default for Settings {
             matrix_homeserver: String::new(),
             matrix_room: String::new(),
             matrix_token: String::new(),
+            mqtt_host: String::new(),
+            mqtt_port: default_mqtt_port(),
+            mqtt_tls: false,
+            mqtt_user: String::new(),
+            mqtt_pass: String::new(),
+            mqtt_prefix: default_mqtt_prefix(),
             background_alerts: false,
             pack_hires_dem: false,
             pack_include_vector: true,
@@ -1512,6 +1544,12 @@ mod tests {
             matrix_homeserver: String::new(),
             matrix_room: String::new(),
             matrix_token: String::new(),
+            mqtt_host: String::new(),
+            mqtt_port: default_mqtt_port(),
+            mqtt_tls: false,
+            mqtt_user: String::new(),
+            mqtt_pass: String::new(),
+            mqtt_prefix: default_mqtt_prefix(),
             background_alerts: false,
             pack_hires_dem: false,
             pack_include_vector: true,

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -1093,6 +1093,47 @@ fn alerts_tab(ui: &mut egui::Ui, settings: &mut Settings) {
     ui.weak("Every alert that goes to ntfy also posts here. Blank fields are off.");
     ui.weak("These URLs and the token are secrets — they stay in your settings file.");
 
+    // No Android (its alerts leave through the foreground service) and no web (no TCP socket).
+    if !cfg!(any(target_os = "android", target_arch = "wasm32")) {
+        ui.add_space(8.0);
+        ui.separator();
+        ui.strong("MQTT");
+        ui.horizontal(|ui| {
+            ui.label("Broker:");
+            ui.add(
+                egui::TextEdit::singleline(&mut settings.mqtt_host)
+                    .desired_width(160.0)
+                    .hint_text("mqtt.lan"),
+            );
+            ui.add(egui::DragValue::new(&mut settings.mqtt_port).range(1..=65535));
+            ui.checkbox(&mut settings.mqtt_tls, "TLS");
+        });
+        ui.horizontal(|ui| {
+            ui.label("User:");
+            ui.add(
+                egui::TextEdit::singleline(&mut settings.mqtt_user)
+                    .desired_width(110.0)
+                    .hint_text("optional"),
+            );
+            ui.label("Password:");
+            ui.add(
+                egui::TextEdit::singleline(&mut settings.mqtt_pass)
+                    .desired_width(110.0)
+                    .password(true),
+            );
+        });
+        ui.horizontal(|ui| {
+            ui.label("Topic prefix:");
+            ui.add(
+                egui::TextEdit::singleline(&mut settings.mqtt_prefix).hint_text("home/weather"),
+            );
+        });
+        ui.weak(
+            "Publishes <prefix>/status and <prefix>/nearest every five minutes, and \
+             <prefix>/alerts as warnings arrive. Takes effect on restart.",
+        );
+    }
+
     if cfg!(target_os = "android") {
         ui.add_space(8.0);
         ui.separator();


### PR DESCRIPTION
`--serve` answers questions and nothing pushes, which is the wrong shape for an automation that has to wait for a tornado warning. This publishes to the broker the rest of the house is already on.

**Topics**, under a user-chosen prefix:

| Topic | Retained | Payload |
|---|---|---|
| `<prefix>/status` | yes | the whole `--status` report as JSON, every five minutes |
| `<prefix>/nearest` | yes | the closest tracked cell to the home spot, or `null` |
| `<prefix>/alerts` | no | one message per delivered alert — title, body, urgency, time |

Alerts are not retained on purpose: a warning is an event, and a subscriber connecting tomorrow must not be handed yesterday's tornado. `nearest` is explicitly `null` when nothing is tracked, because a retained topic that merely stops updating looks the same as a dead app.

Publish-only — no subscribe loop, so a broker cannot drive the app. The alert hook sits exactly where the webhooks already are, so quiet hours and outbreak rollup have had their say first. Native only: no TCP socket in a browser, and Android alerts leave through its foreground service.

**Security**: broker credentials are settings.json only, never the shots template, never logged. `use-rustls` is kept on so a password need not cross a network in the clear. Topic prefixes are cleaned before use — `#` and `+` are wildcards and illegal in a published topic, and a broker drops the publish rather than guessing.

**Verified against a broker**: a configured prefix of `home//weather/#` published retained `home/weather/status` and `home/weather/nearest` carrying real feed data (KTIK observations, a cell at 210 km).

Gate: clippy clean, 305 lib tests pass (+2 new), wasm check clean, `shoot.sh check` passed, web bundle 4,825,194 gz of 4,850,000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)