### PR TITLE
feat(site): redesign R1–R4 onto main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ announce-drafts.md
 /.fpbuild/
 /.fpstate/
 /.fprepo/
+
+# wrangler dev scratch
+site/.wrangler/

--- a/site/package.json
+++ b/site/package.json
@@ -2,11 +2,12 @@
   "name": "hookecho-site",
   "private": true,
   "type": "module",
+  "_comment": "shots copies only the four images this site serves itself -- the hero poster and the social cards. Every other screenshot is hotlinked from the repo at a tag, so GitHub carries the bandwidth. Social cards have to be same-origin: scrapers do not follow hotlinks reliably.",
   "scripts": {
     "dev": "npm run shots && astro dev",
     "build": "npm run shots && astro build",
     "preview": "astro preview",
-    "shots": "mkdir -p public/shots && cp ../docs/shots/*.jpg ../docs/shots/*.gif public/shots/"
+    "shots": "mkdir -p public/shots && cp ../docs/shots/reflectivity.jpg ../docs/shots/alltilts.jpg ../docs/shots/layers.jpg ../docs/shots/velocity.jpg public/shots/"
   },
   "dependencies": {
     "@astrojs/rss": "^4.0.19",

--- a/site/public/_worker.js
+++ b/site/public/_worker.js
@@ -1,14 +1,26 @@
-// Advanced-mode Pages worker: the only reason it exists is the www redirect. Both hookecho.io and
-// www.hookecho.io are custom domains on this project, so without this the site answers on two
-// names and gets indexed twice.
-// ponytail: a _redirects rule cannot do this — Pages matches those on the path only, hostnames are
-// a Netlify feature. Everything that is not www falls straight through to the static assets.
+// Advanced-mode Pages worker. Two jobs: the www redirect, and a /geo.json that hands the page the
+// visitor's rough location so the landing page can say which radar is nearest without asking the
+// browser for a permission the visitor has no reason to grant yet.
+// ponytail: a _redirects rule cannot do the redirect — Pages matches those on the path only,
+// hostnames are a Netlify feature. Everything else falls straight through to the static assets.
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
     if (url.hostname.startsWith("www.")) {
       url.hostname = url.hostname.slice(4);
       return Response.redirect(url.toString(), 301);
+    }
+    // Same shape as the app's own /geo.json (web/_worker.js/index.js), plus the city name the
+    // chip prints. Free and exact enough: request.cf is the edge's own geo-IP lookup.
+    if (url.pathname === "/geo.json") {
+      const { latitude, longitude, city } = request.cf ?? {};
+      const body =
+        latitude && longitude
+          ? JSON.stringify({ lon: +longitude, lat: +latitude, city: city ?? null })
+          : "null";
+      return new Response(body, {
+        headers: { "content-type": "application/json", "cache-control": "private, no-store" },
+      });
     }
     return env.ASSETS.fetch(request);
   },

--- a/site/src/components/Card.astro
+++ b/site/src/components/Card.astro
@@ -21,7 +21,7 @@ const Tag = href ? "a" : "div";
     display: block;
     color: var(--text);
     text-decoration: none;
-    transition: border-color 160ms ease, transform 160ms ease;
+    transition: border-color var(--dur) ease, transform var(--dur) var(--spring);
   }
   a.linked:hover { border-color: var(--accent); transform: translateY(-2px); }
 </style>

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -4,42 +4,132 @@ interface Props {
   tagline: string;
 }
 const { title, tagline } = Astro.props;
+
+// The live app is a whole wasm radar viewer — several MB and a pile of feed requests. Loading it
+// on every landing-page visit would be rude, so the hero shows a still until someone asks for it.
+// `?embed` is the app's chrome-free mode (crates/hookecho/src/app.rs, `is_embed`), and the app
+// geo-IP-centers itself from its own /geo.json, so no coordinates need passing here.
+const appEmbed = "https://app.hookecho.io/?embed";
 ---
 
 <section class="hero">
+  <span class="sweep" aria-hidden="true"></span>
   <div class="wrap">
     <h1>{title}</h1>
     <p class="tagline">{tagline}</p>
     <div class="ctas">
       <a class="btn btn-primary" href="https://app.hookecho.io">Open in your browser</a>
-      <a class="btn" href="https://github.com/d4vid87/hookecho/releases/latest">Download the app</a>
+      <a class="btn" href="/download/">Download the app</a>
     </div>
     <p class="fineprint">Free, open source, no account. Windows, macOS, Linux and Android.</p>
-    <img
-      class="shot"
-      src="/shots/hero.gif"
-      alt="A radar loop animating over an interactive map, with warnings and storm cells drawn on top"
-      width="1600"
-      height="1000"
-    />
+
+    <div class="stage" data-embed={appEmbed}>
+      <img
+        class="poster"
+        src="/shots/reflectivity.jpg"
+        alt="A radar loop over an interactive map, with warnings and storm cells drawn on top"
+        width="1600"
+        height="1000"
+      />
+      <!-- Only rendered by the script below, so the no-JS experience is the poster plus the CTAs
+           above rather than a dead button. -->
+      <noscript><p class="fineprint">Open the radar in your browser from the button above.</p></noscript>
+    </div>
   </div>
 </section>
 
+<script>
+  const stage = document.querySelector<HTMLElement>(".hero .stage");
+  const src = stage?.dataset.embed;
+  if (stage && src) {
+    const play = document.createElement("button");
+    play.type = "button";
+    play.className = "play";
+    play.innerHTML = '<span class="dot" aria-hidden="true"></span> Load the live radar';
+    play.addEventListener(
+      "click",
+      () => {
+        const frame = document.createElement("iframe");
+        frame.src = src;
+        frame.title = "HookEcho live radar";
+        frame.loading = "lazy";
+        frame.allow = "geolocation";
+        stage.replaceChildren(frame);
+      },
+      { once: true },
+    );
+    stage.append(play);
+  }
+</script>
+
 <style>
