### PR TITLE
feat(site): tropical radar explainer + storm-page recipe

### DIFF
--- a/docs/promotion.md
+++ b/docs/promotion.md
@@ -92,12 +92,40 @@ Every post: demo link first, download second. Then stay at the keyboard.
 
 ## Sustained
 
-- **Storm-event pages** within ~48 h of a major event: a `site/src/content/storms`
-  entry plus a short blog post, shareable in that event's threads where on-topic.
+- **Storm-event pages** within ~48 h of a major event. The window is the point:
+  after about two days the threads are dead and the searches have moved on. The
+  recipe is below so it is a fill-in job, not a design job.
 - **One explainer post a month** on the site blog, on a title the existing posts
   do not already cover.
 - **Weekly**: answering radar-app recommendation threads as they appear, on the
   venues above.
+
+### Storm-event page recipe
+
+1. **Find the volume time.** Open the app on the archive, step to the scan that
+   shows the thing the event is remembered for — the couplet at the moment of
+   damage, the eyewall at landfall. Copy the timestamp off the scrubber and
+   convert to UTC; `at:` is RFC3339 and the archive opens exactly there.
+2. **Write `site/src/content/storms/<slug>.md`.** Frontmatter fields are
+   `title`, `description`, `date`, `site`, `lon`, `lat`, `zoom`, `at`, optional
+   `extras`. `site` must be a NEXRAD id that already has a page under `/radar/`.
+   `extras` carries the moment code (`VEL`, `CC`, `ZDR`…), a tilt number and
+   `srv`, in any order. Body: what happened in two or three sentences, then a
+   **What the radar shows** paragraph explaining the product the link opens on
+   and why that product is the one to look at.
+3. **Verify the deep link.** Open the built page's link in the live app and
+   confirm it lands on the right scan with the right product — a wrong `at:` is
+   the one error nobody catches by reading.
+4. **Blog post, only if there is something to teach.** A page per event is
+   enough on its own; a post is worth it when the case shows a signature the
+   existing explainers do not already cover. Link the storm page from it.
+5. **Facts before speed.** Death tolls and ratings move for days after an event.
+   Cite the survey once it exists, and write around the number rather than
+   guessing it. A page that has to be corrected is worse than one posted a day
+   later.
+6. **Ship it**: `cd site && npm run build && npm run linkcheck`, merge, then
+   share into that event's threads *where on-topic* — the same one-venue-a-day
+   and read-the-rules conventions apply. An event page is not a launch post.
 
 ## Conventions
 

