### PR TITLE
feat(site): radar nearby links and per-state pages

### DIFF
--- a/site/src/data/geo.ts
+++ b/site/src/data/geo.ts
@@ -1,0 +1,13 @@
+// Miles between two lat/lon pairs. ponytail: great-circle on a sphere — the error against WGS84 is
+// under half a percent, and this number is only ever read as "which radars are near me".
+// Lives in its own module because Astro hoists getStaticPaths away from the rest of the
+// frontmatter: only imported bindings are in scope there.
+export function milesBetween(a: { lat: number; lon: number }, b: { lat: number; lon: number }) {
+  const rad = Math.PI / 180;
+  const dLat = (b.lat - a.lat) * rad;
+  const dLon = (b.lon - a.lon) * rad;
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(a.lat * rad) * Math.cos(b.lat * rad) * Math.sin(dLon / 2) ** 2;
+  return 3958.8 * 2 * Math.asin(Math.sqrt(h));
+}

--- a/site/src/data/states.ts
+++ b/site/src/data/states.ts
@@ -1,0 +1,19 @@
+// The site table carries two-letter codes; the URLs and headings want the name people type.
+// ponytail: a plain record, not a package — the list is 46 rows and never changes.
+export const STATE_NAMES: Record<string, string> = {
+  AK: "Alaska", AL: "Alabama", AR: "Arkansas", AZ: "Arizona", CA: "California",
+  CO: "Colorado", CT: "Connecticut", DE: "Delaware", FL: "Florida", GA: "Georgia",
+  GU: "Guam", HI: "Hawaii", IA: "Iowa", ID: "Idaho", IL: "Illinois",
+  IN: "Indiana", KS: "Kansas", KY: "Kentucky", LA: "Louisiana", MA: "Massachusetts",
+  MD: "Maryland", ME: "Maine", MI: "Michigan", MN: "Minnesota", MO: "Missouri",
+  MS: "Mississippi", MT: "Montana", NC: "North Carolina", ND: "North Dakota",
+  NE: "Nebraska", NH: "New Hampshire", NJ: "New Jersey", NM: "New Mexico",
+  NV: "Nevada", NY: "New York", OH: "Ohio", OK: "Oklahoma", OR: "Oregon",
+  PA: "Pennsylvania", PR: "Puerto Rico", RI: "Rhode Island", SC: "South Carolina",
+  SD: "South Dakota", TN: "Tennessee", TX: "Texas", UT: "Utah", VA: "Virginia",
+  VI: "Virgin Islands", VT: "Vermont", WA: "Washington", WI: "Wisconsin",
+  WV: "West Virginia", WY: "Wyoming",
+};
+
+export const stateName = (code: string) => STATE_NAMES[code] ?? code;
+export const stateSlug = (code: string) => stateName(code).toLowerCase().replace(/ /g, "-");

--- a/site/src/pages/radar/[id].astro
+++ b/site/src/pages/radar/[id].astro
@@ -2,67 +2,193 @@
 import Base from "../../layouts/Base.astro";
 import LiveMosaic from "../../components/LiveMosaic.astro";
 import sites from "../../data/nexrad-sites.json";
+import { stateName, stateSlug } from "../../data/states";
+import { milesBetween } from "../../data/geo";
 
+type Site = (typeof sites)[number];
+
+// One getStaticPaths for both page kinds: Astro will not allow /radar/[id] and /radar/[state] to
+// be two dynamic files in the same directory, and no state name collides with a four-letter
+// site id, so they share the namespace safely.
 export function getStaticPaths() {
-  return sites.map((site) => ({ params: { id: site.id.toLowerCase() }, props: { site } }));
+  const sitePages = sites.map((site) => ({
+    params: { id: site.id.toLowerCase() },
+    props: {
+      kind: "site" as const,
+      site,
+      nearby: sites
+        .filter((other) => other.id !== site.id)
+        .map((other) => ({ site: other, miles: Math.round(milesBetween(site, other)) }))
+        .sort((a, b) => a.miles - b.miles)
+        .slice(0, 4),
+    },
+  }));
+
+  const codes = [...new Set(sites.map((s) => s.state))];
+  const statePages = codes.map((code) => ({
+    params: { id: stateSlug(code) },
+    props: {
+      kind: "state" as const,
+      code,
+      inState: sites
+        .filter((s) => s.state === code)
+        .sort((a, b) => a.city.localeCompare(b.city)),
+    },
+  }));
+
+  return [...sitePages, ...statePages];
 }
 
