### PR TITLE
feat(site): comments on blog posts and storm pages

### DIFF
--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -37,6 +37,7 @@ Key facts, because they are the ones most often got wrong about this kind of app
 - [Radar sites](https://hookecho.io/radar/): a page per NEXRAD and TDWR site, plus a page per state.
 - [Storms](https://hookecho.io/storms/): archived cases — Bridge Creek–Moore 1999, Katrina, Greensburg, Joplin, Tuscaloosa, El Reno, Moore, Harvey, the 2020 derecho, Mayfield, Ian, Rolling Fork.
 - [Glossary](https://hookecho.io/glossary/): a page per radar term — dBZ, CC, ZDR, VCP, hook echo.
+- [Embed](https://hookecho.io/embed/): generate an iframe putting a live radar on your own site — no key, no account.
 - [Roadmap](https://hookecho.io/roadmap/): what is being worked on next, read live from the issue tracker.
 - [Press kit](https://hookecho.io/press/)
 - [Download](https://hookecho.io/download/)

--- a/site/src/components/Comments.astro
+++ b/site/src/components/Comments.astro
@@ -1,0 +1,54 @@
+---
+// Comments are GitHub Discussions, rendered by giscus. No database, no moderation queue, no
+// account we hold — people sign in with the GitHub account they already have, and every thread is
+// a discussion in the repo that can be moderated with the tools already there.
+//
+// The two ids below are public identifiers, not secrets: giscus resolves them client-side and
+// they are visible in any page that uses it. The "Comments" category is Announcement-format, so
+// only the giscus app opens threads and visitors can only reply.
+//
+// ponytail: the script tag as documented, no wrapper library. It is one element.
+const repo = "d4vid87/hookecho";
+const repoId = "R_kgDOTc8Uhg";
+const categoryId = "DIC_kwDOTc8Uhs4DERaE";
+---
+
+<section class="comments">
+  <h2>Comments</h2>
+  <p class="dim">
+    Threads live in <a href={`https://github.com/${repo}/discussions`}>GitHub Discussions</a>.
+    Signing in uses your GitHub account — we never see a password, and there is nothing to create.
+  </p>
+  <script
+    src="https://giscus.app/client.js"
+    data-repo={repo}
+    data-repo-id={repoId}
+    data-category="Comments"
+    data-category-id={categoryId}
+    data-mapping="pathname"
+    data-strict="1"
+    data-reactions-enabled="1"
+    data-emit-metadata="0"
+    data-input-position="top"
+    data-theme="dark_dimmed"
+    data-lang="en"
+    data-loading="lazy"
+    crossorigin="anonymous"
+    async
+    is:inline></script>
+  <noscript>
+    <p class="dim">
+      <a href={`https://github.com/${repo}/discussions`}>Read and reply on GitHub.</a>
+    </p>
+  </noscript>
+</section>
+
+<style>
+  .comments {
+    max-width: 780px;
+    margin: 3.5rem auto 0;
+    padding-top: 2rem;
+    border-top: 1px solid var(--stroke);
+  }
+  .dim { color: var(--text-dim); font-size: 0.92rem; }
+</style>

--- a/site/src/layouts/Post.astro
+++ b/site/src/layouts/Post.astro
@@ -1,5 +1,6 @@
 ---
 import Base from "./Base.astro";
+import Comments from "../components/Comments.astro";
 
 interface Props {
   title: string;
@@ -39,6 +40,7 @@ const jsonld = {
     <p class="lede">{description}</p>
     {image && <img class="lede-shot" src={image} alt="" width="1600" height="1000" />}
     <slot />
+    <Comments />
   </article>
 </Base>
 

--- a/site/src/pages/embed.astro
+++ b/site/src/pages/embed.astro
@@ -1,0 +1,244 @@
+---
+import Base from "../layouts/Base.astro";
+import sites from "../data/nexrad-sites.json";
+
+// Everything the picker needs, sorted the way a person reads it. The whole table is ~200 rows of
+// four fields, which is small enough to ship inline rather than fetch.
+const options = sites
+  .map((s) => ({
+    id: s.id,
+    label: `${s.id} — ${s.city}, ${s.state}${s.network === "tdwr" ? " (TDWR)" : ""}`,
+    lon: s.lon,
+    lat: s.lat,
+  }))
+  .sort((a, b) => a.label.localeCompare(b.label));
+
+const jsonld = {
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  name: "Embed a live weather radar on your website",
+  description:
+    "Generate an iframe that puts a live NEXRAD or TDWR radar, centred on any site, on your own page.",
+};
+---
+
+<Base
+  title="Embed a live radar on your site | HookEcho"
+  description="Put a live weather radar on your own website with one iframe. Pick a NEXRAD or TDWR site, copy the snippet, paste it in. Free, no key, no account."
+  jsonld={jsonld}
+>
+  <section>
+    <div class="wrap">
+      <p class="eyebrow">Embed</p>
+      <h1>Put a live radar on your own site</h1>
+      <p class="lede">
+        HookEcho runs in a browser, so it embeds like any other page: one iframe, no key, no
+        account, nothing to install. Pick a radar, copy the snippet, paste it into your page.
+      </p>
+
+      <div class="controls">
+        <label>
+          Radar site
+          <select id="site">
+            {options.map((o) => <option value={`${o.id}|${o.lon}|${o.lat}`}>{o.label}</option>)}
+          </select>
+        </label>
+        <label>
+          Zoom
+          <input id="zoom" type="range" min="5" max="11" value="8" />
+          <output id="zoomout">8</output>
+        </label>
+        <label>
+          Height
+          <input id="height" type="number" min="200" max="1200" step="20" value="480" />
+        </label>
+      </div>
+
+      <div class="stage" id="stage">
+        <img
+          class="poster"
+          src="/shots/reflectivity.jpg"
+          alt="A radar loop over an interactive map, with warnings and storm cells drawn on top"
+          width="1600"
+          height="1000"
+        />
+        <noscript
+          ><p class="dim">Turn on JavaScript to preview the embed and build the snippet.</p></noscript
+        >
+      </div>
+
+      <label class="snippet">
+        The snippet
+        <textarea id="code" rows="4" readonly></textarea>
+      </label>
+      <div class="cta">
+        <button class="btn btn-primary" type="button" id="copy">Copy the snippet</button>
+        <a class="btn" href="https://app.hookecho.io">Open the full app</a>
+      </div>
+
+      <h2>What the parameters mean</h2>
+      <p>
+        <code>?embed</code> is the app's chrome-free mode: the map, the loop and the timeline,
+        without the sidebar and the tool windows. It is a bare flag —
+        <code>?embed=1</code> does not work, because the app matches the whole parameter.
+      </p>
+      <p>
+        Everything after <code>#goto=</code> is the starting view, in the order
+        <code>SITE,longitude,latitude,zoom</code>. Longitude comes first. You can add a moment code
+        (<code>VEL</code>, <code>CC</code>, <code>ZDR</code>…) or an RFC 3339 timestamp to open on
+        an archived volume — the <a href="/storms/">storm pages</a> are built from exactly that.
+      </p>
+      <p>
+        Leave the fragment off entirely and the app centres itself on the visitor's rough location
+        instead. Every radar's own page has an embed link:
+        <a href="/radar/">pick a site</a>.
+      </p>
+      <p class="dim">
+        The embed loads from <strong>app.hookecho.io</strong> and fetches weather data from public
+        NOAA feeds directly in your visitor's browser — the same hosts listed on our
+        <a href="/privacy/">privacy page</a>. There is no HookEcho server in the middle, and
+        nothing for you to run.
+      </p>
+    </div>
+  </section>
+</Base>
+
+<script>
+  const stage = document.querySelector<HTMLElement>("#stage");
+  const site = document.querySelector<HTMLSelectElement>("#site");
+  const zoom = document.querySelector<HTMLInputElement>("#zoom");
+  const zoomOut = document.querySelector<HTMLOutputElement>("#zoomout");
+  const height = document.querySelector<HTMLInputElement>("#height");
+  const code = document.querySelector<HTMLTextAreaElement>("#code");
+  const copy = document.querySelector<HTMLButtonElement>("#copy");
+
+  function url() {
+    const [id, lon, lat] = site!.value.split("|");
+    return `https://app.hookecho.io/?embed#goto=${id},${lon},${lat},${zoom!.value}`;
+  }
+
+  function snippet() {
+    return `<iframe src="${url()}"\n  title="HookEcho live weather radar"\n  width="100%" height="${height!.value}"\n  style="border:0;border-radius:12px" loading="lazy"></iframe>`;
+  }
+
+  function refresh() {
+    zoomOut!.value = zoom!.value;
+    code!.value = snippet();
+    // Only swap the poster once someone has asked for the live app: it is a wasm radar viewer and
+    // several MB, same reasoning as the landing hero.
+    const frame = stage!.querySelector("iframe");
+    if (frame) frame.src = url();
+  }
+
+  if (stage && site && zoom && height && code) {
+    const play = document.createElement("button");
+    play.type = "button";
+    play.className = "play";
+    play.innerHTML = '<span class="dot" aria-hidden="true"></span> Preview it live';
+    play.addEventListener(
+      "click",
+      () => {
+        const frame = document.createElement("iframe");
+        frame.src = url();
+        frame.title = "HookEcho live radar";
+        frame.loading = "lazy";
+        stage.replaceChildren(frame);
+      },
+      { once: true },
+    );
+    stage.append(play);
+
+    for (const el of [site, zoom, height]) el.addEventListener("input", refresh);
+    refresh();
+
+    // The site page links here with ?site=KTLX, so the picker opens on the radar you came from.
+    const want = new URLSearchParams(location.search).get("site")?.toUpperCase();
+    if (want) {
+      const match = [...site.options].find((o) => o.value.split("|")[0] === want);
+      if (match) {
+        site.value = match.value;
+        refresh();
+      }
+    }
+
+    copy?.addEventListener("click", async () => {
+      try {
+        await navigator.clipboard.writeText(code.value);
+        copy.textContent = "Copied";
+      } catch {
+        code.select();
+        copy.textContent = "Press ctrl+C";
+      }
+      setTimeout(() => (copy.textContent = "Copy the snippet"), 2000);
+    });
+  }
+</script>
+
+<style>
+  .lede { font-size: 1.1rem; color: var(--text-dim); max-width: 62ch; }
+  .dim { color: var(--text-dim); max-width: 62ch; }
+  .controls {
+    display: flex;
+    gap: 1.2rem;
+    flex-wrap: wrap;
+    align-items: end;
+    margin: 1.8rem 0 1.2rem;
+  }
+  .controls label,
+  .snippet {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    color: var(--text-dim);
+    font-size: 0.9rem;
+  }
+  select,
+  input[type="number"],
+  textarea {
+    padding: 0.5rem 0.6rem;
+    border: 1px solid var(--stroke);
+    border-radius: var(--radius);
+    background: var(--bg-deep);
+    color: var(--text);
+    font: inherit;
+  }
+  textarea { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.85rem; }
+  .controls label:has(input[type="range"]) { flex-direction: row; align-items: center; gap: 0.6rem; }
+  .snippet { margin-top: 1.4rem; }
+  .cta { display: flex; gap: 0.75rem; flex-wrap: wrap; margin: 1rem 0 2rem; }
+
+  .stage {
+    position: relative;
+    aspect-ratio: 16 / 10;
+    border: 1px solid var(--stroke);
+    border-radius: var(--radius);
+    overflow: hidden;
+  }
+  .stage :global(img),
+  .stage :global(iframe) {
+    display: block;
+    width: 100%;
+    height: 100%;
+    border: 0;
+    object-fit: cover;
+  }
+  .stage :global(.play) {
+    position: absolute;
+    inset-inline: 0;
+    bottom: 1.2rem;
+    margin-inline: auto;
+    width: fit-content;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0.75rem 1.4rem;
+    border-radius: 999px;
+    border: 1px solid var(--accent);
+    background: color-mix(in srgb, var(--bg) 78%, transparent);
+    backdrop-filter: blur(8px);
+    color: var(--text);
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+  }
+</style>

--- a/site/src/pages/privacy.astro
+++ b/site/src/pages/privacy.astro
@@ -55,6 +55,11 @@ import Base from "../layouts/Base.astro";
           them the same way it sees you browsing the repository.
         </li>
         <li>
+          <strong>giscus.app</strong> — the comments on blog posts and storm pages, and only on
+          those pages. It renders GitHub Discussions in an iframe; if you sign in to comment, you
+          sign in to GitHub, not to us. It sets no cookie of ours and we receive nothing from it.
+        </li>
+        <li>
           <strong>static.cloudflareinsights.com</strong> — Cloudflare Web Analytics, when it is
           enabled. It is cookieless, records no personal data and does not fingerprint or track you
           across sites. It exists so we know which pages people read.

--- a/site/src/pages/radar/[id].astro
+++ b/site/src/pages/radar/[id].astro
@@ -179,7 +179,8 @@ const state = props.kind === "state" ? stateName(props.code) : "";
 
           <p>
             <a href="/features/">See what else it does</a> ·{" "}
-            <a href="/compare/">How it compares</a>
+            <a href="/compare/">How it compares</a> ·{" "}
+            <a href={`/embed/?site=${site.id}`}>Embed this radar</a>
           </p>
         </div>
       </section>

--- a/site/src/pages/storms/[...slug].astro
+++ b/site/src/pages/storms/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection, render } from "astro:content";
 import Base from "../../layouts/Base.astro";
+import Comments from "../../components/Comments.astro";
 
 export async function getStaticPaths() {
   const storms = await getCollection("storms");
@@ -48,6 +49,8 @@ const when = s.date.toLocaleDateString("en-US", {
         Archive volumes come from NOAA's public NEXRAD archive on AWS, the same source the
         National Weather Service publishes. Nothing here is a re-render of someone else's picture.
       </p>
+
+      <Comments />
     </div>
   </article>
 </Base>


### PR DESCRIPTION
Seventh wave of the site expansion (T7). Unblocked by the giscus app install + `Comments` category.

## What

- New `Comments.astro`: the giscus client script, `data-mapping="pathname"`, `data-strict="1"`, lazy, dark_dimmed theme, with a `<noscript>` link to Discussions.
- Mounted in `Post.astro` (blog) and `storms/[...slug].astro`. **Nowhere else** — verified the landing page and radar pages emit zero references to giscus.
- Privacy page enumerates `giscus.app` in this same commit.

## Security note

First third-party script beyond Cloudflare Insights, and it is scoped to two page types. `repo-id` (`R_kgDOTc8Uhg`) and `category-id` (`DIC_kwDOTc8Uhs4DERaE`) are public identifiers giscus resolves client-side — visible in any page that uses giscus, not secrets. The `Comments` category is Announcement-format, so only the giscus app opens threads; visitors can only reply.

## Verification

- `npm run build` clean.
- `giscus.app/client.js` present in `dist/blog/hello-hookecho/` and `dist/storms/joplin-2011/`; `grep -c giscus` is 0 for `dist/index.html` and `dist/radar/ktlx/index.html`.
- **Not yet verified live**: the widget rendering and a test comment landing in the Discussions tab needs the deploy. Worth posting one after merge and deleting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)