### PR TITLE
feat(site): a features page

### DIFF
--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -18,6 +18,7 @@ const social = new URL(image, Astro.site);
 
 // A link is only listed once the page exists, so the build's link check stays meaningful.
 const nav = [
+  { href: "/features/", label: "Features" },
   { href: "/docs/", label: "Docs" },
   { href: "/blog/", label: "Blog" },
   { href: "/weatherdesk/", label: "WeatherDesk" },

--- a/site/src/pages/features/index.astro
+++ b/site/src/pages/features/index.astro
@@ -1,0 +1,201 @@
+---
+import Base from "../../layouts/Base.astro";
+
+// Screenshots come straight from the repo at a tag, so GitHub carries the bytes and a later
+// commit on main cannot change what this page shows. Bump the tag when a release reshoots.
+const shots = "https://raw.githubusercontent.com/d4vid87/hookecho/v0.12.0-beta.1/docs/shots";
+
+// Every section opens the real app on the thing it just described. The link vocabulary is the
+// app's own #goto grammar (crates/hookecho/src/app.rs, `parse_goto`):
+// SITE,lon,lat,zoom[,product|tilt|RFC3339|bm:slug|thr:n|srv]. KTLX is Oklahoma City — the site
+// with the most storms to point at.
+const app = "https://app.hookecho.io";
+const ktlx = (extra = "") => `${app}/#goto=KTLX,-97.28,35.33,8${extra}`;
+
+const sections = [
+  {
+    id: "radar",
+    eyebrow: "Level 2, every tilt",
+    title: "The volume, not a picture of it",
+    body:
+      "HookEcho decodes the raw Level 2 volume from the radar itself: every elevation angle in " +
+      "the scan, at full range and full gate resolution, not a pre-rendered image of the lowest " +
+      "tilt. Step up through the tilts to see how a storm leans, or put four of them on screen " +
+      "at once.",
+    shot: "alltilts.jpg",
+    alt: "Four elevation angles of the same storm shown side by side",
+    link: { href: ktlx(), label: "Open the radar" },
+  },
+  {
+    id: "velocity",
+    eyebrow: "Velocity and dual-pol",
+    title: "Rotation, debris and hail, called by name",
+    body:
+      "Velocity with dealiasing and a storm-relative view for spotting couplets, plus the full " +
+      "dual-polarization set — ZDR, CC, KDP and differential phase — which is how a debris ball " +
+      "and a hail core stop looking like the same red blob.",
+    shot: "velocity.jpg",
+    alt: "Storm-relative velocity showing a tight rotation couplet in a supercell",
+    link: { href: ktlx(",VEL,srv"), label: "Open storm-relative velocity" },
+  },
+  {
+    id: "mosaic",
+    eyebrow: "The whole country",
+    title: "MRMS mosaic, rotation tracks and hail",
+    body:
+      "The national MRMS mosaic at full resolution, with the derived grids that come with it: " +
+      "rotation tracks showing where a mesocyclone has been, MESH hail size, and QPE rainfall " +
+      "totals for the flooding question.",
+    shot: "mosaic.jpg",
+    alt: "The national MRMS radar mosaic across the United States",
+    link: { href: ktlx(), label: "See the mosaic" },
+  },
+  {
+    id: "alerts",
+    eyebrow: "Warnings and alerts",
+    title: "Every warning polygon, and a phone that tells you",
+    body:
+      "Live watches and warnings with their full text, storm reports as they come in, and " +
+      "spotter positions — drawn on the map rather than buried in a list. Set a rule for your " +
+      "own location and the app tells you when a polygon covers it.",
+    shot: "alerts.jpg",
+    alt: "Warning polygons, storm reports and spotter positions drawn over the map",
+    link: { href: "/docs/alerts-and-notifications/", label: "How alerts work" },
+  },
+  {
+    id: "storms",
+    eyebrow: "Storm interrogation",
+    title: "Cells ranked by how dangerous they look",
+    body:
+      "Every cell in view, sorted by a severity score built from ProbSevere, rotational velocity " +
+      "and hail size, so the one worth watching is at the top. Click one for its history, or cut " +
+      "a vertical cross-section straight through it to find the overhang and the BWER.",
+    shot: "xsection.jpg",
+    alt: "A vertical cross-section cut through a storm, showing the reflectivity structure aloft",
+    link: { href: ktlx(), label: "Interrogate a storm" },
+  },
+  {
+    id: "models",
+    eyebrow: "Models and soundings",
+    title: "HRRR, NAM and the severe parameters",
+    body:
+      "Model fields drawn over the same map as the radar, with Skew-T soundings and the severe " +
+      "composite parameters — CAPE, shear, STP, helicity — so the forecast and the radar are one " +
+      "screen instead of two tabs.",
+    shot: "hrrr.jpg",
+    alt: "HRRR model fields over the map alongside severe composite parameters",
+    link: { href: ktlx(), label: "Open the models" },
+  },
+  {
+    id: "tropical",
+    eyebrow: "Tropical",
+    title: "NHC tracks, cones and advisories",
+    body:
+      "Hurricane forecast tracks and cones from the National Hurricane Center, with the advisory " +
+      "text alongside, over the same radar you use for everything else.",
+    shot: "tropical.jpg",
+    alt: "A hurricane forecast cone and track drawn over the map with advisory text alongside",
+    link: { href: app, label: "Open the app" },
+  },
+  {
+    id: "archive",
+    eyebrow: "Archive and offline",
+    title: "Any storm since 1991, and no signal required",
+    body:
+      "Scrub back through the NOAA archive to any volume since 1991 and replay an event with its " +
+      "warnings and reports time-synced. Or build an offline chase pack ahead of time, for the " +
+      "part of the day when the data connection is the thing that fails.",
+    shot: "verify.jpg",
+    alt: "Archive playback with historical warnings and reports replayed alongside the radar",
+    link: { href: "/docs/getting-started/", label: "Getting started" },
+  },
+];
+---
+
+<Base
+  title="Features — HookEcho"
+  description="Level 2 radar at every tilt, velocity and dual-pol, the MRMS mosaic, warnings, storm interrogation, HRRR and NAM, tropical tracks and archive playback to 1991 — free and open source."
+>
+  <section class="head">
+    <span class="sweep" aria-hidden="true"></span>
+    <div class="wrap">
+      <p class="eyebrow">Features</p>
+      <h1>Everything, from the source</h1>
+      <p class="lede">
+        HookEcho talks straight to the public NOAA, NWS and MRMS feeds from your own machine. No
+        account, no subscription tier holding a product back, no telemetry. Here is what that gets
+        you — each section opens the real app on the thing it describes.
+      </p>
+      <nav class="jump" aria-label="Sections">
+        {sections.map((s) => <a href={`#${s.id}`}>{s.eyebrow}</a>)}
+      </nav>
+    </div>
+  </section>
+
+  {
+    sections.map((s, i) => (
+      <section class={i % 2 ? "alt" : ""} id={s.id}>
+        <div class="wrap row">
+          <div class="copy">
+            <p class="eyebrow">{s.eyebrow}</p>
+            <h2>{s.title}</h2>
+            <p>{s.body}</p>
+            <a class="btn" href={s.link.href}>
+              {s.link.label}
+            </a>
+          </div>
+          <img src={`${shots}/${s.shot}`} alt={s.alt} loading="lazy" />
+        </div>
+      </section>
+    ))
+  }
+
+  <section>
+    <div class="wrap">
+      <h2>Try it before you download anything</h2>
+      <p>The browser version is the whole app, on live data, with nothing to install.</p>
+      <div class="ctas">
+        <a class="btn btn-primary" href={app}>Open it in your browser</a>
+        <a class="btn" href="/download/">Download the app</a>
+      </div>
+    </div>
+  </section>
+</Base>
+
+<style>
+  .head { position: relative; overflow: hidden; }
+  .head .wrap { position: relative; }
+  .lede { font-size: 1.15rem; color: var(--text-dim); }
+  .alt { background: var(--bg-deep); border-block: 1px solid var(--stroke); }
+
+  .jump { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-top: 1.6rem; }
+  .jump a {
+    padding: 0.4rem 0.9rem;
+    border: 1px solid var(--stroke);
+    border-radius: 999px;
+    color: var(--text-dim);
+    text-decoration: none;
+    font-size: 0.85rem;
+    transition: border-color var(--dur) ease, color var(--dur) ease;
+  }
+  .jump a:hover { border-color: var(--accent); color: var(--text); }
+
+  /* Anchored sections land under the sticky header without this. */
+  section[id] { scroll-margin-top: 4.5rem; }
+
+  .row {
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    align-items: center;
+  }
+  .row img {
+    border: 1px solid var(--stroke);
+    border-radius: var(--radius);
+    display: block;
+    box-shadow: 0 18px 44px rgb(0 0 0 / 0.3);
+  }
+  /* Alternate which side the shot sits on, so eight sections do not read as one long column. */
+  .alt .row .copy { order: 2; }
+  .ctas { display: flex; gap: 0.75rem; flex-wrap: wrap; margin-top: 1.4rem; }
+</style>


### PR DESCRIPTION
Wave R2 of the site redesign. **Stacked on #143.**

One `/features` page with eight anchored sections instead of a page per feature: Level 2 tilts, velocity and dual-pol, the MRMS mosaic, warnings, storm interrogation, models and soundings, tropical, archive and offline.

- Each section ends in a link that **opens the real app on what it just described**, built from the app's own `#goto` grammar (`parse_goto`, `crates/hookecho/src/app.rs`). "Open storm-relative velocity" is `#goto=KTLX,-97.28,35.33,8,VEL,srv`.
- Screenshots are **hotlinked from `raw.githubusercontent.com` pinned to `v0.12.0-beta.1`** — GitHub's bandwidth, and a later commit on `main` cannot change what the page shows. The pin needs bumping when a release reshoots.
- Sections alternate which side the shot sits on, so eight of them do not read as one long column.
- The Features nav entry lands with the page, per the rule in `Base.astro` that keeps the link check meaningful.

## Verification

- `npm run build` clean; `npx linkinator dist --recurse` — 76 links, zero broken, the pinned raw URLs among them.
- Headless render of the built page: every hotlinked shot loads, the jump chips and alternating layout hold up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)