### PR TITLE
chore(site): security.txt, a link check in CI, and a copy sweep

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -33,6 +33,13 @@ jobs:
           npm ci
           npm run build
 
+      # Advisory only. These are mostly external links, and a weather agency having a bad morning
+      # must not be able to stop a deploy of this site.
+      - name: Link check
+        continue-on-error: true
+        working-directory: site
+        run: npm run linkcheck
+
       - name: Deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/site/public/.well-known/security.txt
+++ b/site/public/.well-known/security.txt
@@ -1,0 +1,10 @@
+# HookEcho — https://hookecho.io
+# Report a vulnerability privately through GitHub security advisories. No email address is
+# published here on purpose: advisories give us a private thread, a CVE if one is warranted, and a
+# public record afterwards, which an inbox does not.
+
+Contact: https://github.com/d4vid87/hookecho/security/advisories/new
+Expires: 2027-08-26T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://hookecho.io/.well-known/security.txt
+Policy: https://github.com/d4vid87/hookecho/security/policy

--- a/site/src/pages/404.astro
+++ b/site/src/pages/404.astro
@@ -18,9 +18,9 @@ import Base from "../layouts/Base.astro";
         <a class="btn" href="/">Back to the start</a>
       </div>
       <p class="dim">
-        Looking for a specific radar? <a href="/radar/">Every NEXRAD site has a page.</a> Or try
-        the <a href="/docs/">docs</a>, the <a href="/download/">download page</a>, or
-        <a href="/storms/">the storms</a>.
+        Looking for a specific radar? <a href="/radar/">Every NEXRAD and TDWR site has a page.</a>
+        Or try the <a href="/docs/">docs</a>, the <a href="/glossary/">glossary</a>, the
+        <a href="/download/">download page</a>, or <a href="/storms/">the storms</a>.
       </p>
     </div>
   </section>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -192,7 +192,7 @@ const jsonld = {
       <p class="eyebrow">Against the field</p>
       <h2>Yes, we will tell you when to buy something else</h2>
       <p>
-        We put HookEcho next to RadarScope, MyRadar, Windy and RainViewer, row by row, including
+        We put HookEcho next to RadarScope, MyRadar, Windy, RadarOmega and RainViewer, row by row, including
         the four rows they win. If the thing you need is global model data, Windy is better at it.
       </p>
       <div class="platforms">


### PR DESCRIPTION
Tenth and last wave of the site expansion (T10).

## What

- **`/.well-known/security.txt`** (RFC 9116). `Contact` is the GitHub security advisories URL, not an email — an advisory is a private thread, a CVE if warranted, and a public record afterwards. `Expires` set a year out.
- **Link check in CI**: `site.yml` runs `npm run linkcheck` before the deploy step, `continue-on-error: true`. Advisory on purpose — these are mostly external links, and a weather agency having a bad morning must not be able to block a deploy of this site.
- **Copy sweep**: landing page comparison teaser now names RadarOmega; the 404 page mentions the TDWR pages and the glossary.

## Verification

- `npm run build` clean; `dist/.well-known/security.txt` present.
- `npm run linkcheck`: only `/changelog/` (#166 hadn't finished deploying).
- Earlier stale counts (llms.txt "153", radar index) were already fixed in #158/#159; grep found no remaining ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)