### PR TITLE
chore(site): redirect www to the apex

### DIFF
--- a/site/public/_redirects
+++ b/site/public/_redirects
@@ -1,0 +1,4 @@
+# Cloudflare Pages redirects. Both hookecho.io and www.hookecho.io point at this project, so the
+# www copy is redirected here rather than in a dashboard rule — one less thing living outside git.
+# A rule with a scheme+host matches on the full URL; the 301! forces it ahead of the static asset.
+https://www.hookecho.io/* https://hookecho.io/:splat 301!


### PR DESCRIPTION
`site/public/_redirects` with one rule: `https://www.hookecho.io/*` → `https://hookecho.io/:splat`, 301.

Both hostnames are custom domains on the `hookecho-site` Pages project, so today the site answers on both and gets indexed twice. Pages matches a redirect rule that carries a scheme and host against the full URL, which means this can live in git rather than as a dashboard Redirect Rule.

Verified `npm run build` emits `dist/_redirects` verbatim; the live check is a 301 from www after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)