### PR TITLE
chore(release): v0.12.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,75 @@ so **write the section before pushing the tag**, or the release job fails.
 
 The rolling `latest` release tracks `main` and is not listed here.
 
+## 0.12.0-beta.1 - 2026-08-26
+
+Second R18 checkpoint. The phone gets the same chrome the desktop got in
+alpha.1, onboarding stops asking questions, and the data lanes land. Still a
+prerelease: a few lanes (RRFS, the remaining store submissions) come at 0.12.0.
+
+### The phone
+
+- The persistent bottom sheet and the five-slot toolbar are gone. The phone
+  draws the same floating chrome the desktop does — search pill, control
+  column, scrubber — with content in Material modal sheets instead of a
+  drawer. Predictive back still works.
+- Long-press the map to inspect what is under your finger, double-tap and drag
+  to zoom with one hand, swipe sideways between panes.
+- Haptics: ticks as the scrubber crosses a frame, a buzz when a warning lands
+  on you, a bump when a sheet snaps.
+- Tablets and landscape phones get a side rail and a docked drawer instead of
+  sheets.
+- Widgets show how far the nearest storm is. A battery-saver mode stretches
+  the poll cadence and throttles repaints. On a chase, the next radar down the
+  road is prefetched before you need it, and a chase can be replayed against
+  the archive afterwards.
+
+### Getting started
+
+- The setup wizard is gone. First run finds you, picks the nearest radar and
+  draws it — about ten seconds, no questions.
+- Notification permission is asked for when you turn on something that
+  notifies, or when a warning lands near you. Never at install.
+- One help hub behind `?`: glossary, hotkeys, the tour and what's new, all
+  searchable in one place. Labels across the app read in plain language, with
+  the abbreviation kept in parentheses for anyone who wants it.
+- Text products — area forecast discussions, tropical advisories — render in a
+  real webview with real typography, on both desktop and Android.
+
+### Weather
+
+- GOES loops run over archive dates alongside the radar timeline, and the
+  mid-level water vapor bands are selectable.
+- MRMS rotation tracks (30/60/120 minutes) are field layers now, and hail
+  swaths accumulate locally over a window you choose.
+- Snow squalls and banding get their own emphasis in winter.
+- An alert rule can trigger on a lightning jump — the rate of change of flash
+  density inside a cell.
+- NAM nest and NBM join the model list. Synoptic mesonets join the surface
+  obs, with your own API key.
+- Cells are ranked by a composite severity score, and tapping one opens the 3D
+  volume already centered on it.
+- Panes remember their own thresholds and field layers. Events can be saved as
+  replay bundles — time range, site, camera — and replayed with archived
+  radar, warnings, reports and outlooks in sync.
+
+### The web build
+
+- Installable as a PWA, with the app shell cached offline.
+- Tiles, volumes and palettes persist between visits.
+- File dialogs, GPS and notifications all work in the browser now.
+- A share button writes a permalink that carries the site, camera and time.
+
+### Elsewhere
+
+- MQTT publishing, a Home Assistant camera loop endpoint and a live dashboard
+  at the `--serve` index.
+- An update chip appears when a newer release exists. No self-updating.
+- Motion throughout, with `reduce_motion` and an automatic degrade on slow
+  frames. Labels, roles and focus order on all of the new chrome.
+- The application id is `io.hookecho.HookEcho`, and every screenshot in the
+  README, the store listings and this repo was reshot on the new chrome.
+
 ## 0.12.0-alpha.1 - 2026-08-25
 
 First R18 checkpoint: the desktop and web chrome, rebuilt. A prerelease — the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2484,7 +2484,7 @@ dependencies = [
 
 [[package]]
 name = "hdf5lite"
-version = "0.12.0-alpha.1"
+version = "0.12.0-beta.1"
 dependencies = [
  "flate2",
  "log",
@@ -2547,7 +2547,7 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "hookecho"
-version = "0.12.0-alpha.1"
+version = "0.12.0-beta.1"
 dependencies = [
  "android_logger",
  "anyhow",
@@ -2603,7 +2603,7 @@ dependencies = [
 
 [[package]]
 name = "hookecho-ffi"
-version = "0.12.0-alpha.1"
+version = "0.12.0-beta.1"
 dependencies = [
  "nexrad-level3",
  "serde_json",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "nexrad-level3"
-version = "0.12.0-alpha.1"
+version = "0.12.0-beta.1"
 dependencies = [
  "bzip2",
  "flate2",
@@ -7247,7 +7247,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wxdata"
-version = "0.12.0-alpha.1"
+version = "0.12.0-beta.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ opt-level = 3
 opt-level = 3
 
 [workspace.package]
-version = "0.12.0-alpha.1"
+version = "0.12.0-beta.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/d4vid87/hookecho"

--- a/packaging/io.hookecho.HookEcho.metainfo.xml
+++ b/packaging/io.hookecho.HookEcho.metainfo.xml
@@ -37,19 +37,19 @@
   -->
   <screenshots>
     <screenshot type="default">
-      <image>https://raw.githubusercontent.com/d4vid87/hookecho/v0.9.0/docs/shots/alltilts.jpg</image>
+      <image>https://raw.githubusercontent.com/d4vid87/hookecho/v0.12.0-beta.1/docs/shots/alltilts.jpg</image>
       <caption>Level 2 reflectivity at every tilt, over an interactive basemap</caption>
     </screenshot>
     <screenshot>
-      <image>https://raw.githubusercontent.com/d4vid87/hookecho/v0.9.0/docs/shots/mosaic.jpg</image>
+      <image>https://raw.githubusercontent.com/d4vid87/hookecho/v0.12.0-beta.1/docs/shots/mosaic.jpg</image>
       <caption>The national MRMS mosaic</caption>
     </screenshot>
     <screenshot>
-      <image>https://raw.githubusercontent.com/d4vid87/hookecho/v0.9.0/docs/shots/alerts.jpg</image>
+      <image>https://raw.githubusercontent.com/d4vid87/hookecho/v0.12.0-beta.1/docs/shots/alerts.jpg</image>
       <caption>Warnings, storm reports and spotters</caption>
     </screenshot>
     <screenshot>
-      <image>https://raw.githubusercontent.com/d4vid87/hookecho/v0.9.0/docs/shots/hrrr.jpg</image>
+      <image>https://raw.githubusercontent.com/d4vid87/hookecho/v0.12.0-beta.1/docs/shots/hrrr.jpg</image>
       <caption>HRRR model fields and severe composite parameters</caption>
     </screenshot>
   </screenshots>
@@ -79,6 +79,9 @@
   <content_rating type="oars-1.1"/>
 
   <releases>
+    <release version="0.12.0-beta.1" date="2026-08-26" type="development"/>
+    <release version="0.11.0" date="2026-08-25"/>
+    <release version="0.10.0" date="2026-08-14"/>
     <release version="0.9.0" date="2026-08-11"/>
     <release version="0.8.0" date="2026-08-09"/>
     <release version="0.7.0" date="2026-08-09"/>


### PR DESCRIPTION
The version bump and release notes for the second R18 checkpoint, plus the metainfo catch-up that has been quietly rotting.

**Version**: workspace `0.12.0-alpha.1` → `0.12.0-beta.1`. `release.yml` extracts the tag body from the matching CHANGELOG section, so that section has to exist before the tag is pushed — it does now.

**CHANGELOG**: a `0.12.0-beta.1` section covering everything merged since alpha.1 (PRs #89–#133): the phone's floating chrome, gestures and haptics; the ten-second first run and the help hub; webview text products; the GOES/MRMS/hail/banding/lightning-jump/NAM/NBM/Synoptic data lanes; cell ranking and replay bundles; the PWA, persistence, GPS, notifications and permalinks on web; MQTT, the Home Assistant loop and the serve dashboard; the update chip; and the reshoot.

**metainfo**: `0.10.0` and `0.11.0` were never added — the release list stopped at 0.9.0 on 2026-08-11. Added both, plus `0.12.0-beta.1` marked `type="development"` so a stable channel does not offer it. The four screenshots were still pinned to the `v0.9.0` tag, which is the docked-sidebar chrome from two redesigns ago; they now point at `v0.12.0-beta.1`, whose tree has the reshot images from #133.

`appstreamcli validate` is clean apart from the four `screenshot-image-not-found` warnings, which are the tag not existing yet — they resolve the moment it is pushed, and I will re-run the validation then rather than take it on faith.

One thing I did not change: `cid-contains-uppercase-letter` on `io.hookecho.HookEcho`. It is pedantic-level only and the id was picked deliberately in W0; renaming it again after the Android package move is not worth it, and Flathub carries plenty of mixed-case ids.

## Gate

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 276 + 315 + the smaller suites, 0 failed
- `./scripts/shots/shoot.sh check` — passed, 13M
- wasm check and the web build budget are untouched by this PR (no code changes; `Cargo.lock` moves only for the version string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)