-const { site } = Astro.props;
+const props = Astro.props as
+  | { kind: "site"; site: Site; nearby: { site: Site; miles: number }[] }
+  | { kind: "state"; code: string; inState: Site[] };
+
+const site = props.kind === "site" ? props.site : null;
 // lon before lat — the app's #goto vocabulary, same as the deep links on /features.
-const appLink = `https://app.hookecho.io/#goto=${site.id},${site.lon},${site.lat},8`;
-const loop = `https://radar.weather.gov/ridge/standard/${site.id}_loop.gif`;
-const place = `${site.city}, ${site.state}`;
+const appLink = site ? `https://app.hookecho.io/#goto=${site.id},${site.lon},${site.lat},8` : "";
+const loop = site ? `https://radar.weather.gov/ridge/standard/${site.id}_loop.gif` : "";
+const place = site ? `${site.city}, ${site.state}` : "";
+const state = props.kind === "state" ? stateName(props.code) : "";
 ---
 
-<Base
-  title={`${site.id} radar — ${place} | HookEcho`}
-  description={`Live NEXRAD radar for ${site.id}, the WSR-88D at ${place}: the current loop, active warnings near the site, and every tilt of the Level 2 volume in HookEcho.`}
-  image={`/og/radar/${site.id.toLowerCase()}.png`}
->
-  <section>
-    <div class="wrap">
-      <p class="eyebrow"><a href="/radar/">NEXRAD sites</a> · {site.state}</p>
-      <h1>{site.id} — {place}</h1>
-      <p class="lede">
-        The WSR-88D at {place}. Below is the National Weather Service's own loop for this radar;
-        open it in HookEcho for every tilt of the Level 2 volume, velocity, dual-pol and the
-        archive back to 1991.
-      </p>
+{
+  props.kind === "site" && site ? (
+    <Base
+      title={`${site.id} radar — ${place} | HookEcho`}
+      description={`Live NEXRAD radar for ${site.id}, the WSR-88D at ${place}: the current loop, active warnings near the site, and every tilt of the Level 2 volume in HookEcho.`}
+      image={`/og/radar/${site.id.toLowerCase()}.png`}
+    >
+      <section>
+        <div class="wrap">
+          <p class="eyebrow">
+            <a href="/radar/">NEXRAD sites</a> ·{" "}
+            <a href={`/radar/${stateSlug(site.state)}/`}>{stateName(site.state)}</a>
+          </p>
+          <h1>
+            {site.id} — {place}
+          </h1>
+          <p class="lede">
+            The WSR-88D at {place}. Below is the National Weather Service's own loop for this
+            radar; open it in HookEcho for every tilt of the Level 2 volume, velocity, dual-pol and
+            the archive back to 1991.
+          </p>
 
-      <p class="warnings" data-point={`${site.lat},${site.lon}`}>
-        <span class="count">—</span> active warnings over this radar
-      </p>
+          <p class="warnings" data-point={`${site.lat},${site.lon}`}>
+            <span class="count">—</span> active warnings over this radar
+          </p>
 
-      <div class="cta">
-        <a class="btn btn-primary" href={appLink}>Open {site.id} in your browser</a>
-        <a class="btn" href="/download/">Get the app</a>
-      </div>
+          <div class="cta">
+            <a class="btn btn-primary" href={appLink}>
+              Open {site.id} in your browser
+            </a>
+            <a class="btn" href="/download/">
+              Get the app
+            </a>
+          </div>
 
-      <LiveMosaic
-        src={loop}
-        alt={`The current radar loop from ${site.id} at ${place}`}
-        caption={`${site.id} base reflectivity, refreshed live from the NWS.`}
-      />
+          <LiveMosaic
+            src={loop}
+            alt={`The current radar loop from ${site.id} at ${place}`}
+            caption={`${site.id} base reflectivity, refreshed live from the NWS.`}
+          />
 
-      <dl class="facts">
-        <div><dt>Site ID</dt><dd>{site.id}</dd></div>
-        <div><dt>Location</dt><dd>{place}</dd></div>
-        <div><dt>Coordinates</dt><dd>{site.lat}, {site.lon}</dd></div>
-        <div><dt>Elevation</dt><dd>{site.elev_m} m</dd></div>
-        <div><dt>Local time zone</dt><dd>{site.tz}</dd></div>
-      </dl>
+          <dl class="facts">
+            <div>
+              <dt>Site ID</dt>
+              <dd>{site.id}</dd>
+            </div>
+            <div>
+              <dt>Location</dt>
+              <dd>{place}</dd>
+            </div>
+            <div>
+              <dt>Coordinates</dt>
+              <dd>
+                {site.lat}, {site.lon}
+              </dd>
+            </div>
+            <div>
+              <dt>Elevation</dt>
+              <dd>{site.elev_m} m</dd>
+            </div>
+            <div>
+              <dt>Local time zone</dt>
+              <dd>{site.tz}</dd>
+            </div>
+          </dl>
 
-      <h2>What HookEcho shows that the loop above does not</h2>
-      <p>
-        That GIF is one product at one tilt, rendered on someone else's server. HookEcho reads the
-        Level 2 volume from {site.id} directly: every elevation angle, storm-relative velocity with
-        dealiasing, correlation coefficient for debris signatures, and the warnings, storm reports
-        and lightning drawn over the same map.
-      </p>
-      <p><a href="/features/">See what else it does</a> · <a href="/compare/">How it compares</a></p>
-    </div>
-  </section>
-</Base>
+          <h2>What HookEcho shows that the loop above does not</h2>
+          <p>
+            That GIF is one product at one tilt, rendered on someone else's server. HookEcho reads
+            the Level 2 volume from {site.id} directly: every elevation angle, storm-relative
+            velocity with dealiasing, correlation coefficient for debris signatures, and the
+            warnings, storm reports and lightning drawn over the same map.
+          </p>
+
+          <h2>Nearby radars</h2>
+          <p class="dim">
+            When a storm sits between sites, the closer radar sees lower into it. These are the
+            four nearest to {site.id}.
+          </p>
+          <ul class="sites">
+            {props.nearby.map((n) => (
+              <li>
+                <a href={`/radar/${n.site.id.toLowerCase()}/`}>
+                  <strong>{n.site.id}</strong> {n.site.city}, {n.site.state}
+                  <span class="miles">{n.miles} mi</span>
+                </a>
+              </li>
+            ))}
+          </ul>
+
+          <p>
+            <a href="/features/">See what else it does</a> ·{" "}
+            <a href="/compare/">How it compares</a>
+          </p>
+        </div>
+      </section>
+    </Base>
+  ) : (
+    <Base
+      title={`Weather radar in ${state} | HookEcho`}
+      description={`Every NEXRAD radar site in ${state}, with live loops, active warnings and every tilt of the Level 2 volume in HookEcho.`}
+    >
+      <section>
+        <div class="wrap">
+          <p class="eyebrow">
+            <a href="/radar/">NEXRAD sites</a>
+          </p>
+          <h1>Weather radar in {state}</h1>
+          <p class="lede">
+            {props.kind === "state" ? props.inState.length : 0} National Weather Service radars
+            cover {state}. Each one has a page here with its live loop, the warnings currently over
+            it, and a link that opens it in HookEcho at full resolution.
+          </p>
+
+          <div class="cta">
+            <a class="btn btn-primary" href="https://app.hookecho.io">
+              Open the radar
+            </a>
+            <a class="btn" href="/download/">
+              Get the app
+            </a>
+          </div>
+
+          <ul class="sites">
+            {props.kind === "state" &&
+              props.inState.map((s) => (
+                <li>
+                  <a href={`/radar/${s.id.toLowerCase()}/`}>
+                    <strong>{s.id}</strong> {s.city}
+                  </a>
+                </li>
+              ))}
+          </ul>
+        </div>
+      </section>
+    </Base>
+  )
+}
 
 <script>
   // Warnings whose polygon covers the radar itself — the honest reading of "over this site", and
