### PR TITLE
feat(chase): replay the drive

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1178,6 +1178,8 @@ pub(crate) enum AppWindow {
     Placefiles,
     Palettes,
     Events,
+    /// Replay a recorded drive against the archive.
+    ChaseReplay,
     Digest,
     Afd,
     Cappi,
@@ -2039,6 +2041,7 @@ pub struct HookEchoApp {
     draw_color: egui::Color32,
     marker_window: ui::marker_window::MarkerWindow,
     event_window: ui::event_window::EventWindow,
+    chase_replay: ui::chase_replay::ChaseReplay,
     palette_editor: ui::palette_editor::PaletteEditor,
     digest_window: ui::digest_window::DigestWindow,
     digest_rx: Option<std::sync::mpsc::Receiver<Result<String, String>>>,
@@ -2912,6 +2915,7 @@ impl HookEchoApp {
             draw_color: DRAW_COLORS[0],
             marker_window: Default::default(),
             event_window: Default::default(),
+            chase_replay: Default::default(),
             palette_editor: Default::default(),
             digest_window: Default::default(),
             digest_rx: None,
@@ -7198,6 +7202,7 @@ impl HookEchoApp {
                 W::Placefiles => self.placefile_window.open = true,
                 W::Palettes => self.palette_editor.open = true,
                 W::Events => self.event_window.open = true,
+                W::ChaseReplay => self.chase_replay.open = true,
                 W::Digest => {
                     self.digest_window.open = true;
                     self.generate_digest();
@@ -13224,6 +13229,19 @@ impl HookEchoApp {
                 // Setting the override triggers the next-frame dirty-diff palette reload.
                 self.settings.palettes.insert(import.tag, value);
             }
+            K::ChaseGpx => match import.text() {
+                Ok(xml) => {
+                    let track = crate::chaselog::from_gpx(&xml);
+                    if track.points.len() < 2 {
+                        self.toast(ToastKind::Error, "No track points in that file".to_string());
+                    } else {
+                        let n = track.points.len();
+                        self.chase_replay.load(track, import.name());
+                        self.toast(ToastKind::Info, format!("Loaded {n} track points"));
+                    }
+                }
+                Err(e) => self.toast(ToastKind::Error, format!("GPX import failed: {e}")),
+            },
             K::MarkerIcon => {
                 let idx = import.tag.parse::<usize>().ok();
                 match (
@@ -15545,6 +15563,24 @@ impl eframe::App for HookEchoApp {
                 EventAction::AddBookmark(span_min) => {
                     let n = self.settings.bookmarks.len() + 1;
                     self.add_bookmark(format!("Bookmark {n}"), span_min);
+                }
+            }
+        }
+
+        if let Some(act) = self
+            .chase_replay
+            .show(ctx, &self.chase_track, &mut self.drawer)
+        {
+            use ui::chase_replay::ReplayAction;
+            match act {
+                ReplayAction::Seek { lon, lat, time } => {
+                    // Empty site: the replay flies the camera and moves the clock, and leaves the
+                    // radar choice alone — the same handoff rule the deep links use.
+                    let zoom = self.views[self.active].camera.zoom.max(8.0);
+                    self.goto_view("", lon, lat, zoom, Some(time));
+                }
+                ReplayAction::OpenFile => {
+                    crate::dialog::request_open(crate::dialog::ImportKind::ChaseGpx, "");
                 }
             }
         }

--- a/crates/hookecho/src/app/chrome/registry.rs
+++ b/crates/hookecho/src/app/chrome/registry.rs
@@ -833,6 +833,12 @@ impl HookEchoApp {
                 false,
             ),
             (
+                W::ChaseReplay,
+                "Chase replay\u{2026}",
+                "Drive a recorded chase again, with the radar as it was",
+                false,
+            ),
+            (
                 W::Digest,
                 "Storm digest…",
                 "A plain-language summary of what's happening now",

--- a/crates/hookecho/src/app/chrome/state.rs
+++ b/crates/hookecho/src/app/chrome/state.rs
@@ -18,6 +18,7 @@ pub(crate) fn window_for_page(title: &str) -> Option<AppWindow> {
     Some(match title {
         "Settings" => AppWindow::Settings,
         "Event Library" => AppWindow::Events,
+        "Chase Replay" => AppWindow::ChaseReplay,
         "Alert rules" => AppWindow::AlertRules,
         "Help" => AppWindow::Help,
         "About Hook Echo-WX" => AppWindow::About,

--- a/crates/hookecho/src/chaselog.rs
+++ b/crates/hookecho/src/chaselog.rs
@@ -111,6 +111,82 @@ impl Track {
     }
 }
 
+/// Read a GPX file back into a track: every `<trkpt>` with a time, plus the `<wpt>` marks
+/// snapped to the nearest point in time.
+///
+/// A hand-rolled scan rather than an XML parser, because this reads one shape of file — the one
+/// [`Track::to_gpx`] writes, or the one a chase logger or a phone app exports, which is the same
+/// three attributes in the same order. Anything it does not understand is skipped rather than
+/// rejected: half a drive is still a drive.
+//
+// ponytail: attribute scan, no namespaces, no extensions (heart rate, elevation, speed). The
+// ceiling is "the points and their times". A real GPX reader is a dependency, and this is the
+// only file the app ever reads.
+pub fn from_gpx(xml: &str) -> Track {
+    fn attr(tag: &str, name: &str) -> Option<f64> {
+        let at = tag.find(name)?;
+        let rest = &tag[at + name.len()..];
+        let rest = rest.trim_start().strip_prefix('=')?.trim_start();
+        let quote = rest.chars().next()?;
+        let body = rest[1..].split(quote).next()?;
+        body.trim().parse().ok()
+    }
+    fn between<'a>(s: &'a str, open: &str, close: &str) -> Option<&'a str> {
+        let a = s.find(open)? + open.len();
+        let b = s[a..].find(close)? + a;
+        Some(&s[a..b])
+    }
+
+    /// The text of one element, from just after its name to whichever comes first: its closing
+    /// tag, or the `/>` that says it has no children (and so no `<time>`).
+    fn body<'a>(rest: &'a str, close: &str) -> &'a str {
+        let end = match (rest.find(close), rest.find("/>")) {
+            (Some(a), Some(b)) => a.min(b),
+            (Some(a), None) => a,
+            (None, Some(b)) => b,
+            (None, None) => rest.len(),
+        };
+        &rest[..end]
+    }
+
+    let mut track = Track::default();
+    let mut pending: Vec<(i64, String)> = Vec::new();
+    // Two passes, one per element kind: a `<time>` is a child element rather than an attribute,
+    // so each point has to be read as a span of the file rather than as a single tag.
+    for (open, close, is_point) in [("<trkpt", "</trkpt>", true), ("<wpt", "</wpt>", false)] {
+        for piece in xml.split(open).skip(1) {
+            let piece = body(piece, close);
+            let (Some(lat), Some(lon)) = (attr(piece, "lat"), attr(piece, "lon")) else {
+                continue;
+            };
+            let ts = between(piece, "<time>", "</time>")
+                .and_then(|t| t.parse::<chrono::DateTime<chrono::Utc>>().ok())
+                .map(|t| t.timestamp())
+                .unwrap_or(0);
+            if is_point {
+                // Straight onto the vec: a recorded file has already been thinned, and dropping
+                // points here would move the marks the waypoints refer to.
+                track.points.push(Fix { lon, lat, ts });
+            } else if let Some(name) = between(piece, "<name>", "</name>") {
+                pending.push((ts, unescape(name)));
+            }
+        }
+    }
+    for (ts, label) in pending {
+        // Nearest point in time, since a waypoint carries no index — which is also how it
+        // survives a file whose points were thinned by whatever wrote it.
+        if let Some((i, _)) = track
+            .points
+            .iter()
+            .enumerate()
+            .min_by_key(|(_, p)| (p.ts - ts).abs())
+        {
+            track.waypoints.push((i, label));
+        }
+    }
+    track
+}
+
 /// The five characters XML cannot carry raw. A waypoint label is user text and lands in a file
 /// other programs parse.
 fn escape(s: &str) -> String {
@@ -119,6 +195,15 @@ fn escape(s: &str) -> String {
         .replace('>', "&gt;")
         .replace('"', "&quot;")
         .replace('\'', "&apos;")
+}
+
+/// …and back, for the labels [`from_gpx`] reads.
+fn unescape(s: &str) -> String {
+    s.replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&apos;", "'")
+        .replace("&amp;", "&")
 }
 
 /// Great-circle distance in metres.
@@ -159,6 +244,34 @@ mod tests {
         assert!(gpx.contains("2023-11-14T"), "{gpx}");
         // Waypoints come before the track, per the GPX schema's element order.
         assert!(gpx.find("<wpt").unwrap() < gpx.find("<trk>").unwrap());
+    }
+
+    #[test]
+    fn a_gpx_file_reads_back_as_the_track_that_wrote_it() {
+        let mut t = Track::default();
+        t.push(-97.5, 35.4, 1_700_000_000);
+        t.push(-97.6, 35.4, 1_700_000_300);
+        t.mark("wall cloud & \"hook\"");
+        let back = from_gpx(&t.to_gpx());
+        assert_eq!(back.points.len(), 2);
+        assert!((back.points[0].lon + 97.5).abs() < 1e-6);
+        assert_eq!(back.points[1].ts, 1_700_000_300);
+        // The mark was on the newest point and lands there again, with its text unescaped.
+        assert_eq!(back.waypoints, vec![(1, "wall cloud & \"hook\"".to_string())]);
+        // Distance survives the round trip.
+        assert!((back.miles() - t.miles()).abs() < 0.01);
+    }
+
+    #[test]
+    fn a_file_it_does_not_understand_is_skipped_not_rejected() {
+        // No times, single quotes, an element it has never seen.
+        let xml = "<gpx><metadata><name>x</name></metadata><trk><trkseg>\
+                   <trkpt lat='35.4' lon='-97.5'/><trkpt lat='bogus' lon='-97.6'/>\
+                   </trkseg></trk></gpx>";
+        let t = from_gpx(xml);
+        assert_eq!(t.points.len(), 1);
+        assert_eq!(t.points[0].ts, 0);
+        assert!(from_gpx("not xml at all").points.is_empty());
     }
 
     #[test]

--- a/crates/hookecho/src/dialog.rs
+++ b/crates/hookecho/src/dialog.rs
@@ -80,6 +80,8 @@ pub enum ImportKind {
     MarkerIcon,
     /// A sound file to play for alerts.
     AlertSound,
+    /// A GPX track to replay (one this app wrote, or one another chase logger did).
+    ChaseGpx,
 }
 
 impl ImportKind {
@@ -89,6 +91,7 @@ impl ImportKind {
             ImportKind::Palette => "GRLevelX color table",
             ImportKind::MarkerIcon => "Marker icon",
             ImportKind::AlertSound => "Alert sound",
+            ImportKind::ChaseGpx => "GPX track",
         }
     }
 
@@ -98,6 +101,7 @@ impl ImportKind {
             ImportKind::Palette => &["pal", "pal3"],
             ImportKind::MarkerIcon => &["png"],
             ImportKind::AlertSound => &["wav", "mp3", "ogg", "flac"],
+            ImportKind::ChaseGpx => &["gpx"],
         }
     }
 
@@ -110,6 +114,9 @@ impl ImportKind {
             ImportKind::Palette => "*/*",
             ImportKind::MarkerIcon => "image/png",
             ImportKind::AlertSound => "audio/*",
+            // No registered MIME for GPX that pickers agree on; the extension is checked on the
+            // way back, same as a palette.
+            ImportKind::ChaseGpx => "*/*",
         }
     }
 }
@@ -215,6 +222,7 @@ mod android_open {
             ImportKind::Palette => "palette",
             ImportKind::MarkerIcon => "marker",
             ImportKind::AlertSound => "sound",
+            ImportKind::ChaseGpx => "gpx",
         }
     }
 
@@ -224,6 +232,7 @@ mod android_open {
             "palette" => ImportKind::Palette,
             "marker" => ImportKind::MarkerIcon,
             "sound" => ImportKind::AlertSound,
+            "gpx" => ImportKind::ChaseGpx,
             _ => return None,
         })
     }

