### PR TITLE
feat(site): a /changelog page

### DIFF
--- a/.github/workflows/blog-post.yml
+++ b/.github/workflows/blog-post.yml
@@ -73,7 +73,9 @@ jobs:
             cat notes.md
             echo
             echo "The full notes and every platform's build are on the"
-            echo "[release page](https://github.com/d4vid87/hookecho/releases/tag/$TAG)."
+            echo "[release page](https://github.com/d4vid87/hookecho/releases/tag/$TAG),"
+            echo "and every release before this one is on the"
+            echo "[changelog](https://hookecho.io/changelog/)."
           } > "$FILE"
 
           cat "$FILE"

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -38,6 +38,7 @@ Key facts, because they are the ones most often got wrong about this kind of app
 - [Storms](https://hookecho.io/storms/): archived cases — Bridge Creek–Moore 1999, Katrina, Greensburg, Joplin, Tuscaloosa, El Reno, Moore, Harvey, the 2020 derecho, Mayfield, Ian, Rolling Fork.
 - [Glossary](https://hookecho.io/glossary/): a page per radar term — dBZ, CC, ZDR, VCP, hook echo.
 - [Embed](https://hookecho.io/embed/): generate an iframe putting a live radar on your own site — no key, no account.
+- [Changelog](https://hookecho.io/changelog/): every notable change in every release.
 - [Roadmap](https://hookecho.io/roadmap/): what is being worked on next, read live from the issue tracker.
 - [Press kit](https://hookecho.io/press/)
 - [Download](https://hookecho.io/download/)

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -59,4 +59,12 @@ const glossary = defineCollection({
   }),
 });
 
-export const collections = { docs, blog, storms, glossary };
+// The repo's own CHANGELOG.md, loaded as a one-entry collection so Astro's markdown renderer does
+// the work. ponytail: no hand-rolled parser and no new dependency — the file has no frontmatter,
+// so the schema is empty.
+const changelog = defineCollection({
+  loader: glob({ pattern: "CHANGELOG.md", base: "../" }),
+  schema: z.object({}),
+});
+
+export const collections = { docs, blog, storms, glossary, changelog };

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -95,6 +95,7 @@ const nav = [
           <a href="/how-it-works/">How it works</a> ·
           <a href="/glossary/">Glossary</a> ·
           <a href="/roadmap/">Roadmap</a> ·
+          <a href="/changelog/">Changelog</a> ·
           <a href="/privacy/">Privacy</a> ·
           <a href="/press/">Press</a> ·
           <a href="https://github.com/d4vid87/hookecho">Source</a> ·

--- a/site/src/pages/changelog.astro
+++ b/site/src/pages/changelog.astro
@@ -1,0 +1,56 @@
+---
+import { getCollection, render } from "astro:content";
+import Base from "../layouts/Base.astro";
+
+// One file, so take the one entry rather than hard-coding whatever id the loader derives from
+// the path.
+const [entry] = await getCollection("changelog");
+const { Content } = await render(entry);
+---
+
+<Base
+  title="Changelog | HookEcho"
+  description="Every notable change in every HookEcho release, newest first — the same text that becomes each release's notes on GitHub."
+>
+  <article class="wrap log">
+    <p class="eyebrow">Changelog</p>
+    <p class="lede">
+      This is the repository's own CHANGELOG.md, rendered at build time. It is the same text that
+      becomes each release's notes on GitHub and each
+      <a href="/blog/">release post</a>, so the three cannot disagree.
+    </p>
+    <div class="prose"><Content /></div>
+    <p class="dim">
+      <a href="https://github.com/d4vid87/hookecho/releases">Every release, with its downloads</a> ·
+      <a href="/download/">Get the current version</a> · <a href="/roadmap/">What comes next</a>
+    </p>
+  </article>
+</Base>
+
+<style>
+  .log { max-width: 820px; padding-bottom: 4rem; }
+  .lede { color: var(--text-dim); max-width: 62ch; }
+  .dim { color: var(--text-dim); margin-top: 2.5rem; }
+  /* The file opens with its own "# Changelog" heading and a note about the release workflow that
+     only means something to someone editing the file. Hide both; the page has its own. */
+  .prose :global(h1),
+  .prose :global(h1 + p),
+  .prose :global(h1 + p + p) { display: none; }
+  .prose :global(h2) {
+    margin-top: 2.6rem;
+    padding-top: 1.2rem;
+    border-top: 1px solid var(--stroke);
+    font-size: 1.35rem;
+  }
+  .prose :global(h3) { margin-top: 1.6rem; font-size: 1.02rem; color: var(--text-dim); }
+  .prose :global(ul) { padding-left: 1.2rem; max-width: var(--measure); }
+  .prose :global(li) { margin-bottom: 0.5rem; }
+  .prose :global(p) { max-width: var(--measure); }
+  .prose :global(:not(pre) > code) {
+    background: var(--faint);
+    border: 1px solid var(--stroke);
+    border-radius: 5px;
+    padding: 0.1em 0.35em;
+    font-size: 0.9em;
+  }
+</style>


### PR DESCRIPTION
Ninth wave of the site expansion (T9).

## What

`/changelog` renders the repo's own `CHANGELOG.md` at build time — the same text that becomes each GitHub release body and each release blog post, so the three cannot drift. Prereleases show up here even though they deliberately get no blog post.

**ponytail:** no hand-rolled parser and no markdown dependency. The file is loaded as a one-entry content collection with `base: "../"`, which hands it to the renderer Astro already runs for docs and blog. Its own `# Changelog` heading and the note to whoever edits the file are hidden in CSS.

Footer, llms.txt and the release-post workflow template link to it.

## Verification

- `npm run build` clean; all 13 `## version` sections render (`grep -c '<h2'` → 13), newest first, from 0.12.0-beta.1 back.
- `npm run linkcheck`: `/changelog/` and `/embed/` canonicals, neither deployed yet at the time of the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)