### PR TITLE
feat(site): build-time OG cards for radar and storm pages

### DIFF
--- a/crates/wxdata/examples/nexrad_sites.rs
+++ b/crates/wxdata/examples/nexrad_sites.rs
@@ -36,6 +36,9 @@ fn main() {
         })
         .collect();
     out.sort_by_key(|s| s["id"].as_str().unwrap().to_string());
+    // The registry also carries a straight duplicate row (KCCX appears twice, identical), which
+    // would give the website two pages fighting over one URL.
+    out.dedup_by_key(|s| s["id"].as_str().unwrap().to_string());
 
     println!("{}", serde_json::to_string_pretty(&out).unwrap());
 }

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -11,6 +11,8 @@
         "astro": "^5.1.1"
       },
       "devDependencies": {
+        "astro-og-canvas": "^0.13.0",
+        "canvaskit-wasm": "^0.42.0",
         "linkinator": "^6.1.2"
       }
     },
@@ -1667,6 +1669,13 @@
       "integrity": "sha512-JL+CF0GeLHyPWI0rXu7UnxgiuOm9UQWzadi0OYOJNhNO2q6EZElpwlgXkNkfU1PzANDHq3YcwKVZprdvS+BrbQ==",
       "license": "ISC"
     },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.21.tgz",
+      "integrity": "sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/acorn": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
@@ -1917,6 +1926,44 @@
         "sharp": "^0.34.0"
       }
     },
+    "node_modules/astro-og-canvas": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/astro-og-canvas/-/astro-og-canvas-0.13.0.tgz",
+      "integrity": "sha512-jcIDhE9OGIbd7LstZQ4CyzOpbbEKAlxJqEgdkVu6r26m7yJKlQjKysszfDxlox717cnCLPXKivyFjsufcq8sYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "canvaskit-wasm": "^0.41.1",
+        "deterministic-object-hash": "^2.0.2",
+        "entities": "^8.0.0"
+      },
+      "peerDependencies": {
+        "astro": "^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/astro-og-canvas/node_modules/canvaskit-wasm": {
+      "version": "0.41.1",
+      "resolved": "https://registry.npmjs.org/canvaskit-wasm/-/canvaskit-wasm-0.41.1.tgz",
+      "integrity": "sha512-gO2rNMIE0lOQ8MaarM4qNeq2zZAEknAObKP2XAKidMSAY8P5sURGdFkrx1TSdHuBFqTf5w35JqjuUzjibqkD5g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@webgpu/types": "0.1.21"
+      }
+    },
+    "node_modules/astro-og-canvas/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/astro/node_modules/zod": {
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
@@ -2015,6 +2062,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/canvaskit-wasm": {
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/canvaskit-wasm/-/canvaskit-wasm-0.42.0.tgz",
+      "integrity": "sha512-N3ikotmzYwDVAcpQKDMptBT2P5pIEWS9ywdmrQA2awwaMF9cxKEFuxZZHv9ay1Em9kDjxDsPtwUzDm1uNj136g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@webgpu/types": "0.1.21"
       }
     },
     "node_modules/ccount": {

--- a/site/package.json
+++ b/site/package.json
@@ -8,7 +8,7 @@
     "build": "npm run shots && astro build",
     "preview": "astro preview",
     "shots": "mkdir -p public/shots && cp ../docs/shots/reflectivity.jpg ../docs/shots/alltilts.jpg ../docs/shots/layers.jpg ../docs/shots/velocity.jpg public/shots/",
-    "linkcheck": "linkinator dist --recurse --skip \"radar.weather.gov|api.weather.gov\""
+    "linkcheck": "linkinator dist --recurse --skip \"radar.weather.gov|api.weather.gov|hookecho.io/og/\""
   },
   "dependencies": {
     "@astrojs/rss": "^4.0.19",
@@ -16,6 +16,8 @@
     "astro": "^5.1.1"
   },
   "devDependencies": {
+    "astro-og-canvas": "^0.13.0",
+    "canvaskit-wasm": "^0.42.0",
     "linkinator": "^6.1.2"
   }
 }

