### PR TITLE
feat(site): visual system + landing redesign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ announce-drafts.md
 /.fpbuild/
 /.fpstate/
 /.fprepo/
+
+# wrangler dev scratch
+site/.wrangler/

--- a/site/public/_worker.js
+++ b/site/public/_worker.js
@@ -1,14 +1,26 @@
-// Advanced-mode Pages worker: the only reason it exists is the www redirect. Both hookecho.io and
-// www.hookecho.io are custom domains on this project, so without this the site answers on two
-// names and gets indexed twice.
-// ponytail: a _redirects rule cannot do this — Pages matches those on the path only, hostnames are
-// a Netlify feature. Everything that is not www falls straight through to the static assets.
+// Advanced-mode Pages worker. Two jobs: the www redirect, and a /geo.json that hands the page the
+// visitor's rough location so the landing page can say which radar is nearest without asking the
+// browser for a permission the visitor has no reason to grant yet.
+// ponytail: a _redirects rule cannot do the redirect — Pages matches those on the path only,
+// hostnames are a Netlify feature. Everything else falls straight through to the static assets.
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
     if (url.hostname.startsWith("www.")) {
       url.hostname = url.hostname.slice(4);
       return Response.redirect(url.toString(), 301);
+    }
+    // Same shape as the app's own /geo.json (web/_worker.js/index.js), plus the city name the
+    // chip prints. Free and exact enough: request.cf is the edge's own geo-IP lookup.
+    if (url.pathname === "/geo.json") {
+      const { latitude, longitude, city } = request.cf ?? {};
+      const body =
+        latitude && longitude
+          ? JSON.stringify({ lon: +longitude, lat: +latitude, city: city ?? null })
+          : "null";
+      return new Response(body, {
+        headers: { "content-type": "application/json", "cache-control": "private, no-store" },
+      });
     }
     return env.ASSETS.fetch(request);
   },

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -4,42 +4,132 @@ interface Props {
   tagline: string;
 }
 const { title, tagline } = Astro.props;
+
+// The live app is a whole wasm radar viewer — several MB and a pile of feed requests. Loading it
+// on every landing-page visit would be rude, so the hero shows a still until someone asks for it.
+// `?embed` is the app's chrome-free mode (crates/hookecho/src/app.rs, `is_embed`), and the app
+// geo-IP-centers itself from its own /geo.json, so no coordinates need passing here.
+const appEmbed = "https://app.hookecho.io/?embed";
 ---
 
 <section class="hero">
+  <span class="sweep" aria-hidden="true"></span>
   <div class="wrap">
     <h1>{title}</h1>
     <p class="tagline">{tagline}</p>
     <div class="ctas">
       <a class="btn btn-primary" href="https://app.hookecho.io">Open in your browser</a>
-      <a class="btn" href="https://github.com/d4vid87/hookecho/releases/latest">Download the app</a>
+      <a class="btn" href="/download/">Download the app</a>
     </div>
     <p class="fineprint">Free, open source, no account. Windows, macOS, Linux and Android.</p>
-    <img
-      class="shot"
-      src="/shots/hero.gif"
-      alt="A radar loop animating over an interactive map, with warnings and storm cells drawn on top"
-      width="1600"
-      height="1000"
-    />
+
+    <div class="stage" data-embed={appEmbed}>
+      <img
+        class="poster"
+        src="/shots/reflectivity.jpg"
+        alt="A radar loop over an interactive map, with warnings and storm cells drawn on top"
+        width="1600"
+        height="1000"
+      />
+      <!-- Only rendered by the script below, so the no-JS experience is the poster plus the CTAs
+           above rather than a dead button. -->
+      <noscript><p class="fineprint">Open the radar in your browser from the button above.</p></noscript>
+    </div>
   </div>
 </section>
 
+<script>
+  const stage = document.querySelector<HTMLElement>(".hero .stage");
+  const src = stage?.dataset.embed;
+  if (stage && src) {
+    const play = document.createElement("button");
+    play.type = "button";
+    play.className = "play";
+    play.innerHTML = '<span class="dot" aria-hidden="true"></span> Load the live radar';
+    play.addEventListener(
+      "click",
+      () => {
+        const frame = document.createElement("iframe");
+        frame.src = src;
+        frame.title = "HookEcho live radar";
+        frame.loading = "lazy";
+        frame.allow = "geolocation";
+        stage.replaceChildren(frame);
+      },
+      { once: true },
+    );
+    stage.append(play);
+  }
+</script>
+
 <style>
