### PR TITLE
feat(site): /download + /weatherdesk

### DIFF
--- a/site/src/content/docs/install.md
+++ b/site/src/content/docs/install.md
@@ -5,7 +5,8 @@ order: 2
 ---
 
 Every build comes from the same
-[Releases page](https://github.com/d4vid87/hookecho/releases/latest). Versioned
+[Releases page](https://github.com/d4vid87/hookecho/releases/latest), and
+[the download page](/download/) picks the right one for your machine. Versioned
 `v*` releases are the stable channel; a rolling `latest` prerelease carries the
 newest work if you don't want to wait for a tag.
 

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -12,13 +12,13 @@ const { title, description, image = "/shots/alltilts.jpg" } = Astro.props;
 const url = new URL(Astro.url.pathname, Astro.site);
 const social = new URL(image, Astro.site);
 
-// Wave W4 adds its pages here; a link is only listed once the page exists, so the
-// build's link check stays meaningful.
+// A link is only listed once the page exists, so the build's link check stays meaningful.
 const nav = [
   { href: "/docs/", label: "Docs" },
   { href: "/blog/", label: "Blog" },
+  { href: "/weatherdesk/", label: "WeatherDesk" },
   { href: "https://app.hookecho.io", label: "Open in browser" },
-  { href: "https://github.com/d4vid87/hookecho/releases/latest", label: "Download" },
+  { href: "/download/", label: "Download" },
   { href: "https://github.com/d4vid87/hookecho", label: "GitHub" },
 ];
 ---
@@ -73,7 +73,7 @@ const nav = [
         <p class="dim">
           <a href="https://github.com/d4vid87/hookecho">Source</a> ·
           <a href="https://github.com/d4vid87/hookecho/issues">Report a problem</a> ·
-          <a href="https://github.com/d4vid87/weatherdesk">WeatherDesk</a>
+          <a href="/weatherdesk/">WeatherDesk</a>
         </p>
       </div>
     </footer>

--- a/site/src/pages/download/index.astro
+++ b/site/src/pages/download/index.astro
@@ -1,0 +1,154 @@
+---
+import Base from "../../layouts/Base.astro";
+
+const releases = "https://github.com/d4vid87/hookecho/releases/latest";
+const asset = (name: string) => `${releases}/download/${name}`;
+
+// The `id` values are what the OS sniff below matches on, and the order is the order the grid
+// renders in. Artifact names come from the release workflow — keep them in step with the
+// install docs (src/content/docs/install.md) when a filename changes.
+const platforms = [
+  {
+    id: "windows",
+    name: "Windows",
+    note: "Windows 10 or newer, 64-bit.",
+    links: [
+      { label: "Installer (.exe)", href: asset("HookEcho-setup-x86_64.exe"), primary: true },
+      { label: "MSI package", href: asset("HookEcho-x86_64.msi") },
+      { label: "Portable .zip", href: asset("hookecho-windows-x86_64.zip") },
+    ],
+  },
+  {
+    id: "linux",
+    name: "Linux",
+    note: "AppImage runs anywhere; the .deb adds a menu entry on Debian and Ubuntu.",
+    links: [
+      { label: "AppImage", href: asset("HookEcho-x86_64.AppImage"), primary: true },
+      // The .deb filename carries the version, so it can't be a /latest/download/ link.
+      { label: "Debian package (.deb)", href: releases },
+    ],
+  },
+  {
+    id: "mac",
+    name: "macOS",
+    note: "Experimental: built and smoke-tested in CI, never run on real Apple hardware, and ad-hoc signed — Gatekeeper will ask before it opens.",
+    links: [{ label: "HookEcho-macos.zip", href: asset("HookEcho-macos.zip"), primary: true }],
+  },
+  {
+    id: "android",
+    name: "Android",
+    note: "arm64, Android 10 or newer. Sideload it — enable “install unknown apps” first.",
+    links: [{ label: "APK (arm64-v8a)", href: asset("HookEcho-arm64-v8a.apk"), primary: true }],
+  },
+];
+
+// Nothing is published to a store yet; the badges are here so the page doesn't need rebuilding
+// around them later, greyed until each submission lands.
+const stores = ["Flathub", "Snap Store", "AUR", "Homebrew", "winget"];
+---
+
+<Base
+  title="Download HookEcho"
+  description="Download HookEcho for Windows, macOS, Linux or Android — or open it straight in your browser. Free, open source, no account."
+>
+  <section>
+    <div class="wrap">
+      <h1>Download</h1>
+      <p class="lede">
+        Free and open source, no account, no telemetry. Or skip the download entirely:
+        <a href="https://app.hookecho.io">app.hookecho.io</a> is the whole app running in your
+        browser on live data.
+      </p>
+
+      <p id="pick" class="pick" hidden></p>
+
+      <div class="grid">
+        {platforms.map((p) => (
+          <div class="card platform" id={`p-${p.id}`}>
+            <h2>{p.name}</h2>
+            <p class="note">{p.note}</p>
+            <div class="links">
+              {p.links.map((l) => (
+                <a class:list={["btn", { "btn-primary": l.primary }]} href={l.href}>{l.label}</a>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <p class="dim">
+        Every build comes from the same
+        <a href={releases}>Releases page</a>. Versioned <code>v*</code> releases are the stable
+        channel; a rolling <code>latest</code> prerelease carries the newest work. Trouble
+        installing? <a href="/docs/install/">The install guide</a> walks through each platform.
+      </p>
+
+      <h2 class="stores-head">In the app stores</h2>
+      <p>
+        The Flatpak, Snap, AUR, Homebrew and winget manifests all live in the repo and build
+        today, but nothing is published yet. Until then, grab a build above.
+      </p>
+      <ul class="stores">
+        {stores.map((s) => <li>{s} <span>coming soon</span></li>)}
+      </ul>
+    </div>
+  </section>
+</Base>
+
+<script is:inline>
+  // Progressive enhancement only: without JS the full grid is already on the page, and this
+  // just marks the likely one and says so.
+  // ponytail: the UA string, not navigator.userAgentData — userAgentData is Chromium-only and
+  // needs an async call for anything past the low-entropy platform, and this only has to pick
+  // one of four cards. Order matters: Android's UA says "Linux", iOS says "like Mac OS X".
+  (function () {
+    var ua = navigator.userAgent || "";
+    var os = /android/i.test(ua)
+      ? "android"
+      : /iphone|ipad|ipod/i.test(ua)
+        ? ""
+        : /windows/i.test(ua)
+          ? "windows"
+          : /mac os x|macintosh/i.test(ua)
+            ? "mac"
+            : /linux|x11|cros/i.test(ua)
+              ? "linux"
+              : "";
+    if (!os) return;
+    var card = document.getElementById("p-" + os);
+    if (!card) return;
+    card.classList.add("is-yours");
+    var line = document.getElementById("pick");
+    line.textContent = "Looks like you're on " + card.querySelector("h2").textContent + ".";
+    line.hidden = false;
+  })();
+</script>
+
+<style>
+  .lede { font-size: 1.15rem; color: var(--text-dim); }
+  .pick { color: var(--text); font-weight: 600; }
+  .grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    margin: 1.5rem 0 2rem;
+  }
+  .platform { display: flex; flex-direction: column; }
+  .platform h2 { font-size: 1.2rem; }
+  .platform .note { color: var(--text-dim); font-size: 0.95rem; }
+  .platform.is-yours { border-color: var(--accent); }
+  /* Push the buttons to the bottom so they line up across cards with different note lengths. */
+  .links { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: auto; }
+  .links .btn { padding: 0.55rem 1rem; font-size: 0.95rem; }
+  .dim { color: var(--text-dim); font-size: 0.95rem; }
+  .stores-head { margin-top: 3rem; }
+  .stores { list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.6rem; }
+  .stores li {
+    border: 1px solid var(--stroke);
+    border-radius: 999px;
+    padding: 0.5rem 1rem;
+    color: var(--text-dim);
+    font-size: 0.95rem;
+  }
+  .stores span { opacity: 0.7; font-size: 0.85rem; }
+</style>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -90,7 +90,7 @@ const shots = [
       </p>
       <div class="platforms">
         <a class="btn btn-primary" href="https://app.hookecho.io">Try it in the browser</a>
-        <a class="btn" href="https://github.com/d4vid87/hookecho/releases/latest">
+        <a class="btn" href="/download/">
           Windows · macOS · Linux · Android
         </a>
       </div>
@@ -103,7 +103,7 @@ const shots = [
       <h2>WeatherDesk</h2>
       <Card
         title="Your own weather station, on your own dashboard"
-        href="https://github.com/d4vid87/weatherdesk"
+        href="/weatherdesk/"
       >
         <p>
           A self-hosted dashboard for a Tempest weather station: live gauges, history and

--- a/site/src/pages/weatherdesk/index.astro
+++ b/site/src/pages/weatherdesk/index.astro
@@ -1,0 +1,101 @@
+---
+import Base from "../../layouts/Base.astro";
+
+const repo = "https://github.com/d4vid87/weatherdesk";
+// Screenshots are hotlinked from the weatherdesk repo, pinned to a tag so a later commit there
+// can't change what this page shows — and so several MB of GIF stay out of this repo.
+const shots = "https://raw.githubusercontent.com/d4vid87/weatherdesk/v3.2.0/docs";
+---
+
+<Base
+  title="WeatherDesk — your weather station, on your own dashboard"
+  description="A self-hosted weather dashboard for your own station: Tempest, Ecowitt, Ambient, Davis and more. Vanilla JS, no backend, no accounts — with HookEcho radar inside."
+  image={`${shots}/weatherdeskgauges.png`}
+>
+  <section>
+    <div class="wrap">
+      <p class="eyebrow">More from us</p>
+      <h1>WeatherDesk</h1>
+      <p class="lede">
+        A self-hosted weather dashboard for your own weather station, built for a wall tablet on
+        the LAN. WeatherFlow Tempest, Ecowitt, Ambient Weather, Davis, AcuRite, La Crosse and any
+        Weather Underground console all work — and with no station at all, it runs on the forecast
+        for a place you name.
+      </p>
+      <div class="cta">
+        <a class="btn btn-primary" href={repo}>Get WeatherDesk</a>
+        <a class="btn" href={`${repo}/releases/latest`}>Latest release</a>
+      </div>
+
+      <img
+        src={`${shots}/hero-3.0.5.gif`}
+        alt="A walkthrough: pasting a station token into the first-run wizard, the dashboard filling in with live temperature, day cards and dial gauges, a warning polygon with its text, then the radar zoomed on a storm cell"
+        loading="lazy"
+      />
+    </div>
+  </section>
+
+  <section class="alt">
+    <div class="wrap">
+      <h2>What it does</h2>
+      <div class="grid">
+        <div class="card">
+          <h3>Your station, read properly</h3>
+          <p>
+            Live temperature, wind, rain, pressure, humidity, UV, lightning and dew point on dial
+            gauges, with trends, records and a 7-day history you can chart column by column.
+          </p>
+        </div>
+        <div class="card">
+          <h3>Forecast you can argue with</h3>
+          <p>
+            Day cards, a 48-hour chart, an alert center with the full warning text, and a model
+            agreement panel that puts GFS, ECMWF, ICON and GEM side by side — plus a running log
+            of how well each one did.
+          </p>
+        </div>
+        <div class="card">
+          <h3>Nothing to host</h3>
+          <p>
+            Vanilla JavaScript and native modules: no build step, no framework, no chart library,
+            no backend. Every call goes browser-direct to a free public API.
+          </p>
+        </div>
+      </div>
+
+      <img
+        src={`${shots}/weatherdeskgauges.png`}
+        alt="The full dashboard: sky hero, trend panels, a 48-hour forecast chart, day cards and eight dial gauges"
+        loading="lazy"
+      />
+    </div>
+  </section>
+
+  <section>
+    <div class="wrap">
+      <h2>The radar inside it is HookEcho</h2>
+      <p>
+        WeatherDesk embeds HookEcho for its radar, centered on your station and following it as
+        you move the map. It runs in the viewer's embedded mode on the dashboard — no chrome, one
+        frame a minute until you touch it — and full-chrome in the Forecast Lab tab.
+      </p>
+      <div class="cta">
+        <a class="btn btn-primary" href="/download/">Get HookEcho</a>
+        <a class="btn" href="https://app.hookecho.io">Open it in your browser</a>
+      </div>
+    </div>
+  </section>
+</Base>
+
+<style>
+  .lede { font-size: 1.15rem; color: var(--text-dim); }
+  .alt { background: var(--bg-deep); border-block: 1px solid var(--stroke); }
+  .cta { display: flex; gap: 0.75rem; flex-wrap: wrap; margin: 1.4rem 0 2rem; }
+  .grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    margin: 1.5rem 0 2rem;
+  }
+  img { border: 1px solid var(--stroke); border-radius: var(--radius); display: block; }
+</style>


### PR DESCRIPTION
Wave W4 of the hookecho.io site: the last two pages before deploy.

## /download

Every artifact from the release workflow, grouped by platform, with the one
matching the visitor's OS highlighted and named ("Looks like you're on
Windows."). The detection is progressive enhancement only — the full grid is in
the HTML and the script only adds a border plus a line of text.

It reads the UA string rather than `navigator.userAgentData`: userAgentData is
Chromium-only and needs an async call for anything past the low-entropy
platform, and this only has to pick one of four cards. Order matters —
Android's UA says "Linux", iOS says "like Mac OS X" — so those match first, and
iOS deliberately matches nothing (there is no iOS build). Verified against five
spoofed UAs:

| UA | Result |
|---|---|
| Windows 10 Chrome | Windows |
| macOS Safari | macOS |
| Android Chrome | Android |
| Linux Chrome | Linux |
| iPhone Safari | nothing highlighted |

The `.deb` is the one link pointing at the releases page rather than a direct
`/latest/download/` URL — its filename carries the version, so there's no
stable name. Store badges greyed "coming soon" until the submissions land.

## /weatherdesk

Pitch from its README, the walkthrough GIF and the gauges shot, and a
"the radar inside it is HookEcho" hand-off back to /download and the web app.
Screenshots are hotlinked from the weatherdesk repo pinned to `v3.2.0`, so a
later commit there can't change what this page shows and several MB of GIF stay
out of this repo. All three verified 200.

Nav gains both pages; the landing page's download button, WeatherDesk card and
footer link now point at them instead of GitHub, and the install doc links
/download.

## Verification

- `npm run build` clean, 16 pages.
- `linkinator --recurse` over `dist`: one non-OK URL, `https://app.hookecho.io/`
  — the domain doesn't exist until the W5 DNS step. Everything else resolves.
- Puppeteer full-page captures of both pages at 1440 dark, 1440 light and 390
  phone; UA table above from the same run.

Nothing Rust, Android or packaging is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
