### PR TITLE
feat(site): historic storm pages

### DIFF
--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -24,4 +24,26 @@ const blog = defineCollection({
   }),
 });
 
-export const collections = { docs, blog };
+// Historic storms: the frontmatter is the archive deep link, spelled out in fields rather than a
+// pasted URL, so the app's #goto vocabulary lives in one place (storms/[...slug].astro).
+const storms = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/content/storms" }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    /** When the storm happened — used for sorting and for the page's dateline. */
+    date: z.coerce.date(),
+    /** NEXRAD site that watched it, e.g. "KTLX". Must have a page under /radar/. */
+    site: z.string(),
+    lon: z.number(),
+    lat: z.number(),
+    zoom: z.number(),
+    /** RFC3339 volume time the archive opens on. */
+    at: z.string(),
+    /** Extra #goto tokens: a moment code (VEL, CC…), a tilt number, `srv`. */
+    extras: z.array(z.string()).default([]),
+    image: z.string().optional(),
+  }),
+});
+
+export const collections = { docs, blog, storms };

--- a/site/src/content/storms/el-reno-2013.md
+++ b/site/src/content/storms/el-reno-2013.md
@@ -1,0 +1,26 @@
+---
+title: "El Reno, 2013"
+description: "The widest tornado ever measured — 2.6 miles across on 31 May 2013 — from KTLX, with the storm-relative velocity that hid how fast it was growing."
+date: 2013-05-31
+site: KTLX
+lon: -97.9548
+lat: 35.5323
+zoom: 9
+at: "2013-05-31T23:05:00Z"
+extras: ["VEL", "srv"]
+---
+
+The El Reno tornado of 31 May 2013 was 2.6 miles wide, the widest ever
+measured. It killed eight people, including three storm chasers — the first
+chaser deaths in a tornado in the history of the pursuit.
+
+**What the radar shows.** The link opens on storm-relative velocity from
+Twin Lakes, about 40 miles east. Subtracting the storm's own motion is the
+whole point: it separates rotation from translation, and what is left is a
+couplet that widens and accelerates over consecutive volumes rather than
+tracking neatly along one line. The tornado repeatedly turned and expanded
+faster than the radar's five-minute update could describe.
+
+This is the case that made a generation of chasers stop treating a radar
+signature as a position and start treating it as a five-minute-old estimate of
+one.

--- a/site/src/content/storms/greensburg-2007.md
+++ b/site/src/content/storms/greensburg-2007.md
@@ -1,0 +1,25 @@
+---
+title: "Greensburg, 2007"
+description: "The 4 May 2007 Greensburg EF5 from KDDC — the first tornado rated on the Enhanced Fujita scale, and a town that lost 95 percent of its buildings."
+date: 2007-05-04
+site: KDDC
+lon: -99.2926
+lat: 37.6042
+zoom: 10
+at: "2007-05-05T02:45:00Z"
+extras: ["VEL"]
+---
+
+Shortly before 10 pm on 4 May 2007, a 1.7-mile-wide tornado destroyed
+Greensburg, Kansas. Ninety-five percent of the town was flattened. It was the
+first tornado rated EF5 under the Enhanced Fujita scale, introduced three
+months earlier.
+
+**What the radar shows.** Dodge City is 35 miles away and the storm crossed at
+night, which is the situation warnings exist for: nobody was going to confirm
+this one visually. The velocity couplet is enormous and persists volume after
+volume, and the reflectivity shows a textbook hook with a clear inflow notch.
+
+Greensburg pre-dates the dual-polarization upgrade, so there is no correlation
+coefficient to check — the debris signature that makes Joplin and Moore
+unambiguous simply did not exist as a tool yet.

