### PR TITLE
feat(site): per-competitor pages and a RadarOmega column

### DIFF
--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -32,7 +32,7 @@ Key facts, because they are the ones most often got wrong about this kind of app
 
 - [Features](https://hookecho.io/features/): what the app does, section by section.
 - [How it works](https://hookecho.io/how-it-works/): the data sources and what happens locally.
-- [Compare](https://hookecho.io/compare/): an honest matrix against RadarScope, MyRadar, Windy and RainViewer, including the rows they win.
+- [Compare](https://hookecho.io/compare/): an honest matrix against RadarScope, MyRadar, Windy, RadarOmega and Clime/RainViewer, including the rows they win. One page each at /compare/radarscope/, /compare/myradar/, /compare/windy/, /compare/radaromega/, /compare/rainviewer/.
 - [Privacy](https://hookecho.io/privacy/): every host the site and app contact.
 - [Radar sites](https://hookecho.io/radar/): a page per NEXRAD and TDWR site, plus a page per state.
 - [Storms](https://hookecho.io/storms/): archived cases — Joplin, El Reno, Moore, Tuscaloosa, Greensburg, Katrina, the 2020 derecho.

--- a/site/src/data/compare.ts
+++ b/site/src/data/compare.ts
@@ -1,0 +1,315 @@
+// The comparison matrix, shared by /compare/ and the five per-competitor pages so a corrected row
+// is corrected everywhere at once.
+//
+// An honest matrix or none at all: every row a competitor wins is marked as won. Prices are tiers,
+// not dollar amounts — those change without telling us, and a stale number here would be the one
+// thing readers were right to disbelieve.
+//
+// Sources, checked 2026-08: each product's own pricing/feature pages and store listings.
+// RadarScope: base.radarscope.app tier list (Pro Tier One / Tier Two).
+// MyRadar: myradar.com premium features; free tier carries ads.
+// Windy: windy.com Premium page; radar composite is not Level 2.
+// RadarOmega: radaromega.com feature and subscription pages, including the paid add-on packs.
+// Clime and RainViewer are grouped: both are mosaic-imagery apps on a subscription.
+// HookEcho's own column comes from README.md and docs/GUIDE.md.
+export const COLS = [
+  "HookEcho",
+  "RadarScope",
+  "MyRadar",
+  "Windy",
+  "RadarOmega",
+  "Clime / RainViewer",
+];
+
+/** v: "yes" | "no" | "part" — decides the mark; t is the qualifier that makes the mark honest. */
+export const ROWS = [
+  {
+    label: "Price",
+    cells: [
+      { v: "yes", t: "Free, MIT licensed" },
+      { v: "part", t: "Paid app, subscription tiers" },
+      { v: "part", t: "Free with ads, subscription" },
+      { v: "part", t: "Free, optional Premium" },
+      { v: "part", t: "Paid app, subscription add-ons" },
+      { v: "part", t: "Free trial, subscription" },
+    ],
+  },
+  {
+    label: "Ads",
+    cells: [
+      { v: "yes", t: "None" },
+      { v: "yes", t: "None" },
+      { v: "no", t: "Unless you subscribe" },
+      { v: "yes", t: "None" },
+      { v: "yes", t: "None" },
+      { v: "no", t: "Yes" },
+    ],
+  },
+  {
+    label: "Account required",
+    cells: [
+      { v: "yes", t: "Never" },
+      { v: "part", t: "For the paid tiers" },
+      { v: "part", t: "For the paid tier" },
+      { v: "yes", t: "Optional" },
+      { v: "part", t: "For the subscription" },
+      { v: "part", t: "For the paid tier" },
+    ],
+  },
+  {
+    label: "Open source",
+    cells: [
+      { v: "yes", t: "Every line" },
+      { v: "no", t: "" },
+      { v: "no", t: "" },
+      { v: "no", t: "" },
+      { v: "no", t: "" },
+      { v: "no", t: "" },
+    ],
+  },
+  {
+    label: "Level 2, every tilt",
+    cells: [
+      { v: "yes", t: "All elevations, full resolution" },
+      { v: "yes", t: "All elevations" },
+      { v: "no", t: "Mosaic imagery" },
+      { v: "no", t: "Composite only" },
+      { v: "yes", t: "All elevations" },
+      { v: "no", t: "Mosaic imagery" },
+    ],
+  },
+  {
+    label: "Dual-pol products",
+    cells: [
+      { v: "yes", t: "ZDR, CC, KDP, ΦDP" },
+      { v: "yes", t: "Full set" },
+      { v: "no", t: "" },
+      { v: "no", t: "" },
+      { v: "yes", t: "Full set" },
+      { v: "no", t: "" },
+    ],
+  },
+  {
+    label: "Velocity and dealiasing",
+    cells: [
+      { v: "yes", t: "With storm-relative" },
+      { v: "yes", t: "With storm-relative" },
+      { v: "no", t: "" },
+      { v: "no", t: "" },
+      { v: "yes", t: "With storm-relative" },
+      { v: "no", t: "" },
+    ],
+  },
+  {
+    label: "National MRMS mosaic",
+    cells: [
+      { v: "yes", t: "Full resolution" },
+      { v: "part", t: "Paid tier" },
+      { v: "yes", t: "" },
+      { v: "yes", t: "Composite" },
+      { v: "yes", t: "" },
+      { v: "yes", t: "" },
+    ],
+  },
+  {
+    label: "Lightning",
+    cells: [
+      { v: "yes", t: "GOES GLM" },
+      { v: "part", t: "Paid tier" },
+      { v: "part", t: "Paid tier" },
+      { v: "yes", t: "" },
+      { v: "part", t: "Paid add-on" },
+      { v: "part", t: "Paid tier" },
+    ],
+  },
+  {
+    label: "Forecast models",
+    cells: [
+      { v: "part", t: "HRRR, NAM, soundings" },
+      { v: "no", t: "" },
+      { v: "part", t: "Limited" },
+      { v: "yes", t: "The best in the field" },
+      { v: "part", t: "Paid add-on" },
+      { v: "no", t: "" },
+    ],
+  },
+  {
+    label: "Tropical tracks",
+    cells: [
+      { v: "yes", t: "NHC cones and advisories" },
+      { v: "no", t: "" },
+      { v: "yes", t: "" },
+      { v: "yes", t: "" },
+      { v: "yes", t: "" },
+      { v: "yes", t: "" },
+    ],
+  },
+  {
+    label: "Archive playback",
+    cells: [
+      { v: "yes", t: "Back to 1991" },
+      { v: "part", t: "Paid tier, recent only" },
+      { v: "no", t: "" },
+      { v: "no", t: "" },
+      { v: "part", t: "Paid add-on, recent only" },
+      { v: "no", t: "" },
+    ],
+  },
+  {
+    label: "Works offline",
+    cells: [
+      { v: "yes", t: "Chase packs, prefetched" },
+      { v: "no", t: "" },
+      { v: "no", t: "" },
+      { v: "no", t: "" },
+      { v: "no", t: "" },
+      { v: "no", t: "" },
+    ],
+  },
+  {
+    label: "Coverage outside the US",
+    cells: [
+      { v: "part", t: "US plus German DWD radar" },
+      { v: "part", t: "Several countries" },
+      { v: "part", t: "Mostly US" },
+      { v: "yes", t: "Global" },
+      { v: "part", t: "Several countries" },
+      { v: "yes", t: "Global" },
+    ],
+  },
+  {
+    label: "Runs in a browser",
+    cells: [
+      { v: "yes", t: "The whole app, no install" },
+      { v: "no", t: "" },
+      { v: "part", t: "Cut-down web view" },
+      { v: "yes", t: "Web first" },
+      { v: "no", t: "" },
+      { v: "no", t: "" },
+    ],
+  },
+  {
+    label: "iPhone and iPad",
+    cells: [
+      { v: "no", t: "Not yet" },
+      { v: "yes", t: "" },
+      { v: "yes", t: "" },
+      { v: "yes", t: "" },
+      { v: "yes", t: "" },
+      { v: "yes", t: "" },
+    ],
+  },
+  {
+    label: "Desktop app",
+    cells: [
+      { v: "yes", t: "Windows, macOS, Linux" },
+      { v: "part", t: "Windows, macOS" },
+      { v: "part", t: "Windows" },
+      { v: "no", t: "" },
+      { v: "part", t: "Windows" },
+      { v: "no", t: "" },
+    ],
+  },
+  {
+    label: "Mobile polish",
+    cells: [
+      { v: "part", t: "Android only, and younger" },
+      { v: "yes", t: "The bar everyone measures against" },
+      { v: "yes", t: "" },
+      { v: "yes", t: "" },
+      { v: "yes", t: "Deep, and heavily configurable" },
+      { v: "yes", t: "" },
+    ],
+  },
+  {
+    label: "Telemetry",
+    cells: [
+      { v: "yes", t: "None, at all" },
+      { v: "no", t: "Analytics" },
+      { v: "no", t: "Ads and analytics" },
+      { v: "no", t: "Analytics" },
+      { v: "no", t: "Analytics" },
+      { v: "no", t: "Ads and analytics" },
+    ],
+  },
+];
+
+export interface Competitor {
+  slug: string;
+  /** Column index in COLS. */
+  col: number;
+  name: string;
+  /** One line under the H1. */
+  blurb: string;
+  /** The rows they beat us on, said plainly and first. */
+  theyWin: string[];
+  /** The honest close, two or three sentences. */
+  verdict: string;
+}
+
+// Written to be read by someone deciding between the two apps, not by a search engine: the rows
+// they win go above the rows we win.
+export const COMPETITORS: Competitor[] = [
+  {
+    slug: "radarscope",
+    col: 1,
+    name: "RadarScope",
+    blurb: "The chaser standard, and the app HookEcho is measured against most often.",
+    theyWin: [
+      "The phone app is more polished than ours, and has been for a decade.",
+      "There is an iPhone and iPad build. We have Android and desktop.",
+      "Its data plumbing — SPC outlooks, extra products, the pro tiers — is deeper in places.",
+    ],
+    verdict:
+      "RadarScope is a good app that costs money, and the things you buy on top of it — lightning, the mosaic, archive playback — are things HookEcho gives away because they come from public NOAA feeds. If the polish of the phone app is what you care about, buy RadarScope. If you want every Level 2 product, the archive back to 1991 and no bill, take ours for a drive in the browser first.",
+  },
+  {
+    slug: "myradar",
+    col: 2,
+    name: "MyRadar",
+    blurb: "The popular free radar app, paid for with ads.",
+    theyWin: [
+      "A far bigger phone app team, and an iPhone build.",
+      "Route and aviation extras HookEcho does not attempt.",
+    ],
+    verdict:
+      "MyRadar shows mosaic imagery: one national picture, one product, already rendered. That is fine for whether it is about to rain. It is not enough to tell a rotating storm from a heavy one, which needs velocity and dual-pol at the radar's own resolution — what HookEcho reads directly, with no ads and no subscription.",
+  },
+  {
+    slug: "windy",
+    col: 3,
+    name: "Windy",
+    blurb: "The best model visualisation on the web. Its radar is the weak part.",
+    theyWin: [
+      "Global forecast models, and nobody in this list is close.",
+      "Genuinely global coverage, and a beautiful web app.",
+    ],
+    verdict:
+      "Use Windy for the models — we say so on the comparison page too. But Windy's radar is a composite: one blended image, no tilts, no velocity, no dual-pol. When a storm is over your house, that is the moment HookEcho is for. They are complementary, and both run in a browser, so keep both tabs open.",
+  },
+  {
+    slug: "rainviewer",
+    col: 5,
+    name: "RainViewer",
+    blurb: "Global rain mosaics on a subscription. Clime is the same shape of product.",
+    theyWin: [
+      "Worldwide coverage: HookEcho is the US plus the German DWD network.",
+      "iPhone builds, and a simpler app for a simpler question.",
+    ],
+    verdict:
+      "RainViewer answers \"is rain coming\" well, worldwide, and if that is your question it is a reasonable app to pay for. It cannot answer \"is this storm rotating\", because mosaic imagery has thrown that information away before it reaches you. HookEcho decodes the volume on your own machine, so nothing is thrown away — inside the US, for free.",
+  },
+  {
+    slug: "radaromega",
+    col: 4,
+    name: "RadarOmega",
+    blurb: "The other serious Level 2 viewer, sold as an app plus add-on packs.",
+    theyWin: [
+      "A more configurable phone app, with a long list of paid add-on data packs.",
+      "iPhone and iPad builds.",
+      "More non-US radar networks than our US-plus-Germany coverage.",
+    ],
+    verdict:
+      "RadarOmega and HookEcho read the same public Level 2 volumes and show the same tilts, velocity and dual-pol products. The difference is the bill and the source: RadarOmega charges for the app and again for the add-ons, and you cannot read its code. HookEcho is MIT licensed, runs in a browser with nothing installed, and the archive goes back to 1991 without an add-on.",
+  },
+];

--- a/site/src/pages/compare/[slug].astro
+++ b/site/src/pages/compare/[slug].astro
@@ -1,0 +1,118 @@
+---
+import Base from "../../layouts/Base.astro";
+import { COLS, ROWS, COMPETITORS } from "../../data/compare";
+
+export function getStaticPaths() {
+  return COMPETITORS.map((c) => ({ params: { slug: c.slug }, props: { c } }));
+}
+
+const { c } = Astro.props;
+// Two columns only: us and them. The full six-column matrix stays on /compare/.
+const rows = ROWS.map((r) => ({ label: r.label, us: r.cells[0], them: r.cells[c.col] }));
+const mark = (v: string) => (v === "yes" ? "Yes" : v === "part" ? "Partly" : "No");
+---
+
+<Base
+  title={`HookEcho vs ${c.name} — a free ${c.name} alternative`}
+  description={`${c.name} compared with HookEcho feature by feature, including the rows ${c.name} wins. HookEcho is free, open source, reads Level 2 directly and runs in a browser.`}
+>
+  <section class="head">
+    <span class="sweep" aria-hidden="true"></span>
+    <div class="wrap">
+      <p class="eyebrow"><a href="/compare/">Comparison</a></p>
+      <h1>HookEcho vs {c.name}</h1>
+      <p class="lede">{c.blurb}</p>
+    </div>
+  </section>
+
+  <section>
+    <div class="wrap">
+      <h2>Where {c.name} wins</h2>
+      <ul class="wins">
+        {c.theyWin.map((w) => <li>{w}</li>)}
+      </ul>
+      <p class="verdict">{c.verdict}</p>
+      <div class="ctas">
+        <a class="btn btn-primary" href="https://app.hookecho.io">Try HookEcho in your browser</a>
+        <a class="btn" href="/download/">Get the app</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="alt">
+    <div class="wrap">
+      <h2>Feature by feature</h2>
+      <div class="scroller">
+        <table>
+          <thead>
+            <tr>
+              <th scope="col"><span class="sr-only">Feature</span></th>
+              <th scope="col" class="us">HookEcho</th>
+              <th scope="col">{COLS[c.col]}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {
+              rows.map((r) => (
+                <tr>
+                  <th scope="row">{r.label}</th>
+                  <td class:list={[r.us.v, "us"]}>
+                    <span class="mark" aria-hidden="true" />
+                    <span class="sr-only">{mark(r.us.v)}</span>
+                    {r.us.t && <span class="note">{r.us.t}</span>}
+                  </td>
+                  <td class:list={[r.them.v]}>
+                    <span class="mark" aria-hidden="true" />
+                    <span class="sr-only">{mark(r.them.v)}</span>
+                    {r.them.t && <span class="note">{r.them.t}</span>}
+                  </td>
+                </tr>
+              ))
+            }
+          </tbody>
+        </table>
+      </div>
+      <p class="foot">
+        Verified August 2026, from each product's own pricing and feature pages. Tiers and prices
+        move; if a row here is wrong,
+        <a href="https://github.com/d4vid87/hookecho/issues">tell us</a> and it gets fixed.
+        {COLS[c.col].includes("/") && " That column covers both apps, which sell the same thing."}
+      </p>
+      <p><a href="/compare/">See all of them side by side</a></p>
+    </div>
+  </section>
+</Base>
+
+<style>
+  .head { position: relative; overflow: hidden; }
+  .head .wrap { position: relative; }
+  .eyebrow a { color: inherit; }
+  .lede { font-size: 1.15rem; color: var(--text-dim); max-width: 62ch; }
+  .alt { background: var(--bg-deep); border-block: 1px solid var(--stroke); }
+  .wins { max-width: 62ch; color: var(--text-dim); }
+  .wins li { margin-bottom: 0.4rem; }
+  .verdict { max-width: 62ch; }
+  .ctas { display: flex; gap: 0.75rem; flex-wrap: wrap; margin-top: 1.4rem; }
+  .scroller { overflow-x: auto; }
+  table { border-collapse: collapse; width: 100%; min-width: 520px; font-size: 0.92rem; }
+  th, td {
+    text-align: left;
+    padding: 0.7rem 0.9rem;
+    border-bottom: 1px solid var(--stroke);
+    vertical-align: top;
+  }
+  thead th { color: var(--text-dim); font-weight: 600; }
+  th.us, td.us { background: color-mix(in srgb, var(--accent) 8%, transparent); }
+  tbody th { color: var(--text); font-weight: 600; }
+  .note { display: block; color: var(--text-dim); font-size: 0.85rem; margin-top: 0.15rem; }
+  .mark {
+    display: inline-block;
+    width: 0.8rem;
+    height: 0.8rem;
+    border-radius: 50%;
+    border: 2px solid var(--text-dim);
+  }
+  td.yes .mark { background: var(--accent); border-color: var(--accent); }
+  td.part .mark { background: linear-gradient(90deg, var(--accent) 50%, transparent 50%); }
+  .foot { color: var(--text-dim); font-size: 0.9rem; margin-top: 1rem; }
+</style>

--- a/site/src/pages/compare/index.astro
+++ b/site/src/pages/compare/index.astro
@@ -1,219 +1,14 @@
 ---
 import Base from "../../layouts/Base.astro";
-
-// An honest matrix or none at all: every row a competitor wins is marked as won, and there are
-// four of those. Prices are tiers, not dollar amounts — those change without telling us, and a
-// stale number on this page would be the one thing readers were right to disbelieve.
-//
-// Sources, checked 2026-08: each product's own pricing/feature pages and store listings.
-// RadarScope: base.radarscope.app tier list (Pro Tier One / Tier Two).
-// MyRadar: myradar.com premium features; free tier carries ads.
-// Windy: windy.com Premium page; radar composite is not Level 2.
-// Clime and RainViewer are grouped: both are mosaic-imagery apps on a subscription.
-// HookEcho's own column comes from README.md and docs/GUIDE.md.
-const cols = ["HookEcho", "RadarScope", "MyRadar", "Windy", "Clime / RainViewer"];
-
-// v: "yes" | "no" | "part" — decides the mark; t is the qualifier that makes the mark honest.
-const rows = [
-  {
-    label: "Price",
-    cells: [
-      { v: "yes", t: "Free, MIT licensed" },
-      { v: "part", t: "Paid app, subscription tiers" },
-      { v: "part", t: "Free with ads, subscription" },
-      { v: "part", t: "Free, optional Premium" },
-      { v: "part", t: "Free trial, subscription" },
-    ],
-  },
-  {
-    label: "Ads",
-    cells: [
-      { v: "yes", t: "None" },
-      { v: "yes", t: "None" },
-      { v: "no", t: "Unless you subscribe" },
-      { v: "yes", t: "None" },
-      { v: "no", t: "Yes" },
-    ],
-  },
-  {
-    label: "Account required",
-    cells: [
-      { v: "yes", t: "Never" },
-      { v: "part", t: "For the paid tiers" },
-      { v: "part", t: "For the paid tier" },
-      { v: "yes", t: "Optional" },
-      { v: "part", t: "For the paid tier" },
-    ],
-  },
-  {
-    label: "Open source",
-    cells: [
-      { v: "yes", t: "Every line" },
-      { v: "no", t: "" },
-      { v: "no", t: "" },
-      { v: "no", t: "" },
-      { v: "no", t: "" },
-    ],
-  },
-  {
-    label: "Level 2, every tilt",
-    cells: [
-      { v: "yes", t: "All elevations, full resolution" },
-      { v: "yes", t: "All elevations" },
-      { v: "no", t: "Mosaic imagery" },
-      { v: "no", t: "Composite only" },
-      { v: "no", t: "Mosaic imagery" },
-    ],
-  },
-  {
-    label: "Dual-pol products",
-    cells: [
-      { v: "yes", t: "ZDR, CC, KDP, ΦDP" },
-      { v: "yes", t: "Full set" },
-      { v: "no", t: "" },
-      { v: "no", t: "" },
-      { v: "no", t: "" },
-    ],
-  },
-  {
-    label: "Velocity and dealiasing",
-    cells: [
-      { v: "yes", t: "With storm-relative" },
-      { v: "yes", t: "With storm-relative" },
-      { v: "no", t: "" },
-      { v: "no", t: "" },
-      { v: "no", t: "" },
-    ],
-  },
-  {
-    label: "National MRMS mosaic",
-    cells: [
-      { v: "yes", t: "Full resolution" },
-      { v: "part", t: "Paid tier" },
-      { v: "yes", t: "" },
-      { v: "yes", t: "Composite" },
-      { v: "yes", t: "" },
-    ],
-  },
-  {
-    label: "Lightning",
-    cells: [
-      { v: "yes", t: "GOES GLM" },
-      { v: "part", t: "Paid tier" },
-      { v: "part", t: "Paid tier" },
-      { v: "yes", t: "" },
-      { v: "part", t: "Paid tier" },
-    ],
-  },
-  {
-    label: "Forecast models",
-    cells: [
-      { v: "part", t: "HRRR, NAM, soundings" },
-      { v: "no", t: "" },
-      { v: "part", t: "Limited" },
-      { v: "yes", t: "The best in the field" },
-      { v: "no", t: "" },
-    ],
-  },
-  {
-    label: "Tropical tracks",
-    cells: [
-      { v: "yes", t: "NHC cones and advisories" },
-      { v: "no", t: "" },
-      { v: "yes", t: "" },
-      { v: "yes", t: "" },
-      { v: "yes", t: "" },
-    ],
-  },
-  {
-    label: "Archive playback",
-    cells: [
-      { v: "yes", t: "Back to 1991" },
-      { v: "part", t: "Paid tier, recent only" },
-      { v: "no", t: "" },
-      { v: "no", t: "" },
-      { v: "no", t: "" },
-    ],
-  },
-  {
-    label: "Works offline",
-    cells: [
-      { v: "yes", t: "Chase packs, prefetched" },
-      { v: "no", t: "" },
-      { v: "no", t: "" },
-      { v: "no", t: "" },
-      { v: "no", t: "" },
-    ],
-  },
-  {
-    label: "Coverage outside the US",
-    cells: [
-      { v: "part", t: "US plus German DWD radar" },
-      { v: "part", t: "Several countries" },
-      { v: "part", t: "Mostly US" },
-      { v: "yes", t: "Global" },
-      { v: "yes", t: "Global" },
-    ],
-  },
-  {
-    label: "Runs in a browser",
-    cells: [
-      { v: "yes", t: "The whole app, no install" },
-      { v: "no", t: "" },
-      { v: "part", t: "Cut-down web view" },
-      { v: "yes", t: "Web first" },
-      { v: "no", t: "" },
-    ],
-  },
-  {
-    label: "iPhone and iPad",
-    cells: [
-      { v: "no", t: "Not yet" },
-      { v: "yes", t: "" },
-      { v: "yes", t: "" },
-      { v: "yes", t: "" },
-      { v: "yes", t: "" },
-    ],
-  },
-  {
-    label: "Desktop app",
-    cells: [
-      { v: "yes", t: "Windows, macOS, Linux" },
-      { v: "part", t: "Windows, macOS" },
-      { v: "part", t: "Windows" },
-      { v: "no", t: "" },
-      { v: "no", t: "" },
-    ],
-  },
-  {
-    label: "Mobile polish",
-    cells: [
-      { v: "part", t: "Android only, and younger" },
-      { v: "yes", t: "The bar everyone measures against" },
-      { v: "yes", t: "" },
-      { v: "yes", t: "" },
-      { v: "yes", t: "" },
-    ],
-  },
-  {
-    label: "Telemetry",
-    cells: [
-      { v: "yes", t: "None, at all" },
-      { v: "no", t: "Analytics" },
-      { v: "no", t: "Ads and analytics" },
-      { v: "no", t: "Analytics" },
-      { v: "no", t: "Ads and analytics" },
-    ],
-  },
-];
+import { COLS as cols, ROWS as rows, COMPETITORS } from "../../data/compare";
 
 // ponytail: the marks are drawn in CSS, not typed as ●◐○ — the bundled Inter subset is Latin
 // only, so the half-filled glyph in particular falls through to whatever the system has.
 ---
 
 <Base
-  title="How HookEcho compares — RadarScope, MyRadar, Windy, RainViewer"
-  description="An honest feature-by-feature comparison of HookEcho against RadarScope, MyRadar, Windy and Clime/RainViewer — including the rows where they win."
+  title="How HookEcho compares — RadarScope, MyRadar, Windy, RadarOmega, RainViewer"
+  description="An honest feature-by-feature comparison of HookEcho against RadarScope, MyRadar, Windy, RadarOmega and Clime/RainViewer — including the rows where they win."
 >
   <section class="head">
     <span class="sweep" aria-hidden="true"></span>
@@ -221,7 +16,7 @@ const rows = [
       <p class="eyebrow">Comparison</p>
       <h1>How HookEcho compares</h1>
       <p class="lede">
-        Four apps people actually use, and the rows where each of them beats us. If you want the
+        Five apps people actually use, and the rows where each of them beats us. If you want the
         best global model data, use Windy. If you want the most polished phone app, buy
         RadarScope. If you want every Level 2 product, the full archive and no bill, keep reading.
       </p>
@@ -270,6 +65,20 @@ const rows = [
 
   <section>
     <div class="wrap">
+      <h2>One at a time</h2>
+      <ul class="one-by-one">
+        {
+          COMPETITORS.map((c) => (
+            <li>
+              <a href={`/compare/${c.slug}/`}>
+                <strong>HookEcho vs {c.name}</strong>
+                <span>{c.blurb}</span>
+              </a>
+            </li>
+          ))
+        }
+      </ul>
+
       <h2>What we are actually claiming</h2>
       <p>
         HookEcho is a chaser-grade radar viewer that reads the same public NOAA feeds the
@@ -291,9 +100,22 @@ const rows = [
   .lede { font-size: 1.15rem; color: var(--text-dim); max-width: 62ch; }
   .alt { background: var(--bg-deep); border-block: 1px solid var(--stroke); }
 
-  /* Nineteen rows by five columns does not fit a phone. Scroll it rather than pretend. */
+  .one-by-one { list-style: none; padding: 0; margin: 1rem 0 2.4rem; display: grid; gap: 0.6rem; }
+  .one-by-one a {
+    display: block;
+    padding: 0.8rem 1rem;
+    border: 1px solid var(--stroke);
+    border-radius: var(--radius);
+    color: var(--text-dim);
+    text-decoration: none;
+  }
+  .one-by-one a:hover { border-color: var(--accent); }
+  .one-by-one strong { display: block; color: var(--text); margin-bottom: 0.2rem; }
+  .one-by-one span { font-size: 0.95rem; }
+
+  /* Nineteen rows by six columns does not fit a phone. Scroll it rather than pretend. */
   .scroller { overflow-x: auto; }
-  table { border-collapse: collapse; width: 100%; min-width: 820px; font-size: 0.92rem; }
+  table { border-collapse: collapse; width: 100%; min-width: 960px; font-size: 0.92rem; }
   th, td {
     text-align: left;
     padding: 0.7rem 0.9rem;


### PR DESCRIPTION
Fourth wave of the site expansion (T4).

## What

- Matrix rows move to `site/src/data/compare.ts`, shared by `/compare/` and the new pages, so a corrected row is corrected once.
- Five pages at `/compare/{radarscope,myradar,windy,radaromega,rainviewer}/`: two-column table (us vs them), the rows **they** win listed first, then a verdict. Titled for the "{Name} alternative" search.
- **RadarOmega** becomes the sixth matrix column and gets a page. It reads the same public Level 2 volumes we do — the honest difference is the app price, the paid add-on packs and the closed source, not the data.
- The RainViewer page notes that its column covers Clime too, since both sell the same thing.
- llms.txt lists the new pages.

## Verification

- `npm run build` clean; five competitor pages emitted, RadarOmega present in the matrix header and every row.
- `npm run linkcheck`: 5 failures, all canonicals for the not-yet-deployed competitor pages.

Row sources stay in the module header comment, and the "Verified August 2026" footnote carries onto every page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)