### PR TITLE
feat(update): notify chip instead of a four-second toast

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1824,6 +1824,8 @@ pub struct HookEchoApp {
     /// About window + the once-per-session release check.
     about_open: bool,
     update_state: ui::about_window::UpdateState,
+    /// Update chip dismissed this session (see `chrome::chips::update_chip`).
+    update_chip_hidden: bool,
     update_tx: Sender<ui::about_window::UpdateState>,
     update_rx: Receiver<ui::about_window::UpdateState>,
     geocode_tx: Sender<Result<(String, f64, f64), String>>,
@@ -2785,6 +2787,7 @@ impl HookEchoApp {
             msg_tx,
             about_open: false,
             update_state: ui::about_window::UpdateState::Idle,
+            update_chip_hidden: false,
             update_tx,
             update_rx,
             geocode_tx,
@@ -15054,6 +15057,7 @@ impl eframe::App for HookEchoApp {
                 self.basemap_panel(ctx);
                 self.info_chip(ctx);
                 self.error_chip(ctx);
+                self.update_chip(ctx);
             }
         }
 
@@ -15093,9 +15097,6 @@ impl eframe::App for HookEchoApp {
         }
         while let Ok(state) = self.update_rx.try_recv() {
             self.update_state = state;
-            if let ui::about_window::UpdateState::Newer(v) = self.update_state.clone() {
-                self.toast(ToastKind::Info, format!("HookEcho {v} is available"));
-            }
         }
         if self.about_open {
             let accent = crate::theme::accent(self.settings.theme);

--- a/crates/hookecho/src/app/chrome/chips.rs
+++ b/crates/hookecho/src/app/chrome/chips.rs
@@ -247,6 +247,58 @@ impl HookEchoApp {
             });
     }
 
+    /// Top-center chip when a newer release exists: says so, links to the download, dismisses.
+    ///
+    /// The session's one update check already toasted this, and a toast is four seconds long —
+    /// which is how a stale build stays stale. This persists for the session instead. There is no
+    /// self-update: the chip's whole job is to send you to the release page.
+    ///
+    /// ponytail: dismissal is session-only, not a settings field. Re-appearing once per launch is
+    /// the point; a "don't tell me about 0.13" preference is a preference nobody asked for.
+    pub(crate) fn update_chip(&mut self, ctx: &egui::Context) {
+        let crate::ui::about_window::UpdateState::Newer(tag) = self.update_state.clone() else {
+            return;
+        };
+        // A weather warning owns the top lane while it is up. This can wait.
+        if self.update_chip_hidden || !self.warning_banners.is_empty() {
+            return;
+        }
+        let accent = crate::theme::accent(self.settings.theme);
+        let mut hide = false;
+        egui::Area::new(egui::Id::new("update_chip"))
+            .constrain_to(self.chrome_rect)
+            .anchor(
+                egui::Align2::CENTER_TOP,
+                egui::vec2(0.0, crate::ui::style::LANE_TOP_BANNER),
+            )
+            .show(ctx, |ui| {
+                crate::ui::style::glass(ui, 236)
+                    .stroke(egui::Stroke::new(1.0, accent.gamma_multiply(0.8)))
+                    .show(ui, |ui| {
+                        ui.horizontal(|ui| {
+                            ui.label(
+                                egui::RichText::new(format!("HookEcho {tag} is available"))
+                                    .size(crate::ui::style::FONT_BASE)
+                                    .color(accent),
+                            );
+                            ui.hyperlink_to(
+                                egui::RichText::new("Download")
+                                    .size(crate::ui::style::FONT_BASE),
+                                format!("{}/releases/latest", crate::ui::about_window::REPO),
+                            );
+                            if ui
+                                .small_button(egui_phosphor::regular::X)
+                                .on_hover_text("Dismiss until next launch")
+                                .clicked()
+                            {
+                                hide = true;
+                            }
+                        });
+                    });
+            });
+        self.update_chip_hidden |= hide;
+    }
+
     /// Bottom-center error chip: the active pane's fetch error, auto-hiding after ~6 seconds.
     ///
     /// ponytail: one chip, newest error wins, no toast queue — add a queue if overlapping errors


### PR DESCRIPTION
Wave L, L1. Stacked on #128.

The once-per-session update check already existed and already told you — through a toast, which expires in four seconds. That is how a stale build stays stale. This replaces the toast with a persistent top-center chip: the version, a link to the release page, a dismiss button.

- **No self-update.** The chip's job is to point at `releases/latest`.
- **Dismissal is session-only** (`update_chip_hidden`, not a settings field). A build that is still stale next launch says so again; a "never tell me about 0.13" preference is one nobody asked for.
- **Warnings win the top lane.** The chip yields while `warning_banners` is non-empty and returns when they expire.
- **Chrome-gated**, so OBS mode and `?embed=1` stay bare.
- **Web needs no allowlist change** (plan check #13): the check fetches `api.github.com` directly rather than through the same-origin proxy, and GitHub's API sends CORS headers. Nothing added to `ALLOWED_HOSTS` or `proxy-core.js`.

`app.rs` gains one state field and one call; the drawing lives in `app/chrome/chips.rs`.

### Verified

Run on a nested Xvfb with the state forced to `Newer("v9.9.9")` — screenshotted the chip in the top lane, then clicked the dismiss button and confirmed it goes away and stays away. The first pass used a literal `✕`, which egui's default font has no glyph for and rendered as a tofu box; switched to `egui_phosphor::regular::X`, same as every other close button in the chrome.

Gate: clippy clean · `cargo test --workspace` green (13 suites) · wasm check clean · `shoot.sh check` passed · web build 4,858,172 gzipped, under the 4,880,000 budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)