### PR TITLE
feat(lite): zoom controls and full screen

### DIFF
--- a/crates/hookecho-lite/src/lib.rs
+++ b/crates/hookecho-lite/src/lib.rs
@@ -144,6 +144,7 @@ impl Viewer {
         }
         let nbins = ra.nbins as usize;
         let mut levels = vec![0u8; SLOTS * nbins];
+        let mut filled = [false; SLOTS];
         for radial in &ra.radials {
             // A radial covers the wedge [start, start + delta). Fill every slot whose *center*
             // falls inside it: radials start on arbitrary fractions of a degree, and rounding the
@@ -155,8 +156,22 @@ impl Viewer {
                 let slot = (first + k).rem_euclid(SLOTS as i32) as usize;
                 let n = radial.levels.len().min(nbins);
                 levels[slot * nbins..slot * nbins + n].copy_from_slice(&radial.levels[..n]);
+                filled[slot] = true;
             }
         }
+        // Radial start angles carry jitter, so two neighbours occasionally land in the same slot
+        // and leave the next one empty — which reads as a thin wedge of nothing, most visible when
+        // zoomed in. Backfill an empty slot from the one before it: the wedge is half a degree
+        // wide, and the honest alternative (interpolating) would invent data.
+        let mut last_filled: Option<usize> = (0..SLOTS).rev().find(|&s| filled[s]);
+        for (slot, has_data) in filled.iter().enumerate() {
+            if *has_data {
+                last_filled = Some(slot);
+            } else if let Some(src) = last_filled {
+                levels.copy_within(src * nbins..src * nbins + nbins, slot * nbins);
+            }
+        }
+
         let (table, folded) = match self.product {
             Product::Reflectivity => (&self.ref_table, false),
             Product::Velocity => (&self.vel_table, true),

--- a/web/lite/app.js
+++ b/web/lite/app.js
@@ -21,15 +21,22 @@ const FRAMES = 6; // scans in the loop, ~15 minutes of weather
 const FRAME_MS = 400;
 const DWELL_MS = 1200; // extra time on the newest frame, so the loop reads as "now"
 const REFRESH_MS = 120000;
-const MAX_CANVAS = 1024;
+// The CPU paints every pixel of every frame, so the canvas is capped well below a modern desktop
+// window. Full screen makes the map bigger up to this, then stops growing.
+const MAX_CANVAS = 1400;
+// Zoom range: 5 is most of the country, 12 is a few neighbourhoods. The radar itself runs out at
+// about 300 km, so anything wider than 6 is mostly basemap.
+const MIN_ZOOM = 5;
+const MAX_ZOOM = 12;
 
 const el = (id) => document.getElementById(id);
+const clampZoom = (z) => Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, Math.round(z) || 9));
 const params = new URLSearchParams(location.search);
 
 const state = {
   site: null, // { id, city, state, lat, lon }
   product: params.get("prod") === "vel" ? "vel" : "ref",
-  zoom: Number(params.get("zoom")) || 9,
+  zoom: clampZoom(Number(params.get("zoom")) || 9),
   frame: 0,
   times: [],
   playing: true,
@@ -85,14 +92,37 @@ function drawTiles(w, h) {
 
 function applyView() {
   const [w, h] = canvasSize();
+  el("view").style.width = `${w}px`;
+  el("view").style.height = `${h}px`;
   for (const id of ["radar", "warn"]) {
     const c = el(id);
     c.width = w;
     c.height = h;
   }
+  showRange(w);
   ctx = el("radar").getContext("2d");
   viewer.set_view(state.site.lat, state.site.lon, w, h, state.zoom);
   drawTiles(w, h);
+}
+
+// How wide the view actually is, which is the thing a zoom control is really setting. Web Mercator
+// scale is latitude-dependent, so this is computed rather than labelled per preset.
+function showRange(widthPx) {
+  const kmPerPx =
+    ((40075.017 * Math.cos((state.site.lat * Math.PI) / 180)) / worldPx(state.zoom)) * 1;
+  const km = Math.round(widthPx * kmPerPx);
+  el("range").textContent = km >= 100 ? `${Math.round(km / 10) * 10} km` : `${km} km`;
+}
+
+// The one place a zoom change happens, however it was asked for.
+function setZoom(z) {
+  const next = clampZoom(z);
+  if (next === state.zoom) return;
+  state.zoom = next;
+  applyView();
+  permalink();
+  if (ctx) viewer.render(ctx, state.frame);
+  loadWarnings();
 }
 
 function permalink() {
@@ -273,6 +303,14 @@ function tick() {
   setTimeout(tick, last ? DWELL_MS : FRAME_MS);
 }
 
+// Full screen on the whole document element, so the toolbar comes along — a radar with no site
+// picker and no timestamp is a screensaver.
+function toggleFullscreen() {
+  el("full").blur(); // otherwise the button keeps focus and eats the next space bar
+  if (document.fullscreenElement) document.exitFullscreen();
+  else document.documentElement.requestFullscreen().catch((e) => console.warn("fullscreen:", e));
+}
+
 // --- Boot -------------------------------------------------------------------------------------
 
 const haversine = (a, b) => {
@@ -328,7 +366,6 @@ async function main() {
 
   state.site = await pickSite(sites);
   el("site").value = state.site.id;
-  el("zoom").value = String(state.zoom);
   for (const p of ["ref", "vel"]) el(p).setAttribute("aria-pressed", String(state.product === p));
   applyView();
   permalink();
@@ -341,12 +378,35 @@ async function main() {
     permalink();
     await Promise.all([loadLoop(), loadWarnings()]);
   });
-  el("zoom").addEventListener("change", (e) => {
-    state.zoom = Number(e.target.value);
+  el("in").addEventListener("click", () => setZoom(state.zoom + 1));
+  el("out").addEventListener("click", () => setZoom(state.zoom - 1));
+  // The wheel zooms, which is what anyone who has used a map expects. Passive: false because the
+  // point is to stop the page scrolling underneath it.
+  el("map").addEventListener(
+    "wheel",
+    (e) => {
+      e.preventDefault();
+      setZoom(state.zoom + (e.deltaY < 0 ? 1 : -1));
+    },
+    { passive: false },
+  );
+  addEventListener("keydown", (e) => {
+    // Not while the site picker has focus: typing there jumps to a state, and stealing the keys
+    // would break it.
+    if (/^(INPUT|SELECT|TEXTAREA)$/.test(e.target.tagName)) return;
+    if (e.key === "+" || e.key === "=") setZoom(state.zoom + 1);
+    if (e.key === "-") setZoom(state.zoom - 1);
+    if (e.key === "f") toggleFullscreen();
+  });
+  el("full").addEventListener("click", toggleFullscreen);
+  document.addEventListener("fullscreenchange", () => {
+    const on = !!document.fullscreenElement;
+    el("full").textContent = on ? "Exit full screen" : "Full screen";
+    el("full").setAttribute("aria-pressed", String(on));
+    // The element resized, and on some browsers no resize event follows.
     applyView();
-    permalink();
     if (ctx) viewer.render(ctx, state.frame);
-    loadWarnings();
+    drawWarnings();
   });
   for (const p of ["ref", "vel"]) {
     el(p).addEventListener("click", async () => {

--- a/web/lite/index.src.html
+++ b/web/lite/index.src.html
@@ -15,9 +15,13 @@
       :root { color-scheme: dark; }
       html, body { margin: 0; height: 100%; background: #101014; color: #e6e6ee;
         font: 14px system-ui, sans-serif; }
-      #map { position: relative; overflow: hidden; height: calc(100% - 46px); }
-      /* The tiles, the radar and the warnings are three stacked layers in one fixed view, so
-         they need no transforms and no compositing tricks — just z-order. */
+      /* The canvases are capped below the window on a big screen (a CPU raster of a 4K canvas is
+         not what this page is for), so the layers live in a centered box of exactly their size —
+         otherwise the tile grid would start at the window corner and the radar would not sit on
+         its own geography. */
+      #map { position: relative; overflow: hidden; height: calc(100% - 46px);
+        display: grid; place-items: center; }
+      #view { position: relative; overflow: hidden; }
       #tiles { position: absolute; inset: 0; }
       #tiles img { position: absolute; width: 256px; height: 256px; }
       canvas { position: absolute; left: 0; top: 0; }
@@ -27,6 +31,7 @@
         border-radius: 6px; padding: 6px 10px; font: inherit; cursor: pointer; }
       #bar button[aria-pressed="true"] { background: #3d6fd6; }
       #time { color: #8a8a95; white-space: nowrap; }
+      #range { color: #8a8a95; white-space: nowrap; min-width: 5.5em; text-align: center; }
       #warns { margin-left: auto; white-space: nowrap; color: #d8d8e2; }
       #warns b { font-weight: 600; }
       #attrib { position: absolute; right: 4px; bottom: 2px; font-size: 11px; color: #9aa;
@@ -40,19 +45,20 @@
       <select id="site" aria-label="Radar site"></select>
       <button id="ref" type="button" aria-pressed="true">Reflectivity</button>
       <button id="vel" type="button" aria-pressed="false">Velocity</button>
-      <select id="zoom" aria-label="Range">
-        <option value="8">Wide</option>
-        <option value="9" selected>Medium</option>
-        <option value="10">Close</option>
-      </select>
+      <button id="out" type="button" aria-label="Zoom out" title="Zoom out">−</button>
+      <span id="range" title="Width of the view">—</span>
+      <button id="in" type="button" aria-label="Zoom in" title="Zoom in">+</button>
       <button id="play" type="button" aria-pressed="true">Pause</button>
+      <button id="full" type="button" aria-pressed="false">Full screen</button>
       <span id="warns"></span>
       <span id="time">Loading…</span>
     </div>
     <div id="map">
-      <div id="tiles"></div>
-      <canvas id="radar"></canvas>
-      <canvas id="warn"></canvas>
+      <div id="view">
+        <div id="tiles"></div>
+        <canvas id="radar"></canvas>
+        <canvas id="warn"></canvas>
+      </div>
       <div id="attrib">
         Basemap <a href="https://www.usgs.gov/programs/national-geospatial-program/national-map">USGS
         The National Map</a> · radar NOAA/NWS ·


### PR DESCRIPTION
Both gaps you found on the lite viewer.

**Zoom.** The preset dropdown is gone. Zoom in and out buttons cover levels 5 through 12, and the mouse wheel and the `+`/`-` keys do the same. The toolbar shows the real width of the view in kilometres, computed rather than labelled, because Mercator scale depends on latitude. Verified live: 290 km at the old default, 36 km fully zoomed in, 4640 km fully out, with the deep link staying in step.

**Full screen.** A button plus `f`. Entering and leaving both re-lay the view, since some browsers send no resize event with the fullscreen change.

**Two things that fell out of it**
- The canvases are capped at 1400 px a side so a full-screen 4K window does not ask a weak processor to paint eight million pixels a frame. That cap meant the layers had to move into a centered box of exactly their size, or the tile grid would start at the window corner while the radar drew from the canvas corner, putting the storms in the wrong place.
- Zoomed in, thin empty wedges appeared between radials: start angles carry jitter, so two neighbours occasionally land in the same azimuth slot and leave the next one blank. Empty slots now copy the previous one, which is honest at half a degree wide; interpolating would invent data.

Verified against live weather at KBGM through a real proxy. Lite bundle 71,856 gz against its 80,000 budget. Clippy, tests and `shoot.sh check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)