-  .hero { padding-top: clamp(2.5rem, 7vw, 4.5rem); }
+  .hero { position: relative; overflow: hidden; padding-top: clamp(2.5rem, 7vw, 4.5rem); }
+  .hero .wrap { position: relative; }
+  .hero::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: var(--glow);
+    pointer-events: none;
+  }
   .tagline {
-    font-size: clamp(1.05rem, 2.4vw, 1.3rem);
+    font-size: clamp(1.05rem, 2.4vw, 1.35rem);
     color: var(--text-dim);
     max-width: 46ch;
   }
   .ctas { display: flex; gap: 0.75rem; flex-wrap: wrap; margin: 1.6rem 0 0.8rem; }
   .fineprint { color: var(--text-dim); font-size: 0.9rem; }
-  .shot {
-    display: block;
+
+  .stage {
+    position: relative;
     margin-top: 2.2rem;
-    width: 100%;
+    aspect-ratio: 16 / 10;
     border: 1px solid var(--stroke);
     border-radius: var(--radius);
+    overflow: hidden;
     box-shadow: 0 24px 60px rgb(0 0 0 / 0.35);
   }
+  .stage :global(img),
+  .stage :global(iframe) {
+    display: block;
+    width: 100%;
+    height: 100%;
+    border: 0;
+    object-fit: cover;
+  }
+  .stage :global(.play) {
+    position: absolute;
+    inset-inline: 0;
+    bottom: 1.2rem;
+    margin-inline: auto;
+    width: fit-content;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0.75rem 1.4rem;
+    border-radius: 999px;
+    border: 1px solid var(--accent);
+    background: color-mix(in srgb, var(--bg) 78%, transparent);
+    backdrop-filter: blur(8px);
+    color: var(--text);
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform var(--dur) var(--spring), box-shadow var(--dur) ease;
+  }
+  .stage :global(.play:hover) {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 30px color-mix(in srgb, var(--accent) 30%, transparent);
+  }
+  .stage :global(.dot) {
+    width: 0.6rem;
+    height: 0.6rem;
+    border-radius: 50%;
+    background: var(--accent);
+    animation: pulse 1.8s ease-in-out infinite;
+  }
+  @keyframes pulse {
+    50% { opacity: 0.25; transform: scale(0.7); }
+  }
+  .stage noscript { position: absolute; bottom: 0.4rem; inset-inline: 0; text-align: center; }
 </style>

--- a/site/src/components/LiveMosaic.astro
+++ b/site/src/components/LiveMosaic.astro
@@ -1,0 +1,41 @@
+---
+// The national mosaic, hotlinked live from the NWS's own RIDGE image server and re-fetched on a
+// timer. It is the cheapest possible proof that the page is looking at real weather right now.
+// ponytail: a cache-busting query on an <img> is the whole refresh mechanism — no canvas, no
+// preloading, no fade. The server updates roughly every 10 minutes; we ask every 5.
+const src = "https://radar.weather.gov/ridge/standard/CONUS_0.gif";
+const everyMs = 5 * 60 * 1000;
+---
+
+<figure class="mosaic" data-src={src} data-every={everyMs}>
+  <img src={src} alt="The national radar mosaic across the United States, updated live" />
+  <figcaption>
+    Live national mosaic, straight from the NWS. HookEcho draws this from MRMS at full resolution.
+  </figcaption>
+</figure>
+
+<script>
+  const fig = document.querySelector<HTMLElement>(".mosaic");
+  const img = fig?.querySelector("img");
+  const src = fig?.dataset.src;
+  const every = Number(fig?.dataset.every ?? 0);
+  if (img && src && every > 0) {
+    setInterval(() => {
+      // Only while the tab is visible: a backgrounded tab refreshing a national radar image all
+      // day is exactly the kind of thing that gets a hotlink blocked.
+      if (document.visibilityState === "visible") img.src = `${src}?t=${Date.now()}`;
+    }, every);
+  }
+</script>
+
+<style>
+  .mosaic { margin: 0; }
+  .mosaic img {
+    display: block;
+    width: 100%;
+    border: 1px solid var(--stroke);
+    border-radius: var(--radius);
+    background: var(--bg-deep);
+  }
+  figcaption { color: var(--text-dim); font-size: 0.9rem; margin-top: 0.7rem; }
+</style>

--- a/site/src/components/NearYou.astro
+++ b/site/src/components/NearYou.astro
@@ -1,0 +1,43 @@
+---
+// "Open radar near Norman" — the city comes from the edge's own geo-IP (site/public/_worker.js
+// serves /geo.json from request.cf), so the page can be specific without a permission prompt.
+// The app does its own identical lookup on load, so no coordinates need handing over.
+---
+
+<a class="near" href="https://app.hookecho.io">
+  <span class="pin" aria-hidden="true">◎</span>
+  <span class="text">Open the radar<span class="where"></span></span>
+</a>
+
+<script>
+  fetch("/geo.json")
+    .then((r) => (r.ok ? r.json() : null))
+    .then((geo) => {
+      if (!geo?.city) return;
+      const where = document.querySelector(".near .where");
+      if (where) where.textContent = ` near ${geo.city}`;
+    })
+    // No city, no worry: the link still reads "Open the radar" and still works.
+    .catch(() => {});
+</script>
+
+<style>
+  .near {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.75rem 1.4rem;
+    border-radius: 999px;
+    border: 1px solid var(--accent);
+    background: color-mix(in srgb, var(--accent) 12%, transparent);
+    color: var(--text);
+    font-weight: 600;
+    text-decoration: none;
+    transition: transform var(--dur) var(--spring), box-shadow var(--dur) ease;
+  }
+  .near:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 30px color-mix(in srgb, var(--accent) 28%, transparent);
+  }
+  .pin { color: var(--accent); }
+</style>

