### PR TITLE
chore(site): deploy workflow, analytics, cross-links

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,0 +1,40 @@
+name: Site
+
+# hookecho.io — the marketing/docs site in site/, deployed to its own Pages project. Separate from
+# demo.yml, which deploys the wasm app to the `hookecho` project at app.hookecho.io.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "site/**"
+      - "docs/shots/**"
+      - ".github/workflows/site.yml"
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Cloudflare Pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: site/package-lock.json
+
+      - name: Build
+        working-directory: site
+        # The analytics beacon only renders when the token is set, so a fork's build stays clean.
+        env:
+          PUBLIC_CF_ANALYTICS_TOKEN: ${{ secrets.CF_ANALYTICS_TOKEN }}
+        run: |
+          npm ci
+          npm run build
+
+      - name: Deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx --yes wrangler@3 pages deploy site/dist --project-name=hookecho-site --branch=main

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ with `wgpu` + `egui`. Deep per-site Level 2 / Level 3 analysis plus national
 situational awareness, forecast environment overlays, and warning intelligence —
 on Windows, Linux, and Android.
 
-### **[Try it in your browser →](https://hookecho.pages.dev/)**
+### **[hookecho.io](https://hookecho.io/)** · **[Try it in your browser →](https://app.hookecho.io/)**
 
 The whole app as wasm, on live data, with nothing to install.
 
@@ -675,7 +675,7 @@ it is the one that is always up.
 
 ### In a browser
 
-A hosted build of `main` runs at **<https://hookecho.pages.dev/>** if you only
+A hosted build of `main` runs at **<https://app.hookecho.io/>** if you only
 want to look at it.
 
 The app also builds for wasm and runs on a canvas — the same `HookEchoApp`, not
@@ -733,8 +733,10 @@ looking at, archive time included. The share button in the control column does
 the same thing through the platform's share sheet where there is one.
 
 **Cloudflare Pages** — `web/_worker.js/`, deployed by
-`.github/workflows/demo.yml`. That's what `hookecho.pages.dev` is, and it is the
-only host this repo deploys to.
+`.github/workflows/demo.yml`. That's what `app.hookecho.io` is (`hookecho.pages.dev`
+underneath). The website in `site/` deploys the same way from
+`.github/workflows/site.yml`, to a second Pages project at
+<https://hookecho.io/>.
 
 Any other host works the same way if it can run one small function on
 `/proxy/*`. A purely static host cannot: without the proxy the app opens, and
@@ -780,7 +782,7 @@ The browser build takes the same thing in the URL fragment, which never leaves
 the client — no server sees where you are looking:
 
 ```
-https://hookecho.pages.dev/#goto=KTLX,-97.28,35.33,9,VEL
+https://app.hookecho.io/#goto=KTLX,-97.28,35.33,9,VEL
 ```
 
 "Copy link to this view" in the command palette writes the right form for

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -2,7 +2,7 @@
 
 Task by task: how to actually do the thing you opened the app for. The
 [README](../README.md) is the tour and the feature list; this is the "how do I…"