@@ -85,6 +211,7 @@ const place = `${site.city}, ${site.state}`;
 
 <style>
   .lede { font-size: 1.1rem; color: var(--text-dim); max-width: 60ch; }
+  .dim { color: var(--text-dim); max-width: 60ch; }
   .eyebrow a { color: inherit; }
   .cta { display: flex; gap: 0.75rem; flex-wrap: wrap; margin: 1.4rem 0 2rem; }
   .warnings {
@@ -112,4 +239,24 @@ const place = `${site.city}, ${site.state}`;
   }
   .facts dt { color: var(--text-dim); font-size: 0.85rem; }
   .facts dd { margin: 0.2rem 0 0; font-weight: 600; }
+  .sites {
+    list-style: none;
+    padding: 0;
+    margin: 1rem 0 2rem;
+    display: grid;
+    gap: 0.4rem;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  }
+  .sites a {
+    display: block;
+    padding: 0.5rem 0.7rem;
+    border: 1px solid var(--stroke);
+    border-radius: var(--radius);
+    color: var(--text-dim);
+    text-decoration: none;
+    font-size: 0.95rem;
+  }
+  .sites a:hover { border-color: var(--accent); color: var(--text); }
+  .sites strong { color: var(--text); margin-right: 0.4rem; }
+  .miles { float: right; font-variant-numeric: tabular-nums; }
 </style>