--- a/site/src/components/Ticker.astro
+++ b/site/src/components/Ticker.astro
@@ -1,0 +1,61 @@
+---
+// Live warning counts, straight from the NWS API in the visitor's own browser — no backend, no
+// key, no build-time snapshot that goes stale. CORS is open on api.weather.gov and every response
+// is public data, so the whole thing is a fetch and a number.
+// ponytail: the GeoJSON carries polygons we throw away (~3 KB per alert), because the lighter
+// ld+json needs an Accept header and the API's preflight only allows API-Key and User-Agent.
+const events = ["Tornado Warning", "Severe Thunderstorm Warning", "Flash Flood Warning"];
+---
+
+<a class="ticker" href="https://app.hookecho.io" data-events={JSON.stringify(events)}>
+  {
+    events.map((event) => (
+      <span class="item" data-event={event}>
+        <span class="count">—</span>
+        <span class="label">{event.replace(" Warning", "")}</span>
+      </span>
+    ))
+  }
+  <span class="cta">See them on the map</span>
+</a>
+
+<script>
+  const ticker = document.querySelector<HTMLElement>(".ticker");
+  const events: string[] = JSON.parse(ticker?.dataset.events ?? "[]");
+  for (const event of events) {
+    const slot = ticker?.querySelector(`[data-event="${event}"] .count`);
+    if (!slot) continue;
+    fetch(`https://api.weather.gov/alerts/active?event=${encodeURIComponent(event)}`)
+      .then((r) => (r.ok ? r.json() : Promise.reject(r.status)))
+      .then((d) => {
+        const n = d?.features?.length ?? 0;
+        slot.textContent = String(n);
+        slot.parentElement?.classList.toggle("hot", n > 0);
+      })
+      // A blocked or failing fetch leaves the em dash: the row still reads as a list of the
+      // warning types the app tracks, which is the point of it being on the page.
+      .catch(() => {});
+  }
+</script>
+
+<style>
+  .ticker {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+    padding: 0.85rem 1.2rem;
+    border: 1px solid var(--stroke);
+    border-radius: 999px;
+    background: var(--faint);
+    color: var(--text);
+    text-decoration: none;
+    transition: border-color var(--dur) ease, transform var(--dur) var(--spring);
+  }
+  .ticker:hover { border-color: var(--accent); transform: translateY(-2px); }
+  .item { display: inline-flex; align-items: baseline; gap: 0.45rem; }
+  .count { font-size: 1.35rem; font-weight: 700; font-variant-numeric: tabular-nums; }
+  .item.hot .count { color: var(--accent); }
+  .label { color: var(--text-dim); font-size: 0.9rem; }
+  .cta { margin-left: auto; color: var(--accent); font-size: 0.9rem; font-weight: 600; }
+</style>

--- a/site/src/content/blog/hello-hookecho.md
+++ b/site/src/content/blog/hello-hookecho.md
@@ -2,7 +2,7 @@
 title: "Hello, HookEcho"
 description: "A free, open-source weather radar app that talks straight to the public NOAA feeds — why it exists, and who it's for."
 date: 2026-08-26
