### PR TITLE
fix(chrome): archive-less sites said "(no volumes)" while live

### DIFF
--- a/crates/hookecho/src/app/chrome/scrubber.rs
+++ b/crates/hookecho/src/app/chrome/scrubber.rs
@@ -30,6 +30,13 @@ impl HookEchoApp {
             format!("\u{b7} {} ago", humanize(secs))
         });
         let loading = self.views[self.active].loading;
+        // TDWR and DWD radars publish no archive, so their timeline is empty by design and stays
+        // live. Saying "(no volumes)" there reads as a failed fetch while a live volume is on
+        // screen; only a site that HAS an archive can be genuinely missing one.
+        let archived = self.views[self.active]
+            .site
+            .as_deref()
+            .is_some_and(wxdata::sites::is_nexrad);
         let mut go_head = false;
         // Soonest rain arrival and the DVR buffer depth ride the pill: both are about time, and
         // both used to sit in an always-on chip in the opposite corner.
@@ -211,8 +218,10 @@ impl HookEchoApp {
                     if observed == 0 {
                         ui.weak(if t.listing {
                             "listing volumes\u{2026}"
-                        } else {
+                        } else if archived {
                             "(no volumes)"
+                        } else {
+                            "live only"
                         });
                     } else {
                         let readout = match t.forecast_hour() {


### PR DESCRIPTION
## Problem

Spotted in a DWD screenshot: the scrubber read `(no volumes)` while a live volume was rendering on the map.

TDWR and DWD radars publish no archive, so `app.rs` deliberately skips the listing for them — *"TDWRs and DWD radars have no archive to list; their timeline stays empty and always live."* The scrubber then fell through to the same string it shows when a NEXRAD site genuinely has no volumes for the selected day. All 17 DWD and 44 TDWR sites reported a failed-looking fetch that had never been attempted.

## Fix

Distinguish "has an archive and it's empty" from "has no archive at all". Archive-less sites read `live only`; NEXRAD keeps `(no volumes)`; `listing volumes…` is untouched.

Reuses the `wxdata::sites::is_nexrad` predicate the listing gate itself uses, so the label can't drift from the behavior it describes.

Not a data bug — display only. No fetch, timeline or dispatch changes.

## Verification

Gate: `cargo clippy --workspace --all-targets -- -D warnings` clean · `cargo test --workspace` 614 passed · wasm check builds · `./scripts/shots/shoot.sh check` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)