-  .hero { padding-top: clamp(2.5rem, 7vw, 4.5rem); }
+  .hero { position: relative; overflow: hidden; padding-top: clamp(2.5rem, 7vw, 4.5rem); }
+  .hero .wrap { position: relative; }
+  .hero::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: var(--glow);
+    pointer-events: none;
+  }
   .tagline {
-    font-size: clamp(1.05rem, 2.4vw, 1.3rem);
+    font-size: clamp(1.05rem, 2.4vw, 1.35rem);
     color: var(--text-dim);
     max-width: 46ch;
   }
   .ctas { display: flex; gap: 0.75rem; flex-wrap: wrap; margin: 1.6rem 0 0.8rem; }
   .fineprint { color: var(--text-dim); font-size: 0.9rem; }
-  .shot {
-    display: block;
+
+  .stage {
+    position: relative;
     margin-top: 2.2rem;
-    width: 100%;
+    aspect-ratio: 16 / 10;
     border: 1px solid var(--stroke);
     border-radius: var(--radius);
+    overflow: hidden;
     box-shadow: 0 24px 60px rgb(0 0 0 / 0.35);
   }
+  .stage :global(img),
+  .stage :global(iframe) {
+    display: block;
+    width: 100%;
+    height: 100%;
+    border: 0;
+    object-fit: cover;
+  }
+  .stage :global(.play) {
+    position: absolute;
+    inset-inline: 0;
+    bottom: 1.2rem;
+    margin-inline: auto;
+    width: fit-content;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0.75rem 1.4rem;
+    border-radius: 999px;
+    border: 1px solid var(--accent);
+    background: color-mix(in srgb, var(--bg) 78%, transparent);
+    backdrop-filter: blur(8px);
+    color: var(--text);
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform var(--dur) var(--spring), box-shadow var(--dur) ease;
+  }
+  .stage :global(.play:hover) {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 30px color-mix(in srgb, var(--accent) 30%, transparent);
+  }
+  .stage :global(.dot) {
+    width: 0.6rem;
+    height: 0.6rem;
+    border-radius: 50%;
+    background: var(--accent);
+    animation: pulse 1.8s ease-in-out infinite;
+  }
+  @keyframes pulse {
+    50% { opacity: 0.25; transform: scale(0.7); }
+  }
+  .stage noscript { position: absolute; bottom: 0.4rem; inset-inline: 0; text-align: center; }
 </style>

--- a/site/src/components/LiveMosaic.astro
+++ b/site/src/components/LiveMosaic.astro
@@ -1,0 +1,41 @@
+---
+// The national mosaic, hotlinked live from the NWS's own RIDGE image server and re-fetched on a
+// timer. It is the cheapest possible proof that the page is looking at real weather right now.
+// ponytail: a cache-busting query on an <img> is the whole refresh mechanism — no canvas, no
+// preloading, no fade. The server updates roughly every 10 minutes; we ask every 5.
+const src = "https://radar.weather.gov/ridge/standard/CONUS_0.gif";
+const everyMs = 5 * 60 * 1000;
+---
+
+<figure class="mosaic" data-src={src} data-every={everyMs}>
+  <img src={src} alt="The national radar mosaic across the United States, updated live" />
+  <figcaption>
+    Live national mosaic, straight from the NWS. HookEcho draws this from MRMS at full resolution.
+  </figcaption>
+</figure>
+
+<script>
+  const fig = document.querySelector<HTMLElement>(".mosaic");
+  const img = fig?.querySelector("img");
+  const src = fig?.dataset.src;
+  const every = Number(fig?.dataset.every ?? 0);
+  if (img && src && every > 0) {
+    setInterval(() => {
+      // Only while the tab is visible: a backgrounded tab refreshing a national radar image all
+      // day is exactly the kind of thing that gets a hotlink blocked.
+      if (document.visibilityState === "visible") img.src = `${src}?t=${Date.now()}`;
+    }, every);
+  }
+</script>
+
+<style>
+  .mosaic { margin: 0; }
+  .mosaic img {
+    display: block;
+    width: 100%;
+    border: 1px solid var(--stroke);
+    border-radius: var(--radius);
+    background: var(--bg-deep);
+  }
+  figcaption { color: var(--text-dim); font-size: 0.9rem; margin-top: 0.7rem; }
+</style>

--- a/site/src/components/NearYou.astro
+++ b/site/src/components/NearYou.astro
@@ -1,0 +1,43 @@
+---
+// "Open radar near Norman" — the city comes from the edge's own geo-IP (site/public/_worker.js
+// serves /geo.json from request.cf), so the page can be specific without a permission prompt.
+// The app does its own identical lookup on load, so no coordinates need handing over.
+---
+
+<a class="near" href="https://app.hookecho.io">
+  <span class="pin" aria-hidden="true">◎</span>
+  <span class="text">Open the radar<span class="where"></span></span>
+</a>
+
+<script>
+  fetch("/geo.json")
+    .then((r) => (r.ok ? r.json() : null))
+    .then((geo) => {
+      if (!geo?.city) return;
+      const where = document.querySelector(".near .where");
+      if (where) where.textContent = ` near ${geo.city}`;
+    })
+    // No city, no worry: the link still reads "Open the radar" and still works.
+    .catch(() => {});
+</script>
+
+<style>
+  .near {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.75rem 1.4rem;
+    border-radius: 999px;
+    border: 1px solid var(--accent);
+    background: color-mix(in srgb, var(--accent) 12%, transparent);
+    color: var(--text);
+    font-weight: 600;
+    text-decoration: none;
+    transition: transform var(--dur) var(--spring), box-shadow var(--dur) ease;
+  }
+  .near:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 30px color-mix(in srgb, var(--accent) 28%, transparent);
+  }
+  .pin { color: var(--accent); }
+</style>

