### PR TITLE
feat(site): blog + RSS

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "hookecho-site",
       "dependencies": {
+        "@astrojs/rss": "^4.0.19",
         "@astrojs/sitemap": "^3.2.1",
         "astro": "^5.1.1"
       }
@@ -61,6 +62,17 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@astrojs/rss": {
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.19.tgz",
+      "integrity": "sha512-e+z5wYeYtffQdHQO8c2tkSd2JEBdAuRXJV4ZEU5IxkYeE6e39woDd7nw1PH1Kk2tEYNCYuKdylnnbhGmt61awA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.7",
+        "piccolore": "^0.1.3",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/sitemap": {
@@ -1064,6 +1076,18 @@
         "node": "^22.20 || ^24.12 || >=25"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
@@ -1678,6 +1702,18 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/arg": {
       "version": "5.0.2",
@@ -2402,6 +2438,45 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.1.tgz",
+      "integrity": "sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.11.0.tgz",
+      "integrity": "sha512-9IGxMqvqLOnqP+Egi1nqDHKv5k8aZ7r9n558enxcucmyVGEBNPAU+MOg/8jPIS7rO7sSq4gFm1/nHtiaubMruw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.2",
+        "xml-naming": "^0.3.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2769,6 +2844,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-unsafe": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.2.tgz",
+      "integrity": "sha512-HgbIHPBH0KHHCcjLfGsCvhtPTVxjaAZlXjwdz7/GQC40SjSe4sfQsar8J5VFo8JOSbarkpV0OLG95bbaNd9aAQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/is-wsl": {
       "version": "3.1.1",
@@ -3860,6 +3947,21 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/piccolore": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
@@ -4423,6 +4525,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.2.tgz",
+      "integrity": "sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
       }
     },
     "node_modules/svgo": {
@@ -5478,6 +5595,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xxhash-wasm": {

--- a/site/package.json
+++ b/site/package.json
@@ -9,6 +9,7 @@
     "shots": "mkdir -p public/shots && cp ../docs/shots/*.jpg ../docs/shots/*.gif public/shots/"
   },
   "dependencies": {
+    "@astrojs/rss": "^4.0.19",
     "@astrojs/sitemap": "^3.2.1",
     "astro": "^5.1.1"
   }

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -12,4 +12,16 @@ const docs = defineCollection({
   }),
 });
 
-export const collections = { docs };
+// Posts are dated rather than ordered; the index and the feed both sort on `date`.
+const blog = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/content/blog" }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    date: z.coerce.date(),
+    /** Absolute-from-root path to the social card image, if the post has one of its own. */
+    image: z.string().optional(),
+  }),
+});
+
+export const collections = { docs, blog };

