### PR TITLE
chore(packaging): app-id io.hookecho.HookEcho

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -300,7 +300,7 @@ jobs:
           <dict>
             <key>CFBundleName</key><string>HookEcho</string>
             <key>CFBundleDisplayName</key><string>HookEcho</string>
-            <key>CFBundleIdentifier</key><string>zip.batman.hookecho</string>
+            <key>CFBundleIdentifier</key><string>io.hookecho.HookEcho</string>
             <key>CFBundleVersion</key><string>$VERSION</string>
             <key>CFBundleShortVersionString</key><string>$VERSION</string>
             <key>CFBundleExecutable</key><string>hookecho</string>

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ announce-drafts.md
 
 # Local puppeteer for scripts/web/smoke.mjs (npm install --no-save).
 /node_modules/
+
+# Local flatpak-builder scratch (packaging/flatpak/*.yml built in-repo; the sandbox can't see /tmp).
+/.fpbuild/
+/.fpstate/
+/.fprepo/

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -31,11 +31,11 @@ val cargoVersionCode: Int = cargoVersion.split(".", "-")
     .let { it[0].toInt() * 1_000_000 + it[1].toInt() * 10_000 + it[2].toInt() }
 
 android {
-    namespace = "zip.batman.hookecho"
+    namespace = "io.hookecho.HookEcho"
     compileSdk = 35
 
     defaultConfig {
-        applicationId = "zip.batman.hookecho"
+        applicationId = "io.hookecho.HookEcho"
         // API 29 (Android 10): guarantees Vulkan 1.1 + AAudio + scoped storage semantics we design
         // around. arm64-v8a only for v1 — every phone that can run this ships it.
         minSdk = 29

--- a/android/app/src/main/kotlin/io/hookecho/HookEcho/AlertAlarm.kt
+++ b/android/app/src/main/kotlin/io/hookecho/HookEcho/AlertAlarm.kt
@@ -1,4 +1,4 @@
-package zip.batman.hookecho
+package io.hookecho.HookEcho
 
 import android.app.AlarmManager
 import android.app.PendingIntent

--- a/android/app/src/main/kotlin/io/hookecho/HookEcho/AlertService.kt
+++ b/android/app/src/main/kotlin/io/hookecho/HookEcho/AlertService.kt
@@ -1,4 +1,4 @@
-package zip.batman.hookecho
+package io.hookecho.HookEcho
 
 import android.app.Notification
 import android.app.NotificationChannel

--- a/android/app/src/main/kotlin/io/hookecho/HookEcho/AlertWidget.kt
+++ b/android/app/src/main/kotlin/io/hookecho/HookEcho/AlertWidget.kt
@@ -1,4 +1,4 @@
-package zip.batman.hookecho
+package io.hookecho.HookEcho
 
 import android.app.PendingIntent
 import android.appwidget.AppWidgetManager

--- a/android/app/src/main/kotlin/io/hookecho/HookEcho/AlertWorker.kt
+++ b/android/app/src/main/kotlin/io/hookecho/HookEcho/AlertWorker.kt
@@ -1,4 +1,4 @@
-package zip.batman.hookecho
+package io.hookecho.HookEcho
 
 import android.app.ForegroundServiceStartNotAllowedException
 import android.content.Context

--- a/android/app/src/main/kotlin/io/hookecho/HookEcho/BootReceiver.kt
+++ b/android/app/src/main/kotlin/io/hookecho/HookEcho/BootReceiver.kt
@@ -1,4 +1,4 @@
-package zip.batman.hookecho
+package io.hookecho.HookEcho
 
 import android.content.BroadcastReceiver
 import android.content.Context

--- a/android/app/src/main/kotlin/io/hookecho/HookEcho/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/hookecho/HookEcho/MainActivity.kt
@@ -1,4 +1,4 @@
-package zip.batman.hookecho
+package io.hookecho.HookEcho
 
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts

--- a/android/app/src/main/kotlin/io/hookecho/HookEcho/Nws.kt
+++ b/android/app/src/main/kotlin/io/hookecho/HookEcho/Nws.kt
@@ -1,4 +1,4 @@
-package zip.batman.hookecho
+package io.hookecho.HookEcho
 
 import org.json.JSONObject
 import java.io.File

--- a/android/app/src/main/kotlin/io/hookecho/HookEcho/RadarTile.kt
+++ b/android/app/src/main/kotlin/io/hookecho/HookEcho/RadarTile.kt
@@ -1,4 +1,4 @@
-package zip.batman.hookecho
+package io.hookecho.HookEcho
 
 import android.content.Intent
 import android.service.quicksettings.TileService

--- a/android/app/src/main/kotlin/io/hookecho/HookEcho/RadarWidget.kt
+++ b/android/app/src/main/kotlin/io/hookecho/HookEcho/RadarWidget.kt
@@ -1,4 +1,4 @@
-package zip.batman.hookecho
+package io.hookecho.HookEcho
 
 import android.app.PendingIntent
 import android.appwidget.AppWidgetManager

--- a/android/app/src/main/kotlin/io/hookecho/HookEcho/TextViewActivity.kt
+++ b/android/app/src/main/kotlin/io/hookecho/HookEcho/TextViewActivity.kt
@@ -1,4 +1,4 @@
-package zip.batman.hookecho
+package io.hookecho.HookEcho
 
 import android.app.Activity
 import android.os.Bundle

--- a/crates/hookecho/Cargo.toml
+++ b/crates/hookecho/Cargo.toml
@@ -194,7 +194,7 @@ depends = "$auto"
 assets = [
     ["../../target/release/hookecho", "usr/bin/", "755"],
     ["../../packaging/hookecho.desktop", "usr/share/applications/", "644"],
-    ["../../packaging/zip.batman.hookecho.metainfo.xml", "usr/share/metainfo/", "644"],
+    ["../../packaging/io.hookecho.HookEcho.metainfo.xml", "usr/share/metainfo/", "644"],
     ["../../target/deb-assets/hookecho-256.png", "usr/share/icons/hicolor/256x256/apps/hookecho.png", "644"],
     ["../../target/deb-assets/hookecho-128.png", "usr/share/icons/hicolor/128x128/apps/hookecho.png", "644"],
 ]

--- a/crates/hookecho/src/platform.rs
+++ b/crates/hookecho/src/platform.rs
@@ -529,7 +529,7 @@ mod android_alerts {
     }
 
     fn try_call_alarm(method: &str) -> jni::errors::Result<()> {
-        with_class("zip.batman.hookecho.AlertAlarm", |env, class, activity| {
+        with_class("io.hookecho.HookEcho.AlertAlarm", |env, class, activity| {
             let res = env.call_static_method(
                 class,
                 method,
@@ -545,7 +545,7 @@ mod android_alerts {
 
     /// `AlertAlarm.health(Context)` as its raw tab-separated line.
     pub(super) fn health() -> Option<String> {
-        let out = with_class("zip.batman.hookecho.AlertAlarm", |env, class, activity| {
+        let out = with_class("io.hookecho.HookEcho.AlertAlarm", |env, class, activity| {
             let s = env
                 .call_static_method(
                     class,
@@ -607,7 +607,7 @@ mod android_alerts {
     }
 
     fn try_set_saver(on: bool) -> jni::errors::Result<()> {
-        with_class("zip.batman.hookecho.AlertService", |env, class, activity| {
+        with_class("io.hookecho.HookEcho.AlertService", |env, class, activity| {
             let res = env.call_static_method(
                 class,
                 "setBatterySaver",
@@ -622,7 +622,7 @@ mod android_alerts {
     }
 
     fn try_set(enabled: bool) -> jni::errors::Result<()> {
-        with_class("zip.batman.hookecho.AlertService", |env, class, activity| {
+        with_class("io.hookecho.HookEcho.AlertService", |env, class, activity| {
             let res = env.call_static_method(
                 class,
                 "setEnabled",
@@ -731,7 +731,7 @@ mod android_widget {
                 &[],
             )?
             .l()?;
-        let name = env.new_string("zip.batman.hookecho.RadarWidget")?;
+        let name = env.new_string("io.hookecho.HookEcho.RadarWidget")?;
         let class = env
             .call_method(
                 &loader,
@@ -1098,7 +1098,7 @@ mod android_textview {
         let mut env = vm.attach_current_thread()?;
         let activity = unsafe { JObject::from_raw(app.activity_as_ptr() as jni::sys::jobject) };
         let intent = env.new_object("android/content/Intent", "()V", &[])?;
-        let class = env.new_string("zip.batman.hookecho.TextViewActivity")?;
+        let class = env.new_string("io.hookecho.HookEcho.TextViewActivity")?;
         env.call_method(
             &intent,
             "setClassName",

--- a/packaging/SUBMITTING.md
+++ b/packaging/SUBMITTING.md
@@ -17,7 +17,7 @@ stamps is committed back to this repo; the stamped copies are submission inputs.
 
 Longest review, so start here.
 
-- Input: `packaging/flatpak/zip.batman.hookecho.yml` and
+- Input: `packaging/flatpak/io.hookecho.HookEcho.yml` and
   `packaging/flatpak/cargo-sources.json`.
 - Regenerate the sources file after any `Cargo.lock` change:
   `python3 flatpak-cargo-generator.py Cargo.lock -o packaging/flatpak/cargo-sources.json`.
@@ -27,7 +27,7 @@ Longest review, so start here.
   must have a source entry, so a dependency bump that forgets the regenerate
   step fails `cargo test` here rather than in Flathub's CI a week later.
 - Build it locally first — `flatpak-builder --force-clean build
-  packaging/flatpak/zip.batman.hookecho.yml` — because a build failure in their
+  packaging/flatpak/io.hookecho.HookEcho.yml` — because a build failure in their
   CI costs another round trip through the queue.
 - Submit: a pull request to
   [flathub/flathub](https://github.com/flathub/flathub) on the `new-pr` branch,
@@ -60,7 +60,7 @@ Longest review, so start here.
   Windows machine, `winget install --manifest packaging/winget`.
 - Submit: a pull request to
   [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) under
-  `manifests/z/zip.batman/hookecho/<version>/`. Their bot does most of the
+  `manifests/i/io.hookecho/HookEcho/<version>/`. Their bot does most of the
   review; the usual failure is a hash that does not match the URL's contents.
 
 ## 5. Snap — needs a name registration first

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -36,8 +36,8 @@ package() {
   cd "$pkgname-$pkgver"
   install -Dm755 "target/release/$pkgname" "$pkgdir/usr/bin/$pkgname"
   install -Dm644 packaging/hookecho.desktop "$pkgdir/usr/share/applications/hookecho.desktop"
-  install -Dm644 packaging/zip.batman.hookecho.metainfo.xml \
-    "$pkgdir/usr/share/metainfo/zip.batman.hookecho.metainfo.xml"
+  install -Dm644 packaging/io.hookecho.HookEcho.metainfo.xml \
+    "$pkgdir/usr/share/metainfo/io.hookecho.HookEcho.metainfo.xml"
   install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
   # Same procedural icon the AppImage renders, at every hicolor size.
   for px in 48 64 128 256 512; do

--- a/packaging/build-appimage.sh
+++ b/packaging/build-appimage.sh
@@ -44,7 +44,7 @@ done
 
 # AppStream metadata, so software centres have something to show.
 mkdir -p "$APPDIR/usr/share/metainfo"
-cp "$ROOT/packaging/zip.batman.hookecho.metainfo.xml" "$APPDIR/usr/share/metainfo/"
+cp "$ROOT/packaging/io.hookecho.HookEcho.metainfo.xml" "$APPDIR/usr/share/metainfo/"
 
 # AppRun -> the binary.
 ln -sf usr/bin/hookecho "$APPDIR/AppRun"

--- a/packaging/flatpak/io.hookecho.HookEcho.yml
+++ b/packaging/flatpak/io.hookecho.HookEcho.yml
@@ -10,7 +10,7 @@
 #   python3 flatpak-cargo-generator.py Cargo.lock -o packaging/flatpak/cargo-sources.json
 #
 # (from https://github.com/flatpak/flatpak-builder-tools/tree/master/cargo)
-app-id: zip.batman.hookecho
+app-id: io.hookecho.HookEcho
 runtime: org.freedesktop.Platform
 runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
@@ -48,23 +48,23 @@ modules:
     build-commands:
       - cargo --offline build --release -p hookecho
       - install -Dm755 target/release/hookecho /app/bin/hookecho
-      - install -Dm644 packaging/hookecho.desktop /app/share/applications/zip.batman.hookecho.desktop
+      - install -Dm644 packaging/hookecho.desktop /app/share/applications/io.hookecho.HookEcho.desktop
       # flatpak-builder only exports files under /app/share whose name starts with the app id, so
-      # the desktop file and the icons are installed as `zip.batman.hookecho`. Every other
+      # the desktop file and the icons are installed as `io.hookecho.HookEcho`. Every other
       # packager installs them as plain `hookecho`, which is what the committed copies say — so
       # the two id references inside them are rewritten here rather than renamed repo-wide.
-      - sed -i 's|^Icon=hookecho$|Icon=zip.batman.hookecho|'
-        /app/share/applications/zip.batman.hookecho.desktop
-      - install -Dm644 packaging/zip.batman.hookecho.metainfo.xml
-        /app/share/metainfo/zip.batman.hookecho.metainfo.xml
+      - sed -i 's|^Icon=hookecho$|Icon=io.hookecho.HookEcho|'
+        /app/share/applications/io.hookecho.HookEcho.desktop
+      - install -Dm644 packaging/io.hookecho.HookEcho.metainfo.xml
+        /app/share/metainfo/io.hookecho.HookEcho.metainfo.xml
       - sed -i 's|<launchable type="desktop-id">hookecho.desktop</launchable>|<launchable
-        type="desktop-id">zip.batman.hookecho.desktop</launchable>|'
-        /app/share/metainfo/zip.batman.hookecho.metainfo.xml
+        type="desktop-id">io.hookecho.HookEcho.desktop</launchable>|'
+        /app/share/metainfo/io.hookecho.HookEcho.metainfo.xml
       # Icons are drawn by the binary that was just built, one per size.
       - for px in 48 64 128 256 512; do
         mkdir -p /app/share/icons/hicolor/${px}x${px}/apps;
         /app/bin/hookecho --headless-icon
-        /app/share/icons/hicolor/${px}x${px}/apps/zip.batman.hookecho.png ${px};
+        /app/share/icons/hicolor/${px}x${px}/apps/io.hookecho.HookEcho.png ${px};
         done
     sources:
       - type: dir

--- a/packaging/io.hookecho.HookEcho.metainfo.xml
+++ b/packaging/io.hookecho.HookEcho.metainfo.xml
@@ -6,7 +6,7 @@
   Flatpak and Snap builds all install this same copy.
 -->
 <component type="desktop-application">
-  <id>zip.batman.hookecho</id>
+  <id>io.hookecho.HookEcho</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>MIT</project_license>
   <name>HookEcho</name>
@@ -26,7 +26,7 @@
     </p>
   </description>
 
-  <developer id="zip.batman">
+  <developer id="io.hookecho">
     <name>David May</name>
   </developer>
 

--- a/packaging/winget/io.hookecho.HookEcho.installer.yaml
+++ b/packaging/winget/io.hookecho.HookEcho.installer.yaml
@@ -1,4 +1,4 @@
-PackageIdentifier: zip.batman.hookecho
+PackageIdentifier: io.hookecho.HookEcho
 PackageVersion: 0.8.0
 InstallerType: inno
 Scope: user

--- a/packaging/winget/io.hookecho.HookEcho.locale.en-US.yaml
+++ b/packaging/winget/io.hookecho.HookEcho.locale.en-US.yaml
@@ -1,4 +1,4 @@
-PackageIdentifier: zip.batman.hookecho
+PackageIdentifier: io.hookecho.HookEcho
 PackageVersion: 0.8.0
 PackageLocale: en-US
 Publisher: d4vid87

--- a/packaging/winget/io.hookecho.HookEcho.yaml
+++ b/packaging/winget/io.hookecho.HookEcho.yaml
@@ -7,7 +7,7 @@
 # At tag time:
 #   sha256sum dist/HookEcho-setup-x86_64.exe
 # and paste the result into the installer manifest below.
-PackageIdentifier: zip.batman.hookecho
+PackageIdentifier: io.hookecho.HookEcho
 PackageVersion: 0.8.0
 DefaultLocale: en-US
 ManifestType: version

--- a/scripts/release/stamp-manifests.sh
+++ b/scripts/release/stamp-manifests.sh
@@ -24,9 +24,9 @@ sed -i \
   -e "s|^PackageVersion: .*|PackageVersion: $VER|" \
   -e "s|releases/download/v[^/]*/|releases/download/v$VER/|" \
   -e "s|^\( *InstallerSha256: \).*|\1${EXE_SHA^^}|" \
-  "$W/zip.batman.hookecho.installer.yaml"
+  "$W/io.hookecho.HookEcho.installer.yaml"
 sed -i "s|^PackageVersion: .*|PackageVersion: $VER|" \
-  "$W/zip.batman.hookecho.yaml" "$W/zip.batman.hookecho.locale.en-US.yaml"
+  "$W/io.hookecho.HookEcho.yaml" "$W/io.hookecho.HookEcho.locale.en-US.yaml"
 
 # Homebrew and the AUR both build from the GitHub tag tarball, so both want its hash. GitHub
 # generates that tarball on demand but it is byte-stable for a given tag.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,8 +49,8 @@ parts:
       craftctl default
       install -Dm644 packaging/hookecho.desktop \
         "$CRAFT_PART_INSTALL/usr/share/applications/hookecho.desktop"
-      install -Dm644 packaging/zip.batman.hookecho.metainfo.xml \
-        "$CRAFT_PART_INSTALL/usr/share/metainfo/zip.batman.hookecho.metainfo.xml"
+      install -Dm644 packaging/io.hookecho.HookEcho.metainfo.xml \
+        "$CRAFT_PART_INSTALL/usr/share/metainfo/io.hookecho.HookEcho.metainfo.xml"
       for px in 48 64 128 256 512; do
         d="$CRAFT_PART_INSTALL/usr/share/icons/hicolor/${px}x${px}/apps"
         mkdir -p "$d"


### PR DESCRIPTION
`zip.batman.hookecho` was a placeholder from before hookecho.io existed. Nothing is published to any store yet, so renaming is free today and a forced migration for every installed user later — and Flathub wants an app id under a domain we control.

**What moves**

- `packaging/flatpak/*.yml`, `packaging/*.metainfo.xml`, `packaging/winget/*.yaml` — renamed on disk as well as inside (the id is part of each filename).
- `snap/snapcraft.yaml`, `packaging/aur/PKGBUILD`, `packaging/build-appimage.sh`, `packaging/SUBMITTING.md`, `scripts/release/stamp-manifests.sh`, `.github/workflows/release.yml` (macOS `CFBundleIdentifier`), `crates/hookecho/Cargo.toml` (metainfo path).
- Android: `applicationId`, Gradle `namespace`, the Kotlin package and its directory, and the matching class names passed to JNI in `platform.rs`. `AndroidManifest.xml` only ever used relative `.Class` names, so it needed no edit.

**Unaffected on purpose**: the snap name, AUR pkgname, Homebrew formula, `hookecho.desktop` and `with_app_id("hookecho")` — all plain `hookecho`, none of them app ids.

**Blocks**: the Flathub submission, which should go out under the new id.

**Verified**

- `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, wasm check, `./scripts/shots/shoot.sh check` — green.
- Local `flatpak-builder` run succeeds and exports `io.hookecho.HookEcho.{desktop,metainfo.xml,png}` (builder only exports `/app/share` files prefixed with the app id, so this is the real check).
- Debug APK builds, installs and launches on the S24 Ultra; no `ClassNotFoundException` in logcat. The old `zip.batman.hookecho` package was uninstalled — settings do not carry across an applicationId change.

Also gitignores the in-repo `flatpak-builder` scratch dirs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)