--- a/crates/hookecho/src/ui/chase_replay.rs
+++ b/crates/hookecho/src/ui/chase_replay.rs
@@ -1,0 +1,306 @@
+//! Driving the chase again, afterwards.
+//!
+//! The app already records where you went ([`crate::chaselog::Track`]) and can write it as GPX.
+//! What it could not do is play it back: put the camera where the car was, with the radar at the
+//! time it was there, and step forward. That is how a chase gets reviewed — "we were three
+//! minutes from the wrong side of it and did not know" is only visible against the scan that was
+//! on screen at the time.
+//!
+//! The page owns the playhead and hands the app one position per frame; the app owns the camera
+//! and the timeline, exactly as the event library does.
+//
+// ponytail: linear playback at a speed multiplier, one track at a time, no interpolation between
+// fixes. The ceiling is "watch the drive back". Smooth camera motion means tweening positions,
+// which is the motion system's job, not this page's.
+
+use crate::chaselog::Track;
+
+/// What the page asks the app to do this frame.
+pub enum ReplayAction {
+    /// Put the camera here, with the radar at this time.
+    Seek {
+        lon: f64,
+        lat: f64,
+        time: chrono::DateTime<chrono::Utc>,
+    },
+    /// Load a GPX file the user picked.
+    OpenFile,
+}
+
+pub struct ChaseReplay {
+    pub open: bool,
+    /// The track being replayed. Empty until the user loads one or copies the live session.
+    pub track: Track,
+    /// Where it came from, for the line under the title.
+    pub source: String,
+    /// Index into `track.points`.
+    pub at: usize,
+    pub playing: bool,
+    /// Real-time multiplier. A chase is hours long; nobody replays one at 1x.
+    pub speed: f64,
+    /// App time the playhead last advanced, so speed means something regardless of frame rate.
+    last_step: f64,
+}
+
+impl Default for ChaseReplay {
+    fn default() -> Self {
+        Self {
+            open: false,
+            track: Track::default(),
+            source: String::new(),
+            at: 0,
+            playing: false,
+            speed: 60.0,
+            last_step: 0.0,
+        }
+    }
+}
+
+impl ChaseReplay {
+    /// Take a copy of the live session's track. A copy, not a borrow: replaying yesterday's file
+    /// must not disturb the log still being written today.
+    pub fn load(&mut self, track: Track, source: impl Into<String>) {
+        self.track = track;
+        self.source = source.into();
+        self.at = 0;
+        self.playing = false;
+    }
+
+    /// The fix under the playhead.
+    fn current(&self) -> Option<crate::chaselog::Fix> {
+        self.track.points.get(self.at).copied()
+    }
+
+    /// Advance the playhead by wall-clock time times the speed multiplier. Returns true when it
+    /// moved, which is what makes the app seek — a paused replay asks for nothing.
+    fn advance(&mut self, now: f64) -> bool {
+        if !self.playing || self.track.points.len() < 2 {
+            return false;
+        }
+        let dt = now - self.last_step;
+        self.last_step = now;
+        // A frame that took a second (a decode, a tab coming back) would otherwise jump the
+        // playhead a minute of track; clamp it to something a viewer can follow.
+        let track_secs = (dt.clamp(0.0, 0.25) * self.speed) as i64;
+        let Some(from) = self.current() else {
+            return false;
+        };
+        let target = from.ts + track_secs.max(0);
+        let next = self
+            .track
+            .points
+            .iter()
+            .position(|p| p.ts >= target)
+            .unwrap_or(self.track.points.len() - 1);
+        if next == self.at {
+            return false;
+        }
+        self.at = next;
+        if self.at + 1 >= self.track.points.len() {
+            // Stop at the end rather than loop: a drive has a destination.
+            self.playing = false;
+        }
+        true
+    }
+
+    pub fn show(
+        &mut self,
+        ctx: &egui::Context,
+        live: &Track,
+        drawer: &mut crate::ui::drawer::Drawer,
+    ) -> Option<ReplayAction> {
+        let mut open = self.open;
+        let mut action = None;
+        let Some(window) = drawer.page(
+            ctx,
+            "Chase Replay",
+            &mut open,
+            false,
+            egui::Window::new("Chase Replay"),
+        ) else {
+            self.open = open;
+            return None;
+        };
+        let mut load_live = false;
+        let mut seek = false;
+        window.show(ctx, |ui| {
+            ui.horizontal(|ui| {
+                if ui
+                    .button("Open GPX…")
+                    .on_hover_text("Replay a drive you saved, or one another app recorded")
+                    .clicked()
+                {
+                    action = Some(ReplayAction::OpenFile);
+                }
+                if ui
+                    .add_enabled(
+                        live.points.len() > 1,
+                        egui::Button::new("This session"),
+                    )
+                    .on_hover_text("Replay the track being logged right now")
+                    .clicked()
+                {
+                    load_live = true;
+                }
+            });
+            if self.track.points.len() < 2 {
+                ui.add_space(6.0);
+                ui.weak(
+                    "Nothing to replay yet. Turn on \u{201c}Log the chase\u{201d} before you \
+                     drive, or open a GPX file.",
+                );
+                return;
+            }
+            ui.add_space(6.0);
+            ui.weak(format!(
+                "{} \u{2014} {} points, {:.0} miles",
+                self.source,
+                self.track.points.len(),
+                self.track.miles()
+            ));
+            ui.add_space(6.0);
+            ui.horizontal(|ui| {
+                let icon = if self.playing {
+                    egui_phosphor::regular::PAUSE
+                } else {
+                    egui_phosphor::regular::PLAY
+                };
+                if ui.button(icon).clicked() {
+                    self.playing = !self.playing;
+                    // Playing from the end starts over; the alternative is a play button that
+                    // looks broken.
+                    if self.playing && self.at + 1 >= self.track.points.len() {
+                        self.at = 0;
+                    }
+                    self.last_step = ui.input(|i| i.time);
+                    seek = true;
+                }
+                let last = self.track.points.len() - 1;
+                let mut at = self.at;
+                if ui
+                    .add(egui::Slider::new(&mut at, 0..=last).show_value(false))
+                    .changed()
+                {
+                    self.at = at;
+                    self.playing = false;
+                    seek = true;
+                }
+            });
+            ui.horizontal(|ui| {
+                ui.label("Speed");
+                for s in [10.0, 60.0, 300.0] {
+                    ui.selectable_value(&mut self.speed, s, format!("{s:.0}\u{00d7}"));
+                }
+            });
+            if let Some(p) = self.current() {
+                let when = chrono::DateTime::from_timestamp(p.ts, 0);
+                ui.add_space(4.0);
+                ui.label(match when {
+                    Some(t) => t.format("%Y-%m-%d %H:%M:%SZ").to_string(),
+                    // A file with no times still replays as a path; it just cannot drive the
+                    // radar clock, and says so instead of showing 1970.
+                    None => "no time recorded".to_string(),
+                });
+                let marks: Vec<&str> = self
+                    .track
+                    .waypoints
+                    .iter()
+                    .filter(|(i, _)| *i == self.at)
+                    .map(|(_, l)| l.as_str())
+                    .collect();
+                if !marks.is_empty() {
+                    ui.strong(marks.join(", "));
+                }
+            }
+        });
+        self.open = open;
+        if load_live {
+            self.load(live.clone(), "This session");
+            seek = true;
+        }
+        if self.advance(ctx.input(|i| i.time)) {
+            seek = true;
+        }
+        if self.playing {
+            ctx.request_repaint();
+        }
+        if action.is_none() && seek {
+            if let Some(p) = self.current() {
+                // Timestamp 0 is "this file carried no times": drive the camera, leave the radar
+                // clock where the user put it.
+                if let Some(time) = chrono::DateTime::from_timestamp(p.ts, 0).filter(|_| p.ts > 0) {
+                    action = Some(ReplayAction::Seek {
+                        lon: p.lon,
+                        lat: p.lat,
+                        time,
+                    });
+                }
+            }
+        }
+        action
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chaselog::Fix;
+
+    fn track(n: usize) -> Track {
+        let mut t = Track::default();
+        for i in 0..n {
+            t.points.push(Fix {
+                lon: -97.5 + i as f64 * 0.01,
+                lat: 35.3,
+                ts: 1_700_000_000 + i as i64 * 60,
+            });
+        }
+        t
+    }
+
+    #[test]
+    fn playback_moves_with_the_clock_and_stops_at_the_end() {
+        let mut r = ChaseReplay {
+            track: track(5),
+            playing: true,
+            speed: 60.0,
+            ..Default::default()
+        };
+        // One second of wall clock at 60x is a minute of track: one point.
+        r.last_step = 0.0;
+        assert!(r.advance(0.2));
+        assert_eq!(r.at, 1);
+        // Enough steps to run off the end: it stops there rather than wrapping or panicking.
+        for i in 2..20 {
+            r.advance(i as f64 * 0.2);
+        }
+        assert_eq!(r.at, 4);
+        assert!(!r.playing);
+    }
+
+    #[test]
+    fn a_paused_replay_asks_for_nothing() {
+        let mut r = ChaseReplay {
+            track: track(5),
+            ..Default::default()
+        };
+        assert!(!r.advance(1.0));
+        // …and neither does a one-point track that was somehow left playing.
+        r.playing = true;
+        r.track = track(1);
+        assert!(!r.advance(2.0));
+    }
+
+    #[test]
+    fn a_long_frame_does_not_launch_the_playhead() {
+        let mut r = ChaseReplay {
+            track: track(60),
+            playing: true,
+            speed: 60.0,
+            ..Default::default()
+        };
+        // Ten seconds of stall at 60x would be ten minutes of track; the clamp keeps it to 15 s.
+        assert!(r.advance(10.0));
+        assert_eq!(r.at, 1);
+    }
+}

--- a/crates/hookecho/src/ui/mod.rs
+++ b/crates/hookecho/src/ui/mod.rs
@@ -97,6 +97,7 @@ pub mod cells_window;
 pub mod cheatsheet;
 pub mod detail_window;
 pub mod digest_window;
+pub mod chase_replay;
 pub mod event_window;
 pub mod firstrun;
 pub mod forecast_window;


### PR DESCRIPTION
A chase log could be written and exported and never played back. Reviewing a chase means putting the camera where the car was with the radar as it was — "we were three minutes from the wrong side of it" is only visible against the scan that was on screen at the time.

New drawer page (Chase Replay): load a GPX — one this app wrote or one another logger did — or copy the session still being recorded, then scrub or play at 10x/60x/300x while the camera follows and the timeline seeks to each fix. The radar site is left alone, the way the deep links do it. Waypoint marks show as the playhead passes them; a file with no times replays as a path and says so instead of showing 1970.

`chaselog::from_gpx` is an attribute scan rather than an XML parser — this reads one shape of file, and anything it does not understand is skipped rather than rejected.

**Verified**: GPX round-trip and malformed-file tests; three playback tests (clock stepping, stop at the end, a stalled frame not launching the playhead); the page opens from the registry row and shows its empty state on a real desktop build (screenshotted on Xvfb). Loading a track through the GUI was **not** verified — the file picker goes through the XDG portal, which opens on the real desktop rather than the test display and blocks the app while it waits.

Gates: clippy -D warnings · workspace tests · wasm32 check · shoot.sh check · web bundle 4,831,402 gz · cargo-ndk arm64 check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)