### PR TITLE
feat(site): Android showcase

### DIFF
--- a/site/src/components/GitHubStats.astro
+++ b/site/src/components/GitHubStats.astro
@@ -7,7 +7,7 @@ const ttlMs = 60 * 60 * 1000;
 ---
 
 <div class="stats" data-repo={repo} data-ttl={ttlMs} hidden>
-  <a class="stat" href={`https://github.com/${repo}/stargazers`}>
+  <a class="stat" href={`https://github.com/${repo}`}>
     <span class="n" data-slot="stars">—</span>
     <span class="l">stars on GitHub</span>
   </a>

--- a/site/src/pages/features/index.astro
+++ b/site/src/pages/features/index.astro
@@ -109,6 +109,19 @@ const sections = [
     alt: "Archive playback with historical warnings and reports replayed alongside the radar",
     link: { href: "/docs/getting-started/", label: "Getting started" },
   },
+  {
+    id: "android",
+    eyebrow: "On Android",
+    title: "The same radar, in the field",
+    body:
+      "Not a stripped-down companion app: the Android build reads the same Level 2 volumes and " +
+      "draws the same products, with a layout built for one thumb. Home-screen widget, quick " +
+      "settings tile, and warning notifications for where you actually are — which, when you are " +
+      "chasing, keeps changing.",
+    shot: "android/hero.gif",
+    alt: "The Android app: opening to live radar, panning the map and opening a warning",
+    link: { href: "/download/", label: "Get the Android build" },
+  },
 ];
 ---
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -63,6 +63,29 @@ const shots = [
   },
 ];
 
+const androidShots = [
+  {
+    src: `${repoShots}/android/map.jpg`,
+    alt: "The Android app showing live radar over the map",
+    caption: "Live radar, one thumb.",
+  },
+  {
+    src: `${repoShots}/android/alerts.jpg`,
+    alt: "A warning polygon and its full text open on the Android app",
+    caption: "Warnings with their full text.",
+  },
+  {
+    src: `${repoShots}/android/layers.jpg`,
+    alt: "The layer picker open on the Android app",
+    caption: "The same layers as the desktop build.",
+  },
+  {
+    src: `${repoShots}/android/site.jpg`,
+    alt: "The radar site picker on the Android app",
+    caption: "Switch radars as you drive.",
+  },
+];
+
 const weatherdeskRepo = "https://github.com/d4vid87/weatherdesk";
 ---
 
@@ -130,6 +153,23 @@ const weatherdeskRepo = "https://github.com/d4vid87/weatherdesk";
 
   <section class="alt">
     <div class="wrap">
+      <p class="eyebrow">In the field</p>
+      <h2>It goes where the storm is</h2>
+      <p>
+        The Android build is the same app, not a companion: the same Level 2 volumes, the same
+        products, laid out for one thumb. Widgets and warning notifications for wherever you have
+        driven to.
+      </p>
+      <ShotGallery shots={androidShots} />
+      <div class="platforms">
+        <a class="btn btn-primary" href="/download/">Get it on Android</a>
+        <a class="btn" href="/features/#android">What it does</a>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <div class="wrap">
       <p class="eyebrow">Against the field</p>
       <h2>Yes, we will tell you when to buy something else</h2>
       <p>
@@ -142,7 +182,7 @@ const weatherdeskRepo = "https://github.com/d4vid87/weatherdesk";
     </div>
   </section>
 
-  <section>
+  <section class="alt">
     <div class="wrap">
       <p class="eyebrow">More from us</p>
       <h2>WeatherDesk</h2>


### PR DESCRIPTION
All five Android screenshots were unused. Now both surfaces from the interview use them.

- **Landing** — an "In the field" section between the gallery and the comparison teaser, with `map`, `alerts`, `layers` and `site` through the existing `ShotGallery`. Section shading re-alternated so the stripes still read correctly.
- **`/features`** — ninth anchored section (`#android`) using `android/hero.gif`, `loading="lazy"` since it is 1.9 MB. It joins the jump nav automatically.
- All hotlinked from the repo at `v0.12.0-beta.1`, same as every other shot on the site.

Also fixed in passing: #152's stars stat linked to `/stargazers`, which GitHub answers 404 for when logged out — the link check caught it. Now points at the repo page, which shows the count anyway.

Verified: `npm run build` clean, 183 pages. `npm run linkcheck` — 412 links, zero broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)