-The [browser demo](https://hookecho.pages.dev/) runs everything below except the
+The [browser demo](https://app.hookecho.io/) runs everything below except the
 parts that need a filesystem or GPS.
 
 ## Getting oriented

--- a/docs/promotion.md
+++ b/docs/promotion.md
@@ -16,7 +16,8 @@ Everything below then happens on its own:
 | Workflow | Trigger | Does |
 |---|---|---|
 | `release.yml` | tag `v*`, and every push to main | builds AppImage / Windows / macOS / Android / container, attaches them, and uses the CHANGELOG section as the notes |
-| `demo.yml` | push to main | rebuilds and deploys <https://hookecho.pages.dev/>, then smoke-tests it |
+| `demo.yml` | push to main | rebuilds and deploys <https://app.hookecho.io/>, then smoke-tests it |
+| `site.yml` | push to main touching `site/**` | builds and deploys the website, <https://hookecho.io/> |
 | `announce.yml` | tag `v*` | posts to Bluesky, Mastodon, X and Discord, and attaches `announce-drafts.md` to the release |
 | `digest.yml` | Mondays | mentions and metrics into Discord |
 

--- a/packaging/io.hookecho.HookEcho.metainfo.xml
+++ b/packaging/io.hookecho.HookEcho.metainfo.xml
@@ -55,7 +55,7 @@
   </screenshots>
 
   <launchable type="desktop-id">hookecho.desktop</launchable>
-  <url type="homepage">https://github.com/d4vid87/hookecho</url>
+  <url type="homepage">https://hookecho.io</url>
   <url type="bugtracker">https://github.com/d4vid87/hookecho/issues</url>
 
   <provides>

--- a/scripts/announce/post.mjs
+++ b/scripts/announce/post.mjs
@@ -14,7 +14,7 @@ import { createHmac } from "node:crypto";
 import { readFileSync, writeFileSync } from "node:fs";
 
 const REPO = "d4vid87/hookecho";
-const DEMO = "https://hookecho.pages.dev/";
+const DEMO = "https://app.hookecho.io/";
 const tag = process.argv[2];
 const dryRun = process.argv.includes("--dry-run");
 if (!tag) {

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -10,6 +10,10 @@ interface Props {
 
 const { title, description, image = "/shots/alltilts.jpg" } = Astro.props;
 const url = new URL(Astro.url.pathname, Astro.site);
+// Cloudflare Web Analytics: cookieless, one script tag, and only rendered when the token is set —
+// so local builds and forks stay beacon-free. The token is public by design (it identifies the
+// site, not the account); it comes from the CF_ANALYTICS_TOKEN secret in site.yml.
+const analytics = import.meta.env.PUBLIC_CF_ANALYTICS_TOKEN;
 const social = new URL(image, Astro.site);
 
 // A link is only listed once the page exists, so the build's link check stays meaningful.
@@ -48,6 +52,16 @@ const nav = [
     <meta property="og:url" content={url} />
     <meta property="og:image" content={social} />
     <meta name="twitter:card" content="summary_large_image" />
+
+    {
+      analytics && (
+        <script
+          defer
+          src="https://static.cloudflareinsights.com/beacon.min.js"
+          data-cf-beacon={`{"token": "${analytics}"}`}
+        />
+      )
+    }
   </head>
   <body>
     <header class="site-head">


### PR DESCRIPTION
W5 of the hookecho.io plan, and the last site wave: the site now deploys itself, counts visits, and the repo's links point at the new hostnames.

## What's here

**`.github/workflows/site.yml`** — on push to main touching `site/**` (or `docs/shots/**`, which `npm run shots` copies in), `npm ci` + `astro build` + `wrangler pages deploy site/dist --project-name=hookecho-site`. Reuses the `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` secrets `demo.yml` already has.

**Cloudflare Web Analytics** in `Base.astro`, cookieless, one tag — and only rendered when `PUBLIC_CF_ANALYTICS_TOKEN` is set, which the workflow feeds from a `CF_ANALYTICS_TOKEN` secret. No token, no beacon, so local builds and forks stay clean. Verified both ways: `grep cloudflareinsights dist/index.html` is empty on a plain build and shows the token when the env var is set.

**Cross-links** — `README.md` (hero line, "In a browser", the Pages paragraph, the `#goto` example), `docs/GUIDE.md`, `docs/promotion.md` (plus a `site.yml` row in the workflow table) and `scripts/announce/post.mjs` now use `https://app.hookecho.io/`; the metainfo `<url type="homepage">` is `https://hookecho.io` instead of the GitHub repo. `demo.yml`'s smoke tests still hit `hookecho.pages.dev` on purpose — that's the deploy origin and it doesn't wait on DNS.

## Verified

- `npm run build` clean, 16 pages.
- `linkinator dist --recurse`: 64 links, one unique non-OK — `https://app.hookecho.io/`, which doesn't exist until the custom domain is added. Same known gap as W4.
- `./scripts/shots/shoot.sh check` passes (README edits didn't disturb the shots cross-ref).
- No Rust, Android or packaging-build changes; the metainfo edit is one URL.

## Your steps, then it goes live

1. Point `hookecho.io` nameservers at Cloudflare.
2. Create the Pages project `hookecho-site`; add custom domains `hookecho.io` + `www` to it, and `app.hookecho.io` to the existing `hookecho` project.
3. Enable Web Analytics for `hookecho.io` and put the token in the `CF_ANALYTICS_TOKEN` repo secret.

Until step 2 the deploy job fails on the missing project — merging before or after the dashboard work both work, it just needs one re-run either way.

Still open from the plan: the separate weatherdesk-repo PR ("Hook Echo-WX" → HookEcho + hookecho.io link), and the Flathub submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