--- a/site/src/data/nexrad-sites.json
+++ b/site/src/data/nexrad-sites.json
@@ -189,15 +189,6 @@
     "tz": "America/New_York"
   },
   {
-    "city": "State College",
-    "elev_m": 733,
-    "id": "KCCX",
-    "lat": 40.9231,
-    "lon": -78.0039,
-    "state": "PA",
-    "tz": "America/New_York"
-  },
-  {
     "city": "Cleveland",
     "elev_m": 233,
     "id": "KCLE",

--- a/site/src/pages/og/[...route].ts
+++ b/site/src/pages/og/[...route].ts
@@ -1,0 +1,46 @@
+import { getCollection } from "astro:content";
+import { OGImageRoute } from "astro-og-canvas";
+import sites from "../../data/nexrad-sites.json";
+
+// Build-time social cards for the two page sets that are generated rather than written: 153 radar
+// sites and the storm archive. Everything else keeps the hand-made alltilts.jpg card, which is a
+// screenshot of the actual product and beats anything drawn from text.
+const storms = await getCollection("storms");
+
+const pages = Object.fromEntries([
+  ...sites.map((site) => [
+    `radar/${site.id.toLowerCase()}`,
+    { title: `${site.id} — ${site.city}, ${site.state}`, description: "Live NEXRAD radar, every tilt of the volume, in HookEcho." },
+  ]),
+  ...storms.map((storm) => [
+    `storms/${storm.id}`,
+    { title: storm.data.title, description: `${storm.data.site} · replay the archived volumes in HookEcho.` },
+  ]),
+]);
+
+// ponytail: named re-exports rather than `export const { ... } =` — Astro's route analysis only
+// finds getStaticPaths as a plain named export, and the destructured form fails the build.
+// OGImageRoute is async in 0.13 (it loads CanvasKit), so it has to be awaited before Astro can
+// see the exports.
+const route = await OGImageRoute({
+  param: "route",
+  pages,
+  getImageOptions: (_path, page: { title: string; description: string }) => ({
+    title: page.title,
+    description: page.description,
+    logo: { path: "./public/logo.png", size: [72] },
+    bgGradient: [
+      [20, 22, 27],
+      [12, 14, 18],
+    ],
+    border: { color: [56, 189, 248], width: 12, side: "inline-start" },
+    padding: 60,
+    font: {
+      title: { size: 62, weight: "Bold", color: [235, 238, 245] },
+      description: { size: 30, color: [150, 158, 172] },
+    },
+  }),
+});
+
+export const getStaticPaths = route.getStaticPaths;
+export const GET = route.GET;

--- a/site/src/pages/radar/[id].astro
+++ b/site/src/pages/radar/[id].astro
@@ -17,6 +17,7 @@ const place = `${site.city}, ${site.state}`;
 <Base
   title={`${site.id} radar — ${place} | HookEcho`}
   description={`Live NEXRAD radar for ${site.id}, the WSR-88D at ${place}: the current loop, active warnings near the site, and every tilt of the Level 2 volume in HookEcho.`}
+  image={`/og/radar/${site.id.toLowerCase()}.png`}
 >
   <section>
     <div class="wrap">

--- a/site/src/pages/storms/[...slug].astro
+++ b/site/src/pages/storms/[...slug].astro
@@ -23,7 +23,11 @@ const when = s.date.toLocaleDateString("en-US", {
 });
 ---
 
-<Base title={`${s.title} — on the radar | HookEcho`} description={s.description} image={s.image}>
+<Base
+  title={`${s.title} — on the radar | HookEcho`}
+  description={s.description}
+  image={s.image ?? `/og/storms/${storm.id}.png`}
+>
   <article>
     <div class="wrap">
       <p class="eyebrow"><a href="/storms/">Storms on the radar</a> · {when}</p>


### PR DESCRIPTION
159 generated pages shared one social card. Now each has its own.

- `src/pages/og/[...route].ts` — `astro-og-canvas` route covering the 152 radar pages and 7 storm pages. Dark card matching the site, accent border, logo, title and one line of description.
- Radar and storm pages pass their card to `Base` via `image`. Hand-written pages keep `alltilts.jpg` — a screenshot of the real product beats a card drawn from text.

**Fixes a bug from #148 that this wave surfaced:** the upstream registry lists **KCCX twice**, identical rows. That gave two pages the same URL and would have been an ongoing oddity in the sitemap. The generator now dedupes, and the committed table drops 153 → 152. CI's drift check covers the regenerated file.

Two compat notes for the record, since the plan flagged this wave as unverified:
- astro-og-canvas 0.13 declares `astro: ^5 || ^6 || ^7` — compatible.
- `OGImageRoute` is **async** in 0.13 and must be awaited, and Astro's route analysis only finds `getStaticPaths` as a plain named export. `export const { getStaticPaths } = OGImageRoute(...)` fails the build both ways; both fixes are commented in the file.

Build cost: ~12 s on a cold cache for 159 images, ~1 s afterwards (the library caches). Output is 6.8 MB of PNG, which Pages serves, not us.

`linkcheck` gains a skip for `hookecho.io/og/`: the cards are referenced by absolute URL and so 404 against the live site until the deploy that first publishes them. Their presence is verified by counting `dist/og` instead — 159 files, 1200×630 PNG confirmed.

Verified: `npm run build` clean, 183 pages, 159 cards. `npm run linkcheck` 411 links zero broken. `cargo test -p wxdata` passes. `og:image` spot-checked in the built HTML for KTLX and Joplin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)