--- a/site/src/content/blog/reading-radar-in-a-hurricane.md
+++ b/site/src/content/blog/reading-radar-in-a-hurricane.md
@@ -1,0 +1,110 @@
+---
+title: "Reading radar in a hurricane"
+description: "A landfalling hurricane breaks most of the habits that work on a supercell. What the eyewall, the rainbands and the velocity field are actually telling you."
+date: 2026-09-01
+---
+
+Most radar advice is written for a supercell on the Plains: find the hook, check
+the couplet, watch correlation coefficient for debris. Point those habits at a
+landfalling hurricane and they mislead you. The storm is a thousand times
+larger, the dangerous parts are not where the brightest colours are, and the
+tornadoes — and there will be tornadoes — look nothing like the ones in the
+textbook.
+
+Here is what to look at instead.
+
+## The eye is the least interesting part
+
+The eye is the easiest thing to find and tells you the least. What it does tell
+you is structural: a small, round, sharply-walled eye is a strong, organised
+hurricane. A large ragged one, or an eye that has gone fuzzy, is a storm that is
+weakening or reorganising.
+
+The part that matters is the ring around it. The **eyewall** is where the
+strongest winds in the storm are, and on reflectivity it is a closed or nearly
+closed ring of heavy rain. Watch for two things. First, whether the ring is
+complete — an open eyewall on the side facing you is a weaker storm arriving.
+Second, whether there are *two* rings. A concentric eyewall means the storm is
+going through an eyewall replacement cycle: it will usually weaken slightly at
+the peak and then broaden, which spreads damaging wind over a much wider area.
+A weakening headline and a worse outcome are entirely compatible.
+
+## Rainbands are where the tornadoes are
+
+Tropical tornadoes almost never come out of the eyewall. They come out of the
+outer rainbands, usually in the right-front quadrant relative to the storm's
+motion, and often hundreds of kilometres from the centre — frequently well
+before the eye arrives, and sometimes in places that never see hurricane-force
+sustained wind at all.
+
+They are also nasty to spot. A tropical tornado forms in a small, shallow,
+fast-moving cell embedded in a band of rain. It spins up in minutes, it may
+never produce a hook, and it is often too shallow to be seen at all beyond
+about 60 miles from the radar because the beam has already climbed over it.
+
+So: watch the individual cells inside the bands, not the bands. Look for a cell
+that has turned slightly right of the others around it, and check velocity on
+the lowest tilt you have.
+
+## Velocity is doing two things at once
+
+This is the part that catches people out. In a supercell, a red-green couplet
+sitting side by side means rotation. In a hurricane, the whole velocity field
+is already a huge dipole — half the storm rotating towards the radar, half away
+— because that is what a cyclone is.
+
+The trick is scale. The storm-scale dipole is enormous and smooth. A tornadic
+couplet is small, tight, and sits *inside* one of those halves as a local
+anomaly. Zoom in until the storm-scale flow fills the screen and the small
+features stop hiding inside it.
+
+Two other velocity readings worth having:
+
+- **Where the strongest inbound winds are.** That is the part of the eyewall
+  aimed at you, and radar sees it before it arrives.
+- **Range folding and dealiasing failures.** Hurricane winds routinely exceed
+  what a single pulse repetition frequency can measure unambiguously, so
+  velocity wraps around and a 90-knot wind can display as a 30-knot wind of the
+  opposite sign. Dealiasing fixes most of it; where it fails you get a speckled
+  patch of impossible-looking extremes next to the real ones. Do not read those
+  pixels literally.
+
+## Correlation coefficient still works, differently
+
+CC drops where the beam is full of unlike things. In a supercell that is how you
+confirm lofted debris. In a hurricane, low CC over land near the coast is more
+often *biological*: birds and insects pulled into the circulation, especially in
+and around the eye, where they concentrate. It is a real signature and a
+genuinely useful one for finding the exact centre, but it is not damage.
+
+Debris signatures do happen with tropical tornadoes — they are just smaller,
+briefer and shallower than the Plains version, so you need the lowest tilt and
+some luck on range.
+
+## Do not trust a single radar
+
+Coastal WSR-88Ds get destroyed, lose power, or lose their radome mid-event. It
+has happened repeatedly. Beyond that, the beam climbs with range: 100 miles out
+you are sampling several thousand feet up, well above the shallow tropical
+supercells you are hunting.
+
+So work from more than one site, and use the national mosaic for structure and
+motion while you use the nearest single site for the cell-level detail. If the
+nearest site drops out mid-storm, that itself is information about conditions
+there.
+
+## Try it
+
+Three landfalls worth replaying, all with the warnings that were in force at
+the time:
+
+- [Hurricane Ian, 2022](/storms/hurricane-ian-2022/) — a strong, well-defined
+  eyewall crossing the southwest Florida coast.
+- [Hurricane Harvey, 2017](/storms/hurricane-harvey-2017/) — landfall, then the
+  rainfall catastrophe that followed when it stalled.
+- [Hurricane Katrina, 2005](/storms/katrina-2005/) — the Gulf coast landfall,
+  from a radar that was inside the storm.
+
+Open one, step the timeline through the eyewall, then switch to velocity and go
+hunting in the outer bands. That contrast — the smooth enormous dipole, and the
+small tight thing hiding inside it — is the whole skill.


### PR DESCRIPTION
P5, the sustained programme. Two of its three parts are writable; the third
(answering recommendation threads weekly) is a standing manual action.

**Monthly explainer — "Reading radar in a hurricane".** The open lane: the
existing posts cover reflectivity/velocity/CC/ZDR/tilts and the hook echo, all
framed around a Plains supercell, and none of that transfers cleanly to a
landfall. Covers eyewall structure and replacement cycles, why tropical
tornadoes live in the outer rainbands rather than the eyewall, how a tornadic
couplet hides inside the storm-scale velocity dipole, velocity aliasing at
hurricane wind speeds, biological CC drops versus debris, and why one radar is
not enough when coastal sites lose power mid-event. Ends on the Ian, Harvey and
Katrina storm pages. Dated 2026-09-01 for the September slot.

**Storm-event recipe** in `docs/promotion.md`. The ~48 h promise only holds if
writing the page is mechanical at the time, so the frontmatter fields, the
deep-link verification step, and the rule about not guessing death tolls before
the survey exists are all written down now rather than improvised during an
outbreak.

`npm run build` clean. `linkcheck`: 863 links, one 404 — the new post's own
production URL via canonical/sitemap, which resolves on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)