-image: /shots/hero.gif
+image: /shots/reflectivity.jpg
 ---
 
 Every radar app on your phone is somebody's business model. The data underneath

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -18,6 +18,7 @@ const social = new URL(image, Astro.site);
 
 // A link is only listed once the page exists, so the build's link check stays meaningful.
 const nav = [
+  { href: "/features/", label: "Features" },
   { href: "/docs/", label: "Docs" },
   { href: "/blog/", label: "Blog" },
   { href: "/weatherdesk/", label: "WeatherDesk" },

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -87,7 +87,8 @@ const nav = [
         <p class="dim">
           <a href="https://github.com/d4vid87/hookecho">Source</a> ·
           <a href="https://github.com/d4vid87/hookecho/issues">Report a problem</a> ·
-          <a href="/weatherdesk/">WeatherDesk</a>
+          <a href="/weatherdesk/">WeatherDesk</a> ·
+          <a href="https://github.com/d4vid87/weatherdesk">WeatherDesk source</a>
         </p>
       </div>
     </footer>

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -19,6 +19,7 @@ const social = new URL(image, Astro.site);
 // A link is only listed once the page exists, so the build's link check stays meaningful.
 const nav = [
   { href: "/features/", label: "Features" },
+  { href: "/compare/", label: "Compare" },
   { href: "/docs/", label: "Docs" },
   { href: "/blog/", label: "Blog" },
   { href: "/weatherdesk/", label: "WeatherDesk" },

--- a/site/src/pages/compare/index.astro
+++ b/site/src/pages/compare/index.astro
@@ -1,0 +1,333 @@
+---
+import Base from "../../layouts/Base.astro";
+
+// An honest matrix or none at all: every row a competitor wins is marked as won, and there are
+// four of those. Prices are tiers, not dollar amounts — those change without telling us, and a
+// stale number on this page would be the one thing readers were right to disbelieve.
+//
+// Sources, checked 2026-08: each product's own pricing/feature pages and store listings.
+// RadarScope: base.radarscope.app tier list (Pro Tier One / Tier Two).
+// MyRadar: myradar.com premium features; free tier carries ads.
+// Windy: windy.com Premium page; radar composite is not Level 2.
+// Clime and RainViewer are grouped: both are mosaic-imagery apps on a subscription.
+// HookEcho's own column comes from README.md and docs/GUIDE.md.
+const cols = ["HookEcho", "RadarScope", "MyRadar", "Windy", "Clime / RainViewer"];
+
+// v: "yes" | "no" | "part" — decides the mark; t is the qualifier that makes the mark honest.
+const rows = [
+  {
+    label: "Price",
+    cells: [
+      { v: "yes", t: "Free, MIT licensed" },
+      { v: "part", t: "Paid app, subscription tiers" },
+      { v: "part", t: "Free with ads, subscription" },
+      { v: "part", t: "Free, optional Premium" },
+      { v: "part", t: "Free trial, subscription" },
+    ],
+  },
+  {
+    label: "Ads",
+    cells: [
+      { v: "yes", t: "None" },
+      { v: "yes", t: "None" },
+      { v: "no", t: "Unless you subscribe" },
+      { v: "yes", t: "None" },
+      { v: "no", t: "Yes" },
+    ],
+  },
+  {
+    label: "Account required",
+    cells: [
+      { v: "yes", t: "Never" },
+      { v: "part", t: "For the paid tiers" },
+      { v: "part", t: "For the paid tier" },
+      { v: "yes", t: "Optional" },
+      { v: "part", t: "For the paid tier" },
+    ],
+  },
+  {
+    label: "Open source",
+    cells: [
+      { v: "yes", t: "Every line" },
+      { v: "no", t: "" },
+      { v: "no", t: "" },
+      { v: "no", t: "" },
+      { v: "no", t: "" },
+    ],
+  },
+  {
+    label: "Level 2, every tilt",
+    cells: [
+      { v: "yes", t: "All elevations, full resolution" },
+      { v: "yes", t: "All elevations" },
+      { v: "no", t: "Mosaic imagery" },
+      { v: "no", t: "Composite only" },
+      { v: "no", t: "Mosaic imagery" },
+    ],
+  },
+  {
+    label: "Dual-pol products",
+    cells: [
+      { v: "yes", t: "ZDR, CC, KDP, ΦDP" },
+      { v: "yes", t: "Full set" },
+      { v: "no", t: "" },
+      { v: "no", t: "" },
+      { v: "no", t: "" },
+    ],
+  },
+  {
+    label: "Velocity and dealiasing",
+    cells: [
+      { v: "yes", t: "With storm-relative" },
+      { v: "yes", t: "With storm-relative" },
+      { v: "no", t: "" },
+      { v: "no", t: "" },
+      { v: "no", t: "" },
+    ],
+  },
+  {
+    label: "National MRMS mosaic",
+    cells: [
+      { v: "yes", t: "Full resolution" },
+      { v: "part", t: "Paid tier" },
+      { v: "yes", t: "" },
+      { v: "yes", t: "Composite" },
+      { v: "yes", t: "" },
+    ],
+  },
+  {
+    label: "Lightning",
+    cells: [
+      { v: "yes", t: "GOES GLM" },
+      { v: "part", t: "Paid tier" },
+      { v: "part", t: "Paid tier" },
+      { v: "yes", t: "" },
+      { v: "part", t: "Paid tier" },
+    ],
+  },
+  {
+    label: "Forecast models",
+    cells: [
+      { v: "part", t: "HRRR, NAM, soundings" },
+      { v: "no", t: "" },
+      { v: "part", t: "Limited" },
+      { v: "yes", t: "The best in the field" },
+      { v: "no", t: "" },
+    ],
+  },
+  {
+    label: "Tropical tracks",
+    cells: [
+      { v: "yes", t: "NHC cones and advisories" },
+      { v: "no", t: "" },
+      { v: "yes", t: "" },
+      { v: "yes", t: "" },
+      { v: "yes", t: "" },
+    ],
+  },
+  {
+    label: "Archive playback",
+    cells: [
+      { v: "yes", t: "Back to 1991" },
+      { v: "part", t: "Paid tier, recent only" },
+      { v: "no", t: "" },
+      { v: "no", t: "" },
+      { v: "no", t: "" },
+    ],
+  },
+  {
+    label: "Works offline",
+    cells: [
+      { v: "yes", t: "Chase packs, prefetched" },
+      { v: "no", t: "" },
+      { v: "no", t: "" },
+      { v: "no", t: "" },
+      { v: "no", t: "" },
+    ],
+  },
+  {
+    label: "Coverage outside the US",
+    cells: [
+      { v: "part", t: "US plus German DWD radar" },
+      { v: "part", t: "Several countries" },
+      { v: "part", t: "Mostly US" },
+      { v: "yes", t: "Global" },
+      { v: "yes", t: "Global" },
+    ],
+  },
+  {
+    label: "Runs in a browser",
+    cells: [
+      { v: "yes", t: "The whole app, no install" },
+      { v: "no", t: "" },
+      { v: "part", t: "Cut-down web view" },
+      { v: "yes", t: "Web first" },
+      { v: "no", t: "" },
+    ],
+  },
+  {
+    label: "iPhone and iPad",
+    cells: [
+      { v: "no", t: "Not yet" },
+      { v: "yes", t: "" },
+      { v: "yes", t: "" },
+      { v: "yes", t: "" },
+      { v: "yes", t: "" },
+    ],
+  },
+  {
+    label: "Desktop app",
+    cells: [
+      { v: "yes", t: "Windows, macOS, Linux" },
+      { v: "part", t: "Windows, macOS" },
+      { v: "part", t: "Windows" },
+      { v: "no", t: "" },
+      { v: "no", t: "" },
+    ],
+  },
+  {
+    label: "Mobile polish",
+    cells: [
+      { v: "part", t: "Android only, and younger" },
+      { v: "yes", t: "The bar everyone measures against" },
+      { v: "yes", t: "" },
+      { v: "yes", t: "" },
+      { v: "yes", t: "" },
+    ],
+  },
+  {
+    label: "Telemetry",
+    cells: [
+      { v: "yes", t: "None, at all" },
+      { v: "no", t: "Analytics" },
+      { v: "no", t: "Ads and analytics" },
+      { v: "no", t: "Analytics" },
+      { v: "no", t: "Ads and analytics" },
+    ],
+  },
+];
+
+// ponytail: the marks are drawn in CSS, not typed as ●◐○ — the bundled Inter subset is Latin
+// only, so the half-filled glyph in particular falls through to whatever the system has.
+---
+
+<Base
+  title="How HookEcho compares — RadarScope, MyRadar, Windy, RainViewer"
+  description="An honest feature-by-feature comparison of HookEcho against RadarScope, MyRadar, Windy and Clime/RainViewer — including the rows where they win."
+>
+  <section class="head">
+    <span class="sweep" aria-hidden="true"></span>
+    <div class="wrap">
+      <p class="eyebrow">Comparison</p>
+      <h1>How HookEcho compares</h1>
+      <p class="lede">
+        Four apps people actually use, and the rows where each of them beats us. If you want the
+        best global model data, use Windy. If you want the most polished phone app, buy
+        RadarScope. If you want every Level 2 product, the full archive and no bill, keep reading.
+      </p>
+    </div>
+  </section>
+
+  <section class="alt">
+    <div class="wrap">
+      <div class="scroller">
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">
+                <span class="sr-only">Feature</span>
+              </th>
+              {cols.map((c, i) => <th scope="col" class={i === 0 ? "us" : ""}>{c}</th>)}
+            </tr>
+          </thead>
+          <tbody>
+            {
+              rows.map((r) => (
+                <tr>
+                  <th scope="row">{r.label}</th>
+                  {r.cells.map((c, i) => (
+                    <td class:list={[c.v, { us: i === 0 }]}>
+                      <span class="mark" aria-hidden="true" />
+                      <span class="sr-only">
+                        {c.v === "yes" ? "Yes" : c.v === "part" ? "Partly" : "No"}
+                      </span>
+                      {c.t && <span class="note">{c.t}</span>}
+                    </td>
+                  ))}
+                </tr>
+              ))
+            }
+          </tbody>
+        </table>
+      </div>
+      <p class="foot">
+        Verified August 2026, from each product's own pricing and feature pages. Tiers and prices
+        move; if a row here is wrong,
+        <a href="https://github.com/d4vid87/hookecho/issues">tell us</a> and it gets fixed.
+      </p>
+    </div>
+  </section>
+
+  <section>
+    <div class="wrap">
+      <h2>What we are actually claiming</h2>
+      <p>
+        HookEcho is a chaser-grade radar viewer that reads the same public NOAA feeds the
+        professional apps read, gives away the products they charge for, and never asks for an
+        account. It is younger than the apps above, there is no iPhone build yet, and Windy's
+        model data is better than ours. Those are the trades.
+      </p>
+      <div class="ctas">
+        <a class="btn btn-primary" href="https://app.hookecho.io">Judge it yourself in the browser</a>
+        <a class="btn" href="/features/">See the features</a>
+      </div>
+    </div>
+  </section>
+</Base>
+
+<style>
+  .head { position: relative; overflow: hidden; }
+  .head .wrap { position: relative; }
+  .lede { font-size: 1.15rem; color: var(--text-dim); max-width: 62ch; }
+  .alt { background: var(--bg-deep); border-block: 1px solid var(--stroke); }
+
+  /* Nineteen rows by five columns does not fit a phone. Scroll it rather than pretend. */
+  .scroller { overflow-x: auto; }
+  table { border-collapse: collapse; width: 100%; min-width: 820px; font-size: 0.92rem; }
+  th, td {
+    text-align: left;
+    padding: 0.7rem 0.9rem;
+    border-bottom: 1px solid var(--stroke);
+    vertical-align: top;
+  }
+  thead th { font-size: 0.85rem; color: var(--text-dim); white-space: nowrap; }
+  thead th.us, td.us { background: color-mix(in srgb, var(--accent) 9%, transparent); }
+  thead th.us { color: var(--accent); }
+  tbody th { font-weight: 600; white-space: nowrap; }
+  .mark {
+    display: inline-block;
+    width: 0.72rem;
+    height: 0.72rem;
+    margin-right: 0.5rem;
+    border-radius: 50%;
+    border: 1.5px solid var(--stroke);
+    vertical-align: baseline;
+  }
+  td.yes .mark { background: var(--accent); border-color: var(--accent); }
+  td.part .mark {
+    border-color: var(--text-dim);
+    background: linear-gradient(90deg, var(--text-dim) 50%, transparent 50%);
+  }
+  .note { color: var(--text-dim); }
+  .foot { color: var(--text-dim); font-size: 0.88rem; margin-top: 1.2rem; }
+  .ctas { display: flex; gap: 0.75rem; flex-wrap: wrap; margin-top: 1.4rem; }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+</style>

--- a/site/src/pages/features/index.astro
+++ b/site/src/pages/features/index.astro
@@ -1,0 +1,201 @@
+---
+import Base from "../../layouts/Base.astro";
+
+// Screenshots come straight from the repo at a tag, so GitHub carries the bytes and a later
+// commit on main cannot change what this page shows. Bump the tag when a release reshoots.
+const shots = "https://raw.githubusercontent.com/d4vid87/hookecho/v0.12.0-beta.1/docs/shots";
+
+// Every section opens the real app on the thing it just described. The link vocabulary is the
+// app's own #goto grammar (crates/hookecho/src/app.rs, `parse_goto`):
+// SITE,lon,lat,zoom[,product|tilt|RFC3339|bm:slug|thr:n|srv]. KTLX is Oklahoma City — the site
+// with the most storms to point at.
+const app = "https://app.hookecho.io";
+const ktlx = (extra = "") => `${app}/#goto=KTLX,-97.28,35.33,8${extra}`;
+
+const sections = [
+  {
+    id: "radar",
+    eyebrow: "Level 2, every tilt",
+    title: "The volume, not a picture of it",
+    body:
+      "HookEcho decodes the raw Level 2 volume from the radar itself: every elevation angle in " +
+      "the scan, at full range and full gate resolution, not a pre-rendered image of the lowest " +
+      "tilt. Step up through the tilts to see how a storm leans, or put four of them on screen " +
+      "at once.",
+    shot: "alltilts.jpg",
+    alt: "Four elevation angles of the same storm shown side by side",
+    link: { href: ktlx(), label: "Open the radar" },
+  },
+  {
+    id: "velocity",
+    eyebrow: "Velocity and dual-pol",
+    title: "Rotation, debris and hail, called by name",
+    body:
+      "Velocity with dealiasing and a storm-relative view for spotting couplets, plus the full " +
+      "dual-polarization set — ZDR, CC, KDP and differential phase — which is how a debris ball " +
+      "and a hail core stop looking like the same red blob.",
+    shot: "velocity.jpg",
+    alt: "Storm-relative velocity showing a tight rotation couplet in a supercell",
+    link: { href: ktlx(",VEL,srv"), label: "Open storm-relative velocity" },
+  },
+  {
+    id: "mosaic",
+    eyebrow: "The whole country",
+    title: "MRMS mosaic, rotation tracks and hail",
+    body:
+      "The national MRMS mosaic at full resolution, with the derived grids that come with it: " +
+      "rotation tracks showing where a mesocyclone has been, MESH hail size, and QPE rainfall " +
+      "totals for the flooding question.",
+    shot: "mosaic.jpg",
+    alt: "The national MRMS radar mosaic across the United States",
+    link: { href: ktlx(), label: "See the mosaic" },
+  },
+  {
+    id: "alerts",
+    eyebrow: "Warnings and alerts",
+    title: "Every warning polygon, and a phone that tells you",
+    body:
+      "Live watches and warnings with their full text, storm reports as they come in, and " +
+      "spotter positions — drawn on the map rather than buried in a list. Set a rule for your " +
+      "own location and the app tells you when a polygon covers it.",
+    shot: "alerts.jpg",
+    alt: "Warning polygons, storm reports and spotter positions drawn over the map",
+    link: { href: "/docs/alerts-and-notifications/", label: "How alerts work" },
+  },
+  {
+    id: "storms",
+    eyebrow: "Storm interrogation",
+    title: "Cells ranked by how dangerous they look",
+    body:
+      "Every cell in view, sorted by a severity score built from ProbSevere, rotational velocity " +
+      "and hail size, so the one worth watching is at the top. Click one for its history, or cut " +
+      "a vertical cross-section straight through it to find the overhang and the BWER.",
+    shot: "xsection.jpg",
+    alt: "A vertical cross-section cut through a storm, showing the reflectivity structure aloft",
+    link: { href: ktlx(), label: "Interrogate a storm" },
+  },
+  {
+    id: "models",
+    eyebrow: "Models and soundings",
+    title: "HRRR, NAM and the severe parameters",
+    body:
+      "Model fields drawn over the same map as the radar, with Skew-T soundings and the severe " +
+      "composite parameters — CAPE, shear, STP, helicity — so the forecast and the radar are one " +
+      "screen instead of two tabs.",
+    shot: "hrrr.jpg",
+    alt: "HRRR model fields over the map alongside severe composite parameters",
+    link: { href: ktlx(), label: "Open the models" },
+  },
+  {
+    id: "tropical",
+    eyebrow: "Tropical",
+    title: "NHC tracks, cones and advisories",
+    body:
+      "Hurricane forecast tracks and cones from the National Hurricane Center, with the advisory " +
+      "text alongside, over the same radar you use for everything else.",
+    shot: "tropical.jpg",
+    alt: "A hurricane forecast cone and track drawn over the map with advisory text alongside",
+    link: { href: app, label: "Open the app" },
+  },
+  {
+    id: "archive",
+    eyebrow: "Archive and offline",
+    title: "Any storm since 1991, and no signal required",
+    body:
+      "Scrub back through the NOAA archive to any volume since 1991 and replay an event with its " +
+      "warnings and reports time-synced. Or build an offline chase pack ahead of time, for the " +
+      "part of the day when the data connection is the thing that fails.",
+    shot: "verify.jpg",
+    alt: "Archive playback with historical warnings and reports replayed alongside the radar",
+    link: { href: "/docs/getting-started/", label: "Getting started" },
+  },
+];
+---
+
+<Base
+  title="Features — HookEcho"
+  description="Level 2 radar at every tilt, velocity and dual-pol, the MRMS mosaic, warnings, storm interrogation, HRRR and NAM, tropical tracks and archive playback to 1991 — free and open source."
+>
+  <section class="head">
+    <span class="sweep" aria-hidden="true"></span>
+    <div class="wrap">
+      <p class="eyebrow">Features</p>
+      <h1>Everything, from the source</h1>
+      <p class="lede">
+        HookEcho talks straight to the public NOAA, NWS and MRMS feeds from your own machine. No
+        account, no subscription tier holding a product back, no telemetry. Here is what that gets
+        you — each section opens the real app on the thing it describes.
+      </p>
+      <nav class="jump" aria-label="Sections">
+        {sections.map((s) => <a href={`#${s.id}`}>{s.eyebrow}</a>)}
+      </nav>
+    </div>
+  </section>
+
+  {
+    sections.map((s, i) => (
+      <section class={i % 2 ? "alt" : ""} id={s.id}>
+        <div class="wrap row">
+          <div class="copy">
+            <p class="eyebrow">{s.eyebrow}</p>
+            <h2>{s.title}</h2>
+            <p>{s.body}</p>
+            <a class="btn" href={s.link.href}>
+              {s.link.label}
+            </a>
+          </div>
+          <img src={`${shots}/${s.shot}`} alt={s.alt} loading="lazy" />
+        </div>
+      </section>
+    ))
+  }
+
+  <section>
+    <div class="wrap">
+      <h2>Try it before you download anything</h2>
+      <p>The browser version is the whole app, on live data, with nothing to install.</p>
+      <div class="ctas">
+        <a class="btn btn-primary" href={app}>Open it in your browser</a>
+        <a class="btn" href="/download/">Download the app</a>
+      </div>
+    </div>
+  </section>
+</Base>
+
+<style>
+  .head { position: relative; overflow: hidden; }
+  .head .wrap { position: relative; }
+  .lede { font-size: 1.15rem; color: var(--text-dim); }
+  .alt { background: var(--bg-deep); border-block: 1px solid var(--stroke); }
+
+  .jump { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-top: 1.6rem; }
+  .jump a {
+    padding: 0.4rem 0.9rem;
+    border: 1px solid var(--stroke);
+    border-radius: 999px;
+    color: var(--text-dim);
+    text-decoration: none;
+    font-size: 0.85rem;
+    transition: border-color var(--dur) ease, color var(--dur) ease;
+  }
+  .jump a:hover { border-color: var(--accent); color: var(--text); }
+
+  /* Anchored sections land under the sticky header without this. */
+  section[id] { scroll-margin-top: 4.5rem; }
+
+  .row {
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    align-items: center;
+  }
+  .row img {
+    border: 1px solid var(--stroke);
+    border-radius: var(--radius);
+    display: block;
+    box-shadow: 0 18px 44px rgb(0 0 0 / 0.3);
+  }
+  /* Alternate which side the shot sits on, so eight sections do not read as one long column. */
+  .alt .row .copy { order: 2; }
+  .ctas { display: flex; gap: 0.75rem; flex-wrap: wrap; margin-top: 1.4rem; }
+</style>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -34,24 +34,29 @@ const tiers = [
   },
 ];
 
+// Hotlinked from the repo at a tag, same as /features and /weatherdesk: GitHub carries the
+// bytes, and a later commit on main cannot change what the page shows. Only the hero poster and
+// the social card stay local — those two have to be there on first paint and for scrapers.
+const repoShots = "https://raw.githubusercontent.com/d4vid87/hookecho/v0.12.0-beta.1/docs/shots";
+
 const shots = [
   {
-    src: "/shots/alerts.jpg",
+    src: `${repoShots}/alerts.jpg`,
     alt: "Warning polygons, storm reports and spotter positions on the map",
     caption: "Warnings, storm reports and spotters, live.",
   },
   {
-    src: "/shots/alltilts.jpg",
+    src: `${repoShots}/alltilts.jpg`,
     alt: "Four radar tilts of the same storm side by side",
     caption: "Every tilt of the volume, side by side.",
   },
   {
-    src: "/shots/velocity.jpg",
+    src: `${repoShots}/velocity.jpg`,
     alt: "Storm-relative velocity showing a rotation couplet in a supercell",
     caption: "Velocity and dual-pol, dealiased.",
   },
   {
-    src: "/shots/hrrr.jpg",
+    src: `${repoShots}/hrrr.jpg`,
     alt: "HRRR model fields drawn over the map with severe composite parameters",
     caption: "HRRR and NAM fields, with the severe parameters.",
   },
@@ -122,6 +127,20 @@ const weatherdeskRepo = "https://github.com/d4vid87/weatherdesk";
   </section>
 
   <section class="alt">
+    <div class="wrap">
+      <p class="eyebrow">Against the field</p>
+      <h2>Yes, we will tell you when to buy something else</h2>
+      <p>
+        We put HookEcho next to RadarScope, MyRadar, Windy and RainViewer, row by row, including
+        the four rows they win. If the thing you need is global model data, Windy is better at it.
+      </p>
+      <div class="platforms">
+        <a class="btn btn-primary" href="/compare/">See the comparison</a>
+      </div>
+    </div>
+  </section>
+
+  <section>
     <div class="wrap">
       <p class="eyebrow">More from us</p>
       <h2>WeatherDesk</h2>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -3,6 +3,9 @@ import Base from "../layouts/Base.astro";
 import Hero from "../components/Hero.astro";
 import FeatureGrid from "../components/FeatureGrid.astro";
 import ShotGallery from "../components/ShotGallery.astro";
+import Ticker from "../components/Ticker.astro";
+import NearYou from "../components/NearYou.astro";
+import LiveMosaic from "../components/LiveMosaic.astro";
 import Card from "../components/Card.astro";
 
 // The three tiers are the same progressive-disclosure story the app itself tells: the first
@@ -33,11 +36,6 @@ const tiers = [
 
 const shots = [
   {
-    src: "/shots/mosaic.jpg",
-    alt: "The national MRMS radar mosaic over the United States",
-    caption: "The whole country at once, from the MRMS mosaic.",
-  },
-  {
     src: "/shots/alerts.jpg",
     alt: "Warning polygons, storm reports and spotter positions on the map",
     caption: "Warnings, storm reports and spotters, live.",
@@ -48,11 +46,18 @@ const shots = [
     caption: "Every tilt of the volume, side by side.",
   },
   {
+    src: "/shots/velocity.jpg",
+    alt: "Storm-relative velocity showing a rotation couplet in a supercell",
+    caption: "Velocity and dual-pol, dealiased.",
+  },
+  {
     src: "/shots/hrrr.jpg",
     alt: "HRRR model fields drawn over the map with severe composite parameters",
     caption: "HRRR and NAM fields, with the severe parameters.",
   },
 ];
+
+const weatherdeskRepo = "https://github.com/d4vid87/weatherdesk";
 ---
 
 <Base
@@ -63,6 +68,25 @@ const shots = [
     title="Weather radar for everyone"
     tagline="Live NEXRAD radar, warnings and storm tracking — straight from the public NOAA feeds to your own machine."
   />
+
+  <section class="live">
+    <div class="wrap">
+      <p class="eyebrow">Right now</p>
+      <Ticker />
+      <div class="live-grid">
+        <div>
+          <h2>The weather on this page is real</h2>
+          <p>
+            Those counts are live warnings from the National Weather Service, and the mosaic
+            beside them is the current national radar picture. HookEcho reads the same feeds —
+            at full resolution, from your own machine, with nothing in between.
+          </p>
+          <NearYou />
+        </div>
+        <LiveMosaic />
+      </div>
+    </div>
+  </section>
 
   <section>
     <div class="wrap">
@@ -101,13 +125,15 @@ const shots = [
     <div class="wrap">
       <p class="eyebrow">More from us</p>
       <h2>WeatherDesk</h2>
-      <Card
-        title="Your own weather station, on your own dashboard"
-        href="/weatherdesk/"
-      >
+      <!-- No href on the Card: it would wrap the whole thing in an <a>, and the two links below
+           cannot live inside one. -->
+      <Card title="Your own weather station, on your own dashboard">
         <p>
           A self-hosted dashboard for a Tempest weather station: live gauges, history and
           forecasts on your own hardware. The radar inside it is HookEcho.
+        </p>
+        <p class="wd-links">
+          <a href="/weatherdesk/">What it does</a> · <a href={weatherdeskRepo}>Source on GitHub</a>
         </p>
       </Card>
     </div>
@@ -117,4 +143,12 @@ const shots = [
 <style>
   .alt { background: var(--bg-deep); border-block: 1px solid var(--stroke); }
   .platforms { display: flex; gap: 0.75rem; flex-wrap: wrap; margin-top: 1.4rem; }
+  .live { padding-top: clamp(2rem, 5vw, 3rem); }
+  .live-grid {
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    align-items: center;
+    margin-top: 2.2rem;
+  }
 </style>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -26,6 +26,11 @@
   --radius: 12px;
   --measure: 68ch;
   --page: 1120px;
+  /* Motion + glow, matching the app's playful pass (crates/hookecho/src/ui/m3.rs DUR_*).
+     Every use goes through these so the prefers-reduced-motion block below is the one switch. */
+  --dur: 220ms;
+  --spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --glow: radial-gradient(60% 50% at 50% 0%, color-mix(in srgb, var(--accent) 22%, transparent), transparent 70%);
   color-scheme: dark;
 }
 
@@ -52,6 +57,7 @@ html { scroll-behavior: smooth; }
 @media (prefers-reduced-motion: reduce) {
   html { scroll-behavior: auto; }
   * { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; }
+  .sweep { display: none; }
 }
 
 body {
@@ -65,8 +71,8 @@ body {
 }
 
 h1, h2, h3 { line-height: 1.15; letter-spacing: -0.02em; margin: 0 0 0.4em; }
-h1 { font-size: clamp(2.2rem, 6vw, 3.6rem); font-weight: 700; }
-h2 { font-size: clamp(1.6rem, 3.5vw, 2.2rem); font-weight: 600; }
+h1 { font-size: clamp(2.5rem, 7vw, 4.2rem); font-weight: 700; }
+h2 { font-size: clamp(1.75rem, 4vw, 2.6rem); font-weight: 700; }
 h3 { font-size: 1.15rem; font-weight: 600; }
 p { margin: 0 0 1em; max-width: var(--measure); }
 
@@ -99,9 +105,14 @@ section { padding: clamp(3rem, 8vw, 5.5rem) 0; }
   color: var(--text);
   font-weight: 600;
   text-decoration: none;
-  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+  transition: transform var(--dur) var(--spring), background var(--dur) ease,
+    border-color var(--dur) ease, box-shadow var(--dur) ease;
 }
-.btn:hover { transform: translateY(-1px); border-color: var(--accent); }
+.btn:hover {
+  transform: translateY(-2px);
+  border-color: var(--accent);
+  box-shadow: 0 8px 24px color-mix(in srgb, var(--accent) 24%, transparent);
+}
 .btn-primary {
   background: var(--accent);
   border-color: var(--accent);
@@ -113,4 +124,27 @@ section { padding: clamp(3rem, 8vw, 5.5rem) 0; }
   border: 1px solid var(--stroke);
   border-radius: var(--radius);
   padding: 1.4rem;
+  transition: transform var(--dur) var(--spring), border-color var(--dur) ease;
+}
+.card:hover { transform: translateY(-3px); border-color: var(--accent); }
+
+/* The radar-sweep accent: one conic gradient rotating behind a section, echoing the app's
+   intro sweep. Decorative only — aria-hidden at every call site. */
+.sweep {
+  position: absolute;
+  inset: -30% -10% auto -10%;
+  aspect-ratio: 1;
+  pointer-events: none;
+  border-radius: 50%;
+  background: conic-gradient(
+    from 0deg,
+    color-mix(in srgb, var(--accent) 20%, transparent),
+    transparent 28%
+  );
+  mask-image: radial-gradient(closest-side, #000 40%, transparent 72%);
+  animation: sweep 7s linear infinite;
+  opacity: 0.55;
+}
+@keyframes sweep {
+  to { transform: rotate(1turn); }
 }


### PR DESCRIPTION
#143–#146 merged into their stacked parent branches rather than main (the parent branches still existed, so GitHub did not retarget). Same four commits, unchanged, now landing on main:

- 5d99bb4 visual system + landing redesign (#143)
- 248b34b features page (#144)
- 389c335 comparison page (#145)
- 9b233b7 screenshots served from GitHub (#146)

No new work; each was built, link-checked and rendered on its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)