### PR TITLE
fix(site): www redirect needs a worker, not _redirects

### DIFF
--- a/site/public/_redirects
+++ b/site/public/_redirects
@@ -1,4 +1,0 @@
-# Cloudflare Pages redirects. Both hookecho.io and www.hookecho.io point at this project, so the
-# www copy is redirected here rather than in a dashboard rule — one less thing living outside git.
-# A rule with a scheme+host matches on the full URL; the 301! forces it ahead of the static asset.
-https://www.hookecho.io/* https://hookecho.io/:splat 301!

--- a/site/public/_worker.js
+++ b/site/public/_worker.js
@@ -1,0 +1,15 @@
+// Advanced-mode Pages worker: the only reason it exists is the www redirect. Both hookecho.io and
+// www.hookecho.io are custom domains on this project, so without this the site answers on two
+// names and gets indexed twice.
+// ponytail: a _redirects rule cannot do this — Pages matches those on the path only, hostnames are
+// a Netlify feature. Everything that is not www falls straight through to the static assets.
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    if (url.hostname.startsWith("www.")) {
+      url.hostname = url.hostname.slice(4);
+      return Response.redirect(url.toString(), 301);
+    }
+    return env.ASSETS.fetch(request);
+  },
+};


### PR DESCRIPTION
#141 didn't work. Pages matches `_redirects` rules on the **path**; a rule carrying a scheme and host is Netlify syntax and Cloudflare ignores it. Caught on the live deployment after the merge: `https://www.hookecho.io/docs/` answered 200 rather than a 301.

Replaced with an advanced-mode `_worker.js` — redirect any `www.` hostname to the apex, 301, and hand everything else to `env.ASSETS`. Same shape as `web/_worker.js` on the app project.

Build emits `dist/_worker.js` and no longer emits `_redirects`. Live 301 check after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)