### PR TITLE
fix(lite): content-hash app.js so a stale copy cannot outlive its page

### DIFF
--- a/scripts/web/build.sh
+++ b/scripts/web/build.sh
@@ -125,9 +125,18 @@ lite_glue_hash="$(hash_of "$lite_glue")"
 cp "$lite_glue" "web/dist/lite-$lite_glue_hash.js"
 sed -i "s/lite_bg-$lite_wasm_hash\.wasm/lite_bg.wasm/g" "$lite_glue"
 
+# app.js is hashed like the glue rather than served under its own name. It is generated HTML that
+# names it, and the two are a matched pair: a browser holding a cached app.js against a newer page
+# runs code that expects controls the page no longer has. Pages serves /lite/* with a four-hour
+# max-age, so that window was real.
+rm -f web/dist/lite-app-*.js
+lite_app_hash="$(hash_of web/lite/app.js)"
+cp web/lite/app.js "web/dist/lite-app-$lite_app_hash.js"
+
 # Generated like web/index.html: the committed source keeps plain names, the deployed copy names
-# the hashed glue.
+# the hashed glue and the hashed page script.
 sed -e "s#/dist/lite\.js#/dist/lite-$lite_glue_hash.js#g" \
+  -e "s#\./app\.js#/dist/lite-app-$lite_app_hash.js#g" \
   web/lite/index.src.html > web/lite/index.html
 
 # The site picker's data, derived from the one committed registry (site/src/data/nexrad-sites.json,


### PR DESCRIPTION
Reported as "radar not working": the lite page loaded its chrome and then showed an empty map with `TypeError: Cannot set properties of null (setting 'value')`.

**Cause.** Cloudflare Pages serves `/lite/*` with `max-age=14400`, and `app.js` was the only asset served under a fixed name. Anyone who had loaded the page before the zoom PR kept the old script for up to four hours and ran it against the new HTML. The old script sets the value of the zoom dropdown that PR removed, so it threw before the first fetch and the loop never started.

**Fix.** `app.js` is hashed into `web/dist` like the wasm glue, and the generated `index.html` names the hashed copy. The page and its script are now a matched pair by construction, which is the same rule the app bundle has always followed.

Verified locally through a real proxy: 407,112 painted pixels, six frames.

Anyone currently seeing the broken page gets the fix on their next load, because `index.html` is `must-revalidate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)