--- a/site/src/content/storms/joplin-2011.md
+++ b/site/src/content/storms/joplin-2011.md
@@ -1,0 +1,27 @@
+---
+title: "Joplin, 2011"
+description: "The Joplin EF5 of 22 May 2011, the deadliest US tornado since 1947 — replayed from KSGF's archived volumes, with the debris ball that told forecasters what was on the ground."
+date: 2011-05-22
+site: KSGF
+lon: -94.5133
+lat: 37.0842
+zoom: 9
+at: "2011-05-22T22:40:00Z"
+extras: ["CC"]
+---
+
+At 5:34 pm on a Sunday afternoon, a multiple-vortex EF5 crossed the southern
+edge of Joplin, Missouri, from west to east. It killed 158 people and destroyed
+about a third of the city.
+
+**What the radar shows.** Springfield's WSR-88D was watching from roughly 90
+miles away, so the beam was already thousands of feet above the ground by the
+time it reached Joplin — and it still lit up. The link opens on correlation
+coefficient, the dual-polarization product that measures how alike the targets
+in a radar bin are. Rain is uniform and reads high. Snapped lumber, insulation
+and roof decking lofted into the air are not, and read as a hole in the field
+sitting exactly under the velocity couplet: a tornadic debris signature. On
+this volume there is no ambiguity about whether something is on the ground.
+
+Switch to velocity and the couplet is unmistakable; switch to reflectivity and
+you get the hook the app is named after.

--- a/site/src/content/storms/katrina-2005.md
+++ b/site/src/content/storms/katrina-2005.md
@@ -1,0 +1,24 @@
+---
+title: "Hurricane Katrina, 2005"
+description: "Katrina's landfall on 29 August 2005 from KLIX, the New Orleans radar — an eyewall passing over the site that was watching it."
+date: 2005-08-29
+site: KLIX
+lon: -89.5253
+lat: 29.3547
+zoom: 8
+at: "2005-08-29T11:10:00Z"
+extras: ["REF"]
+---
+
+Katrina made its Louisiana landfall near Buras at about 6:10 am local time on
+29 August 2005 as a Category 3, driving a storm surge that overwhelmed the New
+Orleans levee system.
+
+**What the radar shows.** The link opens on reflectivity from Slidell, on the
+north shore of Lake Pontchartrain. The eye is a clean hole surrounded by a
+closed eyewall, with feeder bands wrapping in from the Gulf, and the whole
+structure walks across the frame as the storm comes ashore.
+
+Slidell's radar was itself inside the storm. The archive gets patchy as the
+site loses power — the gaps in the loop are the landfall happening to the
+instrument recording it.

--- a/site/src/content/storms/midwest-derecho-2020.md
+++ b/site/src/content/storms/midwest-derecho-2020.md
@@ -1,0 +1,24 @@
+---
+title: "The Midwest derecho, 2020"
+description: "10 August 2020 from KDVN: a 770-mile windstorm with 140 mph gusts that crossed Iowa in a morning and cost more than any thunderstorm event in US history."
+date: 2020-08-10
+site: KDVN
+lon: -91.6656
+lat: 41.9779
+zoom: 8
+at: "2020-08-10T17:00:00Z"
+extras: ["VEL"]
+---
+
+On 10 August 2020 a derecho crossed 770 miles from South Dakota to Ohio in 14
+hours. Gusts reached 140 mph near Cedar Rapids. It flattened roughly a third of
+Iowa's corn crop and became the costliest thunderstorm event in US history.
+
+**What the radar shows.** The link opens on velocity from the Quad Cities
+radar. A derecho is a wind event, so reflectivity alone undersells it: the
+bowing line looks like a squall line and not much more. Velocity is where the
+rear-inflow jet appears, a slab of inbound air punching through the back of the
+line and reaching the ground as the damaging gust.
+
+Step the loop and watch the bow accelerate. The line is moving faster than most
+tornadic supercells travel.

--- a/site/src/content/storms/moore-2013.md
+++ b/site/src/content/storms/moore-2013.md
@@ -1,0 +1,25 @@
+---
+title: "Moore, 2013"
+description: "The 20 May 2013 Moore EF5 from KTLX — a violent tornado 20 miles from the radar, sampled about as well as a WSR-88D can sample one."
+date: 2013-05-20
+site: KTLX
+lon: -97.4867
+lat: 35.3395
+zoom: 10
+at: "2013-05-20T20:20:00Z"
+extras: ["VEL"]
+---
+
+An EF5 tracked 14 miles through Newcastle, Oklahoma City and Moore on the
+afternoon of 20 May 2013, killing 24 people, including seven children at
+Plaza Towers Elementary.
+
+**What the radar shows.** Moore sits about 20 miles from Twin Lakes, which is
+close to the best case for a WSR-88D: the beam is still low enough to sample
+the circulation itself rather than the storm's mid-levels. The velocity couplet
+is tight, deep and obvious, and the debris signature on correlation coefficient
+follows the damage path almost tile for tile.
+
+Compare this volume with Joplin's, 90 miles from its radar, and you have the
+argument for why range matters more than almost anything else in radar
+interpretation.

