### PR TITLE
feat(widget): the home screen says how far off the storm is

### DIFF
--- a/android/app/src/main/kotlin/zip/batman/hookecho/AlertWidget.kt
+++ b/android/app/src/main/kotlin/zip/batman/hookecho/AlertWidget.kt
@@ -7,6 +7,7 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.widget.RemoteViews
+import java.io.File
 
 /**
  * Home-screen widget: what is currently warned at your saved locations, and a tap that opens the
@@ -34,11 +35,17 @@ class AlertWidget : AppWidgetProvider() {
                 lines.add("${a.event} — ${m.name}")
             }
         }
-        val text = when {
+        var text = when {
             watched.isEmpty() -> "No saved locations yet"
             lines.isEmpty() -> "All quiet"
             else -> lines.distinct().take(4).joinToString("\n")
         }
+        // The storm line the app last wrote for the radar widget, reused here: "all quiet" and
+        // "a cell 12 miles away" are different kinds of quiet, and this widget has no cell data
+        // of its own. Absent when the app has not run, which is simply no line.
+        runCatching {
+            File(context.filesDir, RadarWidget.CAPTION).takeIf { it.exists() }?.readText()?.trim()
+        }.getOrNull()?.takeIf { it.isNotEmpty() }?.let { text = "$text\n$it" }
         // Tapping opens the app at the first watched point (site left empty: keep the current
         // radar, just fly there), same deep-link string the notifications use.
         val intent = Intent(context, MainActivity::class.java)

--- a/android/app/src/main/kotlin/zip/batman/hookecho/RadarWidget.kt
+++ b/android/app/src/main/kotlin/zip/batman/hookecho/RadarWidget.kt
@@ -31,7 +31,7 @@ class RadarWidget : AppWidgetProvider() {
             runCatching { BitmapFactory.decodeFile(png.absolutePath) }.getOrNull()?.let {
                 views.setImageViewBitmap(R.id.widget_radar_image, it)
             }
-            views.setTextViewText(R.id.widget_radar_text, age(png.lastModified()))
+            views.setTextViewText(R.id.widget_radar_text, caption(context, png.lastModified()))
         } else {
             views.setTextViewText(R.id.widget_radar_text, "Open Hook Echo-WX to fill this in")
         }
@@ -44,6 +44,21 @@ class RadarWidget : AppWidgetProvider() {
         )
         views.setOnClickPendingIntent(R.id.widget_radar_root, tap)
         for (id in ids) manager.updateAppWidget(id, views)
+    }
+
+    /**
+     * The line under the picture: the nearest storm and how far off it is, then the age.
+     *
+     * The app writes the storm half ([CAPTION]) whenever it writes the picture, because the
+     * widget has no cell data of its own and is not going to fetch any on someone's home screen.
+     * No file means nothing is being tracked near them, and the age stands alone.
+     */
+    private fun caption(context: Context, modified: Long): String {
+        val storm = runCatching {
+            File(context.filesDir, CAPTION).takeIf { it.exists() }?.readText()?.trim()
+        }.getOrNull()
+        val age = age(modified)
+        return if (storm.isNullOrEmpty()) age else "$storm\n$age"
     }
 
     /** "4 min ago", and blunt about it once the picture is old enough to mislead. */
