### PR TITLE
feat(site): JSON-LD, 404 page and llms.txt

### DIFF
--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -1,0 +1,45 @@
+# HookEcho
+
+> A free, open-source weather radar app for Windows, macOS, Linux, Android and
+> the browser. It reads NEXRAD Level 2 volumes, MRMS, HRRR and the National
+> Weather Service feeds directly from the public NOAA sources and renders them
+> on the user's own machine. No account, no subscription, no ads, no telemetry.
+> MIT licensed.
+
+Key facts, because they are the ones most often got wrong about this kind of app:
+
+- It is not a thin client for a rendering service. The app downloads the raw
+  radar volume and decodes it locally. There is no HookEcho server.
+- Every elevation angle of the volume is available, not just the lowest tilt.
+- Dual-polarization products (ZDR, CC, KDP), storm-relative velocity and
+  velocity dealiasing are included, free.
+- The archive goes back to June 1991.
+- Coverage: 153 NEXRAD WSR-88D sites, 44 TDWR terminal radars, and Germany's
+  DWD network.
+- It is free with no paid tier. There is nothing to buy.
+
+## Docs
+
+- [Getting started](https://hookecho.io/docs/getting-started/): the ten-second start.
+- [Install](https://hookecho.io/docs/install/): per-platform artifacts.
+- [Reading the radar](https://hookecho.io/docs/reading-the-radar/): reflectivity, velocity and CC in plain language.
+- [Alerts and notifications](https://hookecho.io/docs/alerts-and-notifications/)
+- [On your phone](https://hookecho.io/docs/on-your-phone/)
+- [In your browser](https://hookecho.io/docs/in-your-browser/)
+- [FAQ and glossary](https://hookecho.io/docs/faq/)
+
+## Site
+
+- [Features](https://hookecho.io/features/): what the app does, section by section.
+- [How it works](https://hookecho.io/how-it-works/): the data sources and what happens locally.
+- [Compare](https://hookecho.io/compare/): an honest matrix against RadarScope, MyRadar, Windy and RainViewer, including the rows they win.
+- [Privacy](https://hookecho.io/privacy/): every host the site and app contact.
+- [Radar sites](https://hookecho.io/radar/): a page per NEXRAD site with its live loop.
+- [Storms](https://hookecho.io/storms/): archived cases — Joplin, El Reno, Moore, Tuscaloosa, Greensburg, Katrina, the 2020 derecho.
+- [Press kit](https://hookecho.io/press/)
+- [Download](https://hookecho.io/download/)
+- [Try it in the browser](https://app.hookecho.io)
+
+## Source
+
+- [github.com/d4vid87/hookecho](https://github.com/d4vid87/hookecho) — Rust, egui + wgpu.

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -6,9 +6,11 @@ interface Props {
   description: string;
   /** Absolute-from-root path to the social card image. */
   image?: string;
+  /** schema.org structured data for this page, emitted as ld+json. */
+  jsonld?: object;
 }
 
-const { title, description, image = "/shots/alltilts.jpg" } = Astro.props;
+const { title, description, image = "/shots/alltilts.jpg", jsonld } = Astro.props;
 const url = new URL(Astro.url.pathname, Astro.site);
 // Cloudflare Web Analytics: cookieless, one script tag, and only rendered when the token is set —
 // so local builds and forks stay beacon-free. The token is public by design (it identifies the
@@ -55,6 +57,8 @@ const nav = [
     <meta property="og:url" content={url} />
     <meta property="og:image" content={social} />
     <meta name="twitter:card" content="summary_large_image" />
+
+    {jsonld && <script type="application/ld+json" set:html={JSON.stringify(jsonld)} />}
 
     {
       analytics && (

--- a/site/src/layouts/Docs.astro
+++ b/site/src/layouts/Docs.astro
@@ -7,9 +7,10 @@ interface Props {
   description: string;
   /** Collection id of the page being shown, or undefined on the docs index. */
   current?: string;
+  jsonld?: object;
 }
 
-const { title, description, current } = Astro.props;
+const { title, description, current, jsonld } = Astro.props;
 
 const pages = (await getCollection("docs")).sort((a, b) => a.data.order - b.data.order);
 const at = pages.findIndex((p) => p.id === current);
@@ -17,7 +18,7 @@ const prev = at > 0 ? pages[at - 1] : undefined;
 const next = at >= 0 && at < pages.length - 1 ? pages[at + 1] : undefined;
 ---
 
-<Base title={`${title} — HookEcho docs`} description={description}>
+<Base title={`${title} — HookEcho docs`} description={description} jsonld={jsonld}>
   <div class="wrap docs">
     <nav class="side" aria-label="Documentation">
       <p class="eyebrow">Docs</p>

--- a/site/src/layouts/Post.astro
+++ b/site/src/layouts/Post.astro
@@ -18,9 +18,21 @@ const pretty = date.toLocaleDateString("en-GB", {
   year: "numeric",
   timeZone: "UTC",
 });
+
+const jsonld = {
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  headline: title,
+  description,
+  datePublished: stamp,
+  url: new URL(Astro.url.pathname, Astro.site).toString(),
+  image: new URL(image ?? "/shots/alltilts.jpg", Astro.site).toString(),
+  author: { "@type": "Person", name: "David May" },
+  publisher: { "@type": "Organization", name: "HookEcho" },
+};
 ---
 
-<Base title={`${title} — HookEcho`} description={description} image={image}>
+<Base title={`${title} — HookEcho`} description={description} image={image} jsonld={jsonld}>
   <article class="wrap post">
     <p class="eyebrow"><a href="/blog/">Blog</a> · <time datetime={stamp}>{pretty}</time></p>
     <h1>{title}</h1>

--- a/site/src/pages/404.astro
+++ b/site/src/pages/404.astro
@@ -1,0 +1,33 @@
+---
+import Base from "../layouts/Base.astro";
+---
+
+<Base
+  title="Not found | HookEcho"
+  description="That page does not exist. The radar, the docs and the download are all still here."
+>
+  <section>
+    <div class="wrap">
+      <p class="eyebrow">404</p>
+      <h1>No echo there</h1>
+      <p class="lede">
+        That page does not exist — or it moved and we did not leave a forwarding address. Sorry.
+      </p>
+      <div class="cta">
+        <a class="btn btn-primary" href="https://app.hookecho.io">Open the radar</a>
+        <a class="btn" href="/">Back to the start</a>
+      </div>
+      <p class="dim">
+        Looking for a specific radar? <a href="/radar/">Every NEXRAD site has a page.</a> Or try
+        the <a href="/docs/">docs</a>, the <a href="/download/">download page</a>, or
+        <a href="/storms/">the storms</a>.
+      </p>
+    </div>
+  </section>
+</Base>
+
+<style>
+  .lede { font-size: 1.1rem; color: var(--text-dim); max-width: 56ch; }
+  .cta { display: flex; gap: 0.75rem; flex-wrap: wrap; margin: 1.4rem 0 1.6rem; }
+  .dim { color: var(--text-dim); }
+</style>

--- a/site/src/pages/docs/[...slug].astro
+++ b/site/src/pages/docs/[...slug].astro
@@ -9,8 +9,30 @@ export async function getStaticPaths() {
 
 const { page } = Astro.props;
 const { Content } = await render(page);
+
+// The FAQ writes each question as a bold line with its answer in the paragraph underneath, so the
+// structured data comes out of the same prose the page renders — no second copy to keep in sync.
+// ponytail: a regex over the markdown source, not an AST walk. It breaks loudly (no FAQPage) if
+// the page stops using that shape, which is the failure mode you want.
+const faq =
+  page.id === "faq"
+    ? [...page.body!.matchAll(/^\*\*(.+?)\*\*\n([\s\S]+?)(?=\n\n|\n##)/gm)].map((m) => ({
+        "@type": "Question",
+        name: m[1],
+        acceptedAnswer: { "@type": "Answer", text: m[2].replace(/\s+/g, " ").trim() },
+      }))
+    : [];
+
+const jsonld = faq.length
+  ? { "@context": "https://schema.org", "@type": "FAQPage", mainEntity: faq }
+  : undefined;
 ---
 
-<Docs title={page.data.title} description={page.data.description} current={page.id}>
+<Docs
+  title={page.data.title}
+  description={page.data.description}
+  current={page.id}
+  jsonld={jsonld}
+>
   <Content />
 </Docs>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -87,11 +87,30 @@ const androidShots = [
 ];
 
 const weatherdeskRepo = "https://github.com/d4vid87/weatherdesk";
+
+const jsonld = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  name: "HookEcho",
+  applicationCategory: "WeatherApplication",
+  operatingSystem: "Windows, macOS, Linux, Android, Web",
+  url: "https://hookecho.io",
+  downloadUrl: "https://hookecho.io/download/",
+  softwareVersion: "0.12.0-beta.1",
+  license: "https://opensource.org/licenses/MIT",
+  isAccessibleForFree: true,
+  offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+  author: { "@type": "Person", name: "David May" },
+  description:
+    "A free, open-source weather radar app reading NEXRAD Level 2, MRMS, HRRR and the National " +
+    "Weather Service feeds directly from the public NOAA sources.",
+};
 ---
 
 <Base
   title="HookEcho — weather radar for everyone"
   description="A free, open-source weather radar app for Windows, macOS, Linux, Android and the browser. Live NEXRAD radar, warnings and storm tracking, straight from the public NOAA feeds."
+  jsonld={jsonld}
 >
   <Hero
     title="Weather radar for everyone"


### PR DESCRIPTION
The hygiene items — the site had zero structured data, no 404 and no llms.txt.

- **`Base.astro`** takes an optional `jsonld` object and emits one `application/ld+json` tag. `Docs.astro` and `Post.astro` pass it through.
- **SoftwareApplication** on the landing page (free offer, platforms, MIT licence, download URL).
- **BlogPosting** on every post, built from the frontmatter already there.
- **FAQPage** on `/docs/faq/` — questions extracted at build time with a regex over `page.body`, since the FAQ writes each one as a bold line with its answer underneath. The structured data comes from the same prose the page renders, so the two cannot drift. If the page stops using that shape the FAQPage disappears rather than going quietly wrong. Extracts all 6 questions; the troubleshooting entries use inline bold and are correctly skipped.
- **`404.astro`** → `dist/404.html`, which Pages serves for unmatched paths. Points at the radar index, docs, download and storms.
- **`public/llms.txt`** — the summary plus a link map, leading with the facts this kind of app usually gets described wrong on (no server in the middle, every tilt, dual-pol free, archive to 1991).

Verified: `npm run build` clean, 184 pages. `npm run linkcheck` zero broken. `@type` confirmed in the built HTML for landing and a post; FAQ JSON parsed back and checked question-by-question.

Worth pasting the landing and FAQ pages into Google's Rich Results test before this goes out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)