--- a/site/src/components/Ticker.astro
+++ b/site/src/components/Ticker.astro
@@ -1,0 +1,61 @@
+---
+// Live warning counts, straight from the NWS API in the visitor's own browser — no backend, no
+// key, no build-time snapshot that goes stale. CORS is open on api.weather.gov and every response
+// is public data, so the whole thing is a fetch and a number.
+// ponytail: the GeoJSON carries polygons we throw away (~3 KB per alert), because the lighter
+// ld+json needs an Accept header and the API's preflight only allows API-Key and User-Agent.
+const events = ["Tornado Warning", "Severe Thunderstorm Warning", "Flash Flood Warning"];
+---
+
+<a class="ticker" href="https://app.hookecho.io" data-events={JSON.stringify(events)}>
+  {
+    events.map((event) => (
+      <span class="item" data-event={event}>
+        <span class="count">—</span>
+        <span class="label">{event.replace(" Warning", "")}</span>
+      </span>
+    ))
+  }
+  <span class="cta">See them on the map</span>
+</a>
+
+<script>
+  const ticker = document.querySelector<HTMLElement>(".ticker");
+  const events: string[] = JSON.parse(ticker?.dataset.events ?? "[]");
+  for (const event of events) {
+    const slot = ticker?.querySelector(`[data-event="${event}"] .count`);
+    if (!slot) continue;
+    fetch(`https://api.weather.gov/alerts/active?event=${encodeURIComponent(event)}`)
+      .then((r) => (r.ok ? r.json() : Promise.reject(r.status)))
+      .then((d) => {
+        const n = d?.features?.length ?? 0;
+        slot.textContent = String(n);
+        slot.parentElement?.classList.toggle("hot", n > 0);
+      })
+      // A blocked or failing fetch leaves the em dash: the row still reads as a list of the
+      // warning types the app tracks, which is the point of it being on the page.
+      .catch(() => {});
+  }
+</script>
+
+<style>
+  .ticker {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+    padding: 0.85rem 1.2rem;
+    border: 1px solid var(--stroke);
+    border-radius: 999px;
+    background: var(--faint);
+    color: var(--text);
+    text-decoration: none;
+    transition: border-color var(--dur) ease, transform var(--dur) var(--spring);
+  }
+  .ticker:hover { border-color: var(--accent); transform: translateY(-2px); }
+  .item { display: inline-flex; align-items: baseline; gap: 0.45rem; }
+  .count { font-size: 1.35rem; font-weight: 700; font-variant-numeric: tabular-nums; }
+  .item.hot .count { color: var(--accent); }
+  .label { color: var(--text-dim); font-size: 0.9rem; }
+  .cta { margin-left: auto; color: var(--accent); font-size: 0.9rem; font-weight: 600; }
+</style>

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -87,7 +87,8 @@ const nav = [
         <p class="dim">
           <a href="https://github.com/d4vid87/hookecho">Source</a> ·
           <a href="https://github.com/d4vid87/hookecho/issues">Report a problem</a> ·
-          <a href="/weatherdesk/">WeatherDesk</a>
+          <a href="/weatherdesk/">WeatherDesk</a> ·
+          <a href="https://github.com/d4vid87/weatherdesk">WeatherDesk source</a>
         </p>
       </div>
     </footer>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -3,6 +3,9 @@ import Base from "../layouts/Base.astro";
 import Hero from "../components/Hero.astro";
 import FeatureGrid from "../components/FeatureGrid.astro";
 import ShotGallery from "../components/ShotGallery.astro";
+import Ticker from "../components/Ticker.astro";
+import NearYou from "../components/NearYou.astro";
+import LiveMosaic from "../components/LiveMosaic.astro";
 import Card from "../components/Card.astro";
 
 // The three tiers are the same progressive-disclosure story the app itself tells: the first
@@ -33,11 +36,6 @@ const tiers = [
 
 const shots = [
   {
-    src: "/shots/mosaic.jpg",
-    alt: "The national MRMS radar mosaic over the United States",
-    caption: "The whole country at once, from the MRMS mosaic.",
-  },
-  {
     src: "/shots/alerts.jpg",
     alt: "Warning polygons, storm reports and spotter positions on the map",
     caption: "Warnings, storm reports and spotters, live.",
@@ -48,11 +46,18 @@ const shots = [
     caption: "Every tilt of the volume, side by side.",
   },
   {
+    src: "/shots/velocity.jpg",
+    alt: "Storm-relative velocity showing a rotation couplet in a supercell",
+    caption: "Velocity and dual-pol, dealiased.",
+  },
+  {
     src: "/shots/hrrr.jpg",
     alt: "HRRR model fields drawn over the map with severe composite parameters",
     caption: "HRRR and NAM fields, with the severe parameters.",
   },
 ];
+
+const weatherdeskRepo = "https://github.com/d4vid87/weatherdesk";
 ---
 
 <Base
@@ -63,6 +68,25 @@ const shots = [
     title="Weather radar for everyone"
     tagline="Live NEXRAD radar, warnings and storm tracking — straight from the public NOAA feeds to your own machine."
   />
+
+  <section class="live">
+    <div class="wrap">
+      <p class="eyebrow">Right now</p>
+      <Ticker />
+      <div class="live-grid">
+        <div>
+          <h2>The weather on this page is real</h2>
+          <p>
+            Those counts are live warnings from the National Weather Service, and the mosaic
+            beside them is the current national radar picture. HookEcho reads the same feeds —
+            at full resolution, from your own machine, with nothing in between.
+          </p>
+          <NearYou />
+        </div>
+        <LiveMosaic />
+      </div>
+    </div>
+  </section>
 
   <section>
     <div class="wrap">
@@ -101,13 +125,15 @@ const shots = [
     <div class="wrap">
       <p class="eyebrow">More from us</p>
       <h2>WeatherDesk</h2>
-      <Card
-        title="Your own weather station, on your own dashboard"
-        href="/weatherdesk/"
-      >
+      <!-- No href on the Card: it would wrap the whole thing in an <a>, and the two links below
+           cannot live inside one. -->
+      <Card title="Your own weather station, on your own dashboard">
         <p>
           A self-hosted dashboard for a Tempest weather station: live gauges, history and
           forecasts on your own hardware. The radar inside it is HookEcho.
+        </p>
+        <p class="wd-links">
+          <a href="/weatherdesk/">What it does</a> · <a href={weatherdeskRepo}>Source on GitHub</a>
         </p>
       </Card>
     </div>
@@ -117,4 +143,12 @@ const shots = [
 <style>
   .alt { background: var(--bg-deep); border-block: 1px solid var(--stroke); }
   .platforms { display: flex; gap: 0.75rem; flex-wrap: wrap; margin-top: 1.4rem; }
+  .live { padding-top: clamp(2rem, 5vw, 3rem); }
+  .live-grid {
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    align-items: center;
+    margin-top: 2.2rem;
+  }
 </style>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -26,6 +26,11 @@
   --radius: 12px;
   --measure: 68ch;
   --page: 1120px;
+  /* Motion + glow, matching the app's playful pass (crates/hookecho/src/ui/m3.rs DUR_*).
+     Every use goes through these so the prefers-reduced-motion block below is the one switch. */
+  --dur: 220ms;
+  --spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --glow: radial-gradient(60% 50% at 50% 0%, color-mix(in srgb, var(--accent) 22%, transparent), transparent 70%);
   color-scheme: dark;
 }
 
@@ -52,6 +57,7 @@ html { scroll-behavior: smooth; }
 @media (prefers-reduced-motion: reduce) {
   html { scroll-behavior: auto; }
   * { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; }
+  .sweep { display: none; }
 }
 
 body {
@@ -65,8 +71,8 @@ body {
 }
 
 h1, h2, h3 { line-height: 1.15; letter-spacing: -0.02em; margin: 0 0 0.4em; }
-h1 { font-size: clamp(2.2rem, 6vw, 3.6rem); font-weight: 700; }
-h2 { font-size: clamp(1.6rem, 3.5vw, 2.2rem); font-weight: 600; }
+h1 { font-size: clamp(2.5rem, 7vw, 4.2rem); font-weight: 700; }
+h2 { font-size: clamp(1.75rem, 4vw, 2.6rem); font-weight: 700; }
 h3 { font-size: 1.15rem; font-weight: 600; }
 p { margin: 0 0 1em; max-width: var(--measure); }
 
@@ -99,9 +105,14 @@ section { padding: clamp(3rem, 8vw, 5.5rem) 0; }
   color: var(--text);
   font-weight: 600;
   text-decoration: none;
-  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+  transition: transform var(--dur) var(--spring), background var(--dur) ease,
+    border-color var(--dur) ease, box-shadow var(--dur) ease;
 }
-.btn:hover { transform: translateY(-1px); border-color: var(--accent); }
+.btn:hover {
+  transform: translateY(-2px);
+  border-color: var(--accent);
+  box-shadow: 0 8px 24px color-mix(in srgb, var(--accent) 24%, transparent);
+}
 .btn-primary {
   background: var(--accent);
   border-color: var(--accent);
@@ -113,4 +124,27 @@ section { padding: clamp(3rem, 8vw, 5.5rem) 0; }
   border: 1px solid var(--stroke);
   border-radius: var(--radius);
   padding: 1.4rem;
+  transition: transform var(--dur) var(--spring), border-color var(--dur) ease;
+}
+.card:hover { transform: translateY(-3px); border-color: var(--accent); }
+
+/* The radar-sweep accent: one conic gradient rotating behind a section, echoing the app's
+   intro sweep. Decorative only — aria-hidden at every call site. */
+.sweep {
+  position: absolute;
+  inset: -30% -10% auto -10%;
+  aspect-ratio: 1;
+  pointer-events: none;
+  border-radius: 50%;
+  background: conic-gradient(
+    from 0deg,
+    color-mix(in srgb, var(--accent) 20%, transparent),
+    transparent 28%
+  );
+  mask-image: radial-gradient(closest-side, #000 40%, transparent 72%);
+  animation: sweep 7s linear infinite;
+  opacity: 0.55;
+}
+@keyframes sweep {
+  to { transform: rotate(1turn); }
 }


### PR DESCRIPTION
Wave R1 of the site redesign. **Stacked on #142** — it extends the same `site/public/_worker.js`, so that one merges first.

The landing page claimed HookEcho reads live feeds and then showed four static screenshots. Now the page itself is looking at the weather.

- **Hero**: the 1.9 MB autoplaying GIF becomes a still with a *Load the live radar* button that swaps in `app.hookecho.io/?embed` on click. The app geo-IP-centers itself, so no coordinates change hands.
- **Three live elements**, browser-direct, no backend: live warning counts from `api.weather.gov`, an "Open the radar near {city}" chip, and the NWS national mosaic refreshed every five minutes (only while the tab is visible). Each falls back to something readable with JS off or the fetch blocked.
- **`/geo.json`** added to the site worker — same shape the app serves itself from `request.cf`, plus the city name.
- **Visual system**: motion/spring/glow tokens, a radar-sweep accent, bolder type scale, springy hovers. Everything routes through the existing `prefers-reduced-motion` switch, which now also hides the sweep outright.
- **WeatherDesk repo** linked directly from the landing card and the footer.

Features and Compare land in R2/R3, and their nav entries land with them so the link check stays meaningful.

## Verification

- `npm run build` clean; `npx linkinator dist --recurse` — 66 links, zero broken.
- `wrangler pages dev dist`: `/geo.json` returns `{"lon":-87.65,"lat":41.85,"city":"Chicago"}`, and `Host: www.hookecho.io` still 301s to the apex.
- Headless render against that server: counts read 0 Tornado / 10 Severe Thunderstorm / 1 Flash Flood, the chip reads "Open the radar near Chicago", and the mosaic carries a timestamp from a few minutes ago.

🤖 Generated with [Claude Code](https://claude.com/claude-code)