### PR TITLE
feat(lite): click a neighbouring radar on the map to switch to it

### DIFF
--- a/web/lite/app.js
+++ b/web/lite/app.js
@@ -44,6 +44,7 @@ const state = {
   warnings: [], // [{ event, rings }] already filtered to the current view
 };
 
+let allSites = [];
 let viewer = null;
 let ctx = null;
 
@@ -90,6 +91,41 @@ function drawTiles(w, h) {
   }
 }
 
+// Every other NEXRAD in the current view, as a button that switches to it. This is the map
+// equivalent of the site picker: on a wide view you can see the neighbouring radar's storms
+// arriving and go straight to the site that has them close in.
+function drawMarkers(w, h) {
+  const host = el("markers");
+  host.textContent = "";
+  if (!allSites.length) return;
+  const z = state.zoom;
+  const left = lonToX(state.site.lon, z) - w / 2;
+  const top = latToY(state.site.lat, z) - h / 2;
+  for (const s of allSites) {
+    if (s.id === state.site.id) continue;
+    const x = lonToX(s.lon, z) - left;
+    const y = latToY(s.lat, z) - top;
+    // A margin keeps a marker from hanging half off the edge where it cannot be read.
+    if (x < 12 || y < 12 || x > w - 12 || y > h - 12) continue;
+    const b = document.createElement("button");
+    b.type = "button";
+    b.textContent = s.id;
+    b.title = `Switch to ${s.city} (${s.id})`;
+    b.style.left = `${x}px`;
+    b.style.top = `${y}px`;
+    b.addEventListener("click", () => goToSite(s));
+    host.append(b);
+  }
+}
+
+async function goToSite(site) {
+  state.site = site;
+  el("site").value = site.id;
+  applyView();
+  permalink();
+  await Promise.all([loadLoop(), loadWarnings()]);
+}
+
 function applyView() {
   const [w, h] = canvasSize();
   el("view").style.width = `${w}px`;
@@ -103,6 +139,7 @@ function applyView() {
   ctx = el("radar").getContext("2d");
   viewer.set_view(state.site.lat, state.site.lon, w, h, state.zoom);
   drawTiles(w, h);
+  drawMarkers(w, h);
 }
 
 // How wide the view actually is, which is the thing a zoom control is really setting. Web Mercator
@@ -357,6 +394,7 @@ function fillPicker(sites) {
 
 async function main() {
   const sites = await fetch("./sites.json").then((r) => r.json());
+  allSites = sites;
   fillPicker(sites);
 
   const glue = await import(globalThis.__liteGlue);
@@ -372,12 +410,7 @@ async function main() {
   tick();
   await Promise.all([loadLoop(), loadWarnings()]);
 
-  el("site").addEventListener("change", async (e) => {
-    state.site = sites.find((s) => s.id === e.target.value);
-    applyView();
-    permalink();
-    await Promise.all([loadLoop(), loadWarnings()]);
-  });
+  el("site").addEventListener("change", (e) => goToSite(sites.find((s) => s.id === e.target.value)));
   el("in").addEventListener("click", () => setZoom(state.zoom + 1));
   el("out").addEventListener("click", () => setZoom(state.zoom - 1));
   // The wheel zooms, which is what anyone who has used a map expects. Passive: false because the

--- a/web/lite/index.src.html
+++ b/web/lite/index.src.html
@@ -34,6 +34,16 @@
       #range { color: #8a8a95; white-space: nowrap; min-width: 5.5em; text-align: center; }
       #warns { margin-left: auto; white-space: nowrap; color: #d8d8e2; }
       #warns b { font-weight: 600; }
+      /* Other radars in view, as real buttons rather than canvas hit-testing: they are keyboard
+         reachable and need no pointer maths. */
+      #markers { position: absolute; inset: 0; pointer-events: none; }
+      #markers button { position: absolute; transform: translate(-50%, -50%);
+        pointer-events: auto; display: flex; align-items: center; gap: 4px;
+        background: #101014c0; color: #e6e6ee; border: 1px solid #6f7080; border-radius: 999px;
+        padding: 2px 8px 2px 4px; font: 11px system-ui, sans-serif; cursor: pointer; }
+      #markers button:hover, #markers button:focus { background: #3d6fd6; border-color: #8fb3ff; }
+      #markers button::before { content: ""; width: 6px; height: 6px; border-radius: 50%;
+        background: #8fb3ff; }
       #attrib { position: absolute; right: 4px; bottom: 2px; font-size: 11px; color: #9aa;
         background: #101014b0; padding: 1px 5px; border-radius: 4px; }
       #attrib a { color: inherit; }
@@ -58,6 +68,7 @@
         <div id="tiles"></div>
         <canvas id="radar"></canvas>
         <canvas id="warn"></canvas>
+        <div id="markers"></div>
       </div>
       <div id="attrib">
         Basemap <a href="https://www.usgs.gov/programs/national-geospatial-program/national-map">USGS


### PR DESCRIPTION
Every other NEXRAD site inside the current view is drawn as a labelled dot, and clicking one switches to it. On a wide view you can watch a storm arriving from the next radar's territory and jump to the site that has it close in, without going through the dropdown.

They are real buttons positioned over the canvases, not canvas hit testing: keyboard reachable, screen-reader labelled with the city name, and no pointer-to-geography maths beyond the projection the view already does. Markers within twelve pixels of an edge are dropped, since a half-visible label cannot be read.

The dropdown and the map now share one code path for switching sites, so the picker, the permalink, the loop and the warnings cannot disagree.

Verified live from KTLX at a wide zoom: fourteen neighbours drawn on correct geography, clicking KAMA moved the loop, the picker, the URL and the marker set to Amarillo, six frames decoded there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)