--- a/site/src/pages/radar/index.astro
+++ b/site/src/pages/radar/index.astro
@@ -1,8 +1,9 @@
 ---
 import Base from "../../layouts/Base.astro";
 import sites from "../../data/nexrad-sites.json";
+import { stateName, stateSlug } from "../../data/states";
 
-// Grouped by state, states alphabetical — 153 links need some spine, and "which radar covers me"
+// Grouped by state, states alphabetical — 152 links need some spine, and "which radar covers me"
 // is a geography question before it is anything else.
 const byState = new Map<string, typeof sites>();
 for (const site of sites) {
@@ -10,12 +11,12 @@ for (const site of sites) {
   list.push(site);
   byState.set(site.state, list);
 }
-const states = [...byState.keys()].sort();
+const states = [...byState.keys()].sort((a, b) => stateName(a).localeCompare(stateName(b)));
 ---
 
 <Base
   title="Every NEXRAD radar site | HookEcho"
-  description="All 153 WSR-88D NEXRAD radar sites, by state: live loops, active warnings and every tilt of the Level 2 volume, opened straight in HookEcho."
+  description="All 152 WSR-88D NEXRAD radar sites, by state: live loops, active warnings and every tilt of the Level 2 volume, opened straight in HookEcho."
 >
   <section>
     <div class="wrap">
@@ -30,7 +31,9 @@ const states = [...byState.keys()].sort();
       {
         states.map((state) => (
           <div class="state">
-            <h2 id={state.toLowerCase()}>{state}</h2>
+            <h2 id={state.toLowerCase()}>
+              <a href={`/radar/${stateSlug(state)}/`}>{stateName(state)}</a>
+            </h2>
             <ul>
               {byState
                 .get(state)!
@@ -53,6 +56,8 @@ const states = [...byState.keys()].sort();
   .lede { font-size: 1.1rem; color: var(--text-dim); max-width: 62ch; }
   .state { margin-top: 2.2rem; }
   .state h2 { margin-bottom: 0.6rem; font-size: 1.15rem; color: var(--text-dim); }
+  .state h2 a { color: inherit; text-decoration: none; }
+  .state h2 a:hover { color: var(--accent); }
   ul {
     list-style: none;
     padding: 0;


### PR DESCRIPTION
First wave of the second site expansion (T1).

## What

- **Nearby radars** on every site page: the four closest sites with distances in miles, computed at build time by haversine over the committed `nexrad-sites.json`.
- **Per-state pages** at `/radar/oklahoma/` etc. — 46 new pages listing every site in the state. The site page eyebrow and the index's state headings link to them, and the headings now show full state names.
- Stale "153" count on the index corrected to 152 (left over from the KCCX dedupe).

## Notes

Both page kinds are emitted by a single `getStaticPaths` in `radar/[id].astro` with a `kind` prop: Astro rejects two dynamic routes in one directory, and no state slug collides with a four-letter site id. `milesBetween` sits in `src/data/geo.ts` because `getStaticPaths` is hoisted out of the frontmatter and only sees imported bindings.

## Verification

- `npm run build` clean; `dist/radar` has 152 site pages + 46 state pages + the index.
- KTLX nearby list reads KVNX, KINX, KFDR, KICT — correct geography for Oklahoma City.
- `npm run linkcheck`: the only failures are the 46 not-yet-deployed state canonicals on hookecho.io. No other broken links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)