### PR TITLE
fix(site): compare teaser said the opposite of what it meant

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -96,12 +96,15 @@ const weatherdeskRepo = "https://github.com/d4vid87/weatherdesk";
 // The four rows that decide it for most people, pulled from the same data the full matrix uses so
 // the teaser can never disagree with the page it links to.
 import { COLS, ROWS } from "../data/compare";
-const teaserLabels = ["Price", "Ads", "Level 2 all tilts", "Open source"];
+const teaserLabels = ["Price", "Ads", "Open source", "Level 2, every tilt"];
 const teaserCols = [0, 1, 2]; // HookEcho, RadarScope, MyRadar
 const teaserRows = teaserLabels
   .map((label) => ROWS.find((r) => r.label === label))
   .filter((r): r is (typeof ROWS)[number] => Boolean(r));
-const mark = (v: string) => (v === "yes" ? "Yes" : v === "no" ? "No" : "Partly");
+// The cell's own qualifier is the label — `v` only says whether the answer is good for you, so
+// rendering it as a word turns "Ads: none" into "Ads: yes".
+const say = (cell: { v: string; t: string }) =>
+  cell.t || (cell.v === "yes" ? "Yes" : cell.v === "no" ? "No" : "Partly");
 
 const jsonld = {
   "@context": "https://schema.org",
@@ -281,7 +284,7 @@ const jsonld = {
                 <th scope="row">{row.label}</th>
                 {
                   teaserCols.map((c) => (
-                    <td class={row.cells[c].v} title={row.cells[c].t}>{mark(row.cells[c].v)}</td>
+                    <td class={row.cells[c].v}>{say(row.cells[c])}</td>
                   ))
                 }
               </tr>


### PR DESCRIPTION
The landing teaser rendered each cell's `v` flag as a word, but `v` says whether the answer is *good for you*, not whether the thing is present. So the ads row read "Ads — HookEcho: Yes, RadarScope: Yes", which is the exact opposite of the truth, on the page whose whole pitch is an honest comparison.

Now the cell's own qualifier is the label, which is what the full matrix shows on hover anyway:

| | HookEcho | RadarScope | MyRadar |
|---|---|---|---|
| Price | Free, MIT licensed | Paid app, subscription tiers | Free with ads, subscription |
| Ads | None | None | Unless you subscribe |
| Open source | Every line | No | No |
| Level 2, every tilt | All elevations, full resolution | All elevations | Mosaic imagery |

The colour still comes from `v`, so a win stays green and a partial stays amber.

Also fixes a silent bug from the same PR: the fourth row was requested as `"Level 2 all tilts"`, which is not a label in `compare.ts` — it was filtered out and the teaser quietly rendered three rows instead of four. The real label is `"Level 2, every tilt"`.

## Verification

- `npm run build` clean; the four rows and their wording confirmed in `dist/index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)