### PR TITLE
perf(lite): parallel frame fetch, cached rasters, decode yields

### DIFF
--- a/crates/hookecho-lite/src/lib.rs
+++ b/crates/hookecho-lite/src/lib.rs
@@ -30,6 +30,10 @@ struct Frame {
     nbins: usize,
     levels: Vec<u8>,
     lut: [u8; 1024],
+    /// The frame already rasterized for the current view. A loop plays the same six frames over
+    /// and over, so the second pass onward is a memcpy instead of a million table lookups — which
+    /// is the difference between smooth and stuttering on the hardware this page is for.
+    rgba: Option<Vec<u8>>,
 }
 
 /// The product being displayed. Both are super-res digital radial arrays with the same tenths
@@ -85,6 +89,9 @@ impl Viewer {
         self.slot = vec![0; width * height];
         self.bin = vec![u16::MAX; width * height];
         self.rgba = vec![0; width * height * 4];
+        for f in &mut self.frames {
+            f.rgba = None; // a cached raster belongs to the view it was drawn for
+        }
 
         let world = 256.0 * 2f64.powf(zoom);
         let (cx, cy) = merc(lat, lon, world);
@@ -180,6 +187,7 @@ impl Viewer {
             nbins,
             levels,
             lut: table.bake(&p.thresholds, folded),
+            rgba: None,
         });
         true
     }
@@ -203,26 +211,28 @@ impl Viewer {
     /// Paint frame `idx` over the whole canvas. Out-of-range indices and an unset view are a
     /// no-op — the JS side drives this from a timer and must not have to synchronize with it.
     pub fn render(&mut self, ctx: &CanvasRenderingContext2d, idx: usize) -> Result<(), JsValue> {
-        let Some(frame) = self.frames.get(idx) else {
-            return Ok(());
-        };
-        if self.width == 0 || self.height == 0 {
+        if self.width == 0 || self.height == 0 || idx >= self.frames.len() {
             return Ok(());
         }
-        let nbins = frame.nbins;
-        for i in 0..self.width * self.height {
-            let out = i * 4;
-            let bin = self.bin[i] as usize;
-            let level = if bin < nbins {
-                frame.levels[self.slot[i] as usize * nbins + bin]
-            } else {
-                0
-            };
-            let c = level as usize * 4;
-            self.rgba[out..out + 4].copy_from_slice(&frame.lut[c..c + 4]);
+        let px = self.width * self.height;
+        if self.frames[idx].rgba.is_none() {
+            let frame = &self.frames[idx];
+            let nbins = frame.nbins;
+            for i in 0..px {
+                let out = i * 4;
+                let bin = self.bin[i] as usize;
+                let level = if bin < nbins {
+                    frame.levels[self.slot[i] as usize * nbins + bin]
+                } else {
+                    0
+                };
+                let c = level as usize * 4;
+                self.rgba[out..out + 4].copy_from_slice(&frame.lut[c..c + 4]);
+            }
+            self.frames[idx].rgba = Some(self.rgba.clone());
         }
         let img = ImageData::new_with_u8_clamped_array_and_sh(
-            Clamped(&self.rgba),
+            Clamped(self.frames[idx].rgba.as_deref().unwrap_or(&self.rgba)),
             self.width as u32,
             self.height as u32,
         )?;

--- a/web/lite/app.js
+++ b/web/lite/app.js
@@ -225,13 +225,33 @@ async function loadLoop() {
   showTime();
   try {
     const keys = await listKeys();
+    // All six at once. Fetched one after another this was six round trips deep, which is most of
+    // the wait on a slow link; the decode below is the same work either way.
+    const loaded = await Promise.all(
+      keys.map((key) =>
+        fetch(`${S3}/${key}`)
+          .then((r) => (r.ok ? r.arrayBuffer() : null))
+          .then((buf) => (buf ? { key, bytes: new Uint8Array(buf) } : null))
+          .catch(() => null),
+      ),
+    );
     viewer.clear_frames();
     const times = [];
-    for (const key of keys) {
-      const res = await fetch(`${S3}/${key}`).catch(() => null);
-      if (!res || !res.ok) continue;
-      const bytes = new Uint8Array(await res.arrayBuffer());
-      if (viewer.add_frame(bytes)) times.push(keyTime(key));
+    for (const item of loaded) {
+      if (!item || !viewer.add_frame(item.bytes)) continue;
+      times.push(keyTime(item.key));
+      // Paint the oldest frame the moment it decodes rather than sitting on a blank map for the
+      // length of five more decodes.
+      if (times.length === 1 && ctx) {
+        state.frame = 0;
+        state.times = times;
+        viewer.render(ctx, 0);
+        showTime();
+      }
+      // Decoding six scans is a second of solid work on a slow machine. Yielding between them
+      // lets the browser actually put the frame above on screen, and keeps the toolbar clickable
+      // while the rest arrive.
+      await new Promise((r) => setTimeout(r, 0));
     }
     state.times = times;
     state.frame = Math.max(0, times.length - 1);


### PR DESCRIPTION
Reported as "lite radar is still slow". Three separate causes, all measured rather than guessed.

**Six sequential round trips.** Each scan was fetched only after the previous one finished, so the loop was six round trips deep before it could play. They go out together now; the decode work is unchanged.

**Re-rasterizing every animation step.** Playing the loop redrew a frame from its data levels four times a second, a million table lookups each time, forever, even though the same six frames repeat. Each frame now keeps the pixels it was drawn into and replays them. The cache belongs to the view, so changing site or zoom drops it. Cost is about 5 MB a frame.

**A second of unbroken decode.** Six scans decoded back to back never let the browser paint the ones already done. The loop yields between frames, so the first scan appears while the rest are still decoding and the toolbar stays responsive.

Measured in headless Chrome at 6x CPU throttling against KFWS, comparing this build to what is deployed:

| | production | this |
|---|---|---|
| First radar pixels | 3.3 s | 2.2 s |
| Worst frame gap, settled loop | 69 ms | 28 ms |

The full-loop number is not comparable between the two, because the local run goes through an uncached proxy while production is edge-cached; the parallel fetch can only help there.

Clippy, tests and the lite smoke test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)