### PR TITLE
feat(site): live hero + most-active-site helper

### DIFF
--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -1,135 +1,147 @@
 ---
 interface Props {
+  /** Everything before the gradient word: the headline reads "{title} NOW". */
   title: string;
   tagline: string;
 }
 const { title, tagline } = Astro.props;
 
-// The live app is a whole wasm radar viewer — several MB and a pile of feed requests. Loading it
-// on every landing-page visit would be rude, so the hero shows a still until someone asks for it.
-// `?embed` is the app's chrome-free mode (crates/hookecho/src/app.rs, `is_embed`), and the app
-// geo-IP-centers itself from its own /geo.json, so no coordinates need passing here.
-const appEmbed = "https://app.hookecho.io/?embed";
+// The backdrop is the lite viewer (app.hookecho.io/lite/) in its chrome-free hero mode, pointed at
+// whichever radar is watching the most active weather in the country right now. It is a real,
+// current scan rather than a screenshot of one — which is the entire argument for the product.
+// A poster holds the frame until the ranking resolves, and stays put with JavaScript off.
+const LITE = "https://app.hookecho.io/lite/";
 ---
 
 <section class="hero">
-  <span class="sweep" aria-hidden="true"></span>
+  <div class="backdrop" data-lite={LITE} aria-hidden="true">
+    <img
+      class="poster"
+      src="/shots/reflectivity.jpg"
+      alt=""
+      width="1600"
+      height="1000"
+    />
+    <span class="scrim"></span>
+  </div>
+
   <div class="wrap">
-    <h1>{title}</h1>
+    <p class="chip" hidden>
+      <span class="dot" aria-hidden="true"></span>
+      <span class="chip-text"></span>
+    </p>
+    <h1>{title} <span class="grad-text">NOW</span></h1>
     <p class="tagline">{tagline}</p>
     <div class="ctas">
       <a class="btn btn-primary" href="https://app.hookecho.io">Open in your browser</a>
       <a class="btn" href="/download/">Download the app</a>
     </div>
     <p class="fineprint">Free, open source, no account. Windows, macOS, Linux and Android.</p>
-
-    <div class="stage" data-embed={appEmbed}>
-      <img
-        class="poster"
-        src="/shots/reflectivity.jpg"
-        alt="A radar loop over an interactive map, with warnings and storm cells drawn on top"
-        width="1600"
-        height="1000"
-      />
-      <!-- Only rendered by the script below, so the no-JS experience is the poster plus the CTAs
-           above rather than a dead button. -->
-      <noscript><p class="fineprint">Open the radar in your browser from the button above.</p></noscript>
-    </div>
   </div>
 </section>
 
 <script>
