### PR TITLE
docs(odim): module doc said nothing fetches ODIM

### DIFF
--- a/crates/wxdata/src/odim.rs
+++ b/crates/wxdata/src/odim.rs
@@ -7,11 +7,18 @@
 //! look". Decoding it lands on the same [`Scan`] the NEXRAD path produces, so rendering, palettes,
 //! SRV and thresholds treat a European radar exactly like a WSR-88D.
 //!
-//! **This is decode only — nothing fetches ODIM yet.** There is no open volume-scan feed to point
-//! it at: Environment Canada publishes only rendered GIF/CAPPI imagery on Datamart and keeps its
-//! ODIM volumes behind HTTP basic auth, and OPERA's own archive is licensed. Germany's
-//! `opendata.dwd.de` is the likely first real consumer — it publishes single-sweep ODIM files
-//! without registration — and when that fetcher is written this module is what it hands bytes to.
+//! [`crate::dwd`] is the live consumer: `opendata.dwd.de` publishes single-sweep ODIM files
+//! without registration, one per elevation, and hands the bytes here. Other European volumes are
+//! harder to reach — Environment Canada publishes only rendered GIF/CAPPI imagery on Datamart and
+//! keeps its ODIM volumes behind HTTP basic auth, and OPERA's own archive is licensed.
+//!
+//! # Azimuth registration
+//!
+//! Rays are decoded in file order, azimuth `(i + 0.5) × 360/nrays`, and `a1gate` is deliberately
+//! ignored. ODIM's `a1gate` names the ray radiated *first in time*, not the ray pointing north:
+//! DWD files carry values like 55 or 247 while `/dataset<n>/how/startazA[0]` is ~0.01°, so ray 0
+//! already starts at north. Rotating the sweep by `a1gate` would misregister it by that many
+//! degrees. Verified against live DWD volumes; do not "fix" this without checking `startazA`.
 
 use chrono::{DateTime, NaiveDate, NaiveTime, TimeZone, Utc};
 use hdf5lite::Value;


### PR DESCRIPTION
## Problem

`odim.rs`'s header still read **"This is decode only — nothing fetches ODIM yet"** and speculated that `opendata.dwd.de` was "the likely first real consumer". `dwd.rs` has fetched it for a release.

## Change

- Header now names `crate::dwd` as the live consumer and keeps the genuinely still-true part (Environment Canada is auth-walled, OPERA's archive is licensed).
- New **Azimuth registration** section recording why `a1gate` is ignored.

That second half is the useful bit. `a1gate` was the presumed cause of the DWD render bug and was wrong: it names the ray radiated *first in time*, not the ray pointing north. DWD files carry values like 55 or 247 while `/dataset<n>/how/startazA[0]` is ~0.01°, so ray 0 already starts at north — "fixing" it would misregister every sweep by that many degrees. The real cause was the azimuth binner, fixed in #191.

Cheap trap to fall into twice, so the reasoning now sits next to the code instead of in a plan file.

Docs only — no code changes.

## Verification

`cargo clippy -p wxdata --all-targets -- -D warnings` clean · `cargo doc -p wxdata --no-deps` resolves the new `crate::dwd` link (remaining warnings are pre-existing, in other modules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)