@@ -60,6 +75,9 @@ class RadarWidget : AppWidgetProvider() {
     companion object {
         /** Where the Rust side writes the picture, relative to `filesDir`. */
         const val SNAPSHOT = "widget-radar.png"
+
+        /** Where the Rust side writes the storm line that goes under it. */
+        const val CAPTION = "widget-radar.txt"
 
         /** Re-render every placed widget now. Called from Rust after it writes a new snapshot. */
         @JvmStatic

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -13351,8 +13351,41 @@ impl HookEchoApp {
         // Silent: nobody asked for this one, so a toast would be the app talking to itself. A
         // failed write costs the widget one stale caption.
         match small.save(path) {
-            Ok(()) => crate::platform::refresh_radar_widget(),
+            Ok(()) => {
+                self.save_widget_caption();
+                crate::platform::refresh_radar_widget();
+            }
             Err(e) => log::warn!("widget snapshot failed: {e}"),
+        }
+    }
+
+    /// Write the widget's storm line beside the picture, measured from the place the user cares
+    /// about: where they are while chasing, else their home marker. Neither one means no line —
+    /// a distance from an arbitrary map centre is a number that misleads.
+    ///
+    /// Deleted rather than left stale when there is nothing to say: the file is read on its own
+    /// clock by a widget that has no idea how old it is.
+    fn save_widget_caption(&self) {
+        let Some(path) = crate::paths::widget_caption() else {
+            return;
+        };
+        let here = self.chase_pos.or_else(|| {
+            self.settings
+                .markers
+                .iter()
+                .find(|m| m.home)
+                .map(|m| (m.lon, m.lat))
+        });
+        let line = here.and_then(|(lon, lat)| widget_storm_line(self.active_storm_cells(), lon, lat));
+        match line {
+            Some(line) => {
+                if let Err(e) = std::fs::write(&path, line) {
+                    log::warn!("widget caption failed: {e}");
+                }
+            }
+            None => {
+                let _ = std::fs::remove_file(&path);
+            }
         }
     }
 
@@ -14077,6 +14110,33 @@ fn nearest_cell(cells: &[Cell], lon: f64, lat: f64, max_km: f64) -> Option<&Cell
         .filter(|(_, km)| *km <= max_km)
         .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
         .map(|(c, _)| c)
+}
+
+/// The widget's storm line: the nearest tracked cell to `(lon, lat)`, in the words a glance can
+/// read — "R3 12 mi SSW, moving NE 35 mph". `None` when nothing is being tracked nearby, which
+/// the widget renders as no line at all rather than as "no storms" (the app may simply have been
+/// looking at another part of the country).
+fn widget_storm_line(cells: &[Cell], lon: f64, lat: f64) -> Option<String> {
+    let c = nearest_cell(cells, lon, lat, 300.0)?;
+    let (km, bearing) = crate::geo::great_circle([c.lon, c.lat], [lon, lat]);
+    // Bearing is measured from the cell to you, so the compass point is the side of you the storm
+    // sits on once it is flipped back.
+    let from = crate::geo::compass(((bearing + 180.0) % 360.0) as f32);
+    let mut line = format!(
+        "{} {:.0} mi {from}",
+        if c.id.is_empty() { &c.title } else { &c.id },
+        km * 0.621_371
+    );
+    if let (Some(dir), Some(kt)) = (c.mvt_deg, c.mvt_kt) {
+        if kt >= 1.0 {
+            line.push_str(&format!(
+                ", moving {} {:.0} mph",
+                crate::geo::compass(dir),
+                kt * 1.150_779
+            ));
+        }
+    }
+    Some(line)
 }
 
 /// The longest consecutive segment of a screen-space polyline (for placing a contour label).
@@ -16039,7 +16099,7 @@ mod place_name_tests {
 
 #[cfg(test)]
 mod follow_tests {
-    use super::nearest_cell;
+    use super::{nearest_cell, widget_storm_line};
     use wxdata::level3::Cell;
 
     fn cell(id: &str, lon: f64, lat: f64) -> Cell {
@@ -16049,6 +16109,21 @@ mod follow_tests {
             lat,
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn the_widget_line_reads_from_where_you_are() {
+        // A cell due west of the reader, moving northeast at 30 kt.
+        let mut c = cell("R3", -97.72, 35.30);
+        c.mvt_deg = Some(45.0);
+        c.mvt_kt = Some(30.0);
+        let line = widget_storm_line(&[c], -97.5, 35.3).unwrap();
+        // West of you: the compass point names the side the storm is on, not the bearing to it.
+        assert!(line.starts_with("R3 12 mi W"), "{line}");
+        assert!(line.ends_with("moving NE 35 mph"), "{line}");
+        // Nothing within 300 km is no line at all.
+        assert!(widget_storm_line(&[cell("Z1", -80.0, 35.3)], -97.5, 35.3).is_none());
+        assert!(widget_storm_line(&[], -97.5, 35.3).is_none());
     }
 
     #[test]

--- a/crates/hookecho/src/geo.rs
+++ b/crates/hookecho/src/geo.rs
@@ -119,6 +119,17 @@ pub fn nearest_site_id(lon: f64, lat: f64) -> Option<String> {
     wxdata::sites::nearest_site(lat as f32, lon as f32).map(|s| s.id.to_string())
 }
 
+
+/// 16-point compass label for a bearing in degrees. Lives here rather than beside any one caller
+/// because the widget caption, the status report and the spoken scripts all want the same words.
+pub fn compass(deg: f32) -> &'static str {
+    const D: [&str; 16] = [
+        "N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE", "S", "SSW", "SW", "WSW", "W", "WNW",
+        "NW", "NNW",
+    ];
+    D[((deg.rem_euclid(360.0) / 22.5).round() as usize) % 16]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/hookecho/src/paths.rs
+++ b/crates/hookecho/src/paths.rs
@@ -85,6 +85,12 @@ pub fn widget_snapshot() -> Option<PathBuf> {
     BASE.get().map(|b| b.join("widget-radar.png"))
 }
 
+/// Where the app writes the one-line storm caption the radar widget shows under its picture.
+/// Beside the PNG, in the same files dir the Kotlin side reads.
+pub fn widget_caption() -> Option<PathBuf> {
+    BASE.get().map(|b| b.join("widget-radar.txt"))
+}
+
 /// Cache root (tiles, vector tiles, climatology CSV).
 pub fn cache_dir() -> Option<PathBuf> {
     root("cache")

--- a/crates/hookecho/src/status.rs
+++ b/crates/hookecho/src/status.rs
@@ -256,7 +256,7 @@ fn status_for(
         wind_dir: o
             .as_ref()
             .and_then(|o| o.wind_dir_deg)
-            .map(|d| compass(d).to_string()),
+            .map(|d| crate::geo::compass(d).to_string()),
         pressure_in: o
             .as_ref()
             .and_then(|o| o.slp_pa.or(o.pressure_pa))
@@ -272,15 +272,6 @@ fn c_to_f(c: f32) -> f32 {
 
 fn kmh_to_kt(kmh: f32) -> f32 {
     kmh / 1.852
-}
-
-/// 16-point compass label for a wind direction in degrees.
-fn compass(deg: f32) -> &'static str {
-    const D: [&str; 16] = [
-        "N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE", "S", "SSW", "SW", "WSW", "W", "WNW",
-        "NW", "NNW",
-    ];
-    D[((deg / 22.5).round() as usize) % 16]
 }
 
 /// Conditions as one phrase: `74°F 62%rh SW 12kt`. Empty when the station reported nothing.


### PR DESCRIPTION
The radar widget showed a picture and its age. "Is that cell near me" is exactly the question someone looks at a home screen to answer, and a picture cannot supply it.

The app now writes a one-line storm caption (`widget-radar.txt`) beside the snapshot whenever it writes the picture — nearest tracked cell, distance in miles, the side of you it is on, and its motion. Measured from where you are while chasing, else your home marker; a distance from an arbitrary map centre would mislead. Nothing tracked means the file is deleted rather than left stale.

The alert widget reads the same line: "all quiet" and "a cell twelve miles away" are different kinds of quiet.

`compass()` moved from status.rs (native-only) to geo.rs.

**Verified**: on the S24 Ultra with a home marker at Paducah during live convection, the app wrote `W5 2 mi E` beside the snapshot. Unit test covers the wording and the 300 km cutoff. The widget's own on-screen render was not verified — no widget host instance is placed on the device and `adb` has no way to place one.

Gates: clippy -D warnings · workspace tests · wasm32 check · shoot.sh check · web bundle 4,826,941 gz (budget 4,850,000) · cargo-ndk arm64 check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)