### PR TITLE
feat(site): live GitHub stars and download counts

### DIFF
--- a/site/src/components/GitHubStats.astro
+++ b/site/src/components/GitHubStats.astro
@@ -1,0 +1,88 @@
+---
+// Stars and total release downloads, fetched in the visitor's browser from the public GitHub API.
+// ponytail: unauthenticated (60 requests an hour per IP) with a one-hour localStorage cache — a
+// token would mean a build secret and a server to hold it, for two numbers that change slowly.
+const repo = "d4vid87/hookecho";
+const ttlMs = 60 * 60 * 1000;
+---
+
+<div class="stats" data-repo={repo} data-ttl={ttlMs} hidden>
+  <a class="stat" href={`https://github.com/${repo}/stargazers`}>
+    <span class="n" data-slot="stars">—</span>
+    <span class="l">stars on GitHub</span>
+  </a>
+  <a class="stat" href={`https://github.com/${repo}/releases`}>
+    <span class="n" data-slot="downloads">—</span>
+    <span class="l">downloads</span>
+  </a>
+</div>
+
+<script>
+  const el = document.querySelector<HTMLElement>(".stats");
+  const repo = el?.dataset.repo;
+  const ttl = Number(el?.dataset.ttl ?? 0);
+  const key = "hookecho:ghstats";
+
+  function show(stars: number, downloads: number) {
+    if (!el) return;
+    el.querySelector('[data-slot="stars"]')!.textContent = stars.toLocaleString();
+    el.querySelector('[data-slot="downloads"]')!.textContent = downloads.toLocaleString();
+    el.hidden = false;
+  }
+
+  if (el && repo) {
+    let cached: { t: number; stars: number; dl: number } | null = null;
+    try {
+      cached = JSON.parse(localStorage.getItem(key) ?? "null");
+    } catch {
+      cached = null;
+    }
+
+    if (cached && Date.now() - cached.t < ttl) {
+      show(cached.stars, cached.dl);
+    } else {
+      Promise.all([
+        fetch(`https://api.github.com/repos/${repo}`).then((r) => r.json()),
+        // Draft releases are invisible to an unauthenticated caller, and release.yml demotes old
+        // ones to drafts — so this undercounts. Deliberate: a number that is honestly low beats a
+        // number that needs a token to be right.
+        fetch(`https://api.github.com/repos/${repo}/releases?per_page=100`).then((r) => r.json()),
+      ])
+        .then(([info, releases]) => {
+          const stars = info?.stargazers_count;
+          if (typeof stars !== "number" || !Array.isArray(releases)) throw new Error("shape");
+          const dl = releases
+            .flatMap((release) => release.assets ?? [])
+            .reduce((sum, asset) => sum + (asset.download_count ?? 0), 0);
+          try {
+            localStorage.setItem(key, JSON.stringify({ t: Date.now(), stars, dl }));
+          } catch {
+            // Private mode, quota, whatever. The numbers still render this once.
+          }
+          show(stars, dl);
+        })
+        // Rate limited, offline, or GitHub having a day: the block stays hidden rather than
+        // showing a page furniture with em dashes in it.
+        .catch(() => {});
+    }
+  }
+</script>
+
+<style>
+  .stats { display: flex; gap: 1rem; flex-wrap: wrap; margin-top: 1.6rem; }
+  .stat {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    padding: 0.6rem 1.1rem;
+    border: 1px solid var(--stroke);
+    border-radius: 999px;
+    background: var(--faint);
+    text-decoration: none;
+    color: var(--text-dim);
+    transition: border-color var(--dur) ease, transform var(--dur) var(--spring);
+  }
+  .stat:hover { border-color: var(--accent); transform: translateY(-2px); }
+  .n { font-size: 1.2rem; font-weight: 700; color: var(--text); font-variant-numeric: tabular-nums; }
+  .l { font-size: 0.9rem; }
+</style>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -7,6 +7,7 @@ import Ticker from "../components/Ticker.astro";
 import NearYou from "../components/NearYou.astro";
 import LiveMosaic from "../components/LiveMosaic.astro";
 import Card from "../components/Card.astro";
+import GitHubStats from "../components/GitHubStats.astro";
 
 // The three tiers are the same progressive-disclosure story the app itself tells: the first
 // screen answers "is it going to rain on me", and the depth is there when you go looking.
@@ -123,6 +124,7 @@ const weatherdeskRepo = "https://github.com/d4vid87/weatherdesk";
           Windows · macOS · Linux · Android
         </a>
       </div>
+      <GitHubStats />
     </div>
   </section>
 


### PR DESCRIPTION
Social proof on the landing page, under the platform row.

- New `GitHubStats.astro`: fetches `repos/d4vid87/hookecho` and `/releases?per_page=100`, sums `download_count` across assets.
- Unauthenticated (60 req/hr/IP) with a one-hour `localStorage` cache — a token would mean a build secret and somewhere to hold it, for two slow-moving numbers.
- Ships `hidden`; only unhides once both numbers are real. Rate limited, offline or malformed response → stays hidden rather than rendering em dashes.
- Known undercount, commented in the source: `release.yml` demotes old releases to drafts, and drafts are invisible to an unauthenticated caller. A number that is honestly low beats one that needs a token to be right.

Verified: `npm run build` clean, 183 pages. API sanity-checked against the live repo — 48 stars, 9 asset downloads today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)