### PR TITLE
feat(web): DWD radars on the web build, and Esri basemaps that load

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -8629,11 +8629,7 @@ impl HookEchoApp {
             let dwd = wxdata::dwd::is_dwd(&site);
             self.spawner.spawn(async move {
                 let fetched = match dwd {
-                    #[cfg(not(target_arch = "wasm32"))]
                     true => wxdata::dwd::fetch_volume(&http, &site).await,
-                    // `dwd::SITES` is empty on wasm, so no view can be holding a German site.
-                    #[cfg(target_arch = "wasm32")]
-                    true => unreachable!("the web build offers no DWD sites"),
                     false => wxdata::tdwr::fetch_volume(&http, &site).await,
                 };
                 let msg = match fetched {

--- a/crates/hookecho/src/serve.rs
+++ b/crates/hookecho/src/serve.rs
@@ -792,6 +792,8 @@ const ALLOWED_HOSTS: &[&str] = &[
     "www.spotternetwork.org",
     "api.open-meteo.com",
     "gibs.earthdata.nasa.gov",
+    // European radar.
+    "opendata.dwd.de",
     // Basemap and imagery tiles.
     "api.mapbox.com",
     "api.maptiler.com",

--- a/crates/hookecho/src/tiles.rs
+++ b/crates/hookecho/src/tiles.rs
@@ -679,19 +679,19 @@ impl BasemapStyle {
                 BasemapStyle::HybridSatellite => Some(format!(
                     "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
                 )),
-                // The extra Esri services live on `services.` rather than `server.`; both hosts
-                // are already in the proxy allowlist.
+                // These four also answer on `services.arcgisonline.com`, but only `server.` is in
+                // the proxy allowlist, so the web build 403s on that host. Same tiles either way.
                 BasemapStyle::EsriDarkGray => Some(format!(
-                    "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}"
+                    "https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}"
                 )),
                 BasemapStyle::EsriLightGray => Some(format!(
-                    "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}"
+                    "https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}"
                 )),
                 BasemapStyle::EsriNatGeo => Some(format!(
-                    "https://services.arcgisonline.com/ArcGIS/rest/services/NatGeo_World_Map/MapServer/tile/{z}/{y}/{x}"
+                    "https://server.arcgisonline.com/ArcGIS/rest/services/NatGeo_World_Map/MapServer/tile/{z}/{y}/{x}"
                 )),
                 BasemapStyle::EsriOcean => Some(format!(
-                    "https://services.arcgisonline.com/ArcGIS/rest/services/Ocean/World_Ocean_Base/MapServer/tile/{z}/{y}/{x}"
+                    "https://server.arcgisonline.com/ArcGIS/rest/services/Ocean/World_Ocean_Base/MapServer/tile/{z}/{y}/{x}"
                 )),
                 BasemapStyle::CustomXyz => valid_xyz_template(custom)
                     .then(|| crate::vector_tiles::fill_template(custom, z, x, y)),

--- a/crates/wxdata/src/dwd.rs
+++ b/crates/wxdata/src/dwd.rs
@@ -12,27 +12,23 @@
 //! Each has a `-LATEST-` symlink beside it, which is what makes this feed cheap to poll: no
 //! directory index, ten predictable URLs, fetched together.
 //!
-//! Not offered on the web build. A volume is ten unfiltered files of ~440 KB, and every browser
-//! fetch would have to run through the shared `/proxy/` edge cache — 4.4 MB per site per five
-//! minutes of someone else's bandwidth. Native and Android fetch `opendata.dwd.de` directly, so
-//! they carry it; [`SITES`] is empty on wasm and nothing offers a German radar there.
+//! Every build offers it. `opendata.dwd.de` sends no `Access-Control-Allow-Origin`, so the browser
+//! reaches it through the same `/proxy/` route as every other feed (`crate::net::fetch_url`),
+//! which puts a volume — ten unfiltered files of ~440 KB — on the shared edge cache. That is real
+//! bandwidth, and it is the price of a radar app that draws Germany in a browser.
 //!
 //! Reflectivity only. Velocity is published (`sweep_vol_v/`) but has no `-LATEST-` symlink, so
 //! reaching it means downloading a 1 MB HTML directory index per poll to learn one filename.
 //! ponytail: reflectivity-only until someone asks for velocity; the upgrade is one index fetch
 //! per volume, whose newest-per-elevation names also unlock ZDR/RHOHV/PHIDP.
 
-#[cfg(not(target_arch = "wasm32"))]
 use chrono::{DateTime, Utc};
-#[cfg(not(target_arch = "wasm32"))]
 use nexrad_model::data::{Scan, Sweep};
 use nexrad_model::meta::registry::SiteEntry;
 
-#[cfg(not(target_arch = "wasm32"))]
 const BASE: &str = "https://opendata.dwd.de/weather/radar/sites/sweep_vol_z";
 
 /// Elevations in a `vol5minng01` scan. They are numbered by publication slot, not by angle.
-#[cfg(not(target_arch = "wasm32"))]
 const TILTS: u8 = 10;
 
 const fn site(
@@ -54,17 +50,12 @@ const fn site(
 }
 
 /// Every DWD radar the build offers, as registry entries so they interchange with WSR-88Ds
-/// everywhere the app looks a site up — empty on wasm, where the feed is too heavy to proxy. `state` carries the German Land, which is what the site list shows.
+/// everywhere the app looks a site up. `state` carries the German Land, which is what the site
+/// list shows.
 ///
 /// Coordinates and heights are the ones each radar reports in its own ODIM `/where` group, read
 /// out of a live file per site rather than transcribed from a table.
-pub const SITES: &[SiteEntry] = if cfg!(target_arch = "wasm32") {
-    &[]
-} else {
-    ALL_SITES
-};
-
-const ALL_SITES: &[SiteEntry] = &[
+pub const SITES: &[SiteEntry] = &[
     site("DEAS", "Borkum", "NI", 53.5641, 6.7483, 36),
     site("DEBO", "Boostedt", "SH", 54.0044, 10.0469, 124),
     site("DEDR", "Dresden", "SN", 51.1246, 13.7686, 263),
@@ -86,7 +77,6 @@ const ALL_SITES: &[SiteEntry] = &[
 
 /// The URL path slug and WMO number each site's files are named with. Neither is derivable from
 /// the four-letter id (`DEAS` lives under `asb`), so both are carried explicitly.
-#[cfg(not(target_arch = "wasm32"))]
 const PATHS: [(&str, &str, u16); 17] = [
     ("DEAS", "asb", 10103),
     ("DEBO", "boo", 10132),
@@ -117,7 +107,6 @@ pub fn is_dwd(id: &str) -> bool {
     site_by_id(id).is_some()
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 fn path_for(id: &str) -> Option<(&'static str, u16)> {
     PATHS
         .iter()
@@ -129,7 +118,6 @@ fn path_for(id: &str) -> Option<(&'static str, u16)> {
 ///
 /// `th` is total (unfiltered) horizontal reflectivity. The clutter-filtered `dbzh` product has no
 /// `-LATEST-` symlink, so unfiltered is the only version reachable without a directory index.
-#[cfg(not(target_arch = "wasm32"))]
 fn sweep_url(slug: &str, wmo: u16, tilt: u8) -> String {
     format!(
         "{BASE}/{slug}/unfiltered/ras07-vol5minng01_sweeph5onem_th_{tilt:02}-LATEST-{slug}-{wmo}-hd5"
@@ -140,7 +128,6 @@ fn sweep_url(slug: &str, wmo: u16, tilt: u8) -> String {
 ///
 /// DWD's slot numbering is not elevation order, and everything downstream — the tilt selector,
 /// cross sections, the derived grids — assumes sweep 1 is the base tilt.
-#[cfg(not(target_arch = "wasm32"))]
 fn assemble(mut parts: Vec<(f32, Sweep)>) -> Vec<Sweep> {
     parts.sort_by(|a, b| a.0.total_cmp(&b.0));
     parts
@@ -156,7 +143,6 @@ fn assemble(mut parts: Vec<(f32, Sweep)>) -> Vec<Sweep> {
 ///
 /// Returns the scan plus a volume name and time. The URLs never change, so the name is built from
 /// the volume's own start time — that is what the app's "has this volume changed?" check compares.
-#[cfg(not(target_arch = "wasm32"))]
 pub async fn fetch_volume(
     http: &reqwest::Client,
     id: &str,
@@ -250,8 +236,8 @@ mod tests {
 
     #[test]
     fn every_site_has_a_path_and_the_two_tables_agree() {
-        assert_eq!(ALL_SITES.len(), PATHS.len());
-        for s in ALL_SITES {
+        assert_eq!(SITES.len(), PATHS.len());
+        for s in SITES {
             let (slug, wmo) = path_for(s.id).unwrap_or_else(|| panic!("{} has no path", s.id));
             assert_eq!(slug.len(), 3, "{} slug", s.id);
             assert!(slug.chars().all(|c| c.is_ascii_lowercase()), "{} slug", s.id);

--- a/scripts/web/build.sh
+++ b/scripts/web/build.sh
@@ -89,7 +89,9 @@ gz_bytes="$(gzip -9 -c "web/dist/hookecho_bg-$wasm_hash.wasm" | wc -c)"
 # ponytail: a regression gate, not an aspiration. It is set just above what the current build
 # produces, so a careless new dependency trips it; getting the number meaningfully lower means
 # cutting fonts (~1.9 MB of TTF) or a wgpu backend, and neither is free. Raise it deliberately.
-budget="${HOOKECHO_WASM_BUDGET:-4882000}"
+# The number tracks CI's build, which runs ~15 KB above a local one, so a local build has that
+# much slack; CI is the gate that matters.
+budget="${HOOKECHO_WASM_BUDGET:-4897000}"
 printf 'wasm: %s raw, %s gzipped (budget %s)\n' \
   "$(stat -c%s "web/dist/hookecho_bg-$wasm_hash.wasm")" "$gz_bytes" "$budget"
 if [ "$gz_bytes" -gt "$budget" ]; then

--- a/scripts/web/build.sh
+++ b/scripts/web/build.sh
@@ -89,7 +89,7 @@ gz_bytes="$(gzip -9 -c "web/dist/hookecho_bg-$wasm_hash.wasm" | wc -c)"
 # ponytail: a regression gate, not an aspiration. It is set just above what the current build
 # produces, so a careless new dependency trips it; getting the number meaningfully lower means
 # cutting fonts (~1.9 MB of TTF) or a wgpu backend, and neither is free. Raise it deliberately.
-budget="${HOOKECHO_WASM_BUDGET:-4880000}"
+budget="${HOOKECHO_WASM_BUDGET:-4882000}"
 printf 'wasm: %s raw, %s gzipped (budget %s)\n' \
   "$(stat -c%s "web/dist/hookecho_bg-$wasm_hash.wasm")" "$gz_bytes" "$budget"
 if [ "$gz_bytes" -gt "$budget" ]; then

--- a/web/_worker.js/proxy-core.js
+++ b/web/_worker.js/proxy-core.js
@@ -48,6 +48,8 @@ export const ALLOWED_HOSTS = [
   "www.spotternetwork.org",
   "api.open-meteo.com",
   "gibs.earthdata.nasa.gov",
+  // European radar.
+  "opendata.dwd.de",
   // Basemap and imagery tiles.
   "api.mapbox.com",
   "api.maptiler.com",
@@ -74,6 +76,9 @@ export const MAX_BYTES = 64 * 1024 * 1024;
 export const LIVE_HOSTS = new Set([
   "unidata-nexrad-level2-chunks.s3.amazonaws.com",
   "api.weather.gov",
+  // DWD republishes every `-LATEST-` sweep on a five-minute cycle at a URL that never changes,
+  // so the default five-minute TTL can hand out the previous volume for the whole of the next one.
+  "opendata.dwd.de",
 ]);
 
 // Archived Level 2 volumes: the same four volumes are what every visitor on a given radar loads,


### PR DESCRIPTION
Two web-only defects, both in the proxy allowlist seam.

## DWD on web

`dwd::SITES` was empty on wasm and `spawn_fetch` had an `unreachable!` arm to match, so the browser build offered no German radar at all.

Pre-coding check, as planned: does `opendata.dwd.de` send `Access-Control-Allow-Origin`? **No** — a live sweep returns 200 with no ACAO header, so a direct browser fetch is not available and the proxy route is the only way. That means the shared `/proxy/` edge cache carries ~4.4 MB per site per five minutes. Paid deliberately; the module doc now says so instead of claiming the feed is native-only.

The fetch path already went through `net::fetch_url`, so removing the `#[cfg(not(target_arch = "wasm32"))]` gates was the whole change.

`opendata.dwd.de` is added to:
- `ALLOWED_HOSTS` in both `serve.rs` and `proxy-core.js` (byte-identical, drift check green)
- `LIVE_HOSTS` — the `-LATEST-` URLs never change and are rewritten every five minutes, so the default 300 s TTL would serve the previous volume for the whole of the next one

## Esri basemaps

`EsriDarkGray`, `EsriLightGray`, `EsriNatGeo` and `EsriOcean` were built against `services.arcgisonline.com`, next to a comment claiming both Esri hosts were in the allowlist. Only `server.` is — all four 403'd on the web build.

All four services answer identically on `server.arcgisonline.com` (checked: 200 on both hosts for each), so they are repointed. Zero allowlist growth.

## Size

The web build now links `odim`/`hdf5lite`: +19 KB gzipped locally (4861646 → 4880655). CI's build runs ~15 KB above a local one, so the budget tracks CI's number — 4895891 measured, budget set to 4897000.

## Verification

- Native proxy end-to-end: `/proxy/opendata.dwd.de/...` → 200, 193530 bytes starting `89 48 44 46` (HDF5 magic); `/proxy/server.arcgisonline.com/...Canvas/World_Dark_Gray_Base...` → 200
- allowlist drift check (the `demo.yml` awk/diff) run locally: identical
- `cargo clippy --workspace --all-targets -- -D warnings` · `cargo test --workspace` (614 passed) · wasm `cargo check` · `./scripts/shots/shoot.sh check` · `./scripts/web/build.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)