### PR TITLE
feat(site): a glossary section, one page per term

### DIFF
--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -26,7 +26,7 @@ Key facts, because they are the ones most often got wrong about this kind of app
 - [Alerts and notifications](https://hookecho.io/docs/alerts-and-notifications/)
 - [On your phone](https://hookecho.io/docs/on-your-phone/)
 - [In your browser](https://hookecho.io/docs/in-your-browser/)
-- [FAQ and glossary](https://hookecho.io/docs/faq/)
+- [FAQ](https://hookecho.io/docs/faq/)
 
 ## Site
 
@@ -36,6 +36,7 @@ Key facts, because they are the ones most often got wrong about this kind of app
 - [Privacy](https://hookecho.io/privacy/): every host the site and app contact.
 - [Radar sites](https://hookecho.io/radar/): a page per NEXRAD and TDWR site, plus a page per state.
 - [Storms](https://hookecho.io/storms/): archived cases — Joplin, El Reno, Moore, Tuscaloosa, Greensburg, Katrina, the 2020 derecho.
+- [Glossary](https://hookecho.io/glossary/): a page per radar term — dBZ, CC, ZDR, VCP, hook echo.
 - [Press kit](https://hookecho.io/press/)
 - [Download](https://hookecho.io/download/)
 - [Try it in the browser](https://app.hookecho.io)

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -46,4 +46,17 @@ const storms = defineCollection({
   }),
 });
 
-export const collections = { docs, blog, storms };
+// One page per term. The definitions used to live as bold lines inside the FAQ, where they were
+// unlinkable and were also being scraped into the page's FAQPage JSON-LD as if they were questions.
+const glossary = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/content/glossary" }),
+  schema: z.object({
+    /** Display name, e.g. "CC (correlation coefficient)". The file name is the URL. */
+    term: z.string(),
+    description: z.string(),
+    /** Slugs of other terms worth reading next. */
+    related: z.array(z.string()).default([]),
+  }),
+});
+
+export const collections = { docs, blog, storms, glossary };

--- a/site/src/content/docs/faq.md
+++ b/site/src/content/docs/faq.md
@@ -1,6 +1,6 @@
 ---
 title: FAQ and glossary
-description: Common questions, common problems, and what all the abbreviations mean.
+description: Common questions, common problems, and where to find what all the abbreviations mean.
 order: 7
 ---
 
@@ -59,53 +59,26 @@ to replay it.
 
 ## Glossary
 
-**CAPE** — how much energy is available for a thunderstorm to rise. More CAPE,
-taller storms.
+Every radar word has its own page now, with the related ones linked from it:
 
-**CC (correlation coefficient)** — whether everything in the beam looks alike.
-High for rain, low for a mix — hail, melting snow, or tornado debris.
+[CAPE](/glossary/cape/),
+[CC (correlation coefficient)](/glossary/cc/),
+[dBZ](/glossary/dbz/),
+[Dealiasing](/glossary/dealiasing/),
+[Dual-pol](/glossary/dual-pol/),
+[Level 2 / Level 3](/glossary/level-2-and-level-3/),
+[MESH](/glossary/mesh/),
+[MRMS](/glossary/mrms/),
+[NEXRAD](/glossary/nexrad/),
+[Reflectivity (Z)](/glossary/reflectivity/),
+[SRH (storm-relative helicity)](/glossary/srh/),
+[Storm-relative velocity](/glossary/storm-relative-velocity/),
+[TDS (tornado debris signature)](/glossary/tds/),
+[Tilt](/glossary/tilt/),
+[VCP](/glossary/vcp/),
+[Velocity (V)](/glossary/velocity/),
+[VIL](/glossary/vil/),
+[ZDR (differential reflectivity)](/glossary/zdr/), and
+[hook echo](/glossary/hook-echo/) itself.
 
-**dBZ** — the unit of reflectivity. Roughly: how much is coming back.
-
-**Dealiasing** — undoing the fold that happens when wind is faster than the
-radar can measure directly, so a fast couplet reads correctly.
-
-**Dual-pol** — the radar sending both horizontal and vertical pulses, which is
-what makes CC and ZDR possible. Rolled out across the network around 2012.
-
-**Level 2 / Level 3** — Level 2 is the raw volume, every gate of every sweep.
-Level 3 is the smaller set of processed products the NWS publishes from it.
-
-**MESH** — maximum estimated hail size, computed from the storm's vertical
-structure.
-
-**MRMS** — the national grid that stitches every radar in the country into one
-picture, updated every couple of minutes.
-
-**NEXRAD** — the US network of 150-odd weather radars. Each has a four-letter
-ID like KTLX.
-
-**Reflectivity (Z)** — how much energy the echo sends back. Where the rain is.
-
-**SRH (storm-relative helicity)** — how much spin the low-level wind has for a
-storm to use.
-
-**Storm-relative velocity** — velocity with the storm's own travel subtracted,
-so rotation stops hiding inside the storm's motion.
-
-**TDS (tornado debris signature)** — high reflectivity, a velocity couplet, and
-a hole in CC in the same place: the radar seeing lofted debris.
-
-**Tilt** — one sweep of the radar at one elevation angle. A volume is a stack of
-them.
-
-**VCP** — the scanning pattern the radar is running. Storm modes sweep faster
-and use more tilts than clear-air modes.
-
-**Velocity (V)** — motion toward or away from the radar along the beam. Green
-toward, red away.
-
-**VIL** — how much water the storm is holding, integrated through its depth.
-
-**ZDR (differential reflectivity)** — how flat the things in the beam are.
-Positive for raindrops, near zero for tumbling hail.
+[The whole glossary is here.](/glossary/)

--- a/site/src/content/glossary/cape.md
+++ b/site/src/content/glossary/cape.md
@@ -1,0 +1,8 @@
+---
+term: "CAPE"
+description: "How much energy is available for a thunderstorm to rise. More CAPE, taller storms."
+related:
+  - srh
+---
+
+How much energy is available for a thunderstorm to rise. More CAPE, taller storms.

--- a/site/src/content/glossary/cc.md
+++ b/site/src/content/glossary/cc.md
@@ -1,0 +1,10 @@
+---
+term: "CC (correlation coefficient)"
+description: "Whether everything in the beam looks alike. High for rain, low for a mix — hail, melting snow, or tornado debris."
+related:
+  - dual-pol
+  - zdr
+  - tds
+---
+
+Whether everything in the beam looks alike. High for rain, low for a mix — hail, melting snow, or tornado debris.

--- a/site/src/content/glossary/dbz.md
+++ b/site/src/content/glossary/dbz.md
@@ -1,0 +1,8 @@
+---
+term: "dBZ"
+description: "The unit of reflectivity. Roughly: how much is coming back."
+related:
+  - reflectivity
+---
+
+The unit of reflectivity. Roughly: how much is coming back.

--- a/site/src/content/glossary/dealiasing.md
+++ b/site/src/content/glossary/dealiasing.md
@@ -1,0 +1,9 @@
+---
+term: "Dealiasing"
+description: "Undoing the fold that happens when wind is faster than the radar can measure directly, so a fast couplet reads correctly."
+related:
+  - velocity
+  - storm-relative-velocity
+---
+
+Undoing the fold that happens when wind is faster than the radar can measure directly, so a fast couplet reads correctly.

--- a/site/src/content/glossary/dual-pol.md
+++ b/site/src/content/glossary/dual-pol.md
@@ -1,0 +1,9 @@
+---
+term: "Dual-pol"
+description: "The radar sending both horizontal and vertical pulses, which is what makes CC and ZDR possible. Rolled out across the network around 2012."
+related:
+  - cc
+  - zdr
+---
+
+The radar sending both horizontal and vertical pulses, which is what makes CC and ZDR possible. Rolled out across the network around 2012.

--- a/site/src/content/glossary/hook-echo.md
+++ b/site/src/content/glossary/hook-echo.md
@@ -1,0 +1,20 @@
+---
+term: "Hook echo"
+description: "The comma-shaped notch on the back edge of a supercell where the rear-flank downdraft wraps precipitation around the mesocyclone — the classic radar look of a tornadic storm."
+related:
+  - storm-relative-velocity
+  - tds
+  - reflectivity
+---
+
+A comma- or hook-shaped appendage on the rear edge of a supercell's
+reflectivity, where the rear-flank downdraft wraps rain around the
+mesocyclone. It is the oldest tornado signature on radar, spotted in 1953, and
+it is still the shape people look for first.
+
+A hook is a hint, not a verdict: plenty of hooks never produce a tornado, and
+plenty of tornadoes come from storms that never draw a tidy one. Read it
+alongside the velocity — a tight couplet in the same place is the real tell —
+and CC, which drops where debris is being lofted.
+
+[The longer story](/blog/what-is-a-hook-echo/) is where this app got its name.

--- a/site/src/content/glossary/level-2-and-level-3.md
+++ b/site/src/content/glossary/level-2-and-level-3.md
@@ -1,0 +1,9 @@
+---
+term: "Level 2 / Level 3"
+description: "Level 2 is the raw volume, every gate of every sweep. Level 3 is the smaller set of processed products the NWS publishes from it."
+related:
+  - nexrad
+  - tilt
+---
+
+Level 2 is the raw volume, every gate of every sweep. Level 3 is the smaller set of processed products the NWS publishes from it.

--- a/site/src/content/glossary/mesh.md
+++ b/site/src/content/glossary/mesh.md
@@ -1,0 +1,9 @@
+---
+term: "MESH"
+description: "Maximum estimated hail size, computed from the storm's vertical structure."
+related:
+  - vil
+  - dbz
+---
+
+Maximum estimated hail size, computed from the storm's vertical structure.

--- a/site/src/content/glossary/mrms.md
+++ b/site/src/content/glossary/mrms.md
@@ -1,0 +1,9 @@
+---
+term: "MRMS"
+description: "The national grid that stitches every radar in the country into one picture, updated every couple of minutes."
+related:
+  - mesh
+  - reflectivity
+---
+
+The national grid that stitches every radar in the country into one picture, updated every couple of minutes.

--- a/site/src/content/glossary/nexrad.md
+++ b/site/src/content/glossary/nexrad.md
@@ -1,0 +1,10 @@
+---
+term: "NEXRAD"
+description: "The US network of 150-odd weather radars. Each has a four-letter ID like KTLX."
+related:
+  - tilt
+  - vcp
+  - level-2-and-level-3
+---
+
+The US network of 150-odd weather radars. Each has a four-letter ID like KTLX.

--- a/site/src/content/glossary/reflectivity.md
+++ b/site/src/content/glossary/reflectivity.md
@@ -1,0 +1,9 @@
+---
+term: "Reflectivity (Z)"
+description: "How much energy the echo sends back. Where the rain is."
+related:
+  - dbz
+  - velocity
+---
+
+How much energy the echo sends back. Where the rain is.

--- a/site/src/content/glossary/srh.md
+++ b/site/src/content/glossary/srh.md
@@ -1,0 +1,9 @@
+---
+term: "SRH (storm-relative helicity)"
+description: "How much spin the low-level wind has for a storm to use."
+related:
+  - cape
+  - storm-relative-velocity
+---
+
+How much spin the low-level wind has for a storm to use.

--- a/site/src/content/glossary/storm-relative-velocity.md
+++ b/site/src/content/glossary/storm-relative-velocity.md
@@ -1,0 +1,10 @@
+---
+term: "Storm-relative velocity"
+description: "Velocity with the storm's own travel subtracted, so rotation stops hiding inside the storm's motion."
+related:
+  - velocity
+  - dealiasing
+  - hook-echo
+---
+
+Velocity with the storm's own travel subtracted, so rotation stops hiding inside the storm's motion.

--- a/site/src/content/glossary/tds.md
+++ b/site/src/content/glossary/tds.md
@@ -1,0 +1,9 @@
+---
+term: "TDS (tornado debris signature)"
+description: "High reflectivity, a velocity couplet, and a hole in CC in the same place: the radar seeing lofted debris."
+related:
+  - cc
+  - hook-echo
+---
+
+High reflectivity, a velocity couplet, and a hole in CC in the same place: the radar seeing lofted debris.

--- a/site/src/content/glossary/tilt.md
+++ b/site/src/content/glossary/tilt.md
@@ -1,0 +1,9 @@
+---
+term: "Tilt"
+description: "One sweep of the radar at one elevation angle. A volume is a stack of them."
+related:
+  - vcp
+  - level-2-and-level-3
+---
+
+One sweep of the radar at one elevation angle. A volume is a stack of them.

--- a/site/src/content/glossary/vcp.md
+++ b/site/src/content/glossary/vcp.md
@@ -1,0 +1,9 @@
+---
+term: "VCP"
+description: "The scanning pattern the radar is running. Storm modes sweep faster and use more tilts than clear-air modes."
+related:
+  - tilt
+  - nexrad
+---
+
+The scanning pattern the radar is running. Storm modes sweep faster and use more tilts than clear-air modes.

--- a/site/src/content/glossary/velocity.md
+++ b/site/src/content/glossary/velocity.md
@@ -1,0 +1,9 @@
+---
+term: "Velocity (V)"
+description: "Motion toward or away from the radar along the beam. Green toward, red away."
+related:
+  - dealiasing
+  - storm-relative-velocity
+---
+
+Motion toward or away from the radar along the beam. Green toward, red away.

--- a/site/src/content/glossary/vil.md
+++ b/site/src/content/glossary/vil.md
@@ -1,0 +1,8 @@
+---
+term: "VIL"
+description: "How much water the storm is holding, integrated through its depth."
+related:
+  - mesh
+---
+
+How much water the storm is holding, integrated through its depth.

--- a/site/src/content/glossary/zdr.md
+++ b/site/src/content/glossary/zdr.md
@@ -1,0 +1,9 @@
+---
+term: "ZDR (differential reflectivity)"
+description: "How flat the things in the beam are. Positive for raindrops, near zero for tumbling hail."
+related:
+  - dual-pol
+  - cc
+---
+
+How flat the things in the beam are. Positive for raindrops, near zero for tumbling hail.

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -93,6 +93,7 @@ const nav = [
         </p>
         <p class="dim">
           <a href="/how-it-works/">How it works</a> ·
+          <a href="/glossary/">Glossary</a> ·
           <a href="/privacy/">Privacy</a> ·
           <a href="/press/">Press</a> ·
           <a href="https://github.com/d4vid87/hookecho">Source</a> ·

--- a/site/src/pages/glossary/[slug].astro
+++ b/site/src/pages/glossary/[slug].astro
@@ -1,0 +1,84 @@
+---
+import { getCollection, render } from "astro:content";
+import Base from "../../layouts/Base.astro";
+
+export async function getStaticPaths() {
+  const terms = await getCollection("glossary");
+  return terms.map((term) => ({ params: { slug: term.id }, props: { term, all: terms } }));
+}
+
+const { term, all } = Astro.props;
+const { Content } = await render(term);
+
+const related = term.data.related
+  .map((slug: string) => all.find((t) => t.id === slug))
+  .filter((t) => t !== undefined);
+
+const jsonld = {
+  "@context": "https://schema.org",
+  "@type": "DefinedTerm",
+  name: term.data.term,
+  description: term.data.description,
+  inDefinedTermSet: {
+    "@type": "DefinedTermSet",
+    name: "HookEcho weather radar glossary",
+    url: "https://hookecho.io/glossary/",
+  },
+};
+---
+
+<Base
+  title={`${term.data.term} — weather radar glossary | HookEcho`}
+  description={term.data.description}
+  jsonld={jsonld}
+>
+  <section>
+    <div class="wrap narrow">
+      <p class="eyebrow"><a href="/glossary/">Glossary</a></p>
+      <h1>{term.data.term}</h1>
+      <div class="prose"><Content /></div>
+
+      {
+        related.length > 0 && (
+          <>
+            <h2>Related</h2>
+            <ul class="terms">
+              {related.map((t) => (
+                <li>
+                  <a href={`/glossary/${t.id}/`}>
+                    <strong>{t.data.term}</strong>
+                    <span>{t.data.description}</span>
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </>
+        )
+      }
+
+      <p class="dim">
+        See it on real storms: <a href="https://app.hookecho.io">open the radar</a>, or read
+        <a href="/docs/reading-the-radar/">reading the radar</a>.
+      </p>
+    </div>
+  </section>
+</Base>
+
+<style>
+  .narrow { max-width: 70ch; }
+  .eyebrow a { color: inherit; }
+  .prose { font-size: 1.05rem; }
+  .dim { color: var(--text-dim); }
+  .terms { list-style: none; padding: 0; margin: 1rem 0 2rem; display: grid; gap: 0.6rem; }
+  .terms a {
+    display: block;
+    padding: 0.7rem 0.9rem;
+    border: 1px solid var(--stroke);
+    border-radius: var(--radius);
+    color: var(--text-dim);
+    text-decoration: none;
+    font-size: 0.95rem;
+  }
+  .terms a:hover { border-color: var(--accent); }
+  .terms strong { display: block; color: var(--text); }
+</style>

--- a/site/src/pages/glossary/index.astro
+++ b/site/src/pages/glossary/index.astro
@@ -1,0 +1,55 @@
+---
+import { getCollection } from "astro:content";
+import Base from "../../layouts/Base.astro";
+
+const terms = (await getCollection("glossary")).sort((a, b) =>
+  a.data.term.localeCompare(b.data.term, "en", { sensitivity: "base" }),
+);
+---
+
+<Base
+  title="Weather radar glossary | HookEcho"
+  description="Plain-language definitions of the radar words: dBZ, CC, ZDR, velocity, VCP, MESH, hook echo and the rest, each on its own page."
+>
+  <section>
+    <div class="wrap">
+      <p class="eyebrow">Glossary</p>
+      <h1>The radar words, in plain language</h1>
+      <p class="lede">
+        Radar has a vocabulary problem: the products are named after the physics rather than after
+        what you see. Here is the whole list, one page each, no meteorology degree assumed.
+      </p>
+
+      <ul class="terms">
+        {
+          terms.map((t) => (
+            <li>
+              <a href={`/glossary/${t.id}/`}>
+                <strong>{t.data.term}</strong>
+                <span>{t.data.description}</span>
+              </a>
+            </li>
+          ))
+        }
+      </ul>
+
+      <p><a href="/docs/reading-the-radar/">How to read the radar itself</a></p>
+    </div>
+  </section>
+</Base>
+
+<style>
+  .lede { font-size: 1.1rem; color: var(--text-dim); max-width: 62ch; }
+  .terms { list-style: none; padding: 0; margin: 2rem 0; display: grid; gap: 0.6rem; }
+  .terms a {
+    display: block;
+    padding: 0.8rem 1rem;
+    border: 1px solid var(--stroke);
+    border-radius: var(--radius);
+    color: var(--text-dim);
+    text-decoration: none;
+  }
+  .terms a:hover { border-color: var(--accent); }
+  .terms strong { display: block; color: var(--text); margin-bottom: 0.2rem; }
+  .terms span { font-size: 0.95rem; }
+</style>


### PR DESCRIPTION
Third wave of the site expansion (T3). Independent of #158/#159.

## What

- New `glossary` content collection: 19 terms (the 18 that were bold lines in the FAQ, plus **hook echo**, which had no page anywhere despite naming the app).
- `/glossary/` index and `/glossary/{slug}/` pages, each with `DefinedTerm` JSON-LD and a hand-written `related` list so the terms cross-link.
- The FAQ's glossary section becomes links — definitions live in one place, old inbound links to `/docs/faq/` still land somewhere useful.
- Footer and llms.txt gain the glossary.

## Side effect worth calling out

The FAQPage JSON-LD in `docs/[...slug].astro` matches *every* bold line on the FAQ, so it was emitting the 18 glossary terms as Questions. With them gone the page declares its six actual questions:

```
FAQPage 6
['Is it free? Is there an account?', "What's a hook echo?", 'Where does the data come from?',
 'How far back does the archive go?', 'Is the future radar real?', 'Do I need an API key?']
```

## Verification

- `npm run build` clean; 19 term pages + index.
- `dist/glossary/cc/index.html` carries DefinedTerm; FAQPage still emitted on the FAQ, as above.
- `npm run linkcheck`: 20 failures, all canonicals for the not-yet-deployed glossary pages. Nothing else broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)