### PR TITLE
feat(site): docs

### DIFF
--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -1,0 +1,15 @@
+import { defineCollection, z } from "astro:content";
+import { glob } from "astro/loaders";
+
+// `order` drives both the sidebar and prev/next — one number per page, no nested nav.
+// ponytail: flat list; add sections when the page count outgrows a single column.
+const docs = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/content/docs" }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    order: z.number(),
+  }),
+});
+
+export const collections = { docs };

--- a/site/src/content/docs/alerts-and-notifications.md
+++ b/site/src/content/docs/alerts-and-notifications.md
@@ -1,0 +1,54 @@
+---
+title: Alerts and notifications
+description: Get told when weather is coming to a place you care about, without watching the screen.
+order: 4
+---
+
+Alerting is built around **markers** — the places you've saved. Search a place in
+the panel, and take **Save marker** when the map flies there. Mark one of them as
+**home** and it gets a watch ring on the map.
+
+## Choosing how you're told
+
+**Settings → Alerts** picks the channels. You can use as many as you like:
+
+- a **chime** from the app,
+- a **desktop notification**,
+- a phone push via [ntfy.sh](https://ntfy.sh),
+- a webhook into **Discord, Slack or Matrix**,
+- the warning **read aloud** through your system voice.
+
+## Choosing what you're told about
+
+- **Warnings** covering a marker — or coming within its watch radius. Home
+  defaults to 20 miles, and you're alerted when the polygon's *edge* reaches
+  that ring, not only when it swallows your house.
+- **Lightning** striking within about 15 km of a saved spot.
+- **Rain arrival** — "rain in about 20 minutes", from the radar's own motion.
+- **Rotation** and **debris signatures** detected on the live volume.
+
+Severe warnings aren't all equal, and neither are the alerts. HookEcho reads the
+NWS escalation tiers — CONSIDERABLE, then DESTRUCTIVE or an observed tornado,
+then a **Tornado Emergency** — and a higher tier gets a pulsing polygon, a red
+threat chip at the top of the alert list, a dedicated siren, and an
+urgent-priority push that gets through your phone's quiet hours.
+
+## Where the storm actually is
+
+Every warning carries the office's own storm-motion description, which HookEcho
+parses into a vector: the warned storm as a dot, its projected path at 15, 30,
+45 and 60 minutes, and an ETA to each of your saved locations. That turns
+"there's a warning near you" into "it's 22 minutes from home."
+
+## On your phone
+
+Opt into the background service and Android notifies you with the app closed,
+tiered watch / warning / emergency, and tapping through takes you to the storm.
+A home-screen widget shows what's warned at your saved locations. See
+[On your phone](/docs/on-your-phone/).
+
+## On a machine you leave running
+
+The desktop build keeps alerting from the tray. If you want the map itself
+available elsewhere on your own network, `--serve` publishes it as a local HTTP
+endpoint.

--- a/site/src/content/docs/faq.md
+++ b/site/src/content/docs/faq.md
@@ -1,0 +1,111 @@
+---
+title: FAQ and glossary
+description: Common questions, common problems, and what all the abbreviations mean.
+order: 7
+---
+
+## Questions
+
+**Is it free? Is there an account?**
+Yes, and no. HookEcho is open source under the MIT licence. There's no account,
+no subscription and no telemetry — the app talks to the public NOAA and National
+Weather Service feeds directly from your machine.
+
+**What's a hook echo?**
+The signature the app is named after. A supercell's rotating updraft wraps
+precipitation around itself, and on reflectivity that wrap draws a hook curling
+off the back-right of the storm. It was one of the first radar signatures ever
+tied to tornadoes, and it's still one of the first things a forecaster looks for.
+
+**Where does the data come from?**
+NEXRAD Level 2 and Level 3 from the radar network, MRMS for the national mosaic
+and gridded products, HRRR/NAM/RAP for the model layers, and the NWS for
+warnings, forecasts and storm reports. All of it public, all of it free.
+
+**How far back does the archive go?**
+June 1991. Any archived storm loads the same way the live one does. Products
+that didn't exist yet — CC and ZDR before the dual-pol upgrade around 2012 —
+aren't there for old events.
+
+**Is the future radar real?**
+No, and the app says so the whole time it's on. HRRR future radar, forecast
+rotation tracks and smoke are model output, and they carry a banner for as long
+as they're drawn.
+
+**Do I need an API key?**
+Not for the weather. A couple of optional basemaps use commercial tile services
+and want their own key; a layer that needs one stays empty and says so rather
+than nagging. Keys go in Settings and stay on your machine.
+
+## Things that look broken
+
+**Nothing loads.** The app talks to NOAA and the NWS directly, so this is
+usually the network. `--status` prints a per-feed report from the terminal.
+
+**The times look wrong.** Radar times read in *the selected radar's* local time
+— not yours and not Zulu — so a Texas pane and an Oklahoma pane can differ side
+by side. Settings → Units switches everything to UTC.
+
+**It's slow.** Lower the 3D quality preset, turn off the animated wind
+particles, and use fewer panes. On a phone, close station cards you aren't
+reading.
+
+**The disk is filling up.** Settings → Storage lists every cache against its
+cap, with clear and open buttons. Nothing cached is irreplaceable.
+
+Still stuck? [Open an issue](https://github.com/d4vid87/hookecho/issues) with
+the site, the product and the time you were looking at — that's usually enough
+to replay it.
+
+## Glossary
+
+**CAPE** — how much energy is available for a thunderstorm to rise. More CAPE,
+taller storms.
+
+**CC (correlation coefficient)** — whether everything in the beam looks alike.
+High for rain, low for a mix — hail, melting snow, or tornado debris.
+
+**dBZ** — the unit of reflectivity. Roughly: how much is coming back.
+
+**Dealiasing** — undoing the fold that happens when wind is faster than the
+radar can measure directly, so a fast couplet reads correctly.
+
+**Dual-pol** — the radar sending both horizontal and vertical pulses, which is
+what makes CC and ZDR possible. Rolled out across the network around 2012.
+
+**Level 2 / Level 3** — Level 2 is the raw volume, every gate of every sweep.
+Level 3 is the smaller set of processed products the NWS publishes from it.
+
+**MESH** — maximum estimated hail size, computed from the storm's vertical
+structure.
+
+**MRMS** — the national grid that stitches every radar in the country into one
+picture, updated every couple of minutes.
+
+**NEXRAD** — the US network of 150-odd weather radars. Each has a four-letter
+ID like KTLX.
+
+**Reflectivity (Z)** — how much energy the echo sends back. Where the rain is.
+
+**SRH (storm-relative helicity)** — how much spin the low-level wind has for a
+storm to use.
+
+**Storm-relative velocity** — velocity with the storm's own travel subtracted,
+so rotation stops hiding inside the storm's motion.
+
+**TDS (tornado debris signature)** — high reflectivity, a velocity couplet, and
+a hole in CC in the same place: the radar seeing lofted debris.
+
+**Tilt** — one sweep of the radar at one elevation angle. A volume is a stack of
+them.
+
+**VCP** — the scanning pattern the radar is running. Storm modes sweep faster
+and use more tilts than clear-air modes.
+
+**Velocity (V)** — motion toward or away from the radar along the beam. Green
+toward, red away.
+
+**VIL** — how much water the storm is holding, integrated through its depth.
+
+**ZDR (differential reflectivity)** — how flat the things in the beam are.
+Positive for raindrops, near zero for tumbling hail.

--- a/site/src/content/docs/getting-started.md
+++ b/site/src/content/docs/getting-started.md
@@ -1,0 +1,66 @@
+---
+title: Getting started
+description: From opening HookEcho for the first time to watching a storm, in about ten seconds.
+order: 1
+---
+
+HookEcho asks for one thing on first launch: which radar you open to. Let it use
+your location and it picks the nearest one and gets out of the way. Otherwise,
+search the list — every radar in the network is in there by name or by its
+four-letter ID.
+
+That's the whole of setup. Everything else has a sensible default, and lives in
+**Settings** when you want to change it.
+
+## What you're looking at
+
+The app is a full-bleed map with three floating pieces over it:
+
+- **The search pill**, top-left. It opens **the panel**, which holds everything:
+  the current radar, the product you're viewing, its tilt, and every layer,
+  window and tool the app has — each described in plain English.
+- **The control column**, on the right edge: layers, the background map, and an
+  alert bell badged with the number of warnings covering your view. The colour
+  scale for whatever you're looking at floats there too.
+- **The scrubber**, along the bottom: the radar's clock, a play button, a LIVE
+  badge, and a time track with one tick per scan.
+
+Nothing is docked. The map runs edge to edge underneath all of it.
+
+## If you remember one thing
+
+Press <kbd>Ctrl</kbd>+<kbd>K</kbd>. It searches the panel, and Enter runs the top
+match. Every action in the app is in there — products, layers, windows, and
+"Fly to" for any place name. You never have to learn where anything lives.
+
+## Watch a storm, right now
+
+1. Pick the radar nearest the storm — <kbd>Ctrl</kbd>+<kbd>K</kbd>, type the ID
+   or the city.
+2. Leave the product on **Reflectivity (Z)**. That's where the rain and hail are.
+3. Switch to **Velocity (V)** to see what the storm is *doing* — which way the
+   air inside it is moving.
+4. Walk the tilt row to look higher into the storm. 0.5° is closest to the
+   ground.
+5. The **LIVE** badge means you're on the newest scan. Anything that moves you
+   off it turns the badge off; click it to snap back.
+
+Drag to pan, scroll to zoom. On a trackpad, pinch to zoom and swipe sideways to
+pan; on a touchscreen, two fingers do both.
+
+## Save the places you care about
+
+Search a place in the panel and the map flies there, with a **Save marker**
+button. Markers are what the alerts watch — see
+[Alerts and notifications](/docs/alerts-and-notifications/).
+
+## Replay something that already happened
+
+The timeline reaches back to **June 1991**. Right-click the LIVE badge, pick a
+day, and scrub. Warning polygons and storm reports come along with you: what was
+actually in force at the moment you're parked on, not today's.
+
+## Next
+
+- [Install it](/docs/install/) on your other machines.
+- [Reading the radar](/docs/reading-the-radar/) — what the colours mean.

--- a/site/src/content/docs/in-your-browser.md
+++ b/site/src/content/docs/in-your-browser.md
@@ -1,0 +1,39 @@
+---
+title: In your browser
+description: HookEcho runs as a web app at app.hookecho.io — live data, nothing to install.
+order: 6
+---
+
+[**app.hookecho.io**](https://app.hookecho.io) is the whole application compiled
+to WebAssembly, running on live data, with nothing to install and no account.
+It's the fastest way to try it, and it's a perfectly good way to *use* it.
+
+## What's the same
+
+Nearly everything. Radar products and tilts, velocity dealiasing, the panel and
+<kbd>Ctrl</kbd>+<kbd>K</kbd>, warnings and storm reports, the national mosaic,
+model layers, soundings, cross-sections, the 3D volume, and archive playback all
+the way back to 1991.
+
+## What's different
+
+The browser doesn't hand a web page everything a native app gets:
+
+- **Files.** Importing colour tables or placefiles from disk, and exporting GIFs
+  and MP4s, work best on the desktop build.
+- **Location.** The browser asks before it shares it, and there's no background
+  GPS — chase mode is a desktop and Android feature.
+- **Background alerting.** A tab that isn't open can't warn you. For alerts that
+  reach you when the app is closed, use the [phone
+  app](/docs/on-your-phone/) or leave the desktop build running.
+- **Speed.** WebAssembly is fast, but a native build with your own GPU is
+  faster. On a modest laptop, keep the pane count down.
+
+Settings you change in the browser stay in that browser, on that machine.
+
+## Putting a radar on your own page
+
+Adding `?embed=1` to the URL strips the chrome and throttles the app when it
+isn't visible, which is what you want inside an `<iframe>` on a dashboard. The
+same `#goto` deep links the app uses for sharing work in the browser too, so you
+can link straight to a site, a product and a moment in time.

--- a/site/src/content/docs/install.md
+++ b/site/src/content/docs/install.md
@@ -1,0 +1,70 @@
+---
+title: Install
+description: Download HookEcho for Windows, macOS, Linux or Android — or run it in the browser with nothing to install.
+order: 2
+---
+
+Every build comes from the same
+[Releases page](https://github.com/d4vid87/hookecho/releases/latest). Versioned
+`v*` releases are the stable channel; a rolling `latest` prerelease carries the
+newest work if you don't want to wait for a tag.
+
+Or don't install anything: [app.hookecho.io](https://app.hookecho.io) is the
+whole app running in your browser on live data.
+
+## Windows
+
+Download **`HookEcho-setup-x86_64.exe`** and run it. If you manage machines and
+want a scriptable install, **`HookEcho-x86_64.msi`** is the same app as an MSI.
+There is also a portable **`hookecho-windows-x86_64.zip`** — unzip it and run
+`hookecho.exe`, no installer involved.
+
+## Linux
+
+Download **`HookEcho-x86_64.AppImage`**, make it executable, and run it:
+
+```sh
+chmod +x HookEcho-x86_64.AppImage
+./HookEcho-x86_64.AppImage
+```
+
+On Debian or Ubuntu, **`hookecho_<version>_amd64.deb`** installs it properly
+with a menu entry and icon:
+
+```sh
+sudo apt install ./hookecho_*.deb
+```
+
+Packaging manifests for Flatpak, Snap, the AUR and Homebrew live in the repo and
+build today, but none are published to their stores yet.
+
+## Android
+
+Sideload **`HookEcho-arm64-v8a.apk`** (arm64, Android 10 or newer): open it on
+the device with "install unknown apps" enabled, or run `adb install -r` from a
+computer. It's the same Rust app as the desktop build, with a phone interface —
+see [On your phone](/docs/on-your-phone/).
+
+## macOS (experimental)
+
+**`HookEcho-macos.zip`** is built and smoke-tested in CI, but has never been run
+on real Apple hardware, and it is ad-hoc signed — Gatekeeper will ask before it
+opens. Homebrew users can build it from source instead:
+
+```sh
+brew install --HEAD d4vid87/hookecho/hookecho
+```
+
+If you run it on a Mac,
+[say what happened](https://github.com/d4vid87/hookecho/issues) — that's the
+only way this build stops being experimental.
+
+## From source
+
+```sh
+cargo run --release
+```
+
+Needs a Rust toolchain, and on Linux the ALSA, Wayland and GTK development
+headers. Android builds go through `android/build.sh` with the NDK and
+`cargo-ndk`.

--- a/site/src/content/docs/on-your-phone.md
+++ b/site/src/content/docs/on-your-phone.md
@@ -1,0 +1,50 @@
+---
+title: On your phone
+description: The Android app — the same radar, in your pocket and out in the field.
+order: 5
+---
+
+The Android build is the same Rust application as the desktop one, with an
+interface built for a phone. Install it from
+[Releases](https://github.com/d4vid87/hookecho/releases/latest) —
+`HookEcho-arm64-v8a.apk`, arm64, Android 10 or newer. See
+[Install](/docs/install/) for the two ways to sideload it.
+
+## Getting around
+
+Same three floating pieces as the desktop app: a search pill, an alert badge,
+and the scrubber along the bottom. Anything you'd browse rather than watch opens
+as a sheet you can drag up from the bottom.
+
+- **Long-press** the map to inspect what's under your finger.
+- **Double-tap and drag** up or down to zoom with one hand.
+- **Swipe sideways** to move between panes.
+- The app buzzes on scrubber ticks, sheet snaps, and new warnings.
+
+## Notifications with the app closed
+
+Turn on the background alert service and the phone tells you about warnings for
+your saved locations whether or not HookEcho is running, tiered watch / warning
+/ emergency, with a tornado emergency arriving at urgent priority. Tapping a
+notification opens the app at that storm. Android is asked for notification
+permission only at the moment you switch an alert feature on — never at install.
+
+A **home-screen widget** shows current radar and what's warned at your saved
+locations, and there's a **quick-settings tile** for a one-swipe look.
+
+## Out in the field
+
+- **Chase mode** puts your live GPS position on the map as a blue dot, with a
+  storm-relative readout: closest approach, and an escape bearing.
+- **Offline chase packs** pre-download the basemap tiles for an area before you
+  drive into it. Radar still needs a data connection; the map underneath it
+  won't.
+- **Position sharing** — opt in, and every HookEcho on the same network sees
+  everyone's dot. Off-network, point it at a relay URL you host yourself.
+
+## Keeping it fast
+
+Phones are not workstations. Drop the 3D quality preset, turn off the animated
+wind particles, and close station cards you aren't reading. There's a
+battery-saver mode that slows the polling and repaint cadence when you're
+running on what's left of the battery.

--- a/site/src/content/docs/reading-the-radar.md
+++ b/site/src/content/docs/reading-the-radar.md
@@ -1,0 +1,84 @@
+---
+title: Reading the radar
+description: What the colours actually mean — reflectivity, velocity and the dual-pol products, in plain language.
+order: 3
+---
+
+A radar sends out a pulse and listens for what comes back. Everything on the
+screen is some measurement of that echo. There are only a few you need.
+
+## Reflectivity (Z) — where the rain is
+
+The one everybody knows. It measures how much is coming back, in dBZ. Bigger
+drops, and more of them, send back more.
+
+- **Blue and green, under about 30 dBZ** — light rain, or snow.
+- **Yellow, 35–45 dBZ** — proper rain. Enough to hear on the roof.
+- **Red and beyond, over 50 dBZ** — a downpour, and a candidate for hail.
+
+Reflectivity shows you a storm's *shape*. A neat blob is a shower. A long line
+is a squall. And a curl on the back edge of a supercell is the hook that gives
+this app its name — see [What's a hook echo?](/docs/faq/).
+
+## Velocity (V) — what the storm is doing
+
+Velocity measures whether the echo is moving toward the radar or away from it,
+along the beam. Green is toward, red is away. The radar site is the centre of
+that logic, so the same wind reads differently on either side of it.
+
+What you're hunting for is **green and red tight against each other** over a
+short distance. Air coming at the radar right beside air going away from it is
+air spinning: a rotating storm.
+
+HookEcho dealiases velocity by default, so a fast couplet reads as red against
+green instead of folding back into nonsense.
+
+**Storm-relative velocity** subtracts the storm's own travel across the ground,
+which otherwise hides the rotation inside it. Turn it on in the panel's Layer
+options when a couplet looks marginal.
+
+## Correlation coefficient (CC) — what the echo is made of
+
+CC asks whether everything in the beam looks alike. Rain is uniform, so CC is
+high — near 1.0. Anything mixed pulls it down: hail, melting snow, birds, and
+crucially **debris**. A tornado on the ground lofts fence posts and roof
+shingles, and a hole punched in CC where the reflectivity is high is one of the
+strongest confirmations there is.
+
+## Differential reflectivity (ZDR)
+
+Falling raindrops flatten out, so they're wider than they are tall, and ZDR is
+positive. Hailstones tumble, so they average round, and ZDR goes to zero even
+where the reflectivity is enormous. High Z with low ZDR is a hail signature.
+
+## Three questions, three answers
+
+**Is it rotating?** Velocity, 0.5° tilt: look for a tight inbound/outbound pair
+over a few gates. Then turn on storm-relative velocity to be sure.
+
+**Is it hail?** Reflectivity over about 50 dBZ is the candidate; confirm with CC
+dropping and ZDR going flat. The **storm attributes** table
+(<kbd>Ctrl</kbd>+<kbd>K</kbd> → "cells") lists every tracked cell with its hail
+size, tops and VIL, sorted — click a row to fly there.
+
+**Is it a tornado?** The debris signature is all three together at low tilt: a
+velocity couplet, high reflectivity, and a hole in CC. The app flags candidates,
+but those three panels are the reason.
+
+## Tilts, and why they matter
+
+A radar doesn't take one picture — it sweeps a full circle, steps its beam up,
+and sweeps again, until it has a stack. Each of those sweeps is a **tilt**. The
+beam also climbs as it travels, so far from the radar even 0.5° is well above
+your head.
+
+Climbing the tilts tells you how a storm leans. A rotating column that stands
+straight up through several tilts is a much bigger deal than one that falls
+apart at the second sweep. One action in <kbd>Ctrl</kbd>+<kbd>K</kbd> puts four
+tilts side by side to make that easy to see.
+
+## A caveat about old storms
+
+Dual-polarization — CC and ZDR — arrived across the network around 2012. Replay
+a storm from before your site was upgraded and those products simply aren't
+there. That's the data, not a bug.

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -12,9 +12,10 @@ const { title, description, image = "/shots/alltilts.jpg" } = Astro.props;
 const url = new URL(Astro.url.pathname, Astro.site);
 const social = new URL(image, Astro.site);
 
-// Waves W2–W4 add their pages here; a link is only listed once the page exists, so the
+// Waves W3–W4 add their pages here; a link is only listed once the page exists, so the
 // build's link check stays meaningful.
 const nav = [
+  { href: "/docs/", label: "Docs" },
   { href: "https://app.hookecho.io", label: "Open in browser" },
   { href: "https://github.com/d4vid87/hookecho/releases/latest", label: "Download" },
   { href: "https://github.com/d4vid87/hookecho", label: "GitHub" },

--- a/site/src/layouts/Docs.astro
+++ b/site/src/layouts/Docs.astro
@@ -1,0 +1,121 @@
+---
+import { getCollection } from "astro:content";
+import Base from "./Base.astro";
+
+interface Props {
+  title: string;
+  description: string;
+  /** Collection id of the page being shown, or undefined on the docs index. */
+  current?: string;
+}
+
+const { title, description, current } = Astro.props;
+
+const pages = (await getCollection("docs")).sort((a, b) => a.data.order - b.data.order);
+const at = pages.findIndex((p) => p.id === current);
+const prev = at > 0 ? pages[at - 1] : undefined;
+const next = at >= 0 && at < pages.length - 1 ? pages[at + 1] : undefined;
+---
+
+<Base title={`${title} — HookEcho docs`} description={description}>
+  <div class="wrap docs">
+    <nav class="side" aria-label="Documentation">
+      <p class="eyebrow">Docs</p>
+      <ul>
+        {pages.map((p) => (
+          <li>
+            <a href={`/docs/${p.id}/`} aria-current={p.id === current ? "page" : undefined}>
+              {p.data.title}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+
+    <article class="prose">
+      <h1>{title}</h1>
+      <slot />
+
+      {(prev || next) && (
+        <nav class="seq" aria-label="More documentation">
+          {prev ? (
+            <a class="btn" href={`/docs/${prev.id}/`}>← {prev.data.title}</a>
+          ) : (
+            <span />
+          )}
+          {next && <a class="btn" href={`/docs/${next.id}/`}>{next.data.title} →</a>}
+        </nav>
+      )}
+    </article>
+  </div>
+</Base>
+
+<style>
+  .docs {
+    display: grid;
+    grid-template-columns: 220px minmax(0, 1fr);
+    gap: clamp(2rem, 5vw, 4rem);
+    padding: 3rem 0 4.5rem;
+    align-items: start;
+  }
+  @media (max-width: 800px) {
+    .docs { grid-template-columns: minmax(0, 1fr); }
+    .side { position: static; border-bottom: 1px solid var(--stroke); padding-bottom: 1.5rem; }
+  }
+  .side { position: sticky; top: 5rem; }
+  .side ul { list-style: none; margin: 0; padding: 0; display: grid; gap: 0.55rem; }
+  .side a {
+    color: var(--text-dim);
+    text-decoration: none;
+    font-size: 0.95rem;
+    display: block;
+    border-left: 2px solid transparent;
+    padding-left: 0.7rem;
+  }
+  .side a:hover { color: var(--text); }
+  .side a[aria-current="page"] {
+    color: var(--text);
+    border-left-color: var(--accent);
+    font-weight: 600;
+  }
+
+  .prose h1 { font-size: clamp(1.9rem, 4.5vw, 2.6rem); margin-bottom: 1rem; }
+  .prose :global(h2) { margin-top: 2.2rem; }
+  .prose :global(h3) { margin-top: 1.6rem; }
+  .prose :global(ul), .prose :global(ol) { max-width: var(--measure); padding-left: 1.2rem; }
+  .prose :global(li) { margin-bottom: 0.4rem; }
+  .prose :global(strong) { color: var(--text); font-weight: 600; }
+  .prose :global(kbd) {
+    font: inherit;
+    font-size: 0.85em;
+    background: var(--widget);
+    border: 1px solid var(--stroke);
+    border-radius: 5px;
+    padding: 0.1em 0.4em;
+  }
+  .prose :global(pre) {
+    background: var(--bg-deep);
+    border: 1px solid var(--stroke);
+    border-radius: var(--radius);
+    padding: 1rem 1.1rem;
+    overflow-x: auto;
+    max-width: var(--measure);
+  }
+  .prose :global(code) { font-size: 0.9em; }
+  .prose :global(:not(pre) > code) {
+    background: var(--faint);
+    border: 1px solid var(--stroke);
+    border-radius: 5px;
+    padding: 0.1em 0.35em;
+  }
+
+  .seq {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin-top: 3.5rem;
+    padding-top: 2rem;
+    border-top: 1px solid var(--stroke);
+  }
+</style>

--- a/site/src/pages/docs/[...slug].astro
+++ b/site/src/pages/docs/[...slug].astro
@@ -1,0 +1,16 @@
+---
+import { getCollection, render } from "astro:content";
+import Docs from "../../layouts/Docs.astro";
+
+export async function getStaticPaths() {
+  const pages = await getCollection("docs");
+  return pages.map((page) => ({ params: { slug: page.id }, props: { page } }));
+}
+
+const { page } = Astro.props;
+const { Content } = await render(page);
+---
+
+<Docs title={page.data.title} description={page.data.description} current={page.id}>
+  <Content />
+</Docs>

--- a/site/src/pages/docs/index.astro
+++ b/site/src/pages/docs/index.astro
@@ -1,0 +1,32 @@
+---
+import { getCollection } from "astro:content";
+import Docs from "../../layouts/Docs.astro";
+
+const pages = (await getCollection("docs")).sort((a, b) => a.data.order - b.data.order);
+---
+
+<Docs
+  title="Documentation"
+  description="How to use HookEcho: getting started, installing, reading the radar, alerts, the phone app and the browser version."
+>
+  <p>
+    Short guides, in plain language. If you've just installed it, start with
+    <a href="/docs/getting-started/">Getting started</a>.
+  </p>
+
+  <ul class="toc">
+    {pages.map((p) => (
+      <li>
+        <a href={`/docs/${p.id}/`}>{p.data.title}</a>
+        <span>{p.data.description}</span>
+      </li>
+    ))}
+  </ul>
+</Docs>
+
+<style>
+  .toc { list-style: none; margin: 2rem 0 0; padding: 0; display: grid; gap: 1.1rem; }
+  .toc li { max-width: var(--measure); }
+  .toc a { font-weight: 600; font-size: 1.05rem; }
+  .toc span { display: block; color: var(--text-dim); font-size: 0.95rem; }
+</style>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -5,9 +5,11 @@
 @font-face {
   font-family: "Inter";
   /* The same Latin subset the app bundles (crates/hookecho/data/fonts), converted to woff2.
-     ponytail: Regular only — headings get synthetic weight. Ship a Medium face if it shows. */
+     ponytail: Regular only, declared at 400 so the browser synthesizes bold — a declared
+     400–700 range makes it draw 600 with the Regular outlines and bold stops being visible.
+     Ship a Medium/Bold face if the synthetic weight looks poor. */
   src: url("/fonts/Inter-Regular-subset.woff2") format("woff2");
-  font-weight: 400 700;
+  font-weight: 400;
   font-display: swap;
 }
 


### PR DESCRIPTION
Wave W2 of the hookecho.io plan: the user guide, as an Astro content collection.

## What's here

Seven pages under `/docs/`, plus an index that lists them:

| Page | Covers |
|---|---|
| Getting started | The ten-second start — one question on first launch, the three floating pieces, `Ctrl+K`, watch a storm, save a marker, replay |
| Install | Per-platform, with the real artifact names from the README table; browser first |
| Reading the radar | Z / V / CC / ZDR in plain language, the three questions (rotating? hail? tornado?), tilts, the pre-2012 dual-pol caveat |
| Alerts and notifications | Markers, channels, triggers, escalation tiers, storm-motion ETAs |
| On your phone | Android install, gestures, background alerting, chase mode, offline packs, battery saver |
| In your browser | What's the same, what a web page doesn't get, `?embed=1` and `#goto` |
| FAQ and glossary | Common questions, the "things that look broken" list, and 20 glossary terms |

The content is written fresh for someone who doesn't already know what dBZ is; `README.md` and `docs/GUIDE.md` stay dev-facing and unchanged.

`src/layouts/Docs.astro` does the sidebar, `aria-current` highlighting, prev/next from the collection's `order`, and the prose styles (headings, lists, `kbd`, code). The docs link is now in the nav array in `Base.astro`.

**Not doing:** search. At seven pages in one sidebar column, it's YAGNI — add it when the page count says otherwise.

## One fix that isn't docs

`global.css` declared the bundled Inter face as `font-weight: 400 700`. That's a variable-font range, and this is a static Regular file, so the browser drew 600 and 700 with the Regular outlines and **bold rendered identically to body text**. Invisible on the landing page (which has no inline bold); very visible in a glossary. Now declared at `400` so the browser synthesizes bold. Confirmed in the screenshots below.

## Verified

- `npm run build` — clean, 9 pages, ~880 ms.
- `npx linkinator@6 dist --recurse` — 32 links scanned. Every internal link resolves. The 11 failures are all `https://hookecho.io/...` canonicals and `https://app.hookecho.io/`, i.e. the domains that don't exist until the W5 DNS step. Same known set as #136, just more of them now that there are more pages.
- Puppeteer full-page screenshots: `/docs/reading-the-radar/` at 1440 dark, `/docs/faq/` at 1440 light, `/docs/` dark, `/docs/getting-started/` at 390 (phone — the sidebar stacks above the article, no overflow), and the landing page re-checked for the font change.

Nothing Rust, Android or packaging was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
