### PR TITLE
perf(lite): decode scans as they arrive, not after all of them

### DIFF
--- a/web/lite/app.js
+++ b/web/lite/app.js
@@ -227,17 +227,18 @@ async function loadLoop() {
     const keys = await listKeys();
     // All six at once. Fetched one after another this was six round trips deep, which is most of
     // the wait on a slow link; the decode below is the same work either way.
-    const loaded = await Promise.all(
-      keys.map((key) =>
-        fetch(`${S3}/${key}`)
-          .then((r) => (r.ok ? r.arrayBuffer() : null))
-          .then((buf) => (buf ? { key, bytes: new Uint8Array(buf) } : null))
-          .catch(() => null),
-      ),
+    const inflight = keys.map((key) =>
+      fetch(`${S3}/${key}`)
+        .then((r) => (r.ok ? r.arrayBuffer() : null))
+        .then((buf) => (buf ? { key, bytes: new Uint8Array(buf) } : null))
+        .catch(() => null),
     );
     viewer.clear_frames();
     const times = [];
-    for (const item of loaded) {
+    // Awaited in order, not with Promise.all: the requests are already all in flight, and waiting
+    // for the slowest one before decoding any of them is how the first frame ends up last.
+    for (const pending of inflight) {
+      const item = await pending;
       if (!item || !viewer.add_frame(item.bytes)) continue;
       times.push(keyTime(item.key));
       // Paint the oldest frame the moment it decodes rather than sitting on a blank map for the


### PR DESCRIPTION
Follow-up to #181, which I verified against production after it deployed and found half-right.

The parallel fetch used `Promise.all`, so nothing decoded until the slowest of the six scans landed. On a real connection that made the first frame the *last* thing to happen, and the map sat blank longer than it did when the fetches were sequential. The steady-state gains from #181 were real; this part was not.

The requests still go out together. They are just awaited in order, so the oldest scan decodes and paints the moment its own bytes arrive.

Measured at 6x CPU throttling on an emulated 4 Mbit connection, KOUN, twice, against what is deployed now:

| | deployed | this |
|---|---|---|
| First radar pixels | 6.9 s | 4.5 s |
| Six-frame loop complete | 7.8 s | 6.3 s |

The local side goes through an uncached proxy while production is edge-cached, so the real gap is wider than the table shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)