### PR TITLE
fix(release): the Windows upload runs in bash, not pwsh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,6 +230,10 @@ jobs:
 
       - name: Attach to release
         if: startsWith(github.ref, 'refs/tags/')
+        # bash, not the runner's default pwsh: `"$TAG"` is empty in PowerShell (it wants
+        # `$env:TAG`), so this uploaded into tag "" and failed with "release not found" on
+        # v0.12.0-beta.1 while every other platform, which runs bash, attached fine.
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}


### PR DESCRIPTION
`v0.12.0-beta.1` shipped without its three Windows artifacts. The job built and smoke-tested them, uploaded them as a workflow artifact, and then failed on the last step with `release not found`.

The step had no `shell:`, so it ran under the Windows runner's default pwsh, where `"$TAG"` is not the environment variable — that is `$env:TAG` — and expands to nothing. So it ran `gh release upload "" …` and gh reported, accurately, that there is no release by that name. Every other platform job runs bash, which is why only Windows was affected, and why this has been latent since the step was written.

One line: `shell: bash`, with a comment naming the failure so nobody removes it. I checked the rest of the Windows job the same way — the only other `run` step without an explicit shell is `cargo build --release -p hookecho`, which references no variables.

The beta's assets are not left broken in the meantime: I pulled the three files out of the failed run's `hookecho-windows-x86_64` artifact and attached them to the release by hand, so `v0.12.0-beta.1` now carries the full set (zip, msi, setup exe, AppImage, deb, macOS zip, apk).

Not verifiable until the next tag — nothing on `main` exercises the tag path. The fix is a mechanical one-liner and the failure mode is fully explained by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)