-  const stage = document.querySelector<HTMLElement>(".hero .stage");
-  const src = stage?.dataset.embed;
-  if (stage && src) {
-    const play = document.createElement("button");
-    play.type = "button";
-    play.className = "play";
-    play.innerHTML = '<span class="dot" aria-hidden="true"></span> Load the live radar';
-    play.addEventListener(
-      "click",
-      () => {
+  import { activeSite } from "../scripts/active-site";
+
+  const backdrop = document.querySelector<HTMLElement>(".hero .backdrop");
+  const lite = backdrop?.dataset.lite;
+  const chip = document.querySelector<HTMLElement>(".hero .chip");
+
+  if (backdrop && lite) {
+    activeSite()
+      .then((site) => {
         const frame = document.createElement("iframe");
-        frame.src = src;
-        frame.title = "HookEcho live radar";
-        frame.loading = "lazy";
-        frame.allow = "geolocation";
-        stage.replaceChildren(frame);
-      },
-      { once: true },
-    );
-    stage.append(play);
+        frame.src = `${lite}?site=${site.id}&hero=1`;
+        frame.title = "";
+        frame.loading = "eager";
+        frame.tabIndex = -1;
+        backdrop.prepend(frame);
+
+        if (chip) {
+          const warnings =
+            site.warnings === 1 ? "1 warning" : `${site.warnings} warnings`;
+          chip.querySelector(".chip-text")!.textContent =
+            `LIVE · ${site.id} — ${site.city}, ${site.state}` +
+            (site.warnings ? ` · ${warnings}` : "");
+          chip.hidden = false;
+        }
+      })
+      // The poster is already on screen, so a failure here is simply nothing happening.
+      .catch(() => {});
   }
 </script>
 
 <style>
-  .hero { position: relative; overflow: hidden; padding-top: clamp(2.5rem, 7vw, 4.5rem); }
-  .hero .wrap { position: relative; }
-  .hero::before {
-    content: "";
+  .hero {
+    position: relative;
+    min-height: 90vh;
+    display: flex;
+    align-items: flex-end;
+    overflow: hidden;
+    padding-block: clamp(4rem, 12vw, 9rem) var(--sp-8);
+  }
+
+  .backdrop { position: absolute; inset: 0; pointer-events: none; }
+  .backdrop :global(img),
+  .backdrop :global(iframe) {
     position: absolute;
     inset: 0;
-    background: var(--glow);
-    pointer-events: none;
-  }
-  .tagline {
-    font-size: clamp(1.05rem, 2.4vw, 1.35rem);
-    color: var(--text-dim);
-    max-width: 46ch;
-  }
-  .ctas { display: flex; gap: 0.75rem; flex-wrap: wrap; margin: 1.6rem 0 0.8rem; }
-  .fineprint { color: var(--text-dim); font-size: 0.9rem; }
-
-  .stage {
-    position: relative;
-    margin-top: 2.2rem;
-    aspect-ratio: 16 / 10;
-    border: 1px solid var(--stroke);
-    border-radius: var(--radius);
-    overflow: hidden;
-    box-shadow: 0 24px 60px rgb(0 0 0 / 0.35);
-  }
-  .stage :global(img),
-  .stage :global(iframe) {
-    display: block;
     width: 100%;
     height: 100%;
     border: 0;
     object-fit: cover;
   }
-  .stage :global(.play) {
+  /* Three layers of darkening, because the headline sits over live weather and cannot pick its
+     own background: a bottom fade into the page, a side vignette, and the ramp's aurora wash. */
+  .scrim {
     position: absolute;
-    inset-inline: 0;
-    bottom: 1.2rem;
-    margin-inline: auto;
-    width: fit-content;
+    inset: 0;
+    background:
+      linear-gradient(transparent 25%, color-mix(in srgb, var(--bg) 80%, transparent) 62%, var(--bg)),
+      radial-gradient(120% 90% at 50% 40%, transparent 30%, color-mix(in srgb, var(--bg-deep) 85%, transparent)),
+      var(--mesh);
+  }
+
+  .hero .wrap { position: relative; }
+
+  .chip {
     display: inline-flex;
     align-items: center;
-    gap: 0.55rem;
-    padding: 0.75rem 1.4rem;
+    gap: 0.5rem;
+    margin: 0 0 var(--sp-4);
+    padding: 0.4rem 0.9rem;
+    border: 1px solid var(--stroke-strong);
     border-radius: 999px;
-    border: 1px solid var(--accent);
-    background: color-mix(in srgb, var(--bg) 78%, transparent);
+    background: color-mix(in srgb, var(--bg-deep) 70%, transparent);
     backdrop-filter: blur(8px);
-    color: var(--text);
-    font: inherit;
-    font-weight: 600;
-    cursor: pointer;
-    transition: transform var(--dur) var(--spring), box-shadow var(--dur) ease;
+    font-size: var(--text-sm);
+    letter-spacing: 0.04em;
+    font-variant-numeric: tabular-nums;
   }
-  .stage :global(.play:hover) {
-    transform: translateY(-2px);
-    box-shadow: 0 10px 30px color-mix(in srgb, var(--accent) 30%, transparent);
-  }
-  .stage :global(.dot) {
-    width: 0.6rem;
-    height: 0.6rem;
+  .dot {
+    width: 0.5rem;
+    height: 0.5rem;
     border-radius: 50%;
-    background: var(--accent);
+    background: var(--ramp-1);
+    box-shadow: var(--glow-green);
     animation: pulse 1.8s ease-in-out infinite;
   }
   @keyframes pulse {
     50% { opacity: 0.25; transform: scale(0.7); }
   }
-  .stage noscript { position: absolute; bottom: 0.4rem; inset-inline: 0; text-align: center; }
+
+  .hero h1 {
+    font-size: var(--text-display);
+    font-weight: 750;
+    line-height: 0.95;
+    letter-spacing: -0.04em;
+    max-width: 14ch;
+  }
+  .tagline {
+    font-size: clamp(1.05rem, 2.4vw, 1.35rem);
+    color: var(--text);
+    max-width: 46ch;
+  }
+  .ctas { display: flex; gap: 0.75rem; flex-wrap: wrap; margin: var(--sp-5) 0 var(--sp-3); }
+  .fineprint { color: var(--text-dim); font-size: 0.9rem; margin: 0; }
 </style>

--- a/site/src/components/Ticker.astro
+++ b/site/src/components/Ticker.astro
@@ -4,19 +4,31 @@
 // is public data, so the whole thing is a fetch and a number.
 // ponytail: the GeoJSON carries polygons we throw away (~3 KB per alert), because the lighter
 // ld+json needs an Accept header and the API's preflight only allows API-Key and User-Agent.
-const events = ["Tornado Warning", "Severe Thunderstorm Warning", "Flash Flood Warning"];
+import Icon from "./Icon.astro";
+
+// Icon and hot colour per event, so a busy day reads at a glance instead of as three grey numbers.
+const events = [
+  { event: "Tornado Warning", icon: "warning-diamond", hot: "var(--ramp-5)" },
+  { event: "Severe Thunderstorm Warning", icon: "lightning", hot: "var(--ramp-4)" },
+  { event: "Flash Flood Warning", icon: "gauge", hot: "var(--ramp-3)" },
+] as const;
 ---
 
-<a class="ticker" href="https://app.hookecho.io" data-events={JSON.stringify(events)}>
+<a
+  class="ticker"
+  href="https://app.hookecho.io"
+  data-events={JSON.stringify(events.map((e) => e.event))}
+>
   {
-    events.map((event) => (
-      <span class="item" data-event={event}>
+    events.map(({ event, icon, hot }) => (
+      <span class="item" data-event={event} style={`--hot: ${hot}`}>
+        <Icon name={icon} size={22} />
         <span class="count">—</span>
         <span class="label">{event.replace(" Warning", "")}</span>
       </span>
     ))
   }
-  <span class="cta">See them on the map</span>
+  <span class="cta">See them on the map <Icon name="arrow-right" size={16} /></span>
 </a>
 
 <script>
@@ -30,6 +42,8 @@ const events = ["Tornado Warning", "Severe Thunderstorm Warning", "Flash Flood W
       .then((d) => {
         const n = d?.features?.length ?? 0;
         slot.textContent = String(n);
+        // Hand the number to motion.ts, which counts it up when the row scrolls into view.
+        if (n > 0) (slot as HTMLElement).dataset.countup = String(n);
         slot.parentElement?.classList.toggle("hot", n > 0);
       })
       // A blocked or failing fetch leaves the em dash: the row still reads as a list of the
@@ -47,15 +61,30 @@ const events = ["Tornado Warning", "Severe Thunderstorm Warning", "Flash Flood W
     padding: 0.85rem 1.2rem;
     border: 1px solid var(--stroke);
     border-radius: 999px;
-    background: var(--faint);
+    background: var(--surface-1);
     color: var(--text);
     text-decoration: none;
-    transition: border-color var(--dur) ease, transform var(--dur) var(--spring);
+    box-shadow: var(--shadow-1);
+    transition: border-color var(--dur-2) ease, box-shadow var(--dur-2) var(--ease-out);
   }
-  .ticker:hover { border-color: var(--accent); transform: translateY(-2px); }
-  .item { display: inline-flex; align-items: baseline; gap: 0.45rem; }
-  .count { font-size: 1.35rem; font-weight: 700; font-variant-numeric: tabular-nums; }
-  .item.hot .count { color: var(--accent); }
-  .label { color: var(--text-dim); font-size: 0.9rem; }
-  .cta { margin-left: auto; color: var(--accent); font-size: 0.9rem; font-weight: 600; }
+  .ticker:hover { border-color: var(--stroke-strong); box-shadow: var(--shadow-2); }
+  .item { display: inline-flex; align-items: center; gap: 0.5rem; color: var(--text-dim); }
+  .count {
+    font-size: var(--text-xl);
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    color: var(--text);
+  }
+  .item.hot { color: var(--hot); }
+  .item.hot .count { color: var(--hot); }
+  .label { font-size: 0.9rem; }
+  .cta {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: var(--accent);
+    font-size: 0.9rem;
+    font-weight: 600;
+  }
 </style>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -114,8 +114,8 @@ const jsonld = {
   jsonld={jsonld}
 >
   <Hero
-    title="Weather radar for everyone"
-    tagline="Live NEXRAD radar, warnings and storm tracking — straight from the public NOAA feeds to your own machine."
+    title="Where weather is"
+    tagline="Live NEXRAD radar, warnings and storm tracking — straight from the public NOAA feeds to your own machine. Free, open source, yours."
   />
 
   <section class="live">

--- a/site/src/scripts/active-site.ts
+++ b/site/src/scripts/active-site.ts
@@ -1,0 +1,119 @@
+/*
+  "Where is the weather right now?" — one national warning query, ranked onto the radar site that
+  sees the most of it. Used by the hero backdrop and (later) the storm-of-the-day tile, so the
+  promise is memoized at module level: one fetch per page, whoever asks first.
+
+  Everything is client-side and unauthenticated against api.weather.gov, which is CORS-open and
+  public. No key, no proxy, no backend.
+*/
+import sites from "../data/nexrad-sites.json";
+import { milesBetween } from "../data/geo";
+
+export interface ActiveSite {
+  id: string;
+  city: string;
+  state: string;
+  lat: number;
+  lon: number;
+  /** Warnings counted against this site. Zero when nothing is active and we fell back. */
+  warnings: number;
+}
+
+// ponytail: the three warning types the app leads with. Widening the query mostly adds marine and
+// hydrologic products that make for a duller backdrop.
+const EVENTS = ["Tornado Warning", "Severe Thunderstorm Warning", "Flash Flood Warning"];
+const WEIGHT: Record<string, number> = {
+  "Tornado Warning": 5,
+  "Severe Thunderstorm Warning": 2,
+  "Flash Flood Warning": 1,
+};
+
+// TDWR sites are terminal radars with a short range and no RIDGE loop; they never lead the page.
+const NEXRAD = sites.filter((s) => s.network !== "tdwr");
+type Site = (typeof NEXRAD)[number];
+
+const fallback = () => NEXRAD.find((s) => s.id === "KTLX") ?? NEXRAD[0];
+
+/** Mean of a polygon's outer ring — close enough to "where the warning is" for ranking. */
+function centroid(feature: any): { lat: number; lon: number } | null {
+  const ring = feature?.geometry?.coordinates?.[0];
+  if (!Array.isArray(ring) || !ring.length) return null; // zone-only alerts carry no geometry
+  let lat = 0;
+  let lon = 0;
+  for (const [x, y] of ring) {
+    lon += x;
+    lat += y;
+  }
+  return { lat: lat / ring.length, lon: lon / ring.length };
+}
+
+function nearest(point: { lat: number; lon: number }) {
+  let best: Site = NEXRAD[0];
+  let bestMiles = Infinity;
+  for (const site of NEXRAD) {
+    const miles = milesBetween(point, site);
+    if (miles < bestMiles) {
+      bestMiles = miles;
+      best = site;
+    }
+  }
+  return best;
+}
+
+async function visitorSite(): Promise<ActiveSite> {
+  // The site's own edge worker (site/public/_worker.js) hands back the visitor's rough location.
+  try {
+    const geo = await fetch("/geo.json").then((r) => (r.ok ? r.json() : null));
+    if (typeof geo?.lat === "number" && typeof geo?.lon === "number") {
+      return { ...nearest({ lat: geo.lat, lon: geo.lon }), warnings: 0 };
+    }
+  } catch {
+    // fall through
+  }
+  return { ...fallback(), warnings: 0 };
+}
+
+async function pick(): Promise<ActiveSite> {
+  try {
+    const url =
+      "https://api.weather.gov/alerts/active?status=actual&event=" +
+      // No Accept header: the API's preflight only allows API-Key and User-Agent, so asking for
+      // the lighter ld+json would fail CORS.
+      encodeURIComponent(EVENTS.join(","));
+    const data = await fetch(url).then((r) => (r.ok ? r.json() : Promise.reject(r.status)));
+    const scores = new Map<string, { score: number; count: number }>();
+    for (const feature of data?.features ?? []) {
+      const at = centroid(feature);
+      if (!at) continue;
+      const site = nearest(at);
+      const weight = WEIGHT[feature?.properties?.event] ?? 1;
+      const row = scores.get(site.id) ?? { score: 0, count: 0 };
+      row.score += weight;
+      row.count += 1;
+      scores.set(site.id, row);
+    }
+    let bestId: string | null = null;
+    let bestScore = 0;
+    for (const [id, row] of scores) {
+      if (row.score > bestScore) {
+        bestScore = row.score;
+        bestId = id;
+      }
+    }
+    if (bestId) {
+      const site = NEXRAD.find((s) => s.id === bestId)!;
+      return { ...site, warnings: scores.get(bestId)!.count };
+    }
+  } catch {
+    // A quiet map or a blocked fetch both land on the visitor's own radar, which is never wrong.
+  }
+  return visitorSite();
+}
+
+let cached: Promise<ActiveSite> | null = null;
+
+/** The most-active radar site right now, or the visitor's nearest when the country is quiet. */
+export function activeSite(): Promise<ActiveSite> {
+  cached ??= pick();
+  return cached;
+}


### PR DESCRIPTION
W4 of the REDESIGN 2 plan. Depends on #185, which is merged and live — verified: `app.hookecho.io/lite/?site=KTLX&hero=1` returns 200 and the deployed CSS carries the `body.hero` rules.

The hero was a JPEG of a live-radar product behind a click-to-load button. Now it is the product:

- **`src/scripts/active-site.ts`** — one national query for the three warning types the app leads with, each warning's polygon centroid snapped to the nearest NEXRAD site (TDWR excluded), scored tornado ×5 / severe ×2 / flash flood ×1. Highest score wins. Quiet country or a blocked fetch falls back to the visitor's nearest site via the existing `/geo.json` worker route, then to KTLX. The promise is memoized at module level so the storm-of-the-day tile in W5 reuses it for free. Reuses `data/geo.ts` `milesBetween` and the committed `nexrad-sites.json`.
- **`Hero.astro`** — full-bleed ~90vh. The poster paints first and is replaced by the `?hero=1` iframe once the ranking resolves; with JavaScript off the poster simply stays, which is what shipped before anyway. Scrim is three layers (bottom fade to `--bg`, vignette, `--mesh`) so the headline never fights the weather behind it. "Where weather is **NOW**" at `--text-display` with the full ramp on the last word — its one sanctioned text appearance. A LIVE chip names the site, city and warning count.
- **Ticker** — Phosphor icons per event, hot colours drawn from the ramp instead of one blue accent, and the counts animate through `motion.ts` when they scroll into view.

The iframe is `aria-hidden`, `pointer-events: none` and `tabindex="-1"`; all its data flows same-origin inside app.hookecho.io through the existing proxy, so nothing new is fetched cross-origin from the site beyond the alerts call the ticker already made.

## Verification

- `npm run build` clean; hero markup and the `grad-text` headline present in `dist/index.html`.
- Lite hero mode confirmed live in production before this was opened.
- Wanted on the preview: the poster→iframe swap on a throttled connection, reduced motion (loop holds on the newest scan), and the light-mode scrim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)