--- a/site/src/content/blog/hello-hookecho.md
+++ b/site/src/content/blog/hello-hookecho.md
@@ -1,0 +1,67 @@
+---
+title: "Hello, HookEcho"
+description: "A free, open-source weather radar app that talks straight to the public NOAA feeds — why it exists, and who it's for."
+date: 2026-08-26
+image: /shots/hero.gif
+---
+
+Every radar app on your phone is somebody's business model. The data underneath
+them is free — the United States operates 150-odd Doppler radars and publishes
+every sweep of every one of them, for nothing, to anyone — and yet the way most
+people see that data is through an app that wants a subscription, an account, or
+a look at where you've been.
+
+HookEcho is what happens when you cut all of that out. It's a radar viewer that
+talks to the NOAA and National Weather Service feeds directly, from your own
+machine. No account. No subscription. No telemetry. It's MIT-licensed, and the
+source is all there.
+
+## Weather radar for everyone
+
+There are two kinds of radar software. The consumer apps show you a blob of
+green and a chance of rain. The professional ones — the ones storm chasers and
+broadcast meteorologists use — show you everything, and expect you to already
+know what a correlation coefficient is.
+
+HookEcho tries to be one program that's both, by putting the depth where you go
+looking for it instead of in your way.
+
+Open it and it finds your nearest radar and starts the loop. That's the whole of
+setup: one question, and it answers that one itself if you let it use your
+location. If all you want is to know whether the rain is going to reach you
+before you get home, you are already done.
+
+Go looking, and underneath is the full thing: Level 2 volumes at every tilt,
+velocity with dealiasing and storm-relative motion, the dual-pol products,
+cross-sections, a 3D volume you can orbit, the national MRMS mosaic, HRRR and
+NAM model fields, Skew-T soundings with the severe composite parameters, warning
+verification scored against the storm reports that actually came in, and an
+archive that reaches back to **June 1991**.
+
+Same app. Same map. You just have to want it.
+
+## What it runs on
+
+Windows, macOS, Linux, Android — and the browser, where the whole thing runs as
+WebAssembly on live data with nothing to install. Try it at
+[app.hookecho.io](https://app.hookecho.io) before you download anything.
+
+## Where the data comes from
+
+NEXRAD Level 2 and Level 3 from the radar network. MRMS for the national mosaic
+and the gridded products. HRRR, NAM and RAP for the model layers. The NWS for
+warnings, forecasts and storm reports. The University of Wyoming's archive for
+the real balloon soundings.
+
+All public, all free, all fetched by your machine rather than by a server in the
+middle that gets to see what you're looking at.
+
+## Start here
+
+- [Getting started](/docs/getting-started/) — the ten-second version.
+- [Reading the radar](/docs/reading-the-radar/) — what the colours mean.
+- [The source](https://github.com/d4vid87/hookecho) — it's all there.
+
+If something's broken or missing, [say
+so](https://github.com/d4vid87/hookecho/issues). That's the whole feedback
+mechanism, and it works.

--- a/site/src/content/blog/hookecho-0-12-0-beta.md
+++ b/site/src/content/blog/hookecho-0-12-0-beta.md
@@ -1,0 +1,118 @@
+---
+title: "HookEcho v0.12.0 beta: a new interface, top to bottom"
+description: "The docked panels are gone, the setup wizard is gone, and the phone got the same rebuild the desktop did. What's in the v0.12.0 beta."
+date: 2026-08-26
+image: /shots/layers.jpg
+---
+
+The **v0.12.0 beta** is out, and it's the largest change HookEcho has had. The
+whole interface was rebuilt, the phone app along with it, and about a dozen data
+lanes landed on top. It's a prerelease — a couple of things arrive at the final
+0.12.0 — but it's the version worth using.
+
+[Get it from Releases](https://github.com/d4vid87/hookecho/releases), or just
+[open it in your browser](https://app.hookecho.io).
+
+## The map got the whole window
+
+The old layout was a 264-pixel sidebar down the left, a panel across the bottom,
+and the weather in whatever was left. That's gone. The map is full-bleed now,
+edge to edge, and the controls float over it — a search pill in one corner, a
+control column on the right edge, and the timeline along the bottom.
+
+There's no title bar either: the window is borderless and its buttons float with
+the rest of the chrome. Drag the empty strip along the top to move it,
+double-click to maximize, resize from any edge. If your window manager disagrees
+with any of that, `--decorated` hands the frame back.
+
+The pieces that used to be a dozen floating windows are now pages in one
+slide-over drawer, one at a time, with a back arrow. And anything you click *on
+the map* — a storm cell, a warning polygon, one of your own markers — answers in
+a card next to where you clicked, instead of opening a window somewhere else.
+
+**One panel holds everything**: the radar, the product, the tilt, and every
+layer, window and tool, each one described in plain English and filed under
+categories that carry their own count. `Ctrl+K` searches it, and Enter runs the
+top match. If you learn one thing about the new build, learn that.
+
+## The timeline is a real timeline
+
+The bottom panel became a scrubber: the radar's clock, a play button, a LIVE
+badge that snaps back to the newest scan, and a track with one tick per volume,
+labelled by the hour — in the radar's own local time, not yours and not Zulu.
+Drag it, or click anywhere on it. The shaded stretch at the live end is the loop
+the play button cycles. Right-click the badge for the archive day.
+
+## Setup stopped asking questions
+
+The old first-run wizard is deleted. Now the app finds you, picks the nearest
+radar and draws it — about ten seconds, no questions. There's a 60-second tour
+on offer if you want one, and it's four stops on the live map, two of which you
+finish by doing the thing rather than reading about it. Skip it and nothing
+nags.
+
+Notification permission is asked for at the moment you turn on something that
+notifies, or when a warning lands near you. Never at install.
+
+Labels across the app read in plain language now — "Storm rotation (SRV)",
+"Debris detection (CC)" — with the abbreviation kept in parentheses for people
+who want it. And there's one help hub behind `?`: glossary, hotkeys, the tour
+and what's new, all searchable together.
+
+## The phone got the same rebuild
+
+The persistent bottom sheet and the five-slot toolbar are gone. Android draws
+the same floating chrome the desktop does, with content in Material modal
+sheets. Long-press the map to inspect what's under your finger, double-tap and
+drag to zoom one-handed, swipe sideways between panes. It buzzes as the scrubber
+crosses a frame, when a warning lands on you, and when a sheet snaps.
+
+Tablets and landscape phones get a side rail and a docked drawer instead of
+sheets. The widgets now show how far the nearest storm is, there's a
+battery-saver mode that stretches the polling and throttles repaints, and on a
+chase the next radar down the road is prefetched before you need it — then the
+whole chase can be replayed against the archive afterwards.
+
+## And a lot of weather
+
+- **GOES** satellite loops run over archive dates alongside the radar timeline,
+  with the mid-level water vapour bands selectable.
+- **MRMS rotation tracks** at 30, 60 and 120 minutes are field layers now, and
+  hail swaths accumulate locally over a window you pick.
+- An alert rule can trigger on a **lightning jump** — the rate of change of
+  flash density inside a cell, which is one of the things that spikes before a
+  storm turns severe.
+- **NAM nest and NBM** join the model list; **Synoptic** mesonets join the
+  surface observations, with your own API key.
+- Cells are **ranked by a composite severity score**, and tapping one opens the
+  3D volume already centred on it.
+- Panes remember their own thresholds and layers, and an event can be saved as a
+  **replay bundle** — time range, site, camera — then replayed with archived
+  radar, warnings, reports and outlooks all in sync.
+
+## The browser build grew up
+
+It installs as a **PWA** with the app shell cached offline. Tiles, volumes and
+palettes persist between visits. File dialogs, GPS and notifications all work
+now. And a share button writes a permalink carrying the site, the camera and the
+time, so you can send someone exactly what you're looking at.
+
+## Elsewhere
+
+MQTT publishing, a Home Assistant camera-loop endpoint, and a live dashboard at
+the `--serve` index. An update chip when a newer release exists — and no
+self-updating, ever. Motion throughout, with a reduce-motion setting and an
+automatic degrade when frames get slow. Labels, roles and focus order on all of
+the new chrome.
+
+Every screenshot in the README, on this site and in the store listings was
+reshot on the new interface.
+
+## What's still coming at 0.12.0
+
+RRFS, and the remaining store submissions — Flathub, Snap, AUR, winget and
+Homebrew all have working manifests in the repo, but none are published yet.
+
+Found something broken? [Open an
+issue](https://github.com/d4vid87/hookecho/issues) — the site, the product and
+the time you were looking at is usually enough to replay it.

--- a/site/src/content/blog/how-to-read-weather-radar.md
+++ b/site/src/content/blog/how-to-read-weather-radar.md
@@ -1,0 +1,116 @@
+---
+title: "How to read weather radar"
+description: "Green, yellow and red is where most people stop. Here's what the rest of a radar display is telling you, and how to use it."
+date: 2026-08-26
+image: /shots/velocity.jpg
+---
+
+Most people read weather radar exactly one way: green is rain, yellow is more
+rain, red is get inside. That's not wrong, and for most weather it's enough.
+
+But that colour scale is one measurement out of six, and the other five are the
+ones that tell you whether a storm is dangerous. None of them are hard. Here's
+the whole display.
+
+## Reflectivity: how much is out there
+
+The familiar one. The radar sends a pulse and measures how much energy comes
+back, in **dBZ**. Bigger drops, and more of them, return more.
+
+Under 30 dBZ is drizzle or snow. 35 to 45 is real rain. Over 50 is a downpour
+and a hail candidate. Over 60 dBZ, in most of the country, is hail — plain water
+struggles to return that much.
+
+The number is not rainfall rate. It's a measurement of what's in the beam, and
+the beam is somewhere above your head — which is why the radar can show 45 dBZ
+over a town that's staying completely dry, when the rain is evaporating on the
+way down.
+
+Reflectivity's real use is **shape**. A round blob is an ordinary shower. A long
+line with a bowed section is a squall line, and the bow is where the damaging
+straight-line wind is. And a curl on the back of an isolated storm is a
+[hook echo](/blog/what-is-a-hook-echo/).
+
+## Velocity: what the air is doing
+
+The second product, and the one worth learning.
+
+Radar measures motion along the beam by the Doppler shift: green means the echo
+is moving toward the radar, red means away. Brightness is speed.
+
+The single most important thing on this display is **green and red pressed
+tight against each other**. Air coming at the radar right beside air going away
+from it is air rotating. That's a mesocyclone, and it's the reason tornado
+warnings get issued before anyone sees anything.
+
+Two catches. First, the radar only sees motion along its own beam, so the
+picture is oriented around the radar site, not around north — the same wind
+reads differently on either side of it. Second, above a certain speed the
+measurement folds over and reads backwards; software undoes that, and it's
+called **dealiasing**. If a couplet looks like nonsense with hard edges, that's
+what you're looking at.
+
+**Storm-relative velocity** subtracts the storm's own travel across the ground.
+A storm moving 50 mph carries its rotation along with it, which smears the
+signature; subtract the motion and the rotation stands still and becomes
+obvious.
+
+## Correlation coefficient: what it's made of
+
+Dual-polarization radar sends both a horizontal and a vertical pulse, which lets
+it ask a different question: does everything in this beam look alike?
+
+Rain does — raindrops are all roughly the same shape — so CC sits near 1.0.
+Anything mixed drags it down. Melting snow. Hail among rain. Birds and bats and
+bugs at dusk.
+
+And debris. When a tornado is on the ground it throws fence posts, roof
+shingles, insulation and trees into the air, and those look nothing like each
+other. CC collapses in a small blob exactly where the rotation is. That's the
+**tornado debris signature**, and it doesn't mean a tornado is possible — it
+means something down there is being destroyed at that moment.
+
+## Differential reflectivity: what shape it is
+
+ZDR compares the horizontal return to the vertical one. Falling raindrops
+flatten into little hamburger buns, wider than tall, so ZDR is positive. Big
+hailstones tumble as they fall, so on average they're round, and ZDR drops to
+near zero.
+
+Enormous reflectivity with ZDR near zero is hail. Enormous reflectivity with
+high ZDR is a very heavy rain shaft.
+
+## Tilts: the third dimension
+
+A radar doesn't take one picture. It sweeps a full circle, steps the beam up a
+notch, sweeps again, and keeps going until it has a stack of cones. Each sweep
+is a **tilt**, and the stack is a volume.
+
+This matters more than people expect. A storm that rotates at the lowest tilt
+and nowhere higher is probably not much. A rotating column that stands straight
+up through five tilts, ten thousand feet deep, is a different animal. And
+because the beam climbs with distance, a radar 80 miles away is showing you the
+middle of the storm no matter which tilt you pick — one reason a storm can look
+harmless on one radar and alarming on the next one over.
+
+## Putting it together
+
+The three questions, and the answers:
+
+**Is it going to rain on me?** Reflectivity, and the loop. Watch which way the
+echoes are moving, not where they are.
+
+**Is there hail?** Reflectivity over 50 dBZ, CC dropping, ZDR going flat.
+
+**Is there a tornado?** A velocity couplet, high reflectivity, and a hole in CC
+— all three, in the same place, at the lowest tilt.
+
+## Try it on a real storm
+
+Reading about this is much worse than doing it. Every archived American storm is
+free, and [HookEcho](https://app.hookecho.io) replays them in your browser: pick
+20 May 2013 on KTLX, put reflectivity, velocity, CC and ZDR in four panes, and
+scrub through the afternoon.
+
+More detail in [Reading the radar](/docs/reading-the-radar/), and every
+abbreviation in one place in the [glossary](/docs/faq/).

--- a/site/src/content/blog/what-is-a-hook-echo.md
+++ b/site/src/content/blog/what-is-a-hook-echo.md
@@ -1,0 +1,80 @@
+---
+title: "What is a hook echo?"
+description: "The radar signature that named this app: what makes the hook, why it means a tornado might be underneath it, and how to spot one yourself."
+date: 2026-08-26
+image: /shots/reflectivity.jpg
+---
+
+On 9 April 1953, a radar operator at the Illinois State Water Survey named
+Donald Staggs was watching a thunderstorm near Champaign and saw the echo grow a
+tail — a thin finger of returned energy curling off the storm's south side into
+an almost complete circle. A tornado hit Willard Airport at about the same
+moment.
+
+It was the first time anyone had put a radar picture next to a tornado and found
+a shape. Seventy years later it is still one of the first things a forecaster
+looks for, and it is where this app got its name.
+
+## What actually makes the hook
+
+A supercell is a thunderstorm with a rotating updraft — a column of rising air
+several miles wide, turning. The rotation comes from wind shear: wind that
+changes speed and direction with height rolls the air into a horizontal tube,
+and the updraft tilts that tube upright.
+
+Rain and hail fall out of the back of the storm. If the storm is rotating, that
+falling precipitation gets dragged around the outside of the updraft, the way
+milk wraps around a spoon. On reflectivity — which is just a picture of how much
+precipitation is in the beam — that wrap draws a curl hooking off the
+back-right of the storm.
+
+The hook is precipitation. The thing that matters is the empty space it curls
+around: that hole is the updraft, and if a tornado exists, that's where it is.
+
+## Why a hook is not a tornado
+
+This is the part every guide gets wrong by omission. A hook echo means a storm
+is rotating on the scale of the whole updraft — a mesocyclone, several miles
+across. Tornadoes are a hundred yards across. Most mesocyclones never produce
+one.
+
+Radar also cannot see the tornado directly in reflectivity. The beam climbs as
+it travels, so at 60 miles out even the lowest tilt is thousands of feet above
+the ground, looking clean over the top of whatever is happening underneath.
+
+So the hook is a reason to look harder. It isn't the answer.
+
+## What confirms it
+
+Modern radar gives you two more things, and the combination is what forecasters
+actually issue warnings on:
+
+**Velocity.** The radar measures whether the echo is moving toward it or away
+from it. Rotation shows up as green (toward) directly against red (away) over a
+short distance — a couplet. A tight couplet at the base of the hook is the
+mesocyclone, measured rather than inferred.
+
+**Correlation coefficient.** Dual-polarization radar can tell whether everything
+in the beam looks alike. Raindrops do. Fence posts, roof shingles, insulation
+and shredded trees do not. When a tornado is on the ground it lofts all of that
+into the air, and CC collapses in a small blob right where the couplet is. This
+is the **tornado debris signature**, and it is as close to proof as radar gets:
+it means something down there is being torn apart, right now.
+
+Hook plus couplet plus a hole in CC, all in the same place at low tilt, is the
+picture that ends the argument.
+
+## Seeing one yourself
+
+Every archived storm in the American record is available, free, and HookEcho
+plays it back the same way it plays back live weather. If you want to see a
+textbook hook, load KTLX for 20 May 2013 and scrub through the afternoon — Moore,
+Oklahoma — or KBMX for 27 April 2011. Put reflectivity, velocity and correlation
+coefficient in four panes on the same storm at the same second, and the three
+signatures line up in front of you.
+
+That's a better explanation than this article is.
+
+- [Reading the radar](/docs/reading-the-radar/) — the products, in plain language.
+- [Get HookEcho](/docs/install/), or [open it in your
+  browser](https://app.hookecho.io).

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -12,10 +12,11 @@ const { title, description, image = "/shots/alltilts.jpg" } = Astro.props;
 const url = new URL(Astro.url.pathname, Astro.site);
 const social = new URL(image, Astro.site);
 
-// Waves W3–W4 add their pages here; a link is only listed once the page exists, so the
+// Wave W4 adds its pages here; a link is only listed once the page exists, so the
 // build's link check stays meaningful.
 const nav = [
   { href: "/docs/", label: "Docs" },
+  { href: "/blog/", label: "Blog" },
   { href: "https://app.hookecho.io", label: "Open in browser" },
   { href: "https://github.com/d4vid87/hookecho/releases/latest", label: "Download" },
   { href: "https://github.com/d4vid87/hookecho", label: "GitHub" },
@@ -31,6 +32,7 @@ const nav = [
     <meta name="description" content={description} />
     <link rel="canonical" href={url} />
     <link rel="icon" href="/logo.png" type="image/png" />
+    <link rel="alternate" type="application/rss+xml" title="HookEcho" href="/rss.xml" />
     <meta name="theme-color" content="#14161b" />
     <link
       rel="preload"

--- a/site/src/layouts/Post.astro
+++ b/site/src/layouts/Post.astro
@@ -1,0 +1,55 @@
+---
+import Base from "./Base.astro";
+
+interface Props {
+  title: string;
+  description: string;
+  date: Date;
+  image?: string;
+}
+
+const { title, description, date, image } = Astro.props;
+const stamp = date.toISOString().slice(0, 10);
+// Frontmatter dates parse as UTC midnight; format in UTC too, or a machine west of
+// Greenwich renders every post a day early.
+const pretty = date.toLocaleDateString("en-GB", {
+  day: "numeric",
+  month: "long",
+  year: "numeric",
+  timeZone: "UTC",
+});
+---
+
+<Base title={`${title} — HookEcho`} description={description} image={image}>
+  <article class="wrap post">
+    <p class="eyebrow"><a href="/blog/">Blog</a> · <time datetime={stamp}>{pretty}</time></p>
+    <h1>{title}</h1>
+    <p class="lede">{description}</p>
+    {image && <img class="lede-shot" src={image} alt="" width="1600" height="1000" />}
+    <slot />
+  </article>
+</Base>
+
+<style>
+  .post { max-width: 780px; padding: 3rem 0 4.5rem; }
+  .eyebrow a { color: var(--text-dim); }
+  .lede { font-size: 1.15rem; color: var(--text-dim); }
+  .lede-shot {
+    display: block;
+    width: 100%;
+    border-radius: var(--radius);
+    border: 1px solid var(--stroke);
+    margin: 2rem 0 2.5rem;
+  }
+  .post :global(h2) { margin-top: 2.4rem; }
+  .post :global(ul) { padding-left: 1.2rem; max-width: var(--measure); }
+  .post :global(li) { margin-bottom: 0.5rem; }
+  .post :global(strong) { color: var(--text); font-weight: 600; }
+  .post :global(:not(pre) > code) {
+    background: var(--faint);
+    border: 1px solid var(--stroke);
+    border-radius: 5px;
+    padding: 0.1em 0.35em;
+    font-size: 0.9em;
+  }
+</style>

--- a/site/src/pages/blog/[...slug].astro
+++ b/site/src/pages/blog/[...slug].astro
@@ -1,0 +1,16 @@
+---
+import { getCollection, render } from "astro:content";
+import Post from "../../layouts/Post.astro";
+
+export async function getStaticPaths() {
+  const posts = await getCollection("blog");
+  return posts.map((post) => ({ params: { slug: post.id }, props: { post } }));
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+---
+
+<Post {...post.data}>
+  <Content />
+</Post>

--- a/site/src/pages/blog/index.astro
+++ b/site/src/pages/blog/index.astro
@@ -1,0 +1,46 @@
+---
+import { getCollection } from "astro:content";
+import Base from "../../layouts/Base.astro";
+
+// Same date on every launch post, so the id is the tiebreak that keeps the order stable.
+const posts = (await getCollection("blog")).sort(
+  (a, b) => b.data.date.valueOf() - a.data.date.valueOf() || a.id.localeCompare(b.id),
+);
+---
+
+<Base
+  title="Blog — HookEcho"
+  description="Release notes and plain-language explainers about weather radar, from the people building HookEcho."
+>
+  <div class="wrap blog">
+    <p class="eyebrow">Blog</p>
+    <h1>Release notes, and how radar works</h1>
+    <p>
+      What's new in the app, and explainers for anyone who wants to read a radar display
+      properly. <a href="/rss.xml">RSS</a>.
+    </p>
+
+    <ul class="posts">
+      {posts.map((post) => (
+        <li>
+          <time datetime={post.data.date.toISOString().slice(0, 10)}>
+            {post.data.date.toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric", timeZone: "UTC" })}
+          </time>
+          <h2><a href={`/blog/${post.id}/`}>{post.data.title}</a></h2>
+          <p>{post.data.description}</p>
+        </li>
+      ))}
+    </ul>
+  </div>
+</Base>
+
+<style>
+  .blog { padding: 3rem 0 4.5rem; }
+  .posts { list-style: none; margin: 2.5rem 0 0; padding: 0; display: grid; gap: 2.2rem; }
+  .posts li { max-width: var(--measure); }
+  .posts time { font-size: 0.8rem; color: var(--text-dim); letter-spacing: 0.04em; }
+  .posts h2 { font-size: 1.35rem; margin: 0.3rem 0 0.4rem; }
+  .posts h2 a { color: var(--text); text-decoration: none; }
+  .posts h2 a:hover { color: var(--accent); }
+  .posts p { color: var(--text-dim); margin: 0; }
+</style>

--- a/site/src/pages/rss.xml.js
+++ b/site/src/pages/rss.xml.js
@@ -1,0 +1,19 @@
+import rss from "@astrojs/rss";
+import { getCollection } from "astro:content";
+
+export async function GET(context) {
+  const posts = await getCollection("blog");
+  return rss({
+    title: "HookEcho",
+    description: "Release notes and plain-language explainers about weather radar.",
+    site: context.site,
+    items: posts
+      .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf() || a.id.localeCompare(b.id))
+      .map((post) => ({
+        title: post.data.title,
+        description: post.data.description,
+        pubDate: post.data.date,
+        link: `/blog/${post.id}/`,
+      })),
+  });
+}


### PR DESCRIPTION
Wave W3 of the hookecho.io plan: the blog, as a second content collection, plus a feed.

## The posts

| Post | What it is |
|---|---|
| **Hello, HookEcho** | The announcement — why a free radar app that talks to NOAA directly exists, and the casual-to-chaser story the landing page tells, at length |
| **HookEcho v0.12.0 beta: a new interface, top to bottom** | Release notes, written from `CHANGELOG.md`'s `0.12.0-beta.1` section. Says plainly that it's a prerelease and names what's still coming at 0.12.0 (RRFS, the store submissions) |
| **How to read weather radar** | The explainer. Reflectivity/velocity/CC/ZDR/tilts for someone who only knows green-yellow-red |
| **What is a hook echo?** | The brand-name story — Staggs at the Illinois State Water Survey in 1953, what makes the hook, and the "a hook is not a tornado" caveat most guides leave out |

Both explainers hand off to `/docs/` rather than duplicating it: the docs are reference, the posts are the thing someone lands on from a search.

## The plumbing

- `blog` collection in `content.config.ts` — `title`, `description`, `date`, optional `image` for the social card.
- `layouts/Post.astro` — date line, lede, optional lede image, prose styles.
- `/blog/` index, `/blog/<slug>/` pages, and `/rss.xml` via `@astrojs/rss` (the one new dependency).
- `Base.astro` gains the Blog nav entry and `<link rel="alternate" type="application/rss+xml">`, so a reader autodiscovers the feed from any page.

All four launch posts share one date, so the index and the feed both sort `date desc` with the id as a stable tiebreak.

## A bug caught in the screenshots

The index rendered every post as **25 Aug 2026**. Frontmatter dates parse as UTC midnight, and `toLocaleDateString` was formatting them in the machine's local zone — anywhere west of Greenwich, every post reads a day early. Both formatters now pass `timeZone: "UTC"`. Verified in the built HTML: `26 Aug 2026` / `26 August 2026`.

## Verified

- `npm run build` — clean, 14 pages.
- `/rss.xml` parses as well-formed XML (`xml.dom.minidom`), with absolute `https://hookecho.io/blog/...` links and RFC-822 `pubDate`s.
- `linkinator` — every internal link resolves; the only failures are the `hookecho.io` / `app.hookecho.io` URLs that don't exist until the W5 DNS step.
- Puppeteer: `/blog/` full page dark, `/blog/what-is-a-hook-echo/` at 1440 light, `/blog/hookecho-0-12-0-beta/` at 390 phone.

Nothing Rust, Android or packaging was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
