### PR TITLE
fix(android): warnings buzz the phone, and therefore the watch

### DIFF
--- a/android/app/src/main/kotlin/zip/batman/hookecho/AlertService.kt
+++ b/android/app/src/main/kotlin/zip/batman/hookecho/AlertService.kt
@@ -93,7 +93,11 @@ class AlertService : Service() {
         private const val FOREGROUND_ID = 1
         private const val CH_STATUS = "status"
         private const val CH_WATCH = "watch"
-        private const val CH_WARNING = "warning"
+        // Versioned id: a channel's vibration is fixed at creation and the OS ignores later
+        // edits, so correcting it means a new channel. The old one is deleted in
+        // [createChannels] rather than left behind as a second "Warnings" row in settings.
+        private const val CH_WARNING = "warning_v2"
+        private const val CH_WARNING_OLD = "warning"
         private const val CH_EMERGENCY = "emergency"
         private const val PREFS = "alerts"
         private const val KEY_SEEN = "seen"
@@ -192,8 +196,14 @@ class AlertService : Service() {
             m.createNotificationChannel(
                 NotificationChannel(CH_WATCH, "Watches", NotificationManager.IMPORTANCE_DEFAULT)
             )
+            m.deleteNotificationChannel(CH_WARNING_OLD)
             m.createNotificationChannel(
                 NotificationChannel(CH_WARNING, "Warnings", NotificationManager.IMPORTANCE_HIGH)
+                    // IMPORTANCE_HIGH does not imply vibration, which is how a tornado warning
+                    // arrived silent-to-the-wrist: `mVibrationEnabled=false` on the device. This
+                    // is also the whole Wear story — a bridged notification buzzes the watch on
+                    // the phone channel's terms, so the watch needed nothing of its own.
+                    .apply { enableVibration(true) }
             )
             m.createNotificationChannel(
                 NotificationChannel(CH_EMERGENCY, "Emergencies", NotificationManager.IMPORTANCE_HIGH)


### PR DESCRIPTION
Checking the Wear side of the field kit turned up a phone bug. On device the Warnings channel read `mVibrationEnabled=false`: IMPORTANCE_HIGH gets a heads-up and a sound but not a vibration, and only the Emergencies channel ever asked for one. A tornado warning arrived silent to a wrist — in a pocket, and on a watch bridging it.

A channel's vibration is fixed at creation and later edits are ignored, so this needs a new id (`warning_v2`); the old channel is deleted rather than left as a second "Warnings" row in the system settings.

That is the whole Wear item: a bridged notification buzzes the watch on the phone channel's terms, so nothing Wear-specific was needed — which is what K6 was meant to establish.

**Verified on the S24 Ultra**: after install, `dumpsys notification` shows `warning_v2` with `mVibrationEnabled=true` and the old `warning` channel `mDeleted=true`. An actual buzz still needs a live warning at a watched marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)