### PR TITLE
feat(site): five more storms

### DIFF
--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -35,7 +35,7 @@ Key facts, because they are the ones most often got wrong about this kind of app
 - [Compare](https://hookecho.io/compare/): an honest matrix against RadarScope, MyRadar, Windy, RadarOmega and Clime/RainViewer, including the rows they win. One page each at /compare/radarscope/, /compare/myradar/, /compare/windy/, /compare/radaromega/, /compare/rainviewer/.
 - [Privacy](https://hookecho.io/privacy/): every host the site and app contact.
 - [Radar sites](https://hookecho.io/radar/): a page per NEXRAD and TDWR site, plus a page per state.
-- [Storms](https://hookecho.io/storms/): archived cases — Joplin, El Reno, Moore, Tuscaloosa, Greensburg, Katrina, the 2020 derecho.
+- [Storms](https://hookecho.io/storms/): archived cases — Bridge Creek–Moore 1999, Katrina, Greensburg, Joplin, Tuscaloosa, El Reno, Moore, Harvey, the 2020 derecho, Mayfield, Ian, Rolling Fork.
 - [Glossary](https://hookecho.io/glossary/): a page per radar term — dBZ, CC, ZDR, VCP, hook echo.
 - [Press kit](https://hookecho.io/press/)
 - [Download](https://hookecho.io/download/)

--- a/site/src/content/storms/bridge-creek-moore-1999.md
+++ b/site/src/content/storms/bridge-creek-moore-1999.md
@@ -1,0 +1,27 @@
+---
+title: "Bridge Creek–Moore, 1999"
+description: "The 3 May 1999 F5 that produced the fastest wind ever measured on Earth, from KTLX, thirty miles from the radar."
+date: 1999-05-03
+site: KTLX
+lon: -97.4867
+lat: 35.3395
+zoom: 9
+at: "1999-05-04T00:20:00Z"
+extras: ["VEL"]
+---
+
+The tornado that crossed Bridge Creek and Moore on the evening of 3 May 1999
+killed 36 people and was, for a long time, the costliest tornado in US history.
+A mobile Doppler measured 301 mph inside it, a few hundred feet up — still the
+highest wind speed ever recorded on this planet.
+
+**What the radar shows.** The link opens on velocity from Twin Lakes, about
+thirty miles away. That distance matters: the beam is low enough here to see
+into the circulation rather than over it, and the couplet — bright green
+against bright red, gate to gate — is as clean as this signature ever gets on
+legacy radar.
+
+This was also the pre-dual-pol era. There is no correlation coefficient to
+confirm debris, no TDS to point at. Everything the warning meteorologists had
+that night is on this screen, which is a useful thing to sit with while looking
+at what the same storm would look like today.

--- a/site/src/content/storms/hurricane-harvey-2017.md
+++ b/site/src/content/storms/hurricane-harvey-2017.md
@@ -1,0 +1,25 @@
+---
+title: "Hurricane Harvey, 2017"
+description: "The rainfall that flooded Houston in August 2017, from KHGX — four days of training bands over one city."
+date: 2017-08-27
+site: KHGX
+lon: -95.3600
+lat: 29.7600
+zoom: 8
+at: "2017-08-27T12:00:00Z"
+extras: []
+---
+
+Harvey made landfall near Rockport on 26 August 2017 and then stopped. Over the
+next four days it dropped more than 60 inches of rain on parts of southeast
+Texas — the most from any tropical cyclone in United States history — and
+flooded much of Houston.
+
+**What the radar shows.** The link opens on reflectivity from League City, in
+the middle of it. The thing to look for is not one storm but the arrangement:
+bands that form upwind, move over the same ground, and are replaced by the next
+one. Training, in the jargon. Any single cell here would be an ordinary
+thunderstorm. A hundred of them over the same neighbourhood is a disaster.
+
+Step the loop forward for a few hours rather than a few minutes. Harvey is a
+case where the interesting timescale is days, not volumes.

--- a/site/src/content/storms/hurricane-ian-2022.md
+++ b/site/src/content/storms/hurricane-ian-2022.md
@@ -1,0 +1,26 @@
+---
+title: "Hurricane Ian, 2022"
+description: "The 28 September 2022 landfall on southwest Florida from KTBW: an eyewall crossing the coast, and the tornadoes in the outer bands."
+date: 2022-09-28
+site: KTBW
+lon: -81.9200
+lat: 26.6800
+zoom: 8
+extras: []
+at: "2022-09-28T19:05:00Z"
+---
+
+Ian came ashore near Cayo Costa on 28 September 2022 as a category 4, pushed a
+storm surge of ten to fifteen feet into Fort Myers Beach and Sanibel, and
+killed more than 150 people. It is the deadliest hurricane to hit Florida since
+1935.
+
+**What the radar shows.** The link opens on reflectivity from Ruskin, which
+watched the whole landfall from the north. Zoom out and the structure is the
+storm's own anatomy: the eye, the ring of the eyewall, the spiral bands feeding
+in from the southwest. Zoom in on the bands and you find the small, fast,
+short-lived cells that make landfalling hurricanes a tornado threat as well as
+a wind and water one.
+
+Ruskin's own view degrades as the storm closes in — attenuation, the beam
+losing energy through that much rain, is part of what you are looking at.

--- a/site/src/content/storms/mayfield-2021.md
+++ b/site/src/content/storms/mayfield-2021.md
@@ -1,0 +1,26 @@
+---
+title: "Mayfield and the quad-state, 2021"
+description: "The 10 December 2021 nighttime tornado that ran through western Kentucky, from KPAH — a long-track winter supercell with a textbook debris signature."
+date: 2021-12-10
+site: KPAH
+lon: -88.6367
+lat: 36.7417
+zoom: 9
+at: "2021-12-11T04:35:00Z"
+extras: ["CC"]
+---
+
+A supercell that formed in northeast Arkansas late on 10 December 2021 stayed
+tornadic across four states. Mayfield, Kentucky lost its downtown a little
+after ten at night, local time; the outbreak killed 89 people, most of them in
+Kentucky.
+
+**What the radar shows.** The link opens on correlation coefficient from
+Paducah, close by. CC is the product that tells you something is not rain: it
+drops where the beam is full of unlike things, and lofted building debris is as
+unlike as it gets. The hole in CC sitting on the velocity couplet is a tornado
+debris signature, and here it is unusually deep and unusually persistent.
+
+Two things make this case worth replaying. It was at night, so radar was the
+only thing anyone had. And it was December — the setup was a winter storm
+system, which is why "tornado season" is a misleading phrase.

--- a/site/src/content/storms/rolling-fork-2023.md
+++ b/site/src/content/storms/rolling-fork-2023.md
@@ -1,0 +1,24 @@
+---
+title: "Rolling Fork, 2023"
+description: "The 24 March 2023 EF4 that destroyed Rolling Fork, Mississippi, from KDGX — a long-track nighttime tornado with a violent debris signature."
+date: 2023-03-24
+site: KDGX
+lon: -90.8770
+lat: 32.9070
+zoom: 9
+at: "2023-03-25T00:05:00Z"
+extras: ["CC"]
+---
+
+Just after eight in the evening on 24 March 2023, an EF4 tornado went through
+Rolling Fork, Mississippi, a town of about 1,900 people. It stayed on the
+ground for nearly sixty miles. Seventeen people died in Mississippi that night.
+
+**What the radar shows.** The link opens on correlation coefficient from
+Brandon. The debris ball is unmistakable — a circle of very low CC riding along
+with the reflectivity hook, which is the radar detecting a town in the air.
+Switch to velocity and the couplet is tight and deep; switch to reflectivity
+and the hook is the shape this app is named after.
+
+Rolling Fork is a case worth replaying slowly, because it shows how much of the
+warning decision comes from products other than the picture of rain.


### PR DESCRIPTION
Fifth wave of the site expansion (T5). Independent of the others.

## What

Five cases on the existing `storms` collection, chosen to widen the archive past "plains tornado outbreak":

| Case | Radar | Opens on |
|---|---|---|
| Bridge Creek–Moore 1999 | KTLX | Velocity — the pre-dual-pol era, nothing else existed |
| Mayfield quad-state 2021 | KPAH | CC — deep, persistent debris signature, at night, in December |
| Rolling Fork 2023 | KDGX | CC — debris ball riding the hook |
| Hurricane Ian 2022 | KTBW | Reflectivity — eyewall landfall, tornadoes in the outer bands |
| Hurricane Harvey 2017 | KHGX | Reflectivity — training bands, four days over one city |

Times are the volume nearest the moment the damage surveys describe. llms.txt's storm list updated.

## Verification

- `npm run build` clean; 12 storm pages, OG cards auto-generated for all five.
- Deep links spell out correctly, e.g. `#goto=KPAH,-88.6367,36.7417,9,2021-12-11T04:35:00Z,CC`.
- `npm run linkcheck`: 5 failures, all canonicals for the not-yet-deployed storm pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)