### PR TITLE
docs(promo): drop Reddit from the playbook, record submission eligibility

### DIFF
--- a/docs/promotion.md
+++ b/docs/promotion.md
@@ -32,20 +32,18 @@ same thing in six places at once is the shape spam has.
 **Wave 1 — technical. Skipped for the 2026-08 launch** by decision: no Show HN
 and no r/rust launch post. The Rust-ecosystem *listings* below still apply.
 
-**Wave 2 — domain.** r/tornado, r/weather, r/stormchasing, r/meteorology,
-r/TropicalWeather (only with a named storm active), plus Stormtrack's Equipment
-section, TalkWeather and chaser Discords. Lead
+**Wave 2 — domain.** Stormtrack's Equipment section, TalkWeather and chaser
+Discords. Lead
 with the live demo, and pick a day with active weather so it shows something.
 Lead with what it does for them — soundings, effective-layer parameters, archive
 replay, chase packs — not with the language it is written in.
 
-**Wave 3 — broad.** r/opensource, r/selfhosted (the container image qualifies),
-r/linux. Lead with MIT, no accounts, no telemetry, no hosted service.
+**Wave 3 — broad.** Product Hunt, DevHunt, Uneed. Lead with MIT, no accounts, no telemetry, no hosted service.
 
 Rules that keep this from backfiring:
 
-- Read the subreddit's self-promotion rule before posting. Some require a flair,
-  some require prior participation, some ban it outright.
+- Read the venue's self-promotion rule before posting. Some require prior
+  participation, some ban it outright.
 - One community per day, maximum.
 - Answer every question, including the hostile ones, including "why not just use
   RadarScope".
@@ -59,32 +57,36 @@ Rules that keep this from backfiring:
 Do these once, not per release:
 
 - [awesome-rust](https://github.com/rust-unofficial/awesome-rust) — Applications.
+  Gated on `stars > 50 | crates.io downloads > 2000`; at 48 stars on 2026-08-27,
+  so this waits. They judge on the metric and nothing else.
 - [awesome-selfhosted](https://github.com/awesome-selfhosted/awesome-selfhosted) —
-  the ghcr.io image is the qualifier.
+  the ghcr.io image is the qualifier, but their checklist requires the first
+  release to be **more than 4 months old**: first release was 2026-07-29, so the
+  earliest valid submission is ~2026-11-29. Entries go to the
+  `awesome-selfhosted-data` repo as `software/<slug>.yml`, not the README.
 - [AlternativeTo](https://alternativeto.net/) — listed against RadarScope,
   GR2Analyst and Supercell-Wx.
-- [This Week in Rust](https://this-week-in-rust.org/) — "Call for participants"
-  or the project spotlight.
-- The r/rust "What's everyone working on this week" thread.
+- [This Week in Rust](https://this-week-in-rust.org/) — Project/Tooling Updates
+  no longer takes PRs (editors pull those from r/rust). Call for Participation
+  does: submitted as
+  [#8671](https://github.com/rust-lang/this-week-in-rust/pull/8671) against the
+  2026-09-02 draft. Their guidelines want the linked issue to state a difficulty
+  and link CONTRIBUTING.md — issue #12 was edited to do both.
 
 ## Launch calendar
 
-Two weeks, one community per day, weather communities on days with active
-weather so the demo shows something:
+One venue per day, weather venues on days with active weather so the demo shows
+something. **No Reddit** — dropped for this launch, so the sub rows are gone
+rather than left as drafts:
 
 | Day | Where | Lead with |
 |---|---|---|
-| 1 | r/opensource | MIT, no accounts, no telemetry |
-| 2 | r/selfhosted | the ghcr.io image |
-| 3 | r/linux | one binary, AppImage/Flatpak, wgpu |
-| 4 | r/tornado | storm-replay clip |
-| 5 | r/weather | storm-replay clip |
-| 6 | r/stormchasing | archive replay, chase packs |
-| 7 | r/meteorology | Level 2 all tilts, dual-pol |
-| 8 | Stormtrack (Equipment) | free alternative to the paid Windows tools |
-| 9 | TalkWeather | same, with the live demo link |
-| 10 | Product Hunt (Tue–Thu) | tagline + maker's first comment |
-| — | r/TropicalWeather | only with a named storm active, if rules allow |
+| 1 | Stormtrack (Equipment) | free alternative to the paid Windows tools |
+| 2 | TalkWeather | same, with the live demo link |
+| 3 | Chaser Discords | storm-replay clip |
+| 4 | Product Hunt (Tue–Thu) | tagline + maker's first comment |
+| 5 | DevHunt, Uneed | MIT, no accounts, no telemetry |
+| 6 | Bluesky / Mastodon / X | storm-replay clip, demo link |
 
 Every post: demo link first, download second. Then stay at the keyboard.
 
@@ -94,21 +96,19 @@ Every post: demo link first, download second. Then stay at the keyboard.
   entry plus a short blog post, shareable in that event's threads where on-topic.
 - **One explainer post a month** on the site blog, on a title the existing posts
   do not already cover.
-- **Weekly**: the r/rust "What's everyone working on" thread, and answering
-  radar-app recommendation threads as they appear.
+- **Weekly**: answering radar-app recommendation threads as they appear, on the
+  venues above.
 
 ## Conventions
 
-- **UTM tags** on links you paste by hand only: `?utm_source=reddit`,
-  `?utm_source=hn`, and so on. The automated posts do not carry them — the
+- **UTM tags** on links you paste by hand only: `?utm_source=stormtrack`,
+  `?utm_source=producthunt`, and so on. The automated posts do not carry them — the
   channel is already known from the referrer.
-- **Posting.** Reddit submissions go out through the Reddit API from the
-  maintainer's own account (`scripts/announce/reddit.mjs`), one community per day
-  — the cadence, not the mechanism, is what keeps it from reading as spam.
-  **Replies are always written by hand**, and forums, Product Hunt and Discords
-  have no posting API, so those stay copy-paste from the drafts. Reddit
-  credentials live in a local gitignored env file: never committed, never a
-  GitHub secret, because posting is a local action and not CI.
+- **Posting.** Reddit is out for the 2026-08 launch — no API rig, no submissions.
+  Everything else has no posting API either, so forums, Product Hunt, the
+  directories and the Discords are copy-paste from the drafts, and **replies are
+  always written by hand**. The automated channels stay what `announce.yml`
+  already does: Bluesky, Mastodon, X, Discord, on a tag.
 - **Analytics** is Cloudflare Web Analytics on the Pages project: server-side,
   no script and no code in the app, which is what keeps the no-telemetry claim
   true.


### PR DESCRIPTION
Follow-up to #168. Reddit was dropped for the 2026-08 launch after that PR was
written, so the playbook still described an API posting rig and a calendar that
was seven-tenths subreddits.

- Posting convention rewritten: nothing is automated except what `announce.yml`
  already does on a tag (Bluesky/Mastodon/X/Discord). No Reddit credentials
  anywhere, local or CI.
- Launch calendar rebuilt around reachable venues: Stormtrack, TalkWeather,
  chaser Discords, Product Hunt, DevHunt/Uneed, socials.
- Waves 2 and 3, the self-promo rule and the UTM examples de-Redditted.
- One-time submissions now carry the eligibility facts found while working them:
  awesome-rust's 50-star gate (48 today), awesome-selfhosted's ">4 months since
  first release" rule (eligible ~2026-11-29), and TWiR's closed project-updates
  queue — hence CFP PR rust-lang/this-week-in-rust#8671.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)