### PR TITLE
feat(chase): warm the next radar before the handoff

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -2060,6 +2060,9 @@ pub struct HookEchoApp {
     chase_pos: Option<(f64, f64)>,
     /// Breadcrumb track of this session's fixes (see `settings.chase_log`).
     chase_track: crate::chaselog::Track,
+    /// The site last warmed ahead of a chase handoff, and when — so a fix every two seconds does
+    /// not queue a download every two seconds.
+    warmed_site: Option<(String, Instant)>,
     /// Tornado climatology: the loaded SPC track database (lazy), a pending async load, the last
     /// query result + its center, a window-open flag, and a query queued while the CSV loads.
     climo_tracks: Option<std::sync::Arc<Vec<wxdata::torclimo::TornadoTrack>>>,
@@ -2920,6 +2923,7 @@ impl HookEchoApp {
             recent_hits: Vec::new(),
             chase_pos: None,
             chase_track: crate::chaselog::Track::default(),
+            warmed_site: None,
             climo_tracks: None,
             climo_rx: None,
             climo_hits: Vec::new(),
@@ -5271,6 +5275,37 @@ impl HookEchoApp {
             self.goto_view(&site, lon, lat, zoom, None);
         }
         self.chase_applied = Some((lon, lat));
+        self.warm_next_site();
+    }
+
+    /// Pull the next site's newest volume into the cache before the handoff needs it.
+    ///
+    /// Only ever one download ahead, and only once per site: this runs off a GPS fix, which on a
+    /// moving car is every couple of seconds. Needs the chase log switched on — the prediction
+    /// reads the breadcrumb track, and a single fix has no direction in it.
+    fn warm_next_site(&mut self) {
+        const EVERY: std::time::Duration = std::time::Duration::from_secs(120);
+        if !self.settings.chase_log {
+            return;
+        }
+        let current = self.views[self.active].site.clone();
+        let Some(site) = crate::chase::next_site(
+            &self.chase_track,
+            current.as_deref(),
+            crate::chase::LOOKAHEAD_MIN,
+        ) else {
+            return;
+        };
+        if self
+            .warmed_site
+            .as_ref()
+            .is_some_and(|(s, at)| *s == site && at.elapsed() < EVERY)
+        {
+            return;
+        }
+        self.warmed_site = Some((site.clone(), Instant::now()));
+        log::debug!("chase: warming {site} ahead of the handoff");
+        self.spawner.spawn(crate::chase::warm(site));
     }
 
     /// Start the Google sign-in: bind a loopback port, send the browser to Google, and wait for

--- a/crates/hookecho/src/app/chrome/registry.rs
+++ b/crates/hookecho/src/app/chrome/registry.rs
@@ -708,7 +708,10 @@ impl HookEchoApp {
         }
         push(
             "Mute audio alerts",
-            "Alerts",
+            // "Tools", not "Alerts": there is no Alerts group in the panel, and a row filed under
+            // one draws nowhere — reachable from Ctrl+K and invisible everywhere else. The debug
+            // assertion in `push` caught it; a debug build panicked at startup.
+            "Tools",
             "Silence every chime and spoken warning without changing your sound choices",
             true,
             PaletteAction::ToggleMute,

--- a/crates/hookecho/src/chase.rs
+++ b/crates/hookecho/src/chase.rs
@@ -1,0 +1,143 @@
+//! Looking ahead of the windscreen: where the car will be in a few minutes, and which radar
+//! covers it.
+//!
+//! A chase crosses radar coverage boundaries at 70 mph, and the handoff to the next site is
+//! currently a cold start — the app notices the new nearest site the moment it is already the
+//! nearest one, and then spends a minute listing and downloading a 6 MB volume while the storm is
+//! in front of you. Predicting the handoff a few minutes early turns that into a cache hit.
+//!
+//! Everything here is a heading extrapolated in a straight line. That is wrong on a curve and
+//! wrong at a stop sign, and it does not matter: the cost of a wrong guess is one volume
+//! downloaded and never shown.
+//
+// ponytail: dead-reckoning from the last two fixes, one site ahead, newest volume only. The
+// ceiling is "the next site is warm when you get there". A real version would follow the road
+// network and warm a whole loop; both need data this app does not carry.
+
+use crate::chaselog::Track;
+
+/// How far ahead to look. Long enough to cover a listing plus a download on cellular, short
+/// enough that a straight-line guess is still roughly true.
+pub const LOOKAHEAD_MIN: f64 = 6.0;
+
+/// Below this there is no heading worth extrapolating — a parked car's two fixes differ by GPS
+/// noise, and the "direction" they imply is random.
+const MIN_SPEED_KT: f64 = 15.0;
+
+/// Where the track will be `minutes` from its last fix, dead-reckoned from the last two.
+///
+/// `None` when there is nothing to reckon from: fewer than two points, no time between them, or
+/// a speed low enough that the heading is noise rather than travel.
+pub fn predict(track: &Track, minutes: f64) -> Option<[f64; 2]> {
+    let n = track.points.len();
+    let (a, b) = (track.points.get(n.checked_sub(2)?)?, track.points.last()?);
+    let dt_h = (b.ts - a.ts) as f64 / 3600.0;
+    if dt_h <= 0.0 {
+        return None;
+    }
+    let (km, bearing_to_a) = crate::geo::great_circle([b.lon, b.lat], [a.lon, a.lat]);
+    let kt = crate::geo::km_to_nmi(km) / dt_h;
+    if kt < MIN_SPEED_KT {
+        return None;
+    }
+    // `great_circle` gives the bearing from b back to a; the car is going the other way.
+    let heading = (bearing_to_a + 180.0) % 360.0;
+    Some(crate::geo::destination_point(
+        [b.lon, b.lat],
+        heading,
+        km / dt_h * (minutes / 60.0),
+    ))
+}
+
+/// The site to warm up: the nearest one to where the track is heading, when that is not the site
+/// already on screen. `None` means "no handoff coming", which is the usual answer.
+pub fn next_site(track: &Track, current: Option<&str>, minutes: f64) -> Option<String> {
+    let [lon, lat] = predict(track, minutes)?;
+    let site = crate::geo::nearest_site_id(lon, lat)?;
+    match current {
+        Some(c) if c.eq_ignore_ascii_case(&site) => None,
+        _ => Some(site),
+    }
+}
+
+/// Pull the newest volume for `site` into the on-disk cache, so the handoff finds it there.
+///
+/// Nothing is shown and nothing is reported: a failed warm-up is a handoff that behaves the way
+/// it did before this module existed.
+pub async fn warm(site: String) {
+    let date = chrono::Utc::now().date_naive();
+    let Ok(ids) = wxdata::level2::list_volumes(&site, date).await else {
+        return;
+    };
+    let Some(newest) = ids.into_iter().next_back() else {
+        return;
+    };
+    match wxdata::level2::download_scan(newest, crate::paths::cache_dir()).await {
+        Ok(_) => log::debug!("chase: warmed {site}"),
+        Err(e) => log::debug!("chase: warming {site} failed: {e}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn track(points: &[(f64, f64, i64)]) -> Track {
+        let mut t = Track::default();
+        for (lon, lat, ts) in points {
+            t.points.push(crate::chaselog::Fix {
+                lon: *lon,
+                lat: *lat,
+                ts: *ts,
+            });
+        }
+        t
+    }
+
+    #[test]
+    fn a_car_going_east_is_predicted_east_of_itself() {
+        // ~0.1° of longitude in 60 s at 35°N is ~9 km — about 300 kt, well clear of the floor.
+        let t = track(&[(-97.6, 35.3, 0), (-97.5, 35.3, 60)]);
+        let [lon, lat] = predict(&t, 6.0).unwrap();
+        assert!(lon > -97.5, "predicted west of the last fix: {lon}");
+        assert!((lat - 35.3).abs() < 0.05, "wandered off the heading: {lat}");
+        // Six minutes at that speed is a long way: tens of kilometres, not metres.
+        let (km, _) = crate::geo::great_circle([-97.5, 35.3], [lon, lat]);
+        assert!(km > 40.0 && km < 70.0, "{km} km ahead");
+    }
+
+    #[test]
+    fn a_parked_car_has_no_heading() {
+        // Two fixes a minute apart, a few metres of noise between them.
+        assert!(predict(&track(&[(-97.5, 35.3, 0), (-97.5001, 35.3, 60)]), 6.0).is_none());
+        // And one fix is not a direction.
+        assert!(predict(&track(&[(-97.5, 35.3, 0)]), 6.0).is_none());
+        assert!(predict(&Track::default(), 6.0).is_none());
+    }
+
+    /// Live: warms a real site off the public NEXRAD bucket and checks a volume landed in the
+    /// cache. Ignored by default — it downloads several MB and needs the network.
+    #[test]
+    #[ignore = "network"]
+    fn warming_a_site_leaves_a_volume_in_the_cache() {
+        let dir = std::env::temp_dir().join("hookecho-chase-warm-test");
+        let _ = std::fs::remove_dir_all(&dir);
+        crate::paths::set_base(dir.clone());
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(warm("KTLX".to_string()));
+        let volumes = crate::paths::cache_dir().unwrap().join("volumes");
+        let n = std::fs::read_dir(&volumes).map(|d| d.count()).unwrap_or(0);
+        assert!(n > 0, "nothing cached in {}", volumes.display());
+    }
+
+    #[test]
+    fn the_handoff_only_fires_when_the_site_actually_changes() {
+        // Driving hard west out of Oklahoma City towards the Texas panhandle.
+        let t = track(&[(-98.6, 35.3, 0), (-99.0, 35.3, 120)]);
+        let ahead = next_site(&t, Some("KTLX"), 30.0).expect("a different site is ahead");
+        assert_ne!(ahead, "KTLX");
+        // Whatever that site is, being on it already means there is nothing to warm.
+        assert!(next_site(&t, Some(&ahead), 30.0).is_none());
+        assert!(next_site(&t, Some(&ahead.to_lowercase()), 30.0).is_none());
+    }
+}

--- a/crates/hookecho/src/lib.rs
+++ b/crates/hookecho/src/lib.rs
@@ -16,6 +16,8 @@ pub mod basemap_style;
 /// Live camera video (desktop only — Android cannot spawn an ffmpeg child).
 #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
 pub mod cam;
+/// Dead reckoning ahead of the car, for the next radar handoff.
+pub mod chase;
 pub mod chaselog;
 pub mod cloud;
 pub mod colormap;


### PR DESCRIPTION
Crossing a coverage boundary at 70 mph was a cold start: the app noticed the new nearest site the moment it was already the nearest one, then spent a minute listing and downloading a volume with the storm in front of you.

New `chase.rs` dead-reckons the last two fixes six minutes ahead, asks which site covers that point, and pulls its newest volume into the cache when the answer is not the site already on screen. Wrong on a curve and wrong at a stop sign — the cost of a wrong guess is one volume downloaded and never shown. Needs the chase log on (the prediction reads the breadcrumb track); warms one site at most every two minutes.

Also in here, found while getting a debug build to start: **the "Mute audio alerts" registry row was filed under a category the layers panel does not draw**, so it was reachable from Ctrl+K and invisible in the panel — and the debug assertion that exists to catch that panicked at startup. Filed under "Tools".

**Verified**: three unit tests (heading, parked-car floor, real site geography for the handoff), plus a network-marked test that actually warms KTLX off the public bucket — 9.5 MB landed in `cache/volumes`. The in-app trigger was not driven end to end: it needs a live GPS source plus manual chase-panel interaction, and driving that panel blind over xdotool did not pan out.

Gates: clippy -D warnings · workspace tests · wasm32 check · shoot.sh check · web bundle 4,828,574 gz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)