--- a/site/src/content/storms/tuscaloosa-2011.md
+++ b/site/src/content/storms/tuscaloosa-2011.md
@@ -1,0 +1,24 @@
+---
+title: "Tuscaloosa–Birmingham, 2011"
+description: "27 April 2011 from KBMX: the single worst day of the modern tornado record, with a long-track EF4 crossing two cities inside an hour."
+date: 2011-04-27
+site: KBMX
+lon: -87.5692
+lat: 33.2098
+zoom: 9
+at: "2011-04-27T22:10:00Z"
+extras: ["REF"]
+---
+
+The 2011 Super Outbreak produced 360 tornadoes in three days. On 27 April
+alone, 216 touched down. The Tuscaloosa–Birmingham EF4 stayed on the ground for
+80 miles and killed 64 people.
+
+**What the radar shows.** The link opens on base reflectivity from Birmingham,
+because on this day the classic hook is not the interesting part — the sheer
+count is. Step the loop and you are watching a line of discrete supercells,
+each with its own hook, marching northeast in parallel across the whole state.
+Central Alabama's radar was tracking several simultaneous violent tornadoes.
+
+Turn the warning overlay on and the map fills with polygons faster than the
+loop advances.

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -23,6 +23,7 @@ const nav = [
   { href: "/docs/", label: "Docs" },
   { href: "/blog/", label: "Blog" },
   { href: "/radar/", label: "Radar sites" },
+  { href: "/storms/", label: "Storms" },
   { href: "https://app.hookecho.io", label: "Open in browser" },
   { href: "/download/", label: "Download" },
   { href: "https://github.com/d4vid87/hookecho", label: "GitHub" },

--- a/site/src/pages/storms/[...slug].astro
+++ b/site/src/pages/storms/[...slug].astro
@@ -1,0 +1,57 @@
+---
+import { getCollection, render } from "astro:content";
+import Base from "../../layouts/Base.astro";
+
+export async function getStaticPaths() {
+  const storms = await getCollection("storms");
+  return storms.map((storm) => ({ params: { slug: storm.id }, props: { storm } }));
+}
+
+const { storm } = Astro.props;
+const { Content } = await render(storm);
+const s = storm.data;
+
+// The app's #goto vocabulary: SITE,lon,lat,zoom then order-independent extras (a timestamp, a
+// moment code, a tilt, srv). Built from frontmatter so no storm page hand-writes a URL.
+const goto = [s.site, s.lon, s.lat, s.zoom, s.at, ...s.extras].join(",");
+const appLink = `https://app.hookecho.io/#goto=${goto}`;
+const when = s.date.toLocaleDateString("en-US", {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+  timeZone: "UTC",
+});
+---
+
+<Base title={`${s.title} — on the radar | HookEcho`} description={s.description} image={s.image}>
+  <article>
+    <div class="wrap">
+      <p class="eyebrow"><a href="/storms/">Storms on the radar</a> · {when}</p>
+      <h1>{s.title}</h1>
+
+      <div class="cta">
+        <a class="btn btn-primary" href={appLink}>Replay it in your browser</a>
+        <a class="btn" href={`/radar/${s.site.toLowerCase()}/`}>{s.site} radar</a>
+      </div>
+      <p class="dim">
+        Opens HookEcho on {s.site} at {s.at.replace("T", " ").replace("Z", " UTC")} and loads the
+        archived volumes for that day. The archive goes back to 1991.
+      </p>
+
+      <div class="prose"><Content /></div>
+
+      <p class="dim">
+        Archive volumes come from NOAA's public NEXRAD archive on AWS, the same source the
+        National Weather Service publishes. Nothing here is a re-render of someone else's picture.
+      </p>
+    </div>
+  </article>
+</Base>
+
+<style>
+  .eyebrow a { color: inherit; }
+  .cta { display: flex; gap: 0.75rem; flex-wrap: wrap; margin: 1.4rem 0 1rem; }
+  .dim { color: var(--text-dim); font-size: 0.92rem; max-width: 62ch; }
+  .prose { max-width: 62ch; margin-top: 2rem; }
+  .prose :global(p) { margin: 1rem 0; }
+</style>

--- a/site/src/pages/storms/index.astro
+++ b/site/src/pages/storms/index.astro
@@ -1,0 +1,58 @@
+---
+import { getCollection } from "astro:content";
+import Base from "../../layouts/Base.astro";
+
+const storms = (await getCollection("storms")).sort(
+  (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
+);
+---
+
+<Base
+  title="Storms on the radar | HookEcho"
+  description="Joplin, El Reno, Moore, Tuscaloosa, Greensburg, Katrina and the 2020 derecho — replay the archived NEXRAD volumes of the storms that defined modern radar, one link each."
+>
+  <section>
+    <div class="wrap">
+      <p class="eyebrow">Storms on the radar</p>
+      <h1>The storms that taught us to read radar</h1>
+      <p class="lede">
+        HookEcho's archive goes back to 1991, which means every one of these is still there to
+        replay volume by volume. Each page opens the app on the right radar, at the right minute,
+        on the product that makes the storm legible.
+      </p>
+
+      <ul class="list">
+        {
+          storms.map((storm) => (
+            <li>
+              <a href={`/storms/${storm.id}/`}>
+                <h2>{storm.data.title}</h2>
+                <p>{storm.data.description}</p>
+                <span class="meta">{storm.data.site}</span>
+              </a>
+            </li>
+          ))
+        }
+      </ul>
+    </div>
+  </section>
+</Base>
+
+<style>
+  .lede { font-size: 1.1rem; color: var(--text-dim); max-width: 62ch; }
+  .list { list-style: none; padding: 0; margin: 2.2rem 0 0; display: grid; gap: 1rem; }
+  .list a {
+    display: block;
+    padding: 1.2rem;
+    border: 1px solid var(--stroke);
+    border-radius: var(--radius);
+    background: var(--bg-deep);
+    text-decoration: none;
+    color: var(--text-dim);
+    transition: border-color var(--dur) ease, transform var(--dur) var(--spring);
+  }
+  .list a:hover { border-color: var(--accent); transform: translateY(-2px); }
+  .list h2 { margin: 0 0 0.4rem; font-size: 1.15rem; color: var(--text); }
+  .list p { margin: 0; max-width: 70ch; }
+  .meta { display: inline-block; margin-top: 0.6rem; font-size: 0.85rem; color: var(--accent); }
+</style>


### PR DESCRIPTION
The archive goes back to 1991, so the storms people already search for are the cheapest demonstration of it.

- New `storms` content collection with typed frontmatter: `{title, description, date, site, lon, lat, zoom, at, extras[], image?}`. The deep link is assembled in the layout from those fields, so the `#goto` vocabulary (`SITE,lon,lat,zoom` then order-independent extras) lives in exactly one place.
- Seven pages: Joplin 2011 (KSGF, opens on CC for the debris signature), El Reno 2013 (KTLX, SRV), Moore 2013 (KTLX, VEL), Tuscaloosa 2011 (KBMX, REF), Greensburg 2007 (KDDC, VEL — and notes there is no dual-pol yet), Katrina 2005 (KLIX, REF), 2020 derecho (KDVN, VEL for the rear-inflow jet).
- `/storms/` index, sorted newest first; each page cross-links `/radar/<site>/`; nav gains Storms.

Verified: `npm run build` clean, 180 pages. `npm run linkcheck` zero broken. Generated link spot-checked — El Reno emits `#goto=KTLX,-97.9548,35.5323,9,2013-05-31T23:05:00Z,VEL,srv` (lon before lat, timestamp and moment code as order-independent extras).

🤖 Generated with [Claude Code](https://claude.com/claude-code)