### PR TITLE
chore(site): serve the screenshots from GitHub

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -2,11 +2,12 @@
   "name": "hookecho-site",
   "private": true,
   "type": "module",
+  "_comment": "shots copies only the four images this site serves itself -- the hero poster and the social cards. Every other screenshot is hotlinked from the repo at a tag, so GitHub carries the bandwidth. Social cards have to be same-origin: scrapers do not follow hotlinks reliably.",
   "scripts": {
     "dev": "npm run shots && astro dev",
     "build": "npm run shots && astro build",
     "preview": "astro preview",
-    "shots": "mkdir -p public/shots && cp ../docs/shots/*.jpg ../docs/shots/*.gif public/shots/"
+    "shots": "mkdir -p public/shots && cp ../docs/shots/reflectivity.jpg ../docs/shots/alltilts.jpg ../docs/shots/layers.jpg ../docs/shots/velocity.jpg public/shots/"
   },
   "dependencies": {
     "@astrojs/rss": "^4.0.19",

--- a/site/src/components/Card.astro
+++ b/site/src/components/Card.astro
@@ -21,7 +21,7 @@ const Tag = href ? "a" : "div";
     display: block;
     color: var(--text);
     text-decoration: none;
-    transition: border-color 160ms ease, transform 160ms ease;
+    transition: border-color var(--dur) ease, transform var(--dur) var(--spring);
   }
   a.linked:hover { border-color: var(--accent); transform: translateY(-2px); }
 </style>

--- a/site/src/content/blog/hello-hookecho.md
+++ b/site/src/content/blog/hello-hookecho.md
@@ -2,7 +2,7 @@
 title: "Hello, HookEcho"
 description: "A free, open-source weather radar app that talks straight to the public NOAA feeds — why it exists, and who it's for."
 date: 2026-08-26
-image: /shots/hero.gif
+image: /shots/reflectivity.jpg
 ---
 
 Every radar app on your phone is somebody's business model. The data underneath

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -34,24 +34,29 @@ const tiers = [
   },
 ];
 
+// Hotlinked from the repo at a tag, same as /features and /weatherdesk: GitHub carries the
+// bytes, and a later commit on main cannot change what the page shows. Only the hero poster and
+// the social card stay local — those two have to be there on first paint and for scrapers.
+const repoShots = "https://raw.githubusercontent.com/d4vid87/hookecho/v0.12.0-beta.1/docs/shots";
+
 const shots = [
   {
-    src: "/shots/alerts.jpg",
+    src: `${repoShots}/alerts.jpg`,
     alt: "Warning polygons, storm reports and spotter positions on the map",
     caption: "Warnings, storm reports and spotters, live.",
   },
   {
-    src: "/shots/alltilts.jpg",
+    src: `${repoShots}/alltilts.jpg`,
     alt: "Four radar tilts of the same storm side by side",
     caption: "Every tilt of the volume, side by side.",
   },
   {
-    src: "/shots/velocity.jpg",
+    src: `${repoShots}/velocity.jpg`,
     alt: "Storm-relative velocity showing a rotation couplet in a supercell",
     caption: "Velocity and dual-pol, dealiased.",
   },
   {
-    src: "/shots/hrrr.jpg",
+    src: `${repoShots}/hrrr.jpg`,
     alt: "HRRR model fields drawn over the map with severe composite parameters",
     caption: "HRRR and NAM fields, with the severe parameters.",
   },
@@ -122,6 +127,20 @@ const weatherdeskRepo = "https://github.com/d4vid87/weatherdesk";
   </section>
 
   <section class="alt">
+    <div class="wrap">
+      <p class="eyebrow">Against the field</p>
+      <h2>Yes, we will tell you when to buy something else</h2>
+      <p>
+        We put HookEcho next to RadarScope, MyRadar, Windy and RainViewer, row by row, including
+        the four rows they win. If the thing you need is global model data, Windy is better at it.
+      </p>
+      <div class="platforms">
+        <a class="btn btn-primary" href="/compare/">See the comparison</a>
+      </div>
+    </div>
+  </section>
+
+  <section>
     <div class="wrap">
       <p class="eyebrow">More from us</p>
       <h2>WeatherDesk</h2>


### PR DESCRIPTION
Wave R4, the last of the site redesign. **Stacked on #145.**

The site was copying all nineteen screenshots out of `docs/shots` at build time and serving 8.5 MB of them off Pages. Only four need to be same-origin — the hero poster, which has to be there on first paint, and the three social cards, because scrapers do not follow hotlinks reliably. The rest now point at `raw.githubusercontent.com` pinned to `v0.12.0-beta.1`, same as `/features` and `/weatherdesk` already did.

**`dist` drops from about 10 MB to 1.9 MB.** The `shots` script copies four files instead of nineteen, and says in the manifest why those four.

Also here:
- The **comparison teaser** on the landing page, now that `/compare` exists to link to.
- The one blog post whose social card was `hero.gif` now uses a still — a 1.9 MB animated GIF was a poor card regardless of who served it.
- `Card.astro`'s last hardcoded `160ms` moves onto the motion tokens, so the `prefers-reduced-motion` switch governs it like everything else.

⚠️ The tag pin needs bumping when `v0.12.0` tags and the screenshots are reshot. Same note applies to `/features`.

## Verification

- `npm run build` clean; `npx linkinator dist --recurse` — 73 links, zero broken, pinned raw URLs among them.
- Headless renders of the landing, download, docs, blog and weatherdesk pages: all pick up the new type scale, nav and footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)