### PR TITLE
feat(site): Pagefind search on docs

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -13,7 +13,8 @@
       "devDependencies": {
         "astro-og-canvas": "^0.13.0",
         "canvaskit-wasm": "^0.42.0",
-        "linkinator": "^6.1.2"
+        "linkinator": "^6.1.2",
+        "pagefind": "^1.5.2"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -1159,6 +1160,104 @@
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
+    },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
+      "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
+      "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
+      "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
+      "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
+      "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
+      "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
+      "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -4384,6 +4483,25 @@
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
       "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
       "license": "MIT"
+    },
+    "node_modules/pagefind": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
+      "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.5.2",
+        "@pagefind/darwin-x64": "1.5.2",
+        "@pagefind/freebsd-x64": "1.5.2",
+        "@pagefind/linux-arm64": "1.5.2",
+        "@pagefind/linux-x64": "1.5.2",
+        "@pagefind/windows-arm64": "1.5.2",
+        "@pagefind/windows-x64": "1.5.2"
+      }
     },
     "node_modules/parse-latin": {
       "version": "7.0.0",

--- a/site/package.json
+++ b/site/package.json
@@ -8,7 +8,8 @@
     "build": "npm run shots && astro build",
     "preview": "astro preview",
     "shots": "mkdir -p public/shots && cp ../docs/shots/reflectivity.jpg ../docs/shots/alltilts.jpg ../docs/shots/layers.jpg ../docs/shots/velocity.jpg public/shots/",
-    "linkcheck": "linkinator dist --recurse --skip \"radar.weather.gov|api.weather.gov|hookecho.io/og/\""
+    "linkcheck": "linkinator dist --recurse --skip \"radar.weather.gov|api.weather.gov|hookecho.io/og/\"",
+    "postbuild": "pagefind --site dist"
   },
   "dependencies": {
     "@astrojs/rss": "^4.0.19",
@@ -18,6 +19,7 @@
   "devDependencies": {
     "astro-og-canvas": "^0.13.0",
     "canvaskit-wasm": "^0.42.0",
-    "linkinator": "^6.1.2"
+    "linkinator": "^6.1.2",
+    "pagefind": "^1.5.2"
   }
 }

--- a/site/src/layouts/Docs.astro
+++ b/site/src/layouts/Docs.astro
@@ -22,6 +22,7 @@ const next = at >= 0 && at < pages.length - 1 ? pages[at + 1] : undefined;
   <div class="wrap docs">
     <nav class="side" aria-label="Documentation">
       <p class="eyebrow">Docs</p>
+      <div id="search"></div>
       <ul>
         {pages.map((p) => (
           <li>
@@ -33,7 +34,7 @@ const next = at >= 0 && at < pages.length - 1 ? pages[at + 1] : undefined;
       </ul>
     </nav>
 
-    <article class="prose">
+    <article class="prose" data-pagefind-body>
       <h1>{title}</h1>
       <slot />
 
@@ -50,6 +51,18 @@ const next = at >= 0 && at < pages.length - 1 ? pages[at + 1] : undefined;
     </article>
   </div>
 </Base>
+
+<!-- Pagefind builds its bundle from dist after astro build (the postbuild script), so these two
+     files do not exist during dev and 404 there. is:inline keeps Vite from trying to resolve a
+     path that is not on disk yet. Failing quietly is right: the sidebar is the fallback. -->
+<link rel="stylesheet" href="/pagefind/pagefind-ui.css" />
+<script is:inline type="module">
+  import("/pagefind/pagefind-ui.js")
+    .then(({ PagefindUI }) => {
+      new PagefindUI({ element: "#search", showSubResults: true, showImages: false });
+    })
+    .catch(() => {});
+</script>
 
 <style>
   .docs {

--- a/site/src/pages/press.astro
+++ b/site/src/pages/press.astro
@@ -46,7 +46,7 @@ const assets = [
         <div><dt>Price</dt><dd>Free. No paid tier, no in-app purchase</dd></div>
         <div><dt>Licence</dt><dd>MIT</dd></div>
         <div><dt>Data sources</dt><dd>NOAA NEXRAD, MRMS, HRRR/NAM, National Weather Service API</dd></div>
-        <div><dt>Coverage</dt><dd>153 NEXRAD sites, 44 TDWR terminal radars, Germany's DWD network</dd></div>
+        <div><dt>Coverage</dt><dd>152 NEXRAD sites, 44 TDWR terminal radars, Germany's DWD network</dd></div>
         <div><dt>Archive</dt><dd>Back to 1991</dd></div>
         <div><dt>Source</dt><dd><a href="https://github.com/d4vid87/hookecho">github.com/d4vid87/hookecho</a></dd></div>
       </dl>


### PR DESCRIPTION
Search over the docs, with no workflow change: `npm run postbuild` runs after `astro build` and before the wrangler deploy step, so `pagefind --site dist` slots straight in.

- `package.json` gains `"postbuild": "pagefind --site dist"` and pins pagefind as a dev dependency.
- `Docs.astro` mounts `PagefindUI` into the sidebar. Only the docs `<article>` carries `data-pagefind-body`, so the index is the 7 docs pages — not 152 radar pages of repeated boilerplate, which would drown every real result.
- The UI script and CSS are loaded `is:inline` and fail quietly. Pagefind's bundle only exists after a real build, so in `astro dev` both 404 and the sidebar nav is the fallback. Vite otherwise tries to resolve a path that is not on disk yet and fails the build — that is why it is inline, and it is commented as such.

Also folds in the one-line correction the KCCX fix left behind: `/press` said 153 NEXRAD sites, now 152. The `/radar/` index prints the count from the table, so it corrected itself.

Verified: `npm run build` clean, 183 pages; Pagefind reports **8 pages indexed** (7 docs + the docs index), 884 unique words, and writes `dist/pagefind/`. `npm run linkcheck` zero broken.

Worth a click in `npm run preview` before merge — I verified the index and the mount point, not the rendered search box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)