### PR TITLE
feat(site): Lite nav tab and cross-links

### DIFF
--- a/site/src/content/docs/in-your-browser.md
+++ b/site/src/content/docs/in-your-browser.md
@@ -15,6 +15,18 @@ Nearly everything. Radar products and tilts, velocity dealiasing, the panel and
 model layers, soundings, cross-sections, the 3D volume, and archive playback all
 the way back to 1991.
 
+## On an old machine
+
+[**app.hookecho.io/lite/**](https://app.hookecho.io/lite/) is a second, much
+smaller page for hardware the full app asks too much of. It needs no WebGL and
+downloads about seventy kilobytes instead of five megabytes, because it draws
+the radar on the processor rather than the graphics card.
+
+You get an animated loop of the last six scans, reflectivity or velocity, a
+picker for every NEXRAD site, three fixed zoom levels, and the tornado, severe
+thunderstorm and flash flood warnings currently in view. There's no panning, no
+archive and no other product — for those, use the full app or the desktop build.
+
 ## What's different
 
 The browser doesn't hand a web page everything a native app gets:
@@ -33,7 +45,7 @@ Settings you change in the browser stay in that browser, on that machine.
 
 ## Putting a radar on your own page
 
-Adding `?embed=1` to the URL strips the chrome and throttles the app when it
+Adding `?embed` to the URL strips the chrome and throttles the app when it
 isn't visible, which is what you want inside an `<iframe>` on a dashboard. The
 same `#goto` deep links the app uses for sharing work in the browser too, so you
 can link straight to a site, a product and a moment in time.

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -27,6 +27,7 @@ const nav = [
   { href: "/radar/", label: "Radar sites" },
   { href: "/storms/", label: "Storms" },
   { href: "https://app.hookecho.io", label: "Open in browser" },
+  { href: "https://app.hookecho.io/lite/", label: "Lite" },
   { href: "/download/", label: "Download" },
   { href: "https://github.com/d4vid87/hookecho", label: "GitHub" },
 ];

--- a/site/src/pages/radar/[id].astro
+++ b/site/src/pages/radar/[id].astro
@@ -46,6 +46,9 @@ const props = Astro.props as
 const site = props.kind === "site" ? props.site : null;
 // lon before lat — the app's #goto vocabulary, same as the deep links on /features.
 const appLink = site ? `https://app.hookecho.io/#goto=${site.id},${site.lon},${site.lat},8` : "";
+// The lite viewer carries NEXRAD only: the Level 3 bucket has no super-res digital products for
+// the terminal radars, so a TDWR link there would open an empty loop.
+const liteLink = site && site.network !== "tdwr" ? `https://app.hookecho.io/lite/?site=${site.id}` : "";
 // RIDGE standard loops exist for WSR-88D ids only — TOKC/TDFW/TDAL all 404 there — so terminal
 // radar pages carry the facts and the deep link and skip the loop rather than ship a broken image.
 const isTdwr = site?.network === "tdwr";
@@ -96,6 +99,11 @@ const state = props.kind === "state" ? stateName(props.code) : "";
             <a class="btn btn-primary" href={appLink}>
               Open {site.id} in your browser
             </a>
+            {liteLink && (
+              <a class="btn" href={liteLink}>
+                Lite view
+              </a>
+            )}
             <a class="btn" href="/download/">
               Get the app
             </a>
@@ -206,6 +214,9 @@ const state = props.kind === "state" ? stateName(props.code) : "";
           <div class="cta">
             <a class="btn btn-primary" href="https://app.hookecho.io">
               Open the radar
+            </a>
+            <a class="btn" href="https://app.hookecho.io/lite/">
+              Lite view
             </a>
             <a class="btn" href="/download/">
               Get the app


### PR DESCRIPTION
Wave 4. Merged only now because the target had to exist first: `https://app.hookecho.io/lite/` answers 200 on the deployed origin.

- **Nav**: a Lite entry beside Open in browser, tenth item.
- **Radar site pages**: a "Lite view" button deep-linked with `?site={id}`, on NEXRAD pages only. TDWR sites are excluded on purpose — the Level 3 bucket has no super-res digital products for terminal radars, so the link would open an empty loop. Verified: KTLX has it, TOKC does not.
- **Docs**: a section in "In your browser" describing the lite page and, plainly, what it does not do (no panning, no archive, two products).

One unrelated correction in the same file: it told readers to use `?embed=1`, which does not work because the app matches the whole parameter. The `/embed` page already documents this correctly.

Site build clean, `npm run linkcheck` scanned 1016 links with none broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)