### PR TITLE
feat(site): how-it-works, privacy and press pages

### DIFF
--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -88,7 +88,11 @@ const nav = [
           National Weather Service and other public feeds — no account, no telemetry.
         </p>
         <p class="dim">
+          <a href="/how-it-works/">How it works</a> ·
+          <a href="/privacy/">Privacy</a> ·
+          <a href="/press/">Press</a> ·
           <a href="https://github.com/d4vid87/hookecho">Source</a> ·
+          <a href="https://github.com/d4vid87/hookecho/discussions">Discussions</a> ·
           <a href="https://github.com/d4vid87/hookecho/issues">Report a problem</a> ·
           <a href="/weatherdesk/">WeatherDesk</a> ·
           <a href="https://github.com/d4vid87/weatherdesk">WeatherDesk source</a>

--- a/site/src/pages/how-it-works.astro
+++ b/site/src/pages/how-it-works.astro
@@ -1,0 +1,109 @@
+---
+import Base from "../layouts/Base.astro";
+import ShotGallery from "../components/ShotGallery.astro";
+
+const repoShots = "https://raw.githubusercontent.com/d4vid87/hookecho/v0.12.0-beta.1/docs/shots";
+
+const shots = [
+  {
+    src: `${repoShots}/products.jpg`,
+    alt: "The product picker showing Level 3 algorithm products for the selected site",
+    caption: "Level 3 products, decoded on your machine.",
+  },
+  {
+    src: `${repoShots}/fronts.jpg`,
+    alt: "Surface analysis fronts and pressure centers drawn over the map",
+    caption: "Surface analysis, from the same charts forecasters draw.",
+  },
+  {
+    src: `${repoShots}/forecast.jpg`,
+    alt: "A point forecast panel opened by clicking a location on the map",
+    caption: "Click anywhere: that is the NWS forecast for that point.",
+  },
+  {
+    src: `${repoShots}/qpe.jpg`,
+    alt: "Multi-hour precipitation accumulation shaded across a region",
+    caption: "Rainfall accumulation, straight from MRMS.",
+  },
+];
+---
+
+<Base
+  title="How HookEcho works | HookEcho"
+  description="Where the data comes from, what happens on your machine, and why there is no server in the middle. NEXRAD Level 2, MRMS, HRRR and the NWS API, decoded locally."
+>
+  <section>
+    <div class="wrap prose">
+      <p class="eyebrow">How it works</p>
+      <h1>There is no server in the middle</h1>
+      <p class="lede">
+        Most weather apps are a thin client for someone's rendering service: their server reads the
+        radar, draws a picture, and sends you the picture. HookEcho downloads the radar itself and
+        draws it on your machine. That one difference explains almost everything else about it.
+      </p>
+
+      <h2>Where the data comes from</h2>
+      <p>
+        All of it is public and all of it is free, because the American taxpayer already paid for
+        it. The app reads:
+      </p>
+      <ul>
+        <li>
+          <strong>NEXRAD Level 2</strong> — the full volume scan from a WSR-88D: every elevation
+          angle, reflectivity, velocity, spectrum width and the dual-polarization fields. Live from
+          the real-time feed, and archived back to 1991.
+        </li>
+        <li>
+          <strong>NEXRAD Level 3</strong> — the algorithm products the radar itself computes:
+          storm tracks, hail, mesocyclone detections, precipitation totals.
+        </li>
+        <li>
+          <strong>MRMS</strong> — the national mosaic, rotation tracks, hail swaths and quantitative
+          precipitation estimates, blended across every radar at once.
+        </li>
+        <li>
+          <strong>HRRR and NAM</strong> — hourly model fields, including the severe composite
+          parameters, read straight from the public model buckets.
+        </li>
+        <li>
+          <strong>The National Weather Service API</strong> — warnings, watches, point forecasts,
+          storm reports, surface observations and text products.
+        </li>
+      </ul>
+
+      <h2>What happens on your machine</h2>
+      <p>
+        The app decodes the raw volume, corrects the velocity aliasing, builds the sweep geometry
+        and rasterizes it on your GPU. Nothing has been resampled, smoothed or downscaled by anyone
+        before you see it, because nobody else touched it. When you switch tilts, the data for that
+        tilt is already in memory — it came down in the same volume.
+      </p>
+      <p>
+        It also means the app works in places a thin client cannot. Offline chase packs are just
+        the volumes you already downloaded, and the archive is the same decoder pointed at an older
+        file.
+      </p>
+
+      <ShotGallery shots={shots} />
+
+      <h2>Why it is free</h2>
+      <p>
+        Because it costs nothing to run. There is no rendering server, no data licence, no API
+        contract and no infrastructure bill to pass on to you. The desktop app talks directly to
+        NOAA; the browser version is a static bundle. What is left is the code, which is MIT
+        licensed and
+        <a href="https://github.com/d4vid87/hookecho">on GitHub</a>.
+      </p>
+      <p>
+        <a href="/privacy/">What the app and this site actually contact</a> ·
+        <a href="/compare/">How it compares to the alternatives</a>
+      </p>
+    </div>
+  </section>
+</Base>
+
+<style>
+  .prose { max-width: 70ch; }
+  .lede { font-size: 1.1rem; color: var(--text-dim); }
+  li { margin: 0.5rem 0; }
+</style>

--- a/site/src/pages/press.astro
+++ b/site/src/pages/press.astro
@@ -1,0 +1,104 @@
+---
+import Base from "../layouts/Base.astro";
+
+const tag = "v0.12.0-beta.1";
+const raw = `https://raw.githubusercontent.com/d4vid87/hookecho/${tag}`;
+// Assets are linked at a tag rather than copied into this site: GitHub carries the bandwidth, and
+// a later commit cannot change what a published article ends up pointing at.
+const assets = [
+  { href: `${raw}/assets/brand/hookecho-logo.png`, label: "App icon", note: "PNG, 1024×1024" },
+  { href: `${raw}/docs/shots/alltilts.jpg`, label: "Every tilt", note: "Level 2 volume, all elevations" },
+  { href: `${raw}/docs/shots/velocity.jpg`, label: "Velocity", note: "Storm-relative velocity, dealiased" },
+  { href: `${raw}/docs/shots/alerts.jpg`, label: "Warnings", note: "Polygons, storm reports, spotters" },
+  { href: `${raw}/docs/shots/mosaic.jpg`, label: "National mosaic", note: "MRMS" },
+  { href: `${raw}/docs/shots/hrrr.jpg`, label: "Model fields", note: "HRRR with severe parameters" },
+];
+---
+
+<Base
+  title="Press kit | HookEcho"
+  description="Boilerplate, fact sheet and screenshots for writing about HookEcho — the free, open-source NEXRAD weather radar app."
+>
+  <section>
+    <div class="wrap prose">
+      <p class="eyebrow">Press</p>
+      <h1>Press kit</h1>
+      <p class="lede">
+        Everything here is free to use in coverage of HookEcho, with credit to the project. No
+        permission request needed.
+      </p>
+
+      <h2>Boilerplate</h2>
+      <blockquote>
+        HookEcho is a free, open-source weather radar app for Windows, macOS, Linux, Android and
+        the browser. It reads NEXRAD Level 2 volumes, MRMS, HRRR and the National Weather Service
+        feeds directly from the public NOAA sources and renders them on the user's own machine —
+        every radar tilt, dual-polarization products, storm-relative velocity, warnings and archive
+        playback back to 1991 — with no account, no subscription, no ads and no telemetry. It is
+        MIT licensed.
+      </blockquote>
+
+      <h2>Fact sheet</h2>
+      <dl class="facts">
+        <div><dt>Name</dt><dd>HookEcho (one word, capital H and E)</dd></div>
+        <div><dt>What it is</dt><dd>Desktop, mobile and browser weather radar viewer</dd></div>
+        <div><dt>Platforms</dt><dd>Windows, macOS, Linux, Android, any modern browser</dd></div>
+        <div><dt>Price</dt><dd>Free. No paid tier, no in-app purchase</dd></div>
+        <div><dt>Licence</dt><dd>MIT</dd></div>
+        <div><dt>Data sources</dt><dd>NOAA NEXRAD, MRMS, HRRR/NAM, National Weather Service API</dd></div>
+        <div><dt>Coverage</dt><dd>153 NEXRAD sites, 44 TDWR terminal radars, Germany's DWD network</dd></div>
+        <div><dt>Archive</dt><dd>Back to 1991</dd></div>
+        <div><dt>Source</dt><dd><a href="https://github.com/d4vid87/hookecho">github.com/d4vid87/hookecho</a></dd></div>
+      </dl>
+
+      <h2>Where the name comes from</h2>
+      <p>
+        A hook echo is the comma-shaped appendage on a supercell's radar signature, wrapped around
+        the storm's rotating updraft. It was first documented in Illinois in 1953, and it has been
+        the classic radar indicator of a possible tornado ever since — the thing a forecaster looks
+        for first.
+        <a href="/blog/what-is-a-hook-echo/">The longer version.</a>
+      </p>
+
+      <h2>Images</h2>
+      <p class="dim">
+        Linked from the repository at tag {tag}. Right-click to save; hotlinking is fine too.
+      </p>
+      <ul class="assets">
+        {
+          assets.map((asset) => (
+            <li>
+              <a href={asset.href}>{asset.label}</a> — <span class="dim">{asset.note}</span>
+            </li>
+          ))
+        }
+      </ul>
+
+      <h2>Contact</h2>
+      <p>
+        Questions, corrections and interview requests:
+        <a href="https://github.com/d4vid87/hookecho/discussions">GitHub Discussions</a>, or open an
+        <a href="https://github.com/d4vid87/hookecho/issues">issue</a>.
+      </p>
+    </div>
+  </section>
+</Base>
+
+<style>
+  .prose { max-width: 70ch; }
+  .lede { font-size: 1.1rem; color: var(--text-dim); }
+  .dim { color: var(--text-dim); }
+  blockquote {
+    margin: 1.2rem 0;
+    padding: 1.2rem;
+    border-left: 3px solid var(--accent);
+    background: var(--bg-deep);
+    border-radius: var(--radius);
+  }
+  .facts { display: grid; gap: 0.8rem; margin: 1.2rem 0; }
+  .facts div { display: grid; grid-template-columns: minmax(120px, 180px) 1fr; gap: 1rem; }
+  .facts dt { color: var(--text-dim); }
+  .facts dd { margin: 0; }
+  .assets { padding-left: 1.1rem; }
+  .assets li { margin: 0.4rem 0; }
+</style>

--- a/site/src/pages/privacy.astro
+++ b/site/src/pages/privacy.astro
@@ -1,0 +1,84 @@
+---
+import Base from "../layouts/Base.astro";
+---
+
+<Base
+  title="Privacy | HookEcho"
+  description="What this website loads, what the app sends, and what neither of them collects. No accounts, no telemetry, no ad network."
+>
+  <section>
+    <div class="wrap prose">
+      <p class="eyebrow">Privacy</p>
+      <h1>What we collect: nothing you would call data</h1>
+      <p class="lede">
+        There is no account system, no telemetry, no ad network and no analytics product that
+        follows you between sites. This page is the specific version of that claim, because the
+        vague version is worth nothing.
+      </p>
+
+      <h2>The app</h2>
+      <p>
+        HookEcho runs on your own machine and talks straight to the public weather feeds — NOAA's
+        NEXRAD archive and MRMS, the National Weather Service API, and the model buckets. Those
+        servers see the requests, exactly as they would if you loaded a weather page. Nothing is
+        routed through us, because there is no us to route it through: we run no server that the
+        app contacts.
+      </p>
+      <p>
+        Your settings, bookmarks and chase logs are files on your disk. API keys you enter — for a
+        basemap provider or a mesonet network — stay in your own settings file and are sent only to
+        the service that issued them.
+      </p>
+      <p>
+        Location is used only if you turn it on, and only to pick your nearest radar. It is not
+        sent anywhere.
+      </p>
+
+      <h2>This website</h2>
+      <p>Loading a page here contacts, and only ever contacts:</p>
+      <ul>
+        <li>
+          <strong>api.weather.gov</strong> — the live warning counts on the landing page and the
+          per-radar pages. Public data, no key, requested by your browser directly.
+        </li>
+        <li>
+          <strong>radar.weather.gov</strong> — the live radar loops. Images, hotlinked from the
+          NWS's own server.
+        </li>
+        <li>
+          <strong>raw.githubusercontent.com</strong> — the screenshots, served from our repository
+          at a fixed tag so GitHub carries the bandwidth rather than us.
+        </li>
+        <li>
+          <strong>static.cloudflareinsights.com</strong> — Cloudflare Web Analytics, when it is
+          enabled. It is cookieless, records no personal data and does not fingerprint or track you
+          across sites. It exists so we know which pages people read.
+        </li>
+      </ul>
+      <p>
+        The site also answers a request to its own <code>/geo.json</code>, which returns the rough
+        city and coordinates our host already derived from your IP address, so the page can say
+        which radar is nearest without asking your browser for location permission. It is computed
+        per request and never stored, logged or associated with anything.
+      </p>
+      <p>
+        We set no cookies. There is no login, no newsletter, no form and no comment box, so there
+        is nothing here for you to hand us.
+      </p>
+
+      <h2>If you would rather check than trust</h2>
+      <p>
+        The site and the app are both in
+        <a href="https://github.com/d4vid87/hookecho">the same public repository</a>. Every network
+        call either makes is in that source, and the desktop app's allowed-host list is compiled in
+        and checked by CI.
+      </p>
+    </div>
+  </section>
+</Base>
+
+<style>
+  .prose { max-width: 68ch; }
+  .lede { font-size: 1.1rem; color: var(--text-dim); }
+  li { margin: 0.5rem 0; }
+</style>


### PR DESCRIPTION
The three credibility surfaces from the interview, plus the Discussions link. Footer-linked only — the nav is full.

- **`/how-it-works`** — the "no server in the middle" argument, each data source named (Level 2, Level 3, MRMS, HRRR/NAM, the NWS API), what gets decoded locally and why that makes it free. Uses four previously unused screenshots (`products`, `fronts`, `forecast`, `qpe`).
- **`/privacy`** — enumerates exactly what a page here contacts: api.weather.gov, radar.weather.gov, raw.githubusercontent.com, static.cloudflareinsights.com when analytics is enabled, plus our own `/geo.json` (computed per request from the edge's IP lookup, never stored). States plainly: no cookies, no account, no form.
- **`/press`** — boilerplate paragraph, fact sheet, name origin, image list. Assets are linked at tag `v0.12.0-beta.1` rather than copied in, per the standing rule that GitHub carries the bandwidth.

**Before merging, one manual step is needed** (repo settings are yours, not mine to change):

```
gh api -X PATCH repos/d4vid87/hookecho -F has_discussions=true
```

Until that runs, the footer's Discussions link 404s — it is the single broken link in the check below, and it resolves the moment Discussions is on.

Verified: `npm run build` clean, 183 pages. `npm run linkcheck` — 405 links scanned, 1 broken (the Discussions link above), everything else 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)