### PR TITLE
feat(opera): the OPERA network via EUMETNET OpenRadarData

### DIFF
--- a/crates/hookecho-lite/src/lib.rs
+++ b/crates/hookecho-lite/src/lib.rs
@@ -275,7 +275,10 @@ mod tests {
         let north = 50 * 201 + 100;
         let east = 100 * 201 + 150;
         // One slot of slack: the projection round-trip leaves a pixel a hair off the axis.
-        assert!(v.slot[north] <= 1 || v.slot[north] >= 719, "north is azimuth 0");
+        assert!(
+            v.slot[north] <= 1 || v.slot[north] >= 719,
+            "north is azimuth 0"
+        );
         assert!(
             v.slot[east].abs_diff((SLOTS / 4) as u16) <= 1,
             "east is 90 degrees, got slot {}",

--- a/crates/hookecho-lite/src/palette.rs
+++ b/crates/hookecho-lite/src/palette.rs
@@ -72,7 +72,9 @@ impl Table {
 }
 
 fn lerp(a: u8, b: u8, t: f32) -> u8 {
-    (a as f32 + (b as f32 - a as f32) * t).round().clamp(0.0, 255.0) as u8
+    (a as f32 + (b as f32 - a as f32) * t)
+        .round()
+        .clamp(0.0, 255.0) as u8
 }
 
 /// Parse a GRLevelX `.pal` v2 file. Only the keys the two built-in tables use are recognized;

--- a/crates/hookecho/build.rs
+++ b/crates/hookecho/build.rs
@@ -17,10 +17,7 @@ fn main() {
         let mut res = winresource::WindowsResource::new();
         res.set_icon("../../packaging/windows/icon.ico")
             .set("ProductName", "HookEcho")
-            .set(
-                "FileDescription",
-                "HookEcho — NEXRAD weather radar viewer",
-            )
+            .set("FileDescription", "HookEcho — NEXRAD weather radar viewer")
             .set("LegalCopyright", "MIT licensed");
         if let Err(e) = res.compile() {
             println!("cargo:warning=windows resource compile failed: {e}");

--- a/crates/hookecho/src/alert_rollup.rs
+++ b/crates/hookecho/src/alert_rollup.rs
@@ -106,7 +106,12 @@ mod tests {
         let mut r = Rollup::default();
         let t0 = Instant::now();
         for i in 0..4 {
-            let d = r.offer(t0 + Duration::from_secs(i * 10), "Severe Thunderstorm", 5, win());
+            let d = r.offer(
+                t0 + Duration::from_secs(i * 10),
+                "Severe Thunderstorm",
+                5,
+                win(),
+            );
             assert_eq!(d, Decision::Send, "alert {i}");
         }
     }
@@ -116,9 +121,15 @@ mod tests {
         let mut r = Rollup::default();
         let t0 = Instant::now();
         for i in 0..4 {
-            r.offer(t0 + Duration::from_secs(i * 10), "Severe Thunderstorm", 5, win());
+            r.offer(
+                t0 + Duration::from_secs(i * 10),
+                "Severe Thunderstorm",
+                5,
+                win(),
+            );
         }
-        let Decision::Rollup(text) = r.offer(t0 + Duration::from_secs(50), "Tornado Warning", 5, win())
+        let Decision::Rollup(text) =
+            r.offer(t0 + Duration::from_secs(50), "Tornado Warning", 5, win())
         else {
             panic!("fifth alert inside the window should roll up");
         };
@@ -126,11 +137,17 @@ mod tests {
         assert!(text.contains("Tornado Warning"));
         // Same minute: the summary is current, so nothing goes out.
         assert_eq!(
-            r.offer(t0 + Duration::from_secs(60), "Flash Flood Warning", 5, win()),
+            r.offer(
+                t0 + Duration::from_secs(60),
+                "Flash Flood Warning",
+                5,
+                win()
+            ),
             Decision::Hold
         );
         // A minute later it refreshes, now carrying the held one too.
-        let Decision::Rollup(text) = r.offer(t0 + Duration::from_secs(120), "Special Marine", 5, win())
+        let Decision::Rollup(text) =
+            r.offer(t0 + Duration::from_secs(120), "Special Marine", 5, win())
         else {
             panic!("summary should refresh after a minute");
         };
@@ -142,10 +159,20 @@ mod tests {
         let mut r = Rollup::default();
         let t0 = Instant::now();
         for i in 0..5 {
-            r.offer(t0 + Duration::from_secs(i * 10), "Severe Thunderstorm", 5, win());
+            r.offer(
+                t0 + Duration::from_secs(i * 10),
+                "Severe Thunderstorm",
+                5,
+                win(),
+            );
         }
         // Eleven minutes later the window holds only this one.
-        let d = r.offer(t0 + Duration::from_secs(11 * 60), "Tornado Warning", 5, win());
+        let d = r.offer(
+            t0 + Duration::from_secs(11 * 60),
+            "Tornado Warning",
+            5,
+            win(),
+        );
         assert_eq!(d, Decision::Send);
     }
 }

--- a/crates/hookecho/src/alert_snapshot.rs
+++ b/crates/hookecho/src/alert_snapshot.rs
@@ -66,7 +66,12 @@ mod tests {
 
     fn feat(id: &str, expires: Option<chrono::DateTime<chrono::Utc>>) -> GeoFeature {
         GeoFeature {
-            rings: vec![vec![[-98.0, 35.0], [-97.0, 35.0], [-97.0, 36.0], [-98.0, 35.0]]],
+            rings: vec![vec![
+                [-98.0, 35.0],
+                [-97.0, 35.0],
+                [-97.0, 36.0],
+                [-98.0, 35.0],
+            ]],
             fill: [255, 0, 0, 60],
             stroke: [255, 0, 0, 235],
             kind: FeatureKind::Warning,

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1771,7 +1771,15 @@ fn goto_link(g: &Goto) -> String {
 /// ponytail: a function, not a NOTICE file or a licence registry. Attribution belongs on the map
 /// beside the data it covers; if a distribution ever needs a bundled notice, generate it from here.
 fn data_attribution(site_id: &str) -> Option<&'static str> {
-    wxdata::dwd::is_dwd(site_id).then_some("Radar data © Deutscher Wetterdienst (DL-DE/BY-2.0)")
+    match wxdata::sites::network(site_id) {
+        wxdata::sites::Network::Dwd => Some("Radar data © Deutscher Wetterdienst (DL-DE/BY-2.0)"),
+        // ORD publishes every member's data under one licence, and the credit EUMETNET asks for
+        // names the network rather than the twenty national services behind it.
+        wxdata::sites::Network::Opera => {
+            Some("Radar data © EUMETNET OPERA / OpenRadarData (CC BY 4.0)")
+        }
+        _ => None,
+    }
 }
 
 /// How a lightning flash looks at `age_secs`: bright white-hot when it just happened, fading to a
@@ -3517,9 +3525,10 @@ impl HookEchoApp {
         ];
         /// Bit positions in the mask for the two hail grids.
         const HAIL_BITS: u8 = 0b11000;
-        let mask = LAYERS.iter().enumerate().fold(0u8, |m, (i, l)| {
-            m | u8::from(self.field_wanted(*l)) << i
-        });
+        let mask = LAYERS
+            .iter()
+            .enumerate()
+            .fold(0u8, |m, (i, l)| m | u8::from(self.field_wanted(*l)) << i);
         if mask == 0 {
             self.derived_key = None;
             return;
@@ -8630,16 +8639,20 @@ impl HookEchoApp {
         ctx: egui::Context,
     ) {
         let tx = self.msg_tx.clone();
-        if !wxdata::sites::is_nexrad(&site) {
-            // Neither network has a Level 2 feed or an archive: one volume per poll, synthesized
+        let network = wxdata::sites::network(&site);
+        if network != wxdata::sites::Network::Nexrad {
+            // None of these has a Level 2 feed or an archive: one volume per poll, synthesized
             // from the newest Level 3 tilt products (TDWR) or assembled from the newest ODIM
-            // sweep files (DWD).
+            // files (DWD, OPERA).
             let http = self.http.clone();
-            let dwd = wxdata::dwd::is_dwd(&site);
             self.spawner.spawn(async move {
-                let fetched = match dwd {
-                    true => wxdata::dwd::fetch_volume(&http, &site).await,
-                    false => wxdata::tdwr::fetch_volume(&http, &site).await,
+                use wxdata::sites::Network;
+                let fetched = match network {
+                    Network::Dwd => wxdata::dwd::fetch_volume(&http, &site).await,
+                    Network::Opera => wxdata::opera::fetch_volume(&http, &site).await,
+                    Network::Tdwr | Network::Nexrad => {
+                        wxdata::tdwr::fetch_volume(&http, &site).await
+                    }
                 };
                 let msg = match fetched {
                     Ok((name, _, _)) if current_name.as_deref() == Some(name.as_str()) => {
@@ -9989,16 +10002,15 @@ impl HookEchoApp {
                     })
                     .flatten();
                 // A watch zone under the click, when nothing more specific is there.
-                let zone_hit = (marker_hit.is_none()
-                    && peer_hit.is_none()
-                    && tool == MapTool::Interrogate)
-                    .then(|| {
-                        self.settings
-                            .alert_polygons
-                            .iter()
-                            .position(|z| point_in_ring_ll(&z.ring, lon, lat))
-                    })
-                    .flatten();
+                let zone_hit =
+                    (marker_hit.is_none() && peer_hit.is_none() && tool == MapTool::Interrogate)
+                        .then(|| {
+                            self.settings
+                                .alert_polygons
+                                .iter()
+                                .position(|z| point_in_ring_ll(&z.ring, lon, lat))
+                        })
+                        .flatten();
                 // Interrogate + a click on a radar-site ring switches radars (storm features win,
                 // handled inside try_pick_site). Consumes the click so no popup opens underneath.
                 let picked_site = marker_hit.is_none()
@@ -12161,7 +12173,10 @@ impl HookEchoApp {
 
         // The difference layer reads as "they disagree here" and nothing more without a number,
         // so the cursor samples the grid it was drawn from.
-        if view.fields_on.contains(&crate::render::FieldLayer::ModelDiff) {
+        if view
+            .fields_on
+            .contains(&crate::render::FieldLayer::ModelDiff)
+        {
             if let (Some(grid), Some(hp)) = (self.diff_grid.as_ref(), response.hover_pos()) {
                 let w = cam.screen_to_world((hp.x - prect.left(), hp.y - prect.top()), vp);
                 let (lon, lat) = crate::render::mercator::world_to_lonlat(w.0, w.1);
@@ -13463,7 +13478,8 @@ impl HookEchoApp {
                 .find(|m| m.home)
                 .map(|m| (m.lon, m.lat))
         });
-        let line = here.and_then(|(lon, lat)| widget_storm_line(self.active_storm_cells(), lon, lat));
+        let line =
+            here.and_then(|(lon, lat)| widget_storm_line(self.active_storm_cells(), lon, lat));
         match line {
             Some(line) => {
                 if let Err(e) = std::fs::write(&path, line) {
@@ -13628,9 +13644,7 @@ impl HookEchoApp {
                         );
                         // The mark rides with the caption: a shared loop travels without the app
                         // around it, and the wordmark alone is not what anyone recognises.
-                        ui.add(
-                            egui::Image::new(&logo).fit_to_exact_size(egui::vec2(16.0, 16.0)),
-                        );
+                        ui.add(egui::Image::new(&logo).fit_to_exact_size(egui::vec2(16.0, 16.0)));
                         ui.label(
                             egui::RichText::new("HookEcho · data: NOAA/NWS")
                                 .size(crate::ui::style::FONT_SM)
@@ -14554,8 +14568,8 @@ impl eframe::App for HookEchoApp {
             };
             // The reflectivity tint reads the precipitation-type grid whether or not that
             // layer is being drawn, so wanting the tint counts as wanting the layer's data.
-            let wanted = self.field_wanted(layer)
-                || (layer == FL::PrecipType && self.settings.precip_tint);
+            let wanted =
+                self.field_wanted(layer) || (layer == FL::PrecipType && self.settings.precip_tint);
             let stale = wanted
                 && self.fields.get(&layer).is_none_or(|s| {
                     s.last_fetch
@@ -15147,7 +15161,10 @@ impl eframe::App for HookEchoApp {
                 // Nobody chose this site, so say which one it is and that it can be changed.
                 self.toast(
                     ToastKind::Info,
-                    format!("Nearest radar: {} — change it any time in the panel", fin.site),
+                    format!(
+                        "Nearest radar: {} — change it any time in the panel",
+                        fin.site
+                    ),
                 );
             }
             if fin.take_tour {
@@ -15308,9 +15325,12 @@ impl eframe::App for HookEchoApp {
                 Err(e) => self.marker_window.status = Some(e),
             }
         }
-        let query = self
-            .marker_window
-            .show(ctx, &mut self.settings, &self.marker_icon_tex, &mut self.drawer);
+        let query = self.marker_window.show(
+            ctx,
+            &mut self.settings,
+            &self.marker_icon_tex,
+            &mut self.drawer,
+        );
         // The map popup indexes into the same list: a delete above it leaves it describing the
         // wrong marker, which is the one way this UI can lie about which place you are editing.
         if let (Some(gone), Some(open)) = (self.marker_window.removed, self.marker_popup) {
@@ -15362,7 +15382,9 @@ impl eframe::App for HookEchoApp {
                 }
             }
         }
-        if let Some(ui::digest_window::DigestAction::Generate) = self.digest_window.show(ctx, &mut self.drawer) {
+        if let Some(ui::digest_window::DigestAction::Generate) =
+            self.digest_window.show(ctx, &mut self.drawer)
+        {
             self.generate_digest();
         }
         // Live station cards. Video keeps arriving between input events, so a playing card asks
@@ -15627,7 +15649,10 @@ impl eframe::App for HookEchoApp {
         // same destination as clicking the dot on the map.
         let entries = self.palette_entries();
         let bindings = crate::hotkeys::active(&self.settings).into_owned();
-        if self.help_hub.show(ctx, &mut self.drawer, &bindings, &entries) {
+        if self
+            .help_hub
+            .show(ctx, &mut self.drawer, &bindings, &entries)
+        {
             self.tour.start();
         }
         let cells: &[Cell] = if self.archive_bucket().is_some() {
@@ -15828,9 +15853,13 @@ impl eframe::App for HookEchoApp {
         if self.show_cappi {
             self.update_cappi(ctx);
             let open = match self.cappi_tex.clone() {
-                Some(tex) => {
-                    ui::cappi_window::show(ctx, &tex, &mut self.cappi_alt_km, 300.0, &mut self.drawer)
-                }
+                Some(tex) => ui::cappi_window::show(
+                    ctx,
+                    &tex,
+                    &mut self.cappi_alt_km,
+                    300.0,
+                    &mut self.drawer,
+                ),
                 None => ui::cappi_window::show_empty(ctx, &mut self.drawer),
             };
             self.show_cappi = open;

--- a/crates/hookecho/src/app/chrome/chips.rs
+++ b/crates/hookecho/src/app/chrome/chips.rs
@@ -282,8 +282,7 @@ impl HookEchoApp {
                                     .color(accent),
                             );
                             ui.hyperlink_to(
-                                egui::RichText::new("Download")
-                                    .size(crate::ui::style::FONT_BASE),
+                                egui::RichText::new("Download").size(crate::ui::style::FONT_BASE),
                                 format!("{}/releases/latest", crate::ui::about_window::REPO),
                             );
                             if ui

--- a/crates/hookecho/src/app/chrome/overlay.rs
+++ b/crates/hookecho/src/app/chrome/overlay.rs
@@ -100,157 +100,157 @@ impl HookEchoApp {
         let sheets_layout = sheets(ctx);
         let mut sheet_close = false;
         let mut body = |ui: &mut egui::Ui| {
-                    // Title on the same line as the tabs: the name is branding, not a section, and
-                    // its own row plus separator cost 30 px of every screen height.
-                    ui.horizontal(|ui| {
-                        if !phone() {
-                            ui.label(
-                                egui::RichText::new("HookEcho")
-                                    .size(13.0)
-                                    .strong()
-                                    .color(accent),
-                            );
-                            ui.add_space(4.0);
-                        }
-                        // Data | Alerts. `show_alert_panel` is the same flag the bell and the A hotkey
-                        // flip, so every entry point lands on the same tab.
-                        if ui.selectable_label(!alerts_tab, "Data").clicked() {
-                            alerts_tab = false;
-                        }
-                        let label = if alert_count == 0 {
-                            "Alerts".to_string()
-                        } else {
-                            format!("Alerts ({alert_count})")
-                        };
-                        if ui.selectable_label(alerts_tab, label).clicked() {
-                            alerts_tab = true;
-                        }
-                        // Collapse, on the row it collapses. The floating button that brings the
-                        // panel back lands in the same corner this one sits in. The sheet has a
-                        // ✕ of its own, so the phone does not draw a second one.
-                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                            if !phone()
-                                && ui
-                                .add(
-                                    egui::Button::new(
-                                        egui::RichText::new(egui_phosphor::regular::X).size(14.0),
-                                    )
-                                    .fill(egui::Color32::TRANSPARENT)
-                                    .stroke(egui::Stroke::NONE),
-                                )
-                                .named("Close this panel")
-                                .clicked()
-                            {
-                                hide = true;
-                            }
-                        });
-                    });
-                    ui.separator();
-                    if alerts_tab {
-                        alert_hit = ui::alert_panel::body(ui, &feats, bounds, &mut muted);
-                        return;
-                    }
-                    self.product_section(ui, &mut opts);
-                    ui.separator();
-                    // A drag rewrites the order in place, so persist it when it moves.
-                    let order_was = self.settings.layer_order.clone();
-                    chosen = ui::layers_panel::body(
-                        ui,
-                        &entries,
-                        &mut query,
-                        accent,
-                        // Leave room for the disclosures under the tree, whatever the window
-                        // height. In the sheet there is no height to read yet — it scrolls — so
-                        // the tree takes half the screen and the rest scrolls past it.
-                        if sheets_layout {
-                            chrome.height() * 0.5
-                        } else {
-                            (ui.available_height() - 110.0).max(120.0)
-                        },
-                        std::mem::take(&mut focus_search),
-                        &mut self.settings.layer_order,
-                        |ui| {
-                            // Knobs for the layers that are already on, drawn between the Radar group
-                            // and the rest. Collapsed by default: the list is still the panel's job.
-                            egui::CollapsingHeader::new("Layer options")
-                                .default_open(false)
-                                .show(ui, |ui| {
-                                    let glm_options = self.show_glm
-                                        || self.views[self.active]
-                                            .fields_on
-                                            .contains(&crate::render::FieldLayer::GlmFed);
-                                    crate::ui::layer_options::show(
-                                        ui,
-                                        &mut self.filters,
-                                        &mut self.fields,
-                                        &self.views[self.active].fields_on.clone(),
-                                        &mut self.rotation_minutes,
-                                        &mut self.hail_minutes,
-                                        &mut self.hrrr_fcst_hour,
-                                        self.hrrr_valid,
-                                        tz,
-                                        &mut self.env_cape_ml,
-                                        &mut self.env_srh_km,
-                                        &mut self.env_model,
-                                        &mut self.contour_kind,
-                                        &mut etop_dbz,
-                                        &mut self.snow_hours,
-                                        &self.show_tropical,
-                                        &mut self.tropical_wind_kt,
-                                        &mut self.tropical_surge,
-                                        l3_site.as_deref(),
-                                        &mut self.global_model,
-                                        &mut self.global_fcst_hour,
-                                        &mut self.diff_field,
-                                        self.diff_valid.as_ref(),
-                                        &mut self.settings.lightning_minutes,
-                                        glm_options,
-                                        &mut self.settings.glm_goes_west,
-                                        self.show_spotters,
-                                        &mut self.settings.spotter_range_km,
-                                        &mut self.settings.detectors,
-                                        Some(mosaic.as_str()),
-                                        &mut opts,
-                                    );
-                                });
-                        },
+            // Title on the same line as the tabs: the name is branding, not a section, and
+            // its own row plus separator cost 30 px of every screen height.
+            ui.horizontal(|ui| {
+                if !phone() {
+                    ui.label(
+                        egui::RichText::new("HookEcho")
+                            .size(13.0)
+                            .strong()
+                            .color(accent),
                     );
-                    self.settings.etop_dbz = etop_dbz;
-                    if self.settings.layer_order != order_was {
-                        self.settings.save();
-                    }
-                    // Place search folds in here rather than keeping a pill of its own: action
-                    // matches rank first, and this row is the explicit "I meant a place" answer.
-                    if !query.trim().is_empty() {
-                        ui.add_space(4.0);
-                        let w = ui.available_width();
-                        if ui
+                    ui.add_space(4.0);
+                }
+                // Data | Alerts. `show_alert_panel` is the same flag the bell and the A hotkey
+                // flip, so every entry point lands on the same tab.
+                if ui.selectable_label(!alerts_tab, "Data").clicked() {
+                    alerts_tab = false;
+                }
+                let label = if alert_count == 0 {
+                    "Alerts".to_string()
+                } else {
+                    format!("Alerts ({alert_count})")
+                };
+                if ui.selectable_label(alerts_tab, label).clicked() {
+                    alerts_tab = true;
+                }
+                // Collapse, on the row it collapses. The floating button that brings the
+                // panel back lands in the same corner this one sits in. The sheet has a
+                // ✕ of its own, so the phone does not draw a second one.
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    if !phone()
+                        && ui
                             .add(
                                 egui::Button::new(
-                                    egui::RichText::new(format!(
-                                        "{}  Fly to \u{201c}{}\u{201d}",
-                                        egui_phosphor::regular::MAP_PIN,
-                                        query.trim()
-                                    ))
-                                    .size(13.0),
+                                    egui::RichText::new(egui_phosphor::regular::X).size(14.0),
                                 )
-                                .min_size(egui::vec2(w, 34.0))
-                                .corner_radius(10.0),
+                                .fill(egui::Color32::TRANSPARENT)
+                                .stroke(egui::Stroke::NONE),
                             )
-                            .named("Search the place name and move the map there")
+                            .named("Close this panel")
                             .clicked()
-                        {
-                            fly_to = Some(query.trim().to_string());
-                        }
+                    {
+                        hide = true;
                     }
-                    ui.add_space(4.0);
-                    // The set-once map knobs, and the app's own commands.
-                    egui::CollapsingHeader::new("Map")
+                });
+            });
+            ui.separator();
+            if alerts_tab {
+                alert_hit = ui::alert_panel::body(ui, &feats, bounds, &mut muted);
+                return;
+            }
+            self.product_section(ui, &mut opts);
+            ui.separator();
+            // A drag rewrites the order in place, so persist it when it moves.
+            let order_was = self.settings.layer_order.clone();
+            chosen = ui::layers_panel::body(
+                ui,
+                &entries,
+                &mut query,
+                accent,
+                // Leave room for the disclosures under the tree, whatever the window
+                // height. In the sheet there is no height to read yet — it scrolls — so
+                // the tree takes half the screen and the rest scrolls past it.
+                if sheets_layout {
+                    chrome.height() * 0.5
+                } else {
+                    (ui.available_height() - 110.0).max(120.0)
+                },
+                std::mem::take(&mut focus_search),
+                &mut self.settings.layer_order,
+                |ui| {
+                    // Knobs for the layers that are already on, drawn between the Radar group
+                    // and the rest. Collapsed by default: the list is still the panel's job.
+                    egui::CollapsingHeader::new("Layer options")
                         .default_open(false)
-                        .show(ui, |ui| self.map_rows(ui, &mut opts));
-                    egui::CollapsingHeader::new("App")
-                        .default_open(false)
-                        .show(ui, |ui| self.app_rows(ui));
+                        .show(ui, |ui| {
+                            let glm_options = self.show_glm
+                                || self.views[self.active]
+                                    .fields_on
+                                    .contains(&crate::render::FieldLayer::GlmFed);
+                            crate::ui::layer_options::show(
+                                ui,
+                                &mut self.filters,
+                                &mut self.fields,
+                                &self.views[self.active].fields_on.clone(),
+                                &mut self.rotation_minutes,
+                                &mut self.hail_minutes,
+                                &mut self.hrrr_fcst_hour,
+                                self.hrrr_valid,
+                                tz,
+                                &mut self.env_cape_ml,
+                                &mut self.env_srh_km,
+                                &mut self.env_model,
+                                &mut self.contour_kind,
+                                &mut etop_dbz,
+                                &mut self.snow_hours,
+                                &self.show_tropical,
+                                &mut self.tropical_wind_kt,
+                                &mut self.tropical_surge,
+                                l3_site.as_deref(),
+                                &mut self.global_model,
+                                &mut self.global_fcst_hour,
+                                &mut self.diff_field,
+                                self.diff_valid.as_ref(),
+                                &mut self.settings.lightning_minutes,
+                                glm_options,
+                                &mut self.settings.glm_goes_west,
+                                self.show_spotters,
+                                &mut self.settings.spotter_range_km,
+                                &mut self.settings.detectors,
+                                Some(mosaic.as_str()),
+                                &mut opts,
+                            );
+                        });
+                },
+            );
+            self.settings.etop_dbz = etop_dbz;
+            if self.settings.layer_order != order_was {
+                self.settings.save();
+            }
+            // Place search folds in here rather than keeping a pill of its own: action
+            // matches rank first, and this row is the explicit "I meant a place" answer.
+            if !query.trim().is_empty() {
+                ui.add_space(4.0);
+                let w = ui.available_width();
+                if ui
+                    .add(
+                        egui::Button::new(
+                            egui::RichText::new(format!(
+                                "{}  Fly to \u{201c}{}\u{201d}",
+                                egui_phosphor::regular::MAP_PIN,
+                                query.trim()
+                            ))
+                            .size(13.0),
+                        )
+                        .min_size(egui::vec2(w, 34.0))
+                        .corner_radius(10.0),
+                    )
+                    .named("Search the place name and move the map there")
+                    .clicked()
+                {
+                    fly_to = Some(query.trim().to_string());
+                }
+            }
+            ui.add_space(4.0);
+            // The set-once map knobs, and the app's own commands.
+            egui::CollapsingHeader::new("Map")
+                .default_open(false)
+                .show(ui, |ui| self.map_rows(ui, &mut opts));
+            egui::CollapsingHeader::new("App")
+                .default_open(false)
+                .show(ui, |ui| self.app_rows(ui));
         };
         if sheets(ctx) {
             let title = if alerts_tab_was {
@@ -383,7 +383,10 @@ impl HookEchoApp {
                         // The tour's "everything else" stop points here: the pill is always on
                         // screen, where the panel it opens is not.
                         anchor = Some(menu.rect);
-                        if menu.named_toggle("Show or hide the panel", self.panel_open).clicked() {
+                        if menu
+                            .named_toggle("Show or hide the panel", self.panel_open)
+                            .clicked()
+                        {
                             self.panel_open = !self.panel_open;
                         }
                         if phone() {
@@ -534,10 +537,8 @@ impl HookEchoApp {
             .show(ctx, |ui| {
                 crate::ui::style::glass(ui, 238).show(ui, |ui| {
                     let w = 28.0 * n as f32;
-                    let (rect, resp) = ui.allocate_exact_size(
-                        egui::vec2(w, 24.0),
-                        egui::Sense::click_and_drag(),
-                    );
+                    let (rect, resp) =
+                        ui.allocate_exact_size(egui::vec2(w, 24.0), egui::Sense::click_and_drag());
                     for i in 0..n {
                         let c = egui::pos2(rect.left() + 28.0 * (i as f32 + 0.5), rect.center().y);
                         let on = i == self.active;
@@ -555,7 +556,9 @@ impl HookEchoApp {
                     // so a swipe walks the panes as it passes them.
                     if resp.clicked() || resp.dragged() {
                         if let Some(p) = resp.interact_pointer_pos() {
-                            let i = ((p.x - rect.left()) / 28.0).floor().clamp(0.0, n as f32 - 1.0);
+                            let i = ((p.x - rect.left()) / 28.0)
+                                .floor()
+                                .clamp(0.0, n as f32 - 1.0);
                             pick = Some(i as usize);
                         }
                     }

--- a/crates/hookecho/src/app/chrome/permalink.rs
+++ b/crates/hookecho/src/app/chrome/permalink.rs
@@ -71,7 +71,8 @@ impl HookEchoApp {
             moment: Some(v.moment),
             tilt: Some(v.tilt),
             basemap: None,
-            threshold: v.threshold_enabled[v.moment.index()].then(|| v.thresholds[v.moment.index()]),
+            threshold: v.threshold_enabled[v.moment.index()]
+                .then(|| v.thresholds[v.moment.index()]),
             srv: false,
         });
         link.find('#').map(|i| link[i..].to_string())

--- a/crates/hookecho/src/app/chrome/registry.rs
+++ b/crates/hookecho/src/app/chrome/registry.rs
@@ -910,7 +910,12 @@ impl HookEchoApp {
                 "Historical tornado tracks for this area",
                 false,
             ),
-            (W::Setup, "Set up again…", "Pick your home radar again", false),
+            (
+                W::Setup,
+                "Set up again…",
+                "Pick your home radar again",
+                false,
+            ),
             (
                 W::Tour,
                 "Take the tour…",

--- a/crates/hookecho/src/app/chrome/windows.rs
+++ b/crates/hookecho/src/app/chrome/windows.rs
@@ -21,107 +21,106 @@ impl HookEchoApp {
             return;
         };
         window.show(ctx, |ui| {
-                if let Some((lon, lat)) = self.climo_center {
-                    ui.label(format!("Within 25 mi of {lat:.3}, {lon:.3}"));
+            if let Some((lon, lat)) = self.climo_center {
+                ui.label(format!("Within 25 mi of {lat:.3}, {lon:.3}"));
+            }
+            if self.climo_loading {
+                ui.horizontal(|ui| {
+                    ui.spinner();
+                    ui.label("Loading SPC tornado database (1950–2022)…");
+                });
+            } else if let Some(e) = &self.climo_error {
+                ui.colored_label(
+                    egui::Color32::from_rgb(230, 90, 90),
+                    format!("Load failed: {e}"),
+                );
+            } else {
+                ui.horizontal(|ui| {
+                    ui.strong(format!("{} tornadoes on record", self.climo_hits.len()));
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        let hits = &self.climo_hits;
+                        crate::ui::csv_buttons(
+                            ui,
+                            "tornadoes.csv",
+                            "Every tornado on record here, not just the first 50",
+                            || {
+                                let mut s =
+                                    String::from("year,mag,start_lat,start_lon,end_lat,end_lon\n");
+                                for t in hits {
+                                    s.push_str(&format!(
+                                        "{},{},{:.4},{:.4},{:.4},{:.4}\n",
+                                        t.year, t.mag, t.slat, t.slon, t.elat, t.elon
+                                    ));
+                                }
+                                s
+                            },
+                        );
+                    });
+                });
+                let hist = wxdata::torclimo::mag_histogram(&self.climo_hits);
+                ui.horizontal_wrapped(|ui| {
+                    for (i, label) in ["EF0", "EF1", "EF2", "EF3", "EF4", "EF5", "Unk"]
+                        .iter()
+                        .enumerate()
+                    {
+                        crate::theme::stat_card(ui, label, &hist[i].to_string());
+                    }
+                });
+                ui.separator();
+                egui::ScrollArea::vertical()
+                    .max_height(240.0)
+                    .show(ui, |ui| {
+                        for t in self.climo_hits.iter().take(50) {
+                            let mag = if t.mag < 0 {
+                                "EF?".to_string()
+                            } else {
+                                format!("EF{}", t.mag)
+                            };
+                            ui.label(format!(
+                                "{}  {}  start {:.2},{:.2}",
+                                t.year, mag, t.slat, t.slon
+                            ));
+                        }
+                        if self.climo_hits.len() > 50 {
+                            ui.weak(format!("… and {} more", self.climo_hits.len() - 50));
+                        }
+                    });
+            }
+            ui.separator();
+            ui.strong("Warning history");
+            ui.weak("How often this spot's county has been warned (IEM, 1986–present).");
+            match (&self.climo_warn, self.climo_warn_rx.is_some()) {
+                (Some(s), _) if s.total == 0 => {
+                    ui.label("No warnings on record here.");
                 }
-                if self.climo_loading {
+                (Some(s), _) => {
+                    ui.horizontal_wrapped(|ui| {
+                        crate::theme::stat_card(ui, "Warnings", &s.total.to_string());
+                        if let Some(y) = s.first_year {
+                            crate::theme::stat_card(ui, "Since", &y.to_string());
+                        }
+                        if let Some((y, n)) = s.busiest_year {
+                            crate::theme::stat_card(ui, "Busiest year", &format!("{y} ({n})"));
+                        }
+                        if let Some((d, n)) = s.worst_day {
+                            crate::theme::stat_card(ui, "Worst day", &format!("{d} ({n})"));
+                        }
+                    });
+                    for (name, n) in s.by_name.iter().take(8) {
+                        ui.label(format!("{n} × {name}"));
+                    }
+                }
+                (None, true) => {
                     ui.horizontal(|ui| {
                         ui.spinner();
-                        ui.label("Loading SPC tornado database (1950–2022)…");
+                        ui.label("Loading warning history…");
                     });
-                } else if let Some(e) = &self.climo_error {
-                    ui.colored_label(
-                        egui::Color32::from_rgb(230, 90, 90),
-                        format!("Load failed: {e}"),
-                    );
-                } else {
-                    ui.horizontal(|ui| {
-                        ui.strong(format!("{} tornadoes on record", self.climo_hits.len()));
-                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                            let hits = &self.climo_hits;
-                            crate::ui::csv_buttons(
-                                ui,
-                                "tornadoes.csv",
-                                "Every tornado on record here, not just the first 50",
-                                || {
-                                    let mut s = String::from(
-                                        "year,mag,start_lat,start_lon,end_lat,end_lon\n",
-                                    );
-                                    for t in hits {
-                                        s.push_str(&format!(
-                                            "{},{},{:.4},{:.4},{:.4},{:.4}\n",
-                                            t.year, t.mag, t.slat, t.slon, t.elat, t.elon
-                                        ));
-                                    }
-                                    s
-                                },
-                            );
-                        });
-                    });
-                    let hist = wxdata::torclimo::mag_histogram(&self.climo_hits);
-                    ui.horizontal_wrapped(|ui| {
-                        for (i, label) in ["EF0", "EF1", "EF2", "EF3", "EF4", "EF5", "Unk"]
-                            .iter()
-                            .enumerate()
-                        {
-                            crate::theme::stat_card(ui, label, &hist[i].to_string());
-                        }
-                    });
-                    ui.separator();
-                    egui::ScrollArea::vertical()
-                        .max_height(240.0)
-                        .show(ui, |ui| {
-                            for t in self.climo_hits.iter().take(50) {
-                                let mag = if t.mag < 0 {
-                                    "EF?".to_string()
-                                } else {
-                                    format!("EF{}", t.mag)
-                                };
-                                ui.label(format!(
-                                    "{}  {}  start {:.2},{:.2}",
-                                    t.year, mag, t.slat, t.slon
-                                ));
-                            }
-                            if self.climo_hits.len() > 50 {
-                                ui.weak(format!("… and {} more", self.climo_hits.len() - 50));
-                            }
-                        });
                 }
-                ui.separator();
-                ui.strong("Warning history");
-                ui.weak("How often this spot's county has been warned (IEM, 1986–present).");
-                match (&self.climo_warn, self.climo_warn_rx.is_some()) {
-                    (Some(s), _) if s.total == 0 => {
-                        ui.label("No warnings on record here.");
-                    }
-                    (Some(s), _) => {
-                        ui.horizontal_wrapped(|ui| {
-                            crate::theme::stat_card(ui, "Warnings", &s.total.to_string());
-                            if let Some(y) = s.first_year {
-                                crate::theme::stat_card(ui, "Since", &y.to_string());
-                            }
-                            if let Some((y, n)) = s.busiest_year {
-                                crate::theme::stat_card(ui, "Busiest year", &format!("{y} ({n})"));
-                            }
-                            if let Some((d, n)) = s.worst_day {
-                                crate::theme::stat_card(ui, "Worst day", &format!("{d} ({n})"));
-                            }
-                        });
-                        for (name, n) in s.by_name.iter().take(8) {
-                            ui.label(format!("{n} × {name}"));
-                        }
-                    }
-                    (None, true) => {
-                        ui.horizontal(|ui| {
-                            ui.spinner();
-                            ui.label("Loading warning history…");
-                        });
-                    }
-                    (None, false) => {
-                        ui.weak("Warning history unavailable.");
-                    }
+                (None, false) => {
+                    ui.weak("Warning history unavailable.");
                 }
-            });
+            }
+        });
         self.climo_open = open;
     }
 

--- a/crates/hookecho/src/app/mobile/mod.rs
+++ b/crates/hookecho/src/app/mobile/mod.rs
@@ -364,5 +364,4 @@ impl super::HookEchoApp {
             self.set_basemap(s);
         }
     }
-
 }

--- a/crates/hookecho/src/backtest.rs
+++ b/crates/hookecho/src/backtest.rs
@@ -61,12 +61,7 @@ pub async fn run(
         Err(e) => return finish(&out, &format!("listing {site} for {day} failed: {e}")),
     };
     // The end of the day is where the weather usually is, and the cap has to fall somewhere.
-    let ids: Vec<_> = ids
-        .into_iter()
-        .rev()
-        .take(MAX_VOLUMES)
-        .rev()
-        .collect();
+    let ids: Vec<_> = ids.into_iter().rev().take(MAX_VOLUMES).rev().collect();
     if let Ok(mut p) = out.lock() {
         p.total = ids.len();
     }

--- a/crates/hookecho/src/basemap_style.rs
+++ b/crates/hookecho/src/basemap_style.rs
@@ -42,7 +42,6 @@ impl Palette {
         Palette::Positron,
         Palette::Midnight,
     ];
-
 }
 
 /// The per-palette color table. One struct rather than a pile of parallel `match` arms: adding a
@@ -364,7 +363,10 @@ mod tests {
 
     #[test]
     fn dark_and_light_differ_and_resolve() {
-        assert_ne!(style(Palette::Dark).background, style(Palette::Light).background);
+        assert_ne!(
+            style(Palette::Dark).background,
+            style(Palette::Light).background
+        );
         // Every documented class resolves in both themes.
         for p in [Palette::Dark, Palette::Light] {
             assert!(fill(p, "water", "").is_some());
@@ -393,7 +395,10 @@ mod tests {
             ("landuse", "residential"),
             ("park", ""),
         ] {
-            assert!(fill(p, layer, class).is_none(), "{layer}/{class} fills over imagery");
+            assert!(
+                fill(p, layer, class).is_none(),
+                "{layer}/{class} fills over imagery"
+            );
         }
         // It still draws the roads it exists for, and thicker than the vector basemap's.
         let (_, hybrid_w) = stroke(p, "transportation", "motorway").unwrap();

--- a/crates/hookecho/src/chaselog.rs
+++ b/crates/hookecho/src/chaselog.rs
@@ -257,7 +257,10 @@ mod tests {
         assert!((back.points[0].lon + 97.5).abs() < 1e-6);
         assert_eq!(back.points[1].ts, 1_700_000_300);
         // The mark was on the newest point and lands there again, with its text unescaped.
-        assert_eq!(back.waypoints, vec![(1, "wall cloud & \"hook\"".to_string())]);
+        assert_eq!(
+            back.waypoints,
+            vec![(1, "wall cloud & \"hook\"".to_string())]
+        );
         // Distance survives the round trip.
         assert!((back.miles() - t.miles()).abs() < 0.01);
     }

--- a/crates/hookecho/src/colormap.rs
+++ b/crates/hookecho/src/colormap.rs
@@ -409,7 +409,10 @@ mod tests {
         p.reload(&paths);
         assert_eq!(p.tables[0].stops.len(), 2);
         assert!(p.errors[0].is_none());
-        assert!(p.errors[1].is_some(), "bad inline content reports, not panics");
+        assert!(
+            p.errors[1].is_some(),
+            "bad inline content reports, not panics"
+        );
     }
 
     #[test]

--- a/crates/hookecho/src/crash.rs
+++ b/crates/hookecho/src/crash.rs
@@ -67,7 +67,11 @@ mod tests {
 
     #[test]
     fn the_report_says_what_broke_and_nothing_about_who_was_running_it() {
-        let r = format_report("index out of bounds", Some("src/app.rs:12:3"), "<backtrace>");
+        let r = format_report(
+            "index out of bounds",
+            Some("src/app.rs:12:3"),
+            "<backtrace>",
+        );
         assert!(r.contains("index out of bounds"));
         assert!(r.contains("src/app.rs:12:3"));
         assert!(r.contains(env!("CARGO_PKG_VERSION")));

--- a/crates/hookecho/src/fielddiff.rs
+++ b/crates/hookecho/src/fielddiff.rs
@@ -76,8 +76,8 @@ impl DiffField {
     /// arrive as the model published them: pressure in Pa, height in m, wind in m/s.
     pub fn input_scale(self) -> f32 {
         match self {
-            DiffField::Global(GlobalFieldKind::Mslp) => 0.01,      // Pa → hPa
-            DiffField::Global(GlobalFieldKind::Height500) => 0.1,  // m → dam
+            DiffField::Global(GlobalFieldKind::Mslp) => 0.01, // Pa → hPa
+            DiffField::Global(GlobalFieldKind::Height500) => 0.1, // m → dam
             DiffField::Global(GlobalFieldKind::Wind10m) => 1.943_844, // m/s → kt
             // A difference of two Kelvin fields is already a difference in °C.
             _ => 1.0,
@@ -216,7 +216,11 @@ fn sample(f: &MrmsField, lon: f64, lat: f64) -> Option<f32> {
     let (tx, ty) = ((x - x0 as f64) as f32, (y - y0 as f64) as f32);
     let at = |r: usize, c: usize| {
         let v = f.values[r * f.nx + c];
-        if v.is_finite() { Some(v) } else { None }
+        if v.is_finite() {
+            Some(v)
+        } else {
+            None
+        }
     };
     // One missing corner poisons the cell rather than being treated as zero — a hole in a model
     // field is not a value of zero, and a difference against zero is a fabricated gradient.
@@ -275,7 +279,15 @@ pub fn diff_index(v: f32, range: f32) -> u8 {
 mod tests {
     use super::*;
 
-    fn grid(nx: usize, ny: usize, west: f64, east: f64, south: f64, north: f64, v: f32) -> MrmsField {
+    fn grid(
+        nx: usize,
+        ny: usize,
+        west: f64,
+        east: f64,
+        south: f64,
+        north: f64,
+        v: f32,
+    ) -> MrmsField {
         MrmsField {
             values: vec![v; nx * ny],
             nx,
@@ -333,7 +345,10 @@ mod tests {
         let alpha = |v: f32| lut[diff_index(v, 10.0) as usize * 4 + 3];
         assert_eq!(alpha(0.0), 0, "models agreeing is invisible");
         assert_eq!(alpha(0.5), 0, "inside the deadband is invisible");
-        assert!(alpha(5.0) > 0 && alpha(10.0) > alpha(5.0), "further apart, more opaque");
+        assert!(
+            alpha(5.0) > 0 && alpha(10.0) > alpha(5.0),
+            "further apart, more opaque"
+        );
         // Sign picks the side of the ramp: blue for negative, red for positive.
         let rgb = |v: f32| {
             let i = diff_index(v, 10.0) as usize * 4;

--- a/crates/hookecho/src/geo.rs
+++ b/crates/hookecho/src/geo.rs
@@ -119,7 +119,6 @@ pub fn nearest_site_id(lon: f64, lat: f64) -> Option<String> {
     wxdata::sites::nearest_site(lat as f32, lon as f32).map(|s| s.id.to_string())
 }
 
-
 /// 16-point compass label for a bearing in degrees. Lives here rather than beside any one caller
 /// because the widget caption, the status report and the spoken scripts all want the same words.
 pub fn compass(deg: f32) -> &'static str {

--- a/crates/hookecho/src/headless.rs
+++ b/crates/hookecho/src/headless.rs
@@ -31,7 +31,10 @@ pub fn set_output(px: Option<u32>, zoom: Option<f64>) {
         SIZE_PX.store(px.clamp(256, 2048), std::sync::atomic::Ordering::Relaxed);
     }
     if let Some(z) = zoom {
-        ZOOM_OVERRIDE.store(z.clamp(1.0, 14.0).to_bits(), std::sync::atomic::Ordering::Relaxed);
+        ZOOM_OVERRIDE.store(
+            z.clamp(1.0, 14.0).to_bits(),
+            std::sync::atomic::Ordering::Relaxed,
+        );
     }
 }
 
@@ -92,8 +95,8 @@ fn national_basemap(
                 camera.zoom,
                 &vis,
             )
-                .await
-                .0,
+            .await
+            .0,
         )
     });
     match tiles {
@@ -321,7 +324,9 @@ pub fn run_multipane(site: &str, out_a: &str, out_b: &str) -> anyhow::Result<()>
             vector_over_raster: false,
             new_tiles: Vec::new(),
             visible: Vec::new(),
-            radar_upload: Some(crate::app::to_upload(&sweep, &table, None, false, None, None)),
+            radar_upload: Some(crate::app::to_upload(
+                &sweep, &table, None, false, None, None,
+            )),
             draw_radar: true,
             overlay_upload: None,
             draw_overlay: false,
@@ -547,7 +552,9 @@ pub fn run_dualpol(site: &str, h0_km: f64) -> anyhow::Result<()> {
         let z0 = level2::bin_scan(&scan, Moment::Reflectivity, 0)?;
         let cc0 = level2::bin_scan(&scan, Moment::CorrelationCoefficient, 0)?;
         let take = |m: Moment| -> Vec<wxdata::level2::BinnedSweep> {
-            (0..n).filter_map(|t| level2::bin_scan(&scan, m, t).ok()).collect()
+            (0..n)
+                .filter_map(|t| level2::bin_scan(&scan, m, t).ok())
+                .collect()
         };
         anyhow::Ok((
             z0,
@@ -565,7 +572,11 @@ pub fn run_dualpol(site: &str, h0_km: f64) -> anyhow::Result<()> {
     );
 
     let spikes = wxdata::dualpol::tbss(&z0, &cc0, 60.0, 20.0, 0.8, 4.0, 150.0);
-    println!("TBSS (hail spikes) at {:.2}deg: {}", z0.elevation_deg, spikes.len());
+    println!(
+        "TBSS (hail spikes) at {:.2}deg: {}",
+        z0.elevation_deg,
+        spikes.len()
+    );
     for h in spikes.iter().take(8) {
         println!(
             "  {:.3},{:.3}  core {:.0} dBZ  spike {:.1} km  min CC {:.2}",
@@ -574,7 +585,10 @@ pub fn run_dualpol(site: &str, h0_km: f64) -> anyhow::Result<()> {
     }
 
     let columns = wxdata::dualpol::zdr_columns(&zdr_tilts, &z_tilts, h0_km, 1.0, 1.0, 40.0, 100.0);
-    println!("ZDR columns (>1 dB, >=1 km above the freezing level): {}", columns.len());
+    println!(
+        "ZDR columns (>1 dB, >=1 km above the freezing level): {}",
+        columns.len()
+    );
     for h in columns.iter().take(8) {
         println!(
             "  {:.3},{:.3}  depth {:.1} km  top {:.1} km  max {:.1} dB",
@@ -641,7 +655,11 @@ pub fn run_rules(site: &str) -> anyhow::Result<()> {
             take(Moment::Reflectivity),
         ))
     })?;
-    println!("{site}: {} tilts, lowest {:.2}°", z_tilts.len(), z.elevation_deg);
+    println!(
+        "{site}: {} tilts, lowest {:.2}°",
+        z_tilts.len(),
+        z.elevation_deg
+    );
 
     let d = &settings.detectors;
     let tds = wxdata::tds::detect(&z, &cc, 0.80, 40.0, 150.0, 4);
@@ -696,10 +714,7 @@ pub fn run_rules(site: &str) -> anyhow::Result<()> {
             .find(|h| crate::rules::matches(rule, h, &settings))
         {
             Some(h) => {
-                let strength = h
-                    .strength
-                    .map(|v| format!(" ({v:.0})"))
-                    .unwrap_or_default();
+                let strength = h.strength.map(|v| format!(" ({v:.0})")).unwrap_or_default();
                 println!(
                     "  {label}: FIRES at {:.3},{:.3}{strength} — {place}",
                     h.lat, h.lon
@@ -973,7 +988,9 @@ pub fn run_live(out_path: &str, site: &str, moment: Moment) -> anyhow::Result<()
         vector_over_raster: false,
         new_tiles: Vec::new(),
         visible: Vec::new(),
-        radar_upload: Some(crate::app::to_upload(&sweep, &table, None, false, None, None)),
+        radar_upload: Some(crate::app::to_upload(
+            &sweep, &table, None, false, None, None,
+        )),
         draw_radar: true,
         overlay_upload: None,
         draw_overlay: false,
@@ -2889,7 +2906,9 @@ mod golden_tests {
             vector_over_raster: false,
             new_tiles: Vec::new(),
             visible: Vec::new(),
-            radar_upload: Some(crate::app::to_upload(&sweep, &table, None, false, None, None)),
+            radar_upload: Some(crate::app::to_upload(
+                &sweep, &table, None, false, None, None,
+            )),
             draw_radar: true,
             overlay_upload: None,
             draw_overlay: false,

--- a/crates/hookecho/src/lib.rs
+++ b/crates/hookecho/src/lib.rs
@@ -36,13 +36,13 @@ pub mod gps;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod headless;
 pub mod hotkeys;
-pub mod labelplace;
 pub mod icon;
+pub mod labelplace;
 pub mod loopexport;
-pub mod notify;
 /// MQTT publishing for home automation; native only (no TCP socket in a browser).
 #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
 pub mod mqtt;
+pub mod notify;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod nwr;
 pub mod overlay_build;
@@ -68,13 +68,12 @@ pub mod share;
 pub mod speech;
 /// Live station markers and their telemetry cards.
 pub mod stationlayer;
-pub mod wind_gpu;
-/// Cache sizes and the buttons that clear them; needs a filesystem, so not on the web.
-#[cfg(not(target_arch = "wasm32"))]
-pub mod storage;
 /// The `--status` report; native only — it builds its own runtime.
 #[cfg(not(target_arch = "wasm32"))]
 pub mod status;
+/// Cache sizes and the buttons that clear them; needs a filesystem, so not on the web.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod storage;
 pub mod textview;
 pub mod theme;
 pub mod tiles;
@@ -84,8 +83,9 @@ pub mod tray;
 pub mod ui;
 pub mod vector_tiles;
 pub mod view;
-pub mod workspace;
 pub mod wind_draw;
+pub mod wind_gpu;
+pub mod workspace;
 
 pub use app::HookEchoApp;
 

--- a/crates/hookecho/src/main.rs
+++ b/crates/hookecho/src/main.rs
@@ -643,7 +643,10 @@ fn main() -> eframe::Result<()> {
     // Dual-pol signature verify: `hookecho --headless-dualpol [SITE] [H0_KM]`.
     if let Some(pos) = args.iter().position(|a| a == "--headless-dualpol") {
         let site = args.get(pos + 1).map(String::as_str).unwrap_or("KTLX");
-        let h0 = args.get(pos + 2).and_then(|s| s.parse().ok()).unwrap_or(4.0);
+        let h0 = args
+            .get(pos + 2)
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(4.0);
         if let Err(e) = headless::run_dualpol(site, h0) {
             eprintln!("headless dualpol failed: {e}");
             std::process::exit(1);
@@ -1005,7 +1008,7 @@ fn hand_link_to_running_instance(link: &str) -> bool {
 #[cfg(not(target_os = "android"))]
 mod single_instance {
     use std::io::{Read, Write};
-    use std::net::{Ipv4Addr, TcpListener, TcpStream, SocketAddrV4};
+    use std::net::{Ipv4Addr, SocketAddrV4, TcpListener, TcpStream};
     use std::time::Duration;
 
     /// Registered-user range, and nothing else known claims it.

--- a/crates/hookecho/src/mqtt.rs
+++ b/crates/hookecho/src/mqtt.rs
@@ -181,9 +181,12 @@ mod tests {
 
     #[test]
     fn an_alert_publishes_its_fields_apart() {
-        let v: serde_json::Value =
-            serde_json::from_str(&alert_payload("Tornado Warning", "Norman until 21:15", true))
-                .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&alert_payload(
+            "Tornado Warning",
+            "Norman until 21:15",
+            true,
+        ))
+        .unwrap();
         assert_eq!(v["title"], "Tornado Warning");
         assert_eq!(v["body"], "Norman until 21:15");
         assert_eq!(v["urgent"], true);

--- a/crates/hookecho/src/notify.rs
+++ b/crates/hookecho/src/notify.rs
@@ -152,7 +152,9 @@ static RETRYING: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize
 fn worth_retrying(res: &Result<reqwest::Response, reqwest::Error>) -> bool {
     match res {
         Err(_) => true,
-        Ok(r) => r.status().is_server_error() || r.status() == reqwest::StatusCode::TOO_MANY_REQUESTS,
+        Ok(r) => {
+            r.status().is_server_error() || r.status() == reqwest::StatusCode::TOO_MANY_REQUESTS
+        }
     }
 }
 
@@ -274,7 +276,11 @@ mod tests {
         // returns without ever sleeping, which is what makes this assertion immediate.
         let (url, hits) = mock_sink(vec![404]);
         rt.block_on(send_retrying("test", || http.post(&url).body("x")));
-        assert_eq!(hits.load(Ordering::SeqCst), 1, "a 404 should not be retried");
+        assert_eq!(
+            hits.load(Ordering::SeqCst),
+            1,
+            "a 404 should not be retried"
+        );
     }
 
     #[test]

--- a/crates/hookecho/src/platform.rs
+++ b/crates/hookecho/src/platform.rs
@@ -203,7 +203,11 @@ pub fn share_link(title: &str, link: &str) -> bool {
             return false;
         };
         let data = js_sys::Object::new();
-        let _ = js_sys::Reflect::set(&data, &JsValue::from_str("title"), &JsValue::from_str(title));
+        let _ = js_sys::Reflect::set(
+            &data,
+            &JsValue::from_str("title"),
+            &JsValue::from_str(title),
+        );
         let _ = js_sys::Reflect::set(&data, &JsValue::from_str("url"), &JsValue::from_str(link));
         match f.call1(&nav, &data) {
             // The promise rejects when the user dismisses the sheet, which is not our problem and
@@ -607,33 +611,39 @@ mod android_alerts {
     }
 
     fn try_set_saver(on: bool) -> jni::errors::Result<()> {
-        with_class("io.hookecho.HookEcho.AlertService", |env, class, activity| {
-            let res = env.call_static_method(
-                class,
-                "setBatterySaver",
-                "(Landroid/content/Context;Z)V",
-                &[JValue::Object(activity), JValue::Bool(on as u8)],
-            );
-            if res.is_err() {
-                let _ = env.exception_clear();
-            }
-            res.map(|_| ())
-        })
+        with_class(
+            "io.hookecho.HookEcho.AlertService",
+            |env, class, activity| {
+                let res = env.call_static_method(
+                    class,
+                    "setBatterySaver",
+                    "(Landroid/content/Context;Z)V",
+                    &[JValue::Object(activity), JValue::Bool(on as u8)],
+                );
+                if res.is_err() {
+                    let _ = env.exception_clear();
+                }
+                res.map(|_| ())
+            },
+        )
     }
 
     fn try_set(enabled: bool) -> jni::errors::Result<()> {
-        with_class("io.hookecho.HookEcho.AlertService", |env, class, activity| {
-            let res = env.call_static_method(
-                class,
-                "setEnabled",
-                "(Landroid/content/Context;Z)V",
-                &[JValue::Object(activity), JValue::Bool(enabled as u8)],
-            );
-            if res.is_err() {
-                let _ = env.exception_clear();
-            }
-            res.map(|_| ())
-        })
+        with_class(
+            "io.hookecho.HookEcho.AlertService",
+            |env, class, activity| {
+                let res = env.call_static_method(
+                    class,
+                    "setEnabled",
+                    "(Landroid/content/Context;Z)V",
+                    &[JValue::Object(activity), JValue::Bool(enabled as u8)],
+                );
+                if res.is_err() {
+                    let _ = env.exception_clear();
+                }
+                res.map(|_| ())
+            },
+        )
     }
 }
 

--- a/crates/hookecho/src/profiling.rs
+++ b/crates/hookecho/src/profiling.rs
@@ -143,7 +143,10 @@ mod tests {
     fn quantiles_and_the_over_budget_count_read_the_right_frames() {
         // 1..=100 ms in microseconds.
         let v: Vec<i64> = (1..=100).map(|ms| ms * 1_000).collect();
-        assert_eq!(Pacing::quantiles(&v), "p50 51.00 p90 90.00 p99 99.00 max 100.00");
+        assert_eq!(
+            Pacing::quantiles(&v),
+            "p50 51.00 p90 90.00 p99 99.00 max 100.00"
+        );
         // 80 of them are over 20 ms, and the budget is exclusive: 20 ms itself is not late.
         assert_eq!(Pacing::over(&v, 20_000), 80);
         assert_eq!(Pacing::quantiles(&[]), "n/a");

--- a/crates/hookecho/src/render/mod.rs
+++ b/crates/hookecho/src/render/mod.rs
@@ -534,7 +534,7 @@ impl RenderResources {
                         view_dimension: wgpu::TextureViewDimension::D2,
                         multisampled: false,
                     },
-                    count: None
+                    count: None,
                 },
             ],
         });

--- a/crates/hookecho/src/rules.rs
+++ b/crates/hookecho/src/rules.rs
@@ -65,14 +65,16 @@ pub fn meets_threshold(rule: &AlertRule, hit: &Detection) -> bool {
 pub fn place_contains(place: &RulePlace, hit: &Detection, settings: &Settings) -> bool {
     match place {
         RulePlace::Anywhere => true,
-        RulePlace::Marker { id } => settings
-            .markers
-            .iter()
-            .find(|m| &m.id == id)
-            .is_some_and(|m| {
-                let (km, _) = crate::geo::great_circle([m.lon, m.lat], [hit.lon, hit.lat]);
-                km <= m.alert_radius_mi * crate::geo::KM_PER_MILE
-            }),
+        RulePlace::Marker { id } => {
+            settings
+                .markers
+                .iter()
+                .find(|m| &m.id == id)
+                .is_some_and(|m| {
+                    let (km, _) = crate::geo::great_circle([m.lon, m.lat], [hit.lon, hit.lat]);
+                    km <= m.alert_radius_mi * crate::geo::KM_PER_MILE
+                })
+        }
         RulePlace::Zone { name } => settings
             .alert_polygons
             .iter()
@@ -260,10 +262,22 @@ mod tests {
         let s = Settings::default();
         let mut r = rule(RuleTrigger::Rotation, RulePlace::Anywhere);
         r.threshold = Some(45.0);
-        assert!(matches(&r, &Detection::with_strength(-97.5, 35.3, 52.0), &s));
-        assert!(!matches(&r, &Detection::with_strength(-97.5, 35.3, 30.0), &s));
+        assert!(matches(
+            &r,
+            &Detection::with_strength(-97.5, 35.3, 52.0),
+            &s
+        ));
+        assert!(!matches(
+            &r,
+            &Detection::with_strength(-97.5, 35.3, 30.0),
+            &s
+        ));
         // Exactly at the threshold counts — the user asked for "45 and up".
-        assert!(matches(&r, &Detection::with_strength(-97.5, 35.3, 45.0), &s));
+        assert!(matches(
+            &r,
+            &Detection::with_strength(-97.5, 35.3, 45.0),
+            &s
+        ));
         // A measured trigger with nothing measured stays quiet.
         assert!(!matches(&r, &Detection::at(-97.5, 35.3), &s));
         // A trigger that takes no threshold ignores one that got set anyway.
@@ -365,7 +379,10 @@ mod tests {
         assert!(warning_matches(&tor, "Tornado Warning"));
         assert!(!warning_matches(&tor, "Severe Thunderstorm Warning"));
         // A non-warning trigger is not a warning match, whatever the text says.
-        assert!(!warning_matches(&AlertRule::new(RuleTrigger::Tds), "Tornado Warning"));
+        assert!(!warning_matches(
+            &AlertRule::new(RuleTrigger::Tds),
+            "Tornado Warning"
+        ));
     }
 
     #[test]

--- a/crates/hookecho/src/serve.rs
+++ b/crates/hookecho/src/serve.rs
@@ -158,7 +158,11 @@ fn route(server: &Server, path: &str, query: &str) -> (&'static str, &'static st
     });
     match path {
         "/" if server.web_root.is_some() => static_file(server, "/index.html"),
-        "/" => ("200 OK", "text/html; charset=utf-8", index(server).into_bytes()),
+        "/" => (
+            "200 OK",
+            "text/html; charset=utf-8",
+            index(server).into_bytes(),
+        ),
         "/status.json" | "/alerts.json" | "/obs.json" => match cached_json(server, path) {
             Ok(body) => ("200 OK", "application/json", body),
             Err(e) => error_json(e),
@@ -205,7 +209,10 @@ fn constant_time_eq(a: &str, b: &str) -> bool {
     if a.len() != b.len() {
         return false;
     }
-    a.bytes().zip(b.bytes()).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
+    a.bytes()
+        .zip(b.bytes())
+        .fold(0u8, |acc, (x, y)| acc | (x ^ y))
+        == 0
 }
 
 fn not_found() -> (&'static str, &'static str, Vec<u8>) {
@@ -589,11 +596,7 @@ fn loop_clip(
     let mut last: Option<Vec<u8>> = None;
     for k in (0..count as i64).rev() {
         let at = now - chrono::Duration::minutes(k * LOOP_STEP_MIN);
-        let out = dir.join(format!(
-            "loop-{}-{}.png",
-            f.tag(),
-            at.format("%Y%m%d-%H%M")
-        ));
+        let out = dir.join(format!("loop-{}-{}.png", f.tag(), at.format("%Y%m%d-%H%M")));
         // An archived frame never changes, so one already on disk is the answer. Only the newest
         // step is rendered on a repeat poll.
         let png = match std::fs::read(&out) {
@@ -794,6 +797,9 @@ const ALLOWED_HOSTS: &[&str] = &[
     "gibs.earthdata.nasa.gov",
     // European radar.
     "opendata.dwd.de",
+    // EUMETNET OpenRadarData: the ODIM volumes the OPERA network publishes, plus the
+    // bucket listing that names the newest one.
+    "s3.waw3-1.cloudferro.com",
     // Basemap and imagery tiles.
     "api.mapbox.com",
     "api.maptiler.com",
@@ -1050,10 +1056,13 @@ mod tests {
         assert_eq!(f.px, 512);
         assert_eq!(f.tilt, 2);
         // Two renders that differ in any knob must not share a cache key or a filename.
-        let other = Frame::parse("site=KOUN&product=vel&size=512&zoom=8&tilt=3&basemap=light")
-            .unwrap();
+        let other =
+            Frame::parse("site=KOUN&product=vel&size=512&zoom=8&tilt=3&basemap=light").unwrap();
         assert_ne!(f.tag(), other.tag());
-        assert!(!f.tag().contains(['/', '\\', ' ']), "tag becomes a filename");
+        assert!(
+            !f.tag().contains(['/', '\\', ' ']),
+            "tag becomes a filename"
+        );
 
         // Defaults are the dashboard case: latest reflectivity on the dark vector map.
         let d = Frame::parse("").unwrap();

--- a/crates/hookecho/src/speech.rs
+++ b/crates/hookecho/src/speech.rs
@@ -15,7 +15,8 @@
 /// have no reason to know about settings, and this is one string pair that changes when the user
 /// edits it.
 #[cfg(not(target_arch = "wasm32"))]
-static PIPER: std::sync::RwLock<(String, String)> = std::sync::RwLock::new((String::new(), String::new()));
+static PIPER: std::sync::RwLock<(String, String)> =
+    std::sync::RwLock::new((String::new(), String::new()));
 
 /// Point the speech path at a Piper binary and voice model. Called at startup and whenever the
 /// user edits either field.
@@ -60,7 +61,11 @@ static WANT_VOICE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool
 
 #[cfg(not(target_arch = "wasm32"))]
 pub fn voice_status() -> VoiceStatus {
-    VOICE.read().ok().and_then(|g| g.clone()).unwrap_or_default()
+    VOICE
+        .read()
+        .ok()
+        .and_then(|g| g.clone())
+        .unwrap_or_default()
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -196,7 +201,11 @@ mod imp {
         if voice.is_empty() || !std::path::Path::new(&voice).exists() {
             return Ok(false);
         }
-        let bin = if bin.is_empty() { "piper".to_string() } else { bin };
+        let bin = if bin.is_empty() {
+            "piper".to_string()
+        } else {
+            bin
+        };
         let mut cmd = Command::new(&bin);
         crate::platform::no_window(&mut cmd);
         // `--output_file -` gives a WAV on stdout, which rodio decodes directly. Writing to a

--- a/crates/hookecho/src/status.rs
+++ b/crates/hookecho/src/status.rs
@@ -509,7 +509,12 @@ mod tests {
         let mut sparse = sparse;
         sparse.rh = None;
         sparse.wind_kmh = None;
-        let s = status_for(&spot("Home", true), Some(("KXYZ".into(), sparse)), vec![], None);
+        let s = status_for(
+            &spot("Home", true),
+            Some(("KXYZ".into(), sparse)),
+            vec![],
+            None,
+        );
         assert_eq!(conditions(&s), "50°F");
     }
 
@@ -517,7 +522,7 @@ mod tests {
     fn explicit_point_beats_markers() {
         let mut settings = crate::settings::Settings::default();
         settings.markers.push(crate::settings::Marker {
-                id: crate::settings::new_marker_id(),
+            id: crate::settings::new_marker_id(),
             name: "Home".into(),
             lat: 1.0,
             lon: 2.0,

--- a/crates/hookecho/src/storage.rs
+++ b/crates/hookecho/src/storage.rs
@@ -44,7 +44,11 @@ pub fn report() -> Vec<Entry> {
     [
         ("Map tiles", "tiles", Some(tiles)),
         ("Vector tiles", "vector", Some(tiles)),
-        ("Radar volumes", "volumes", Some(crate::tiles::volume_cache_bytes())),
+        (
+            "Radar volumes",
+            "volumes",
+            Some(crate::tiles::volume_cache_bytes()),
+        ),
         ("Zone geometry", "zones", Some(small)),
         ("Soundings (RAOB)", "raob", Some(small)),
         ("Server snapshots", "snapshots", Some(small)),
@@ -121,7 +125,11 @@ mod tests {
         assert_eq!(dir_size(&root), 300);
 
         clear(&root).unwrap();
-        assert_eq!(dir_size(&root), 0, "cleared, and the directory still exists");
+        assert_eq!(
+            dir_size(&root),
+            0,
+            "cleared, and the directory still exists"
+        );
         assert!(root.is_dir());
         std::fs::remove_dir_all(&root).ok();
     }

--- a/crates/hookecho/src/textview.rs
+++ b/crates/hookecho/src/textview.rs
@@ -79,10 +79,7 @@ fn body(text: &str) -> String {
             out.push_str(&format!("<p>{}</p>", esc(&unwrap_lines(&lines))));
         } else {
             // The spacing is the content here: a wind table, a coordinate summary, a hazard list.
-            out.push_str(&format!(
-                "<pre>{}</pre>",
-                esc(lines.join("\n").trim_end())
-            ));
+            out.push_str(&format!("<pre>{}</pre>", esc(lines.join("\n").trim_end())));
         }
     }
     out
@@ -126,11 +123,7 @@ fn prose(lines: &[&str]) -> bool {
 
 /// Undo the teletype wrap: the line breaks were never in the sentences.
 fn unwrap_lines(lines: &[&str]) -> String {
-    lines
-        .iter()
-        .map(|l| l.trim())
-        .collect::<Vec<_>>()
-        .join(" ")
+    lines.iter().map(|l| l.trim()).collect::<Vec<_>>().join(" ")
 }
 
 fn esc(s: &str) -> String {
@@ -188,7 +181,8 @@ mod tests {
 
     #[test]
     fn wrapped_prose_becomes_one_paragraph() {
-        let text = "A line of forecaster prose that runs right out to the teletype margin and then\n\
+        let text =
+            "A line of forecaster prose that runs right out to the teletype margin and then\n\
                     keeps going onto a second line before it finally stops.";
         let html = body(text);
         assert!(html.starts_with("<p>"), "{html}");

--- a/crates/hookecho/src/theme.rs
+++ b/crates/hookecho/src/theme.rs
@@ -5,8 +5,8 @@
 //! switches. `// ponytail: no bundled font — egui's default proportional face is fine; drop an
 //! Inter/IBM-Plex TTF into data/fonts/ and install it here if a distinct face is wanted.`
 
-use crate::ui::m3::{self, Density};
 use crate::settings::Theme;
+use crate::ui::m3::{self, Density};
 use egui::{Color32, CornerRadius, Margin, Stroke, Style, Visuals};
 
 /// Default accent (matches the built-in Dark theme). Used only as a fallback where the selected

--- a/crates/hookecho/src/tiles.rs
+++ b/crates/hookecho/src/tiles.rs
@@ -471,7 +471,9 @@ impl BasemapStyle {
             BasemapStyle::CustomXyz => 22,
             BasemapStyle::OsmHot => 18,
             BasemapStyle::OsmStandard | BasemapStyle::CyclOsm => 19,
-            BasemapStyle::CartoPositron | BasemapStyle::CartoDarkMatter | BasemapStyle::CartoVoyager => 20,
+            BasemapStyle::CartoPositron
+            | BasemapStyle::CartoDarkMatter
+            | BasemapStyle::CartoVoyager => 20,
             BasemapStyle::EsriImagery | BasemapStyle::EsriStreets | BasemapStyle::EsriTopo => 20,
             _ => 20, // Mapbox and MapTiler raster both serve past 20; the vector styles never get here.
         }
@@ -483,7 +485,9 @@ impl BasemapStyle {
     fn has_2x(self) -> bool {
         matches!(
             self,
-            BasemapStyle::CartoPositron | BasemapStyle::CartoDarkMatter | BasemapStyle::CartoVoyager
+            BasemapStyle::CartoPositron
+                | BasemapStyle::CartoDarkMatter
+                | BasemapStyle::CartoVoyager
         )
     }
 
@@ -1075,7 +1079,11 @@ impl TileManager {
     /// tile. Returns `None` while it is in flight, if it failed, or if the style has no raster
     /// URL — the picker paints a palette swatch in all of those cases, so nothing ever waits on
     /// a network round trip to draw.
-    pub fn thumb(&mut self, style: BasemapStyle, ctx: &egui::Context) -> Option<egui::TextureHandle> {
+    pub fn thumb(
+        &mut self,
+        style: BasemapStyle,
+        ctx: &egui::Context,
+    ) -> Option<egui::TextureHandle> {
         while let Ok((key, fetched)) = self.thumb_rx.try_recv() {
             let state = match fetched {
                 Some(f) => {
@@ -1128,17 +1136,20 @@ impl TileManager {
         self.spawner.spawn(async move {
             let bytes = load_tile_bytes(&client, &url, path.as_deref()).await;
             blocking.spawn_blocking(move || {
-                let decoded = bytes.ok().and_then(|b| image::load_from_memory(&b).ok()).map(|img| {
-                    let rgba = img.to_rgba8();
-                    let (w, h) = rgba.dimensions();
-                    FetchedTile {
-                        id: (6, 14, 24),
-                        style: key,
-                        rgba: rgba.into_raw(),
-                        width: w,
-                        height: h,
-                    }
-                });
+                let decoded = bytes
+                    .ok()
+                    .and_then(|b| image::load_from_memory(&b).ok())
+                    .map(|img| {
+                        let rgba = img.to_rgba8();
+                        let (w, h) = rgba.dimensions();
+                        FetchedTile {
+                            id: (6, 14, 24),
+                            style: key,
+                            rgba: rgba.into_raw(),
+                            width: w,
+                            height: h,
+                        }
+                    });
                 let _ = tx.send((key, decoded));
                 if let Some(ctx) = ctx2 {
                     ctx.request_repaint();
@@ -1206,9 +1217,15 @@ impl TileManager {
                 break;
             }
             let (z, x, y) = v.id;
-            let Some(mut url) =
-                style.url(z, x, y, self.retina, &self.mapbox_key, &self.maptiler_key, &self.custom_template)
-            else {
+            let Some(mut url) = style.url(
+                z,
+                x,
+                y,
+                self.retina,
+                &self.mapbox_key,
+                &self.maptiler_key,
+                &self.custom_template,
+            ) else {
                 continue;
             };
             // GOES frame time: rewrite the `default` time slot in the GIBS URL and tag the cache
@@ -1276,7 +1293,15 @@ impl TileManager {
     pub fn packable(&self, style: BasemapStyle) -> bool {
         style.goes_layer().is_none()
             && style
-                .url(0, 0, 0, false, &self.mapbox_key, &self.maptiler_key, &self.custom_template)
+                .url(
+                    0,
+                    0,
+                    0,
+                    false,
+                    &self.mapbox_key,
+                    &self.maptiler_key,
+                    &self.custom_template,
+                )
                 .is_some()
     }
 
@@ -1302,11 +1327,21 @@ impl TileManager {
         }
         let z_hi = z_hi.min(self.max_z(style));
         // Packs are always 1x: a pack is written once and read on whatever device opens it later.
-        let dir = root.join(style.provider(false, &self.custom_template)).join("default");
+        let dir = root
+            .join(style.provider(false, &self.custom_template))
+            .join("default");
         pack_tile_ids(min_lon, min_lat, max_lon, max_lat, z_lo, z_hi)
             .into_iter()
             .filter_map(|(z, x, y)| {
-                let url = style.url(z, x, y, false, &self.mapbox_key, &self.maptiler_key, &self.custom_template)?;
+                let url = style.url(
+                    z,
+                    x,
+                    y,
+                    false,
+                    &self.mapbox_key,
+                    &self.maptiler_key,
+                    &self.custom_template,
+                )?;
                 Some((url, dir.join(format!("{z}/{x}/{y}"))))
             })
             .collect()
@@ -1856,14 +1891,22 @@ mod tests {
             );
         }
         // ArcGIS services use {z}/{y}/{x}: y before x in the path.
-        let esri = BasemapStyle::EsriImagery.url(6, 15, 25, false, "", "", "").unwrap();
+        let esri = BasemapStyle::EsriImagery
+            .url(6, 15, 25, false, "", "", "")
+            .unwrap();
         assert!(esri.ends_with("/6/25/15"), "Esri y/x order: {esri}");
         // Standard slippy tiles use {z}/{x}/{y}.
-        let osm = BasemapStyle::OsmStandard.url(6, 15, 25, false, "", "", "").unwrap();
+        let osm = BasemapStyle::OsmStandard
+            .url(6, 15, 25, false, "", "", "")
+            .unwrap();
         assert!(osm.ends_with("/6/15/25.png"), "OSM x/y order: {osm}");
         // Mapbox nav styles stay key-gated.
-        assert!(BasemapStyle::MapboxNavDay.url(6, 15, 25, false, "", "", "").is_none());
-        assert!(BasemapStyle::MapboxNavDay.url(6, 15, 25, false, "k", "", "").is_some());
+        assert!(BasemapStyle::MapboxNavDay
+            .url(6, 15, 25, false, "", "", "")
+            .is_none());
+        assert!(BasemapStyle::MapboxNavDay
+            .url(6, 15, 25, false, "k", "", "")
+            .is_some());
     }
 
     /// Retina asks for the `@2x` tile only where the provider serves one, and those tiles get
@@ -1871,12 +1914,21 @@ mod tests {
     #[test]
     fn retina_only_changes_the_sources_that_serve_2x() {
         let carto = BasemapStyle::CartoDarkMatter;
-        assert!(carto.url(6, 15, 25, true, "", "", "").unwrap().ends_with("@2x.png"));
-        assert!(carto.url(6, 15, 25, false, "", "", "").unwrap().ends_with("/25.png"));
+        assert!(carto
+            .url(6, 15, 25, true, "", "", "")
+            .unwrap()
+            .ends_with("@2x.png"));
+        assert!(carto
+            .url(6, 15, 25, false, "", "", "")
+            .unwrap()
+            .ends_with("/25.png"));
         assert_ne!(carto.provider(true, ""), carto.provider(false, ""));
         // No `@2x` upstream: the URL and the cache path are identical either way.
         let osm = BasemapStyle::OsmStandard;
-        assert_eq!(osm.url(6, 15, 25, true, "", "", ""), osm.url(6, 15, 25, false, "", "", ""));
+        assert_eq!(
+            osm.url(6, 15, 25, true, "", "", ""),
+            osm.url(6, 15, 25, false, "", "", "")
+        );
         assert_eq!(osm.provider(true, ""), osm.provider(false, ""));
     }
 
@@ -2014,7 +2066,10 @@ mod goes_window_tests {
         let (hour, from, to) = goes_window(now, Some(old));
         let h = hour.expect("three days back is an archive");
         assert_eq!(h, old.timestamp().div_euclid(3600));
-        assert!(from <= old && old <= to, "the frame we are replaying is covered");
+        assert!(
+            from <= old && old <= to,
+            "the frame we are replaying is covered"
+        );
         assert_eq!(to - from, chrono::Duration::hours(3));
         // Scrubbing a few minutes inside the same hour must not change the refetch key.
         let (again, ..) = goes_window(now, Some(old + chrono::Duration::minutes(5)));

--- a/crates/hookecho/src/timeline.rs
+++ b/crates/hookecho/src/timeline.rs
@@ -268,7 +268,11 @@ impl Timeline {
         // A replay bundle owns the playhead: it wraps inside its own window, live or not.
         if let Some((from, to)) = self.replay {
             let to = to.min(self.frames.len().saturating_sub(1));
-            self.playhead = if self.playhead >= to { from.min(to) } else { self.playhead + 1 };
+            self.playhead = if self.playhead >= to {
+                from.min(to)
+            } else {
+                self.playhead + 1
+            };
             return true;
         }
         if self.playhead + 1 < self.frames.len() {

--- a/crates/hookecho/src/ui/about_window.rs
+++ b/crates/hookecho/src/ui/about_window.rs
@@ -27,65 +27,70 @@ pub fn show(
     accent: egui::Color32,
     drawer: &mut crate::ui::drawer::Drawer,
 ) {
-    let Some(window) = drawer.page(ctx, "About HookEcho", open, false, egui::Window::new("About HookEcho"))
-    else {
+    let Some(window) = drawer.page(
+        ctx,
+        "About HookEcho",
+        open,
+        false,
+        egui::Window::new("About HookEcho"),
+    ) else {
         return;
     };
     let logo = crate::icon::texture(ctx, 128);
     window.show(ctx, |ui| {
-            // The mark beside the name, which is the one place in the app the logo is looked at
-            // rather than glanced at in a taskbar.
-            ui.horizontal(|ui| {
-                ui.add(egui::Image::new(&logo).fit_to_exact_size(egui::vec2(64.0, 64.0)));
-                ui.vertical(|ui| {
-                    ui.label(
-                        egui::RichText::new("HookEcho")
-                            .size(style::FONT_TITLE)
-                            .color(accent)
-                            .strong(),
-                    );
-                    ui.label(egui::RichText::new(format!("Version {VERSION}")).weak());
-                });
+        // The mark beside the name, which is the one place in the app the logo is looked at
+        // rather than glanced at in a taskbar.
+        ui.horizontal(|ui| {
+            ui.add(egui::Image::new(&logo).fit_to_exact_size(egui::vec2(64.0, 64.0)));
+            ui.vertical(|ui| {
+                ui.label(
+                    egui::RichText::new("HookEcho")
+                        .size(style::FONT_TITLE)
+                        .color(accent)
+                        .strong(),
+                );
+                ui.label(egui::RichText::new(format!("Version {VERSION}")).weak());
             });
-            ui.add_space(8.0);
-            ui.label("An advanced NEXRAD weather radar viewer. Free and MIT licensed.");
-            ui.add_space(8.0);
-            ui.hyperlink_to("Source, releases and issues", REPO);
-            ui.add_space(10.0);
-            ui.separator();
-            match update {
-                UpdateState::Idle | UpdateState::Checking => {
-                    crate::ui::loading(ui, "Checking for updates…")
-                }
-                UpdateState::UpToDate => {
-                    ui.label(egui::RichText::new("You're on the latest release.").weak());
-                }
-                UpdateState::Newer(tag) => {
-                    ui.horizontal(|ui| {
-                        ui.label(
-                            egui::RichText::new(format!("Version {tag} is available"))
-                                .color(style::OMEGA_GREEN),
-                        );
-                        ui.hyperlink_to("Download", format!("{REPO}/releases/latest"));
-                    });
-                }
-                UpdateState::NoRelease => {
-                    ui.label(egui::RichText::new("No published release to compare against.").weak());
-                }
-                UpdateState::Failed => {
-                    ui.label(egui::RichText::new("Couldn't check for updates.").weak());
-                }
-            }
-            ui.add_space(6.0);
-            ui.label(
-                egui::RichText::new(
-                    "Radar and warning data from NOAA/NWS and Iowa State's IEM archive. Built \
-                     with egui and wgpu.",
-                )
-                .size(style::FONT_SM)
-                .weak(),
-            );
         });
+        ui.add_space(8.0);
+        ui.label("An advanced NEXRAD weather radar viewer. Free and MIT licensed.");
+        ui.add_space(8.0);
+        ui.hyperlink_to("Source, releases and issues", REPO);
+        ui.add_space(10.0);
+        ui.separator();
+        match update {
+            UpdateState::Idle | UpdateState::Checking => {
+                crate::ui::loading(ui, "Checking for updates…")
+            }
+            UpdateState::UpToDate => {
+                ui.label(egui::RichText::new("You're on the latest release.").weak());
+            }
+            UpdateState::Newer(tag) => {
+                ui.horizontal(|ui| {
+                    ui.label(
+                        egui::RichText::new(format!("Version {tag} is available"))
+                            .color(style::OMEGA_GREEN),
+                    );
+                    ui.hyperlink_to("Download", format!("{REPO}/releases/latest"));
+                });
+            }
+            UpdateState::NoRelease => {
+                ui.label(egui::RichText::new("No published release to compare against.").weak());
+            }
+            UpdateState::Failed => {
+                ui.label(egui::RichText::new("Couldn't check for updates.").weak());
+            }
+        }
+        ui.add_space(6.0);
+        ui.label(
+            egui::RichText::new(
+                "Radar and warning data from NOAA/NWS and Iowa State's IEM archive. Built \
+                     with egui and wgpu.",
+            )
+            .size(style::FONT_SM)
+            .weak(),
+        );
+    });
 }
 
 /// `(major, minor, patch)` from a release tag like `v0.5.0`. `None` if it isn't one.
@@ -119,7 +124,10 @@ pub fn pick_latest_tag(json: &str) -> Option<String> {
         .iter()
         .filter(|r| {
             !r.get("draft").and_then(|v| v.as_bool()).unwrap_or(false)
-                && !r.get("prerelease").and_then(|v| v.as_bool()).unwrap_or(false)
+                && !r
+                    .get("prerelease")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false)
         })
         .filter_map(|r| r.get("tag_name")?.as_str())
         .filter_map(|tag| Some((parse_version(tag)?, tag.to_string())))

--- a/crates/hookecho/src/ui/afd_window.rs
+++ b/crates/hookecho/src/ui/afd_window.rs
@@ -23,46 +23,46 @@ pub fn show(
         return false;
     };
     window.show(ctx, |ui| {
-            ui.horizontal(|ui| {
-                match afd {
-                    Some(a) => {
-                        ui.strong(format!("AFD {}", a.office));
-                        ui.weak(&a.issued);
-                    }
-                    None => {
-                        ui.strong("AFD");
-                    }
+        ui.horizontal(|ui| {
+            match afd {
+                Some(a) => {
+                    ui.strong(format!("AFD {}", a.office));
+                    ui.weak(&a.issued);
                 }
-                if busy {
-                    crate::ui::loading(ui, "Fetching discussion…");
+                None => {
+                    ui.strong("AFD");
                 }
-                if ui.button("⟳ Refresh").clicked() {
-                    refresh = true;
+            }
+            if busy {
+                crate::ui::loading(ui, "Fetching discussion…");
+            }
+            if ui.button("⟳ Refresh").clicked() {
+                refresh = true;
+            }
+            if let Some(a) = afd {
+                crate::ui::reader_button(ui, &format!("AFD {}", a.office), &a.issued, &a.text);
+            }
+        });
+        if let Some(e) = error {
+            ui.colored_label(egui::Color32::from_rgb(230, 90, 90), e);
+        }
+        ui.separator();
+        egui::ScrollArea::vertical()
+            .auto_shrink([false, false])
+            .show(ui, |ui| match afd {
+                Some(a) => {
+                    ui.add(
+                        egui::Label::new(egui::RichText::new(&a.text).monospace().size(12.0))
+                            .wrap(),
+                    );
                 }
-                if let Some(a) = afd {
-                    crate::ui::reader_button(ui, &format!("AFD {}", a.office), &a.issued, &a.text);
+                None if busy => {
+                    ui.weak("Fetching the discussion…");
+                }
+                None => {
+                    ui.weak("No discussion loaded.");
                 }
             });
-            if let Some(e) = error {
-                ui.colored_label(egui::Color32::from_rgb(230, 90, 90), e);
-            }
-            ui.separator();
-            egui::ScrollArea::vertical()
-                .auto_shrink([false, false])
-                .show(ui, |ui| match afd {
-                    Some(a) => {
-                        ui.add(
-                            egui::Label::new(egui::RichText::new(&a.text).monospace().size(12.0))
-                                .wrap(),
-                        );
-                    }
-                    None if busy => {
-                        ui.weak("Fetching the discussion…");
-                    }
-                    None => {
-                        ui.weak("No discussion loaded.");
-                    }
-                });
-        });
+    });
     refresh
 }

--- a/crates/hookecho/src/ui/basemap_picker.rs
+++ b/crates/hookecho/src/ui/basemap_picker.rs
@@ -106,11 +106,7 @@ fn card(
         None => swatch(&painter, img_rect, style),
     }
     if !enabled {
-        painter.rect_filled(
-            img_rect,
-            4.0,
-            egui::Color32::from_black_alpha(150),
-        );
+        painter.rect_filled(img_rect, 4.0, egui::Color32::from_black_alpha(150));
         painter.text(
             img_rect.center(),
             egui::Align2::CENTER_CENTER,

--- a/crates/hookecho/src/ui/cappi_window.rs
+++ b/crates/hookecho/src/ui/cappi_window.rs
@@ -37,19 +37,19 @@ pub fn show(
         return open;
     };
     window.show(ctx, |ui| {
-            ui.horizontal(|ui| {
-                ui.label("Altitude");
-                ui.add(egui::Slider::new(alt_km, 0.5..=15.0).suffix(" km"));
-            });
-            ui.label(format!("{length:.0} km across · reflectivity · north up"));
-            ui.separator();
-            let w = ui.available_size().x.clamp(200.0, 420.0);
-            let img = egui::Image::new(tex)
-                .fit_to_exact_size(egui::vec2(w, w))
-                .texture_options(egui::TextureOptions::NEAREST);
-            ui.add(img);
-            ui.weak("Constant-altitude PPI; gaps = no beam coverage at this height.");
+        ui.horizontal(|ui| {
+            ui.label("Altitude");
+            ui.add(egui::Slider::new(alt_km, 0.5..=15.0).suffix(" km"));
         });
+        ui.label(format!("{length:.0} km across · reflectivity · north up"));
+        ui.separator();
+        let w = ui.available_size().x.clamp(200.0, 420.0);
+        let img = egui::Image::new(tex)
+            .fit_to_exact_size(egui::vec2(w, w))
+            .texture_options(egui::TextureOptions::NEAREST);
+        ui.add(img);
+        ui.weak("Constant-altitude PPI; gaps = no beam coverage at this height.");
+    });
     open
 }
 
@@ -66,7 +66,7 @@ pub fn show_empty(ctx: &egui::Context, drawer: &mut crate::ui::drawer::Drawer) -
         return open;
     };
     window.show(ctx, |ui| {
-            ui.weak("No volume loaded in the active pane.");
-        });
+        ui.weak("No volume loaded in the active pane.");
+    });
     open
 }

--- a/crates/hookecho/src/ui/cells_window.rs
+++ b/crates/hookecho/src/ui/cells_window.rs
@@ -198,241 +198,253 @@ pub fn show(
         return None;
     };
     window.show(ctx, |ui| {
-            if cells.is_empty() {
-                ui.weak("No tracked storm cells for this site right now.");
-                ui.small("Cells come from the radar's own storm-tracking product (SCIT).");
-                return;
-            }
-            ui.horizontal(|ui| {
-                ui.label(
-                    RichText::new(format!("{} cells", cells.len()))
-                        .strong()
-                        .color(accent),
-                );
-                ui.weak("· click a row to fly there");
-                ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-                    crate::ui::csv_buttons(ui, "cells.csv", "Every row, current sort", || {
-                        to_csv(cells, scores, &order)
-                    });
+        if cells.is_empty() {
+            ui.weak("No tracked storm cells for this site right now.");
+            ui.small("Cells come from the radar's own storm-tracking product (SCIT).");
+            return;
+        }
+        ui.horizontal(|ui| {
+            ui.label(
+                RichText::new(format!("{} cells", cells.len()))
+                    .strong()
+                    .color(accent),
+            );
+            ui.weak("· click a row to fly there");
+            ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                crate::ui::csv_buttons(ui, "cells.csv", "Every row, current sort", || {
+                    to_csv(cells, scores, &order)
                 });
-            });
-            ui.separator();
-
-            // Android: TableBuilder row clicks don't register under touch (nested scroll eats
-            // them) — same trap the site dialog hit. Buttons take taps reliably.
-            if cfg!(target_os = "android") {
-                egui::ScrollArea::vertical().show(ui, |ui| {
-                    for &i in &order {
-                        let c = &cells[i];
-                        let line = format!(
-                            "{}  {}   {}   {} dBZ   hail {}\"\n{}   top {} kft   VIL {}",
-                            scores.get(i).copied().unwrap_or(0),
-                            c.title,
-                            position(c),
-                            f0(c.max_dbz),
-                            f1(c.hail_in),
-                            movement(c),
-                            f0(c.top_kft),
-                            f0(c.vil),
-                        );
-                        let btn = egui::Button::new(RichText::new(line).size(14.0))
-                            .fill(egui::Color32::from_rgba_unmultiplied(255, 255, 255, 12))
-                            .corner_radius(8.0)
-                            .wrap_mode(egui::TextWrapMode::Extend)
-                            .min_size(egui::vec2(ui.available_width(), 46.0));
-                        if ui.add(btn).clicked() {
-                            chosen = Some(c.id.clone());
-                        }
-                        ui.add_space(3.0);
-                    }
-                });
-                return;
-            }
-
-            let header = |ui: &mut egui::Ui, label: &str, col: SortCol, w: &mut CellsWindow| {
-                let active = w.sort == col;
-                let text = if active {
-                    format!("{label} {}", if w.desc { "▼" } else { "▲" })
-                } else {
-                    label.to_string()
-                };
-                if ui.button(text).clicked() {
-                    if active {
-                        w.desc = !w.desc;
-                    } else {
-                        w.sort = col;
-                        w.desc = true;
-                    }
-                }
-            };
-
-            // Horizontal scroll keeps every column reachable on a narrow window.
-            egui::ScrollArea::horizontal().show(ui, |ui| {
-                TableBuilder::new(ui)
-                    .striped(true)
-                    .sense(egui::Sense::click())
-                    .column(Column::exact(46.0)) // rank
-                    .column(Column::exact(52.0)) // id
-                    .column(Column::exact(92.0)) // az/range
-                    .column(Column::exact(86.0)) // movement
-                    .column(Column::exact(56.0)) // max dbz
-                    .column(Column::exact(52.0)) // top
-                    .column(Column::exact(52.0)) // vil
-                    .column(Column::exact(48.0)) // poh
-                    .column(Column::exact(52.0)) // posh
-                    .column(Column::exact(56.0)) // hail
-                    .column(Column::exact(64.0)) // trend
-                    .column(Column::remainder()) // flags
-                    .min_scrolled_height(0.0)
-                    .header(22.0, |mut h| {
-                        h.col(|ui| header(ui, "Sev", SortCol::Rank, w));
-                        h.col(|ui| header(ui, "ID", SortCol::Id, w));
-                        h.col(|ui| header(ui, "Pos", SortCol::Range, w));
-                        h.col(|ui| {
-                            ui.label("Moving");
-                        });
-                        h.col(|ui| header(ui, "dBZ", SortCol::MaxDbz, w));
-                        h.col(|ui| header(ui, "Top", SortCol::Top, w));
-                        h.col(|ui| header(ui, "VIL", SortCol::Vil, w));
-                        h.col(|ui| header(ui, "POH", SortCol::Poh, w));
-                        h.col(|ui| header(ui, "SVR", SortCol::Posh, w));
-                        h.col(|ui| header(ui, "Hail", SortCol::Hail, w));
-                        h.col(|ui| {
-                            ui.label("Trend").on_hover_text(
-                                "Peak reflectivity over the volumes this cell has been tracked \
-                                 for \u{2014} whether it is strengthening or falling apart",
-                            );
-                        });
-                        h.col(|ui| {
-                            ui.label("Flags");
-                        });
-                    })
-                    .body(|body| {
-                        body.rows(20.0, order.len(), |mut row| {
-                            let i = order[row.index()];
-                            let c = &cells[i];
-                            let score = scores.get(i).copied().unwrap_or(0);
-                            row.col(|ui| {
-                                ui.label(RichText::new(score.to_string()).strong().color(rank_color(score)))
-                                    .on_hover_text(
-                                        "Severity 0\u{2013}100: ProbSevere, rotation (Vrot) and \
-                                         hail size blended, nudged by the radar's TVS/MESO flags",
-                                    );
-                            });
-                            row.col(|ui| {
-                                ui.label(RichText::new(&c.title).strong());
-                            });
-                            row.col(|ui| {
-                                ui.label(position(c));
-                            });
-                            row.col(|ui| {
-                                ui.label(movement(c));
-                            });
-                            row.col(|ui| {
-                                ui.label(f0(c.max_dbz));
-                            });
-                            row.col(|ui| {
-                                ui.label(f0(c.top_kft));
-                            });
-                            row.col(|ui| {
-                                ui.label(f0(c.vil));
-                            });
-                            row.col(|ui| {
-                                ui.label(num(c.poh));
-                            });
-                            row.col(|ui| {
-                                ui.label(num(c.posh));
-                            });
-                            row.col(|ui| {
-                                // The number people scan for first.
-                                let t = RichText::new(f1(c.hail_in));
-                                ui.label(if c.hail_in.is_some_and(|h| h >= 1.0) {
-                                    t.strong().color(egui::Color32::from_rgb(240, 170, 60))
-                                } else {
-                                    t
-                                });
-                            });
-                            row.col(|ui| {
-                                // A column of numbers says how strong a storm is now; it cannot
-                                // say which way it is going, which is the thing you actually
-                                // triage on when six cells are on screen.
-                                let hist = trends.get(&c.id).map(Vec::as_slice).unwrap_or(&[]);
-                                let dbz: Vec<f32> = hist.iter().filter_map(|s| s.dbz).collect();
-                                let resp = crate::theme::sparkline_sized(
-                                    ui,
-                                    &dbz,
-                                    egui::Color32::from_rgb(240, 170, 60),
-                                    egui::vec2(60.0, 16.0),
-                                );
-                                if !hist.is_empty() {
-                                    resp.on_hover_ui(|ui| {
-                                        ui.label(
-                                            RichText::new(format!("{} over {} volumes", c.title, hist.len()))
-                                                .strong(),
-                                        );
-                                        for (label, vals, color) in [
-                                            ("Peak dBZ", dbz.clone(), egui::Color32::from_rgb(240, 170, 60)),
-                                            (
-                                                "VIL",
-                                                hist.iter().filter_map(|s| s.vil).collect::<Vec<_>>(),
-                                                egui::Color32::from_rgb(120, 200, 240),
-                                            ),
-                                            (
-                                                "Top (kft)",
-                                                hist.iter().filter_map(|s| s.top).collect::<Vec<_>>(),
-                                                egui::Color32::from_rgb(150, 230, 170),
-                                            ),
-                                        ] {
-                                            ui.label(RichText::new(label).small().weak());
-                                            crate::theme::sparkline_sized(
-                                                ui,
-                                                &vals,
-                                                color,
-                                                egui::vec2(160.0, 26.0),
-                                            );
-                                        }
-                                    });
-                                }
-                            });
-                            row.col(|ui| {
-                                ui.with_layout(Layout::left_to_right(Align::Center), |ui| {
-                                    if c.tvs.is_some() {
-                                        ui.label(
-                                            RichText::new("TVS")
-                                                .small()
-                                                .strong()
-                                                .color(egui::Color32::from_rgb(235, 70, 70)),
-                                        );
-                                    }
-                                    if zdr_cells.contains(&c.id) {
-                                        ui.label(
-                                            RichText::new("Z\u{25b2}")
-                                                .small()
-                                                .strong()
-                                                .color(egui::Color32::from_rgb(120, 230, 160)),
-                                        )
-                                        .on_hover_text(
-                                            "A ZDR column reaches above the freezing level here \
-                                             \u{2014} the updraft is deep",
-                                        );
-                                    }
-                                    if c.meso.is_some() {
-                                        ui.label(
-                                            RichText::new("MESO")
-                                                .small()
-                                                .strong()
-                                                .color(egui::Color32::from_rgb(235, 160, 60)),
-                                        );
-                                    }
-                                });
-                            });
-                            if row.response().clicked() {
-                                chosen = Some(c.id.clone());
-                            }
-                        });
-                    });
             });
         });
+        ui.separator();
+
+        // Android: TableBuilder row clicks don't register under touch (nested scroll eats
+        // them) — same trap the site dialog hit. Buttons take taps reliably.
+        if cfg!(target_os = "android") {
+            egui::ScrollArea::vertical().show(ui, |ui| {
+                for &i in &order {
+                    let c = &cells[i];
+                    let line = format!(
+                        "{}  {}   {}   {} dBZ   hail {}\"\n{}   top {} kft   VIL {}",
+                        scores.get(i).copied().unwrap_or(0),
+                        c.title,
+                        position(c),
+                        f0(c.max_dbz),
+                        f1(c.hail_in),
+                        movement(c),
+                        f0(c.top_kft),
+                        f0(c.vil),
+                    );
+                    let btn = egui::Button::new(RichText::new(line).size(14.0))
+                        .fill(egui::Color32::from_rgba_unmultiplied(255, 255, 255, 12))
+                        .corner_radius(8.0)
+                        .wrap_mode(egui::TextWrapMode::Extend)
+                        .min_size(egui::vec2(ui.available_width(), 46.0));
+                    if ui.add(btn).clicked() {
+                        chosen = Some(c.id.clone());
+                    }
+                    ui.add_space(3.0);
+                }
+            });
+            return;
+        }
+
+        let header = |ui: &mut egui::Ui, label: &str, col: SortCol, w: &mut CellsWindow| {
+            let active = w.sort == col;
+            let text = if active {
+                format!("{label} {}", if w.desc { "▼" } else { "▲" })
+            } else {
+                label.to_string()
+            };
+            if ui.button(text).clicked() {
+                if active {
+                    w.desc = !w.desc;
+                } else {
+                    w.sort = col;
+                    w.desc = true;
+                }
+            }
+        };
+
+        // Horizontal scroll keeps every column reachable on a narrow window.
+        egui::ScrollArea::horizontal().show(ui, |ui| {
+            TableBuilder::new(ui)
+                .striped(true)
+                .sense(egui::Sense::click())
+                .column(Column::exact(46.0)) // rank
+                .column(Column::exact(52.0)) // id
+                .column(Column::exact(92.0)) // az/range
+                .column(Column::exact(86.0)) // movement
+                .column(Column::exact(56.0)) // max dbz
+                .column(Column::exact(52.0)) // top
+                .column(Column::exact(52.0)) // vil
+                .column(Column::exact(48.0)) // poh
+                .column(Column::exact(52.0)) // posh
+                .column(Column::exact(56.0)) // hail
+                .column(Column::exact(64.0)) // trend
+                .column(Column::remainder()) // flags
+                .min_scrolled_height(0.0)
+                .header(22.0, |mut h| {
+                    h.col(|ui| header(ui, "Sev", SortCol::Rank, w));
+                    h.col(|ui| header(ui, "ID", SortCol::Id, w));
+                    h.col(|ui| header(ui, "Pos", SortCol::Range, w));
+                    h.col(|ui| {
+                        ui.label("Moving");
+                    });
+                    h.col(|ui| header(ui, "dBZ", SortCol::MaxDbz, w));
+                    h.col(|ui| header(ui, "Top", SortCol::Top, w));
+                    h.col(|ui| header(ui, "VIL", SortCol::Vil, w));
+                    h.col(|ui| header(ui, "POH", SortCol::Poh, w));
+                    h.col(|ui| header(ui, "SVR", SortCol::Posh, w));
+                    h.col(|ui| header(ui, "Hail", SortCol::Hail, w));
+                    h.col(|ui| {
+                        ui.label("Trend").on_hover_text(
+                            "Peak reflectivity over the volumes this cell has been tracked \
+                                 for \u{2014} whether it is strengthening or falling apart",
+                        );
+                    });
+                    h.col(|ui| {
+                        ui.label("Flags");
+                    });
+                })
+                .body(|body| {
+                    body.rows(20.0, order.len(), |mut row| {
+                        let i = order[row.index()];
+                        let c = &cells[i];
+                        let score = scores.get(i).copied().unwrap_or(0);
+                        row.col(|ui| {
+                            ui.label(
+                                RichText::new(score.to_string())
+                                    .strong()
+                                    .color(rank_color(score)),
+                            )
+                            .on_hover_text(
+                                "Severity 0\u{2013}100: ProbSevere, rotation (Vrot) and \
+                                         hail size blended, nudged by the radar's TVS/MESO flags",
+                            );
+                        });
+                        row.col(|ui| {
+                            ui.label(RichText::new(&c.title).strong());
+                        });
+                        row.col(|ui| {
+                            ui.label(position(c));
+                        });
+                        row.col(|ui| {
+                            ui.label(movement(c));
+                        });
+                        row.col(|ui| {
+                            ui.label(f0(c.max_dbz));
+                        });
+                        row.col(|ui| {
+                            ui.label(f0(c.top_kft));
+                        });
+                        row.col(|ui| {
+                            ui.label(f0(c.vil));
+                        });
+                        row.col(|ui| {
+                            ui.label(num(c.poh));
+                        });
+                        row.col(|ui| {
+                            ui.label(num(c.posh));
+                        });
+                        row.col(|ui| {
+                            // The number people scan for first.
+                            let t = RichText::new(f1(c.hail_in));
+                            ui.label(if c.hail_in.is_some_and(|h| h >= 1.0) {
+                                t.strong().color(egui::Color32::from_rgb(240, 170, 60))
+                            } else {
+                                t
+                            });
+                        });
+                        row.col(|ui| {
+                            // A column of numbers says how strong a storm is now; it cannot
+                            // say which way it is going, which is the thing you actually
+                            // triage on when six cells are on screen.
+                            let hist = trends.get(&c.id).map(Vec::as_slice).unwrap_or(&[]);
+                            let dbz: Vec<f32> = hist.iter().filter_map(|s| s.dbz).collect();
+                            let resp = crate::theme::sparkline_sized(
+                                ui,
+                                &dbz,
+                                egui::Color32::from_rgb(240, 170, 60),
+                                egui::vec2(60.0, 16.0),
+                            );
+                            if !hist.is_empty() {
+                                resp.on_hover_ui(|ui| {
+                                    ui.label(
+                                        RichText::new(format!(
+                                            "{} over {} volumes",
+                                            c.title,
+                                            hist.len()
+                                        ))
+                                        .strong(),
+                                    );
+                                    for (label, vals, color) in [
+                                        (
+                                            "Peak dBZ",
+                                            dbz.clone(),
+                                            egui::Color32::from_rgb(240, 170, 60),
+                                        ),
+                                        (
+                                            "VIL",
+                                            hist.iter().filter_map(|s| s.vil).collect::<Vec<_>>(),
+                                            egui::Color32::from_rgb(120, 200, 240),
+                                        ),
+                                        (
+                                            "Top (kft)",
+                                            hist.iter().filter_map(|s| s.top).collect::<Vec<_>>(),
+                                            egui::Color32::from_rgb(150, 230, 170),
+                                        ),
+                                    ] {
+                                        ui.label(RichText::new(label).small().weak());
+                                        crate::theme::sparkline_sized(
+                                            ui,
+                                            &vals,
+                                            color,
+                                            egui::vec2(160.0, 26.0),
+                                        );
+                                    }
+                                });
+                            }
+                        });
+                        row.col(|ui| {
+                            ui.with_layout(Layout::left_to_right(Align::Center), |ui| {
+                                if c.tvs.is_some() {
+                                    ui.label(
+                                        RichText::new("TVS")
+                                            .small()
+                                            .strong()
+                                            .color(egui::Color32::from_rgb(235, 70, 70)),
+                                    );
+                                }
+                                if zdr_cells.contains(&c.id) {
+                                    ui.label(
+                                        RichText::new("Z\u{25b2}")
+                                            .small()
+                                            .strong()
+                                            .color(egui::Color32::from_rgb(120, 230, 160)),
+                                    )
+                                    .on_hover_text(
+                                        "A ZDR column reaches above the freezing level here \
+                                             \u{2014} the updraft is deep",
+                                    );
+                                }
+                                if c.meso.is_some() {
+                                    ui.label(
+                                        RichText::new("MESO")
+                                            .small()
+                                            .strong()
+                                            .color(egui::Color32::from_rgb(235, 160, 60)),
+                                    );
+                                }
+                            });
+                        });
+                        if row.response().clicked() {
+                            chosen = Some(c.id.clone());
+                        }
+                    });
+                });
+        });
+    });
     w.open = open;
     chosen
 }
@@ -470,8 +482,14 @@ mod tests {
             cell("C", None, None),
         ];
         // Only two scores for three cells: the third is unknown, and unknown sorts last either way.
-        assert_eq!(sorted_indices(&cells, &[30, 88], SortCol::Rank, true), vec![1, 0, 2]);
-        assert_eq!(sorted_indices(&cells, &[30, 88], SortCol::Rank, false), vec![0, 1, 2]);
+        assert_eq!(
+            sorted_indices(&cells, &[30, 88], SortCol::Rank, true),
+            vec![1, 0, 2]
+        );
+        assert_eq!(
+            sorted_indices(&cells, &[30, 88], SortCol::Rank, false),
+            vec![0, 1, 2]
+        );
     }
 
     #[test]
@@ -480,8 +498,14 @@ mod tests {
         let order = sorted_indices(&cells, &[], SortCol::Hail, true);
         let csv = to_csv(&cells, &[71, 12], &order);
         let lines: Vec<&str> = csv.lines().collect();
-        assert!(lines[0].starts_with("severity,id,azimuth_deg"), "header first");
-        assert!(lines[1].starts_with("71,A,"), "sorted order, not input order");
+        assert!(
+            lines[0].starts_with("severity,id,azimuth_deg"),
+            "header first"
+        );
+        assert!(
+            lines[1].starts_with("71,A,"),
+            "sorted order, not input order"
+        );
         assert_eq!(lines[2], "12,B,,,,,,,,,,,0,0", "unknowns are empty fields");
     }
 

--- a/crates/hookecho/src/ui/chase_replay.rs
+++ b/crates/hookecho/src/ui/chase_replay.rs
@@ -133,10 +133,7 @@ impl ChaseReplay {
                     action = Some(ReplayAction::OpenFile);
                 }
                 if ui
-                    .add_enabled(
-                        live.points.len() > 1,
-                        egui::Button::new("This session"),
-                    )
+                    .add_enabled(live.points.len() > 1, egui::Button::new("This session"))
                     .on_hover_text("Replay the track being logged right now")
                     .clicked()
                 {

--- a/crates/hookecho/src/ui/drawer.rs
+++ b/crates/hookecho/src/ui/drawer.rs
@@ -208,7 +208,10 @@ impl Drawer {
         }
         ctx.request_repaint();
         let off = (1.0 - crate::ui::motion::ease_out_back(t as f32)) * (head.width() + X);
-        (head.translate(vec2(-off, 0.0)), body.translate(vec2(-off, 0.0)))
+        (
+            head.translate(vec2(-off, 0.0)),
+            body.translate(vec2(-off, 0.0)),
+        )
     }
 }
 

--- a/crates/hookecho/src/ui/glossary.rs
+++ b/crates/hookecho/src/ui/glossary.rs
@@ -128,14 +128,12 @@ pub(crate) fn explains(label: &str) -> Option<usize> {
         let key = e.term.split([' ', '\u{2014}']).next().unwrap_or("");
         key.len() >= 3
             && key.chars().all(|c| c.is_ascii_uppercase())
-            && up
-                .match_indices(key)
-                .any(|(i, _)| {
-                    let before = up[..i].chars().next_back();
-                    let after = up[i + key.len()..].chars().next();
-                    !before.is_some_and(|c| c.is_ascii_alphanumeric())
-                        && !after.is_some_and(|c| c.is_ascii_alphanumeric())
-                })
+            && up.match_indices(key).any(|(i, _)| {
+                let before = up[..i].chars().next_back();
+                let after = up[i + key.len()..].chars().next();
+                !before.is_some_and(|c| c.is_ascii_alphanumeric())
+                    && !after.is_some_and(|c| c.is_ascii_alphanumeric())
+            })
     })
 }
 

--- a/crates/hookecho/src/ui/help_hub.rs
+++ b/crates/hookecho/src/ui/help_hub.rs
@@ -46,7 +46,13 @@ impl HelpHub {
         self.open = true;
         self.query = crate::ui::glossary::ENTRIES
             .get(entry)
-            .map(|e| e.term.split([' ', '\u{2014}']).next().unwrap_or(e.term).to_string())
+            .map(|e| {
+                e.term
+                    .split([' ', '\u{2014}'])
+                    .next()
+                    .unwrap_or(e.term)
+                    .to_string()
+            })
             .unwrap_or_default();
     }
 
@@ -156,11 +162,7 @@ fn terms_empty(q: &str) -> bool {
 
 /// Live bindings as `(key, what it does)`, labelled from the registry so a renamed action renames
 /// its shortcut row too.
-fn shortcut_rows(
-    bindings: &[Binding],
-    entries: &[PaletteEntry],
-    q: &str,
-) -> Vec<(String, String)> {
+fn shortcut_rows(bindings: &[Binding], entries: &[PaletteEntry], q: &str) -> Vec<(String, String)> {
     bindings
         .iter()
         .filter_map(|b| {
@@ -217,7 +219,10 @@ mod tests {
     fn shortcuts_filter_by_label_and_by_key() {
         let bindings = crate::hotkeys::defaults();
         let all = shortcut_rows(&bindings, &[], "");
-        assert!(!all.is_empty(), "app-level bindings always label themselves");
+        assert!(
+            !all.is_empty(),
+            "app-level bindings always label themselves"
+        );
         // No registry passed, so every palette-bound row drops out and only `hotkeys::label` rows
         // remain — which is exactly what a caller with no entries should see.
         assert!(all.iter().any(|(_, l)| l == "Fullscreen"));

--- a/crates/hookecho/src/ui/hodograph_window.rs
+++ b/crates/hookecho/src/ui/hodograph_window.rs
@@ -41,27 +41,27 @@ pub fn show(
         return open;
     };
     window.show(ctx, |ui| {
-            ui.horizontal(|ui| {
-                ui.strong(site.unwrap_or("—"));
-                ui.weak(format!("{} levels", levels.len()));
-                ui.separator();
-                ui.selectable_value(tab, Tab::Hodograph, "Hodograph");
-                ui.selectable_value(tab, Tab::TimeHeight, "Time-height");
-            });
+        ui.horizontal(|ui| {
+            ui.strong(site.unwrap_or("—"));
+            ui.weak(format!("{} levels", levels.len()));
             ui.separator();
-            match *tab {
-                Tab::Hodograph => {
-                    if levels.len() < 2 {
-                        ui.weak("Loading VAD wind profile…");
-                        return;
-                    }
-                    plot(ui, levels);
-                    ui.add_space(4.0);
-                    legend(ui, levels);
-                }
-                Tab::TimeHeight => time_height(ui, history, tz),
-            }
+            ui.selectable_value(tab, Tab::Hodograph, "Hodograph");
+            ui.selectable_value(tab, Tab::TimeHeight, "Time-height");
         });
+        ui.separator();
+        match *tab {
+            Tab::Hodograph => {
+                if levels.len() < 2 {
+                    ui.weak("Loading VAD wind profile…");
+                    return;
+                }
+                plot(ui, levels);
+                ui.add_space(4.0);
+                legend(ui, levels);
+            }
+            Tab::TimeHeight => time_height(ui, history, tz),
+        }
+    });
     open
 }
 

--- a/crates/hookecho/src/ui/layer_options.rs
+++ b/crates/hookecho/src/ui/layer_options.rs
@@ -147,7 +147,9 @@ pub(crate) fn show(
             // The two models rarely share a cycle, and a difference between two instants is only
             // honest if it says which two.
             Some((va, vb)) if va != vb => {
-                ui.weak(format!("⚠ {a} valid {va}, {b} valid {vb} — not the same time."));
+                ui.weak(format!(
+                    "⚠ {a} valid {va}, {b} valid {vb} — not the same time."
+                ));
             }
             Some((va, _)) => {
                 ui.weak(format!("Both valid {va}."));
@@ -338,8 +340,13 @@ pub(crate) fn show(
         ui.horizontal(|ui| {
             ui.label("Window:");
             let mut dur = false;
-            for (m, label) in [(30u16, "30m"), (60, "1h"), (120, "2h"), (360, "6h"), (1440, "24h")]
-            {
+            for (m, label) in [
+                (30u16, "30m"),
+                (60, "1h"),
+                (120, "2h"),
+                (360, "6h"),
+                (1440, "24h"),
+            ] {
                 dur |= ui.selectable_value(hail_minutes, m, label).changed();
             }
             if dur {

--- a/crates/hookecho/src/ui/layer_window.rs
+++ b/crates/hookecho/src/ui/layer_window.rs
@@ -36,65 +36,65 @@ pub(crate) fn show(
         return false;
     };
     window.show(ctx, |ui| {
-            if !active.is_empty() {
-                ui.label(egui::RichText::new("Field layers").strong());
-                for (layer, name) in active {
-                    let op = settings.field_opacity.entry(*layer).or_insert(1.0);
-                    ui.horizontal(|ui| {
-                        ui.label(name);
-                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                            changed |= ui
-                                .add(egui::Slider::new(op, 0.05..=1.0).show_value(false))
-                                .on_hover_text(format!("Opacity {:.0}%", *op * 100.0))
-                                .changed();
-                        });
-                    });
-                }
-                ui.separator();
-            }
-            if settings.placefiles.is_empty() {
-                ui.weak("No placefiles configured — add one from Layers ▸ Placefile manager.");
-                return;
-            }
-            ui.weak("Top of the list paints first (underneath).");
-            ui.separator();
-            let n = settings.placefiles.len();
-            let mut swap: Option<(usize, usize)> = None;
-            for i in 0..n {
-                let cfg = &mut settings.placefiles[i];
+        if !active.is_empty() {
+            ui.label(egui::RichText::new("Field layers").strong());
+            for (layer, name) in active {
+                let op = settings.field_opacity.entry(*layer).or_insert(1.0);
                 ui.horizontal(|ui| {
-                    changed |= ui.checkbox(&mut cfg.enabled, "").changed();
-                    // The URL's file name is the readable part; the full URL is the tooltip.
-                    let name = cfg.url.rsplit('/').next().unwrap_or(&cfg.url).to_string();
-                    ui.label(egui::RichText::new(name).strong())
-                        .on_hover_text(&cfg.url);
+                    ui.label(name);
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                        if ui
-                            .add_enabled(i + 1 < n, egui::Button::new("▼"))
-                            .on_hover_text("Paint later (on top)")
-                            .clicked()
-                        {
-                            swap = Some((i, i + 1));
-                        }
-                        if ui
-                            .add_enabled(i > 0, egui::Button::new("▲"))
-                            .on_hover_text("Paint earlier (underneath)")
-                            .clicked()
-                        {
-                            swap = Some((i, i - 1));
-                        }
                         changed |= ui
-                            .add(egui::Slider::new(&mut cfg.opacity, 0.05..=1.0).show_value(false))
-                            .on_hover_text(format!("Opacity {:.0}%", cfg.opacity * 100.0))
+                            .add(egui::Slider::new(op, 0.05..=1.0).show_value(false))
+                            .on_hover_text(format!("Opacity {:.0}%", *op * 100.0))
                             .changed();
                     });
                 });
             }
-            if let Some((a, b)) = swap {
-                settings.placefiles.swap(a, b);
-                changed = true;
-            }
-        });
+            ui.separator();
+        }
+        if settings.placefiles.is_empty() {
+            ui.weak("No placefiles configured — add one from Layers ▸ Placefile manager.");
+            return;
+        }
+        ui.weak("Top of the list paints first (underneath).");
+        ui.separator();
+        let n = settings.placefiles.len();
+        let mut swap: Option<(usize, usize)> = None;
+        for i in 0..n {
+            let cfg = &mut settings.placefiles[i];
+            ui.horizontal(|ui| {
+                changed |= ui.checkbox(&mut cfg.enabled, "").changed();
+                // The URL's file name is the readable part; the full URL is the tooltip.
+                let name = cfg.url.rsplit('/').next().unwrap_or(&cfg.url).to_string();
+                ui.label(egui::RichText::new(name).strong())
+                    .on_hover_text(&cfg.url);
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    if ui
+                        .add_enabled(i + 1 < n, egui::Button::new("▼"))
+                        .on_hover_text("Paint later (on top)")
+                        .clicked()
+                    {
+                        swap = Some((i, i + 1));
+                    }
+                    if ui
+                        .add_enabled(i > 0, egui::Button::new("▲"))
+                        .on_hover_text("Paint earlier (underneath)")
+                        .clicked()
+                    {
+                        swap = Some((i, i - 1));
+                    }
+                    changed |= ui
+                        .add(egui::Slider::new(&mut cfg.opacity, 0.05..=1.0).show_value(false))
+                        .on_hover_text(format!("Opacity {:.0}%", cfg.opacity * 100.0))
+                        .changed();
+                });
+            });
+        }
+        if let Some((a, b)) = swap {
+            settings.placefiles.swap(a, b);
+            changed = true;
+        }
+    });
     *open = win_open;
     changed
 }

--- a/crates/hookecho/src/ui/layers_panel.rs
+++ b/crates/hookecho/src/ui/layers_panel.rs
@@ -60,8 +60,12 @@ pub(crate) fn glyph(e: &PaletteEntry) -> &'static str {
     let l = e.label.to_lowercase();
     let has = |w: &str| l.contains(w);
     match () {
-        _ if has("velocity") || has("azshear") || has("rotation") || has("srv")
-            || has("srh") || has("spin") =>
+        _ if has("velocity")
+            || has("azshear")
+            || has("rotation")
+            || has("srv")
+            || has("srh")
+            || has("spin") =>
         {
             ph::ARROWS_CLOCKWISE
         }
@@ -69,7 +73,11 @@ pub(crate) fn glyph(e: &PaletteEntry) -> &'static str {
         _ if has("tornado") || has("tds") => ph::TORNADO,
         _ if has("lightning") || has("glm") => ph::LIGHTNING,
         _ if has("snow") || has("winter") || has("ice") => ph::SNOWFLAKE,
-        _ if has("rain") || has("qpe") || has("precip") || has("flood") || has("vil")
+        _ if has("rain")
+            || has("qpe")
+            || has("precip")
+            || has("flood")
+            || has("vil")
             || has("moisture") =>
         {
             ph::DROP

--- a/crates/hookecho/src/ui/legend.rs
+++ b/crates/hookecho/src/ui/legend.rs
@@ -253,7 +253,11 @@ pub fn draw_diff(
     let (a, b) = field.pair();
     for (text, align, x) in [
         (format!("-{range:.0}"), Align2::LEFT_TOP, bar.left()),
-        ("0 (\u{2248})".to_string(), Align2::CENTER_TOP, bar.center().x),
+        (
+            "0 (\u{2248})".to_string(),
+            Align2::CENTER_TOP,
+            bar.center().x,
+        ),
         (format!("+{range:.0}"), Align2::RIGHT_TOP, bar.right()),
     ] {
         painter.text(

--- a/crates/hookecho/src/ui/mod.rs
+++ b/crates/hookecho/src/ui/mod.rs
@@ -87,17 +87,16 @@ pub(crate) fn csv_buttons(
 pub mod a11y;
 pub mod about_window;
 pub mod afd_window;
-pub mod tropical_window;
 pub mod alert_panel;
-pub mod drawer;
 pub mod basemap_picker;
 pub mod cappi_window;
 pub mod cell_window;
 pub mod cells_window;
+pub mod chase_replay;
 pub mod cheatsheet;
 pub mod detail_window;
 pub mod digest_window;
-pub mod chase_replay;
+pub mod drawer;
 pub mod event_window;
 pub mod firstrun;
 pub mod forecast_window;
@@ -111,9 +110,9 @@ pub mod legend;
 /// Material 3 design tokens for the mobile chrome.
 pub mod m3;
 pub mod marker_popup;
+pub mod marker_window;
 /// Easing and the reduced-motion brake.
 pub mod motion;
-pub mod marker_window;
 pub mod palette_editor;
 pub mod placefile_window;
 pub mod popover;
@@ -127,6 +126,7 @@ pub mod station_card;
 pub mod style;
 /// The optional spotlight tour of the live chrome.
 pub mod tour;
+pub mod tropical_window;
 pub mod verify_window;
 pub mod video_window;
 pub mod volume3d_window;

--- a/crates/hookecho/src/ui/motion.rs
+++ b/crates/hookecho/src/ui/motion.rs
@@ -67,13 +67,7 @@ pub fn ease_out_cubic(t: f32) -> f32 {
 /// A 0..1 progress for `on`, eased, or a hard 0/1 when motion is off.
 ///
 /// `ease` is the shape; pass [`ease_out_back`] for arrivals and [`ease_out_cubic`] for the rest.
-pub fn rise(
-    ctx: &egui::Context,
-    id: egui::Id,
-    on: bool,
-    secs: f32,
-    ease: fn(f32) -> f32,
-) -> f32 {
+pub fn rise(ctx: &egui::Context, id: egui::Id, on: bool, secs: f32, ease: fn(f32) -> f32) -> f32 {
     if reduced() {
         return if on { 1.0 } else { 0.0 };
     }

--- a/crates/hookecho/src/ui/palette_editor.rs
+++ b/crates/hookecho/src/ui/palette_editor.rs
@@ -66,112 +66,109 @@ impl PaletteEditor {
             return;
         };
         window.show(ctx, |ui| {
-                ui.horizontal(|ui| {
-                    ui.label("Moment");
-                    egui::ComboBox::from_id_salt("pal_moment")
-                        .selected_text(moment.short_name())
-                        .show_ui(ui, |ui| {
-                            for (i, m) in Moment::ALL.iter().enumerate() {
-                                if ui
-                                    .selectable_value(&mut self.moment_idx, i, m.short_name())
-                                    .clicked()
-                                {
-                                    self.loaded_for = None; // force reload for the new moment
+            ui.horizontal(|ui| {
+                ui.label("Moment");
+                egui::ComboBox::from_id_salt("pal_moment")
+                    .selected_text(moment.short_name())
+                    .show_ui(ui, |ui| {
+                        for (i, m) in Moment::ALL.iter().enumerate() {
+                            if ui
+                                .selectable_value(&mut self.moment_idx, i, m.short_name())
+                                .clicked()
+                            {
+                                self.loaded_for = None; // force reload for the new moment
+                            }
+                        }
+                    });
+            });
+            ui.separator();
+
+            let Some(table) = self.table.as_mut() else {
+                return;
+            };
+
+            // Live gradient preview across the moment's value range.
+            preview_bar(ui, table, moment.value_range());
+            ui.add_space(6.0);
+
+            let mut remove = None;
+            egui::ScrollArea::vertical()
+                .max_height(280.0)
+                .show(ui, |ui| {
+                    egui::Grid::new("stops")
+                        .num_columns(5)
+                        .spacing([8.0, 4.0])
+                        .show(ui, |ui| {
+                            ui.strong("Value");
+                            ui.strong("Color");
+                            ui.strong("End");
+                            ui.strong("Solid");
+                            ui.end_row();
+                            for (i, s) in table.stops.iter_mut().enumerate() {
+                                ui.add(
+                                    egui::DragValue::new(&mut s.value)
+                                        .speed(0.5)
+                                        .max_decimals(2),
+                                );
+                                color_edit(ui, &mut s.rgba);
+                                // Optional second color (hard break).
+                                let mut has_end = s.end.is_some();
+                                if ui.checkbox(&mut has_end, "").changed() {
+                                    s.end = if has_end { Some(s.rgba) } else { None };
                                 }
+                                if let Some(end) = s.end.as_mut() {
+                                    color_edit(ui, end);
+                                } else {
+                                    ui.label("");
+                                }
+                                ui.checkbox(&mut s.solid, "");
+                                if ui.button("✖").clicked() {
+                                    remove = Some(i);
+                                }
+                                ui.end_row();
                             }
                         });
                 });
-                ui.separator();
+            if let Some(i) = remove {
+                table.stops.remove(i);
+            }
 
-                let Some(table) = self.table.as_mut() else {
-                    return;
-                };
-
-                // Live gradient preview across the moment's value range.
-                preview_bar(ui, table, moment.value_range());
-                ui.add_space(6.0);
-
-                let mut remove = None;
-                egui::ScrollArea::vertical()
-                    .max_height(280.0)
-                    .show(ui, |ui| {
-                        egui::Grid::new("stops")
-                            .num_columns(5)
-                            .spacing([8.0, 4.0])
-                            .show(ui, |ui| {
-                                ui.strong("Value");
-                                ui.strong("Color");
-                                ui.strong("End");
-                                ui.strong("Solid");
-                                ui.end_row();
-                                for (i, s) in table.stops.iter_mut().enumerate() {
-                                    ui.add(
-                                        egui::DragValue::new(&mut s.value)
-                                            .speed(0.5)
-                                            .max_decimals(2),
-                                    );
-                                    color_edit(ui, &mut s.rgba);
-                                    // Optional second color (hard break).
-                                    let mut has_end = s.end.is_some();
-                                    if ui.checkbox(&mut has_end, "").changed() {
-                                        s.end = if has_end { Some(s.rgba) } else { None };
-                                    }
-                                    if let Some(end) = s.end.as_mut() {
-                                        color_edit(ui, end);
-                                    } else {
-                                        ui.label("");
-                                    }
-                                    ui.checkbox(&mut s.solid, "");
-                                    if ui.button("✖").clicked() {
-                                        remove = Some(i);
-                                    }
-                                    ui.end_row();
-                                }
-                            });
+            ui.add_space(4.0);
+            ui.horizontal(|ui| {
+                if ui.button("➕ Add stop").clicked() {
+                    let value = table.stops.last().map(|s| s.value + 5.0).unwrap_or(0.0);
+                    table.stops.push(PalStop {
+                        value,
+                        rgba: [255, 255, 255, 255],
+                        end: None,
+                        solid: false,
                     });
-                if let Some(i) = remove {
-                    table.stops.remove(i);
                 }
-
-                ui.add_space(4.0);
-                ui.horizontal(|ui| {
-                    if ui.button("➕ Add stop").clicked() {
-                        let value = table.stops.last().map(|s| s.value + 5.0).unwrap_or(0.0);
-                        table.stops.push(PalStop {
-                            value,
-                            rgba: [255, 255, 255, 255],
-                            end: None,
-                            solid: false,
-                        });
-                    }
-                    if ui.button("Sort by value").clicked() {
-                        table.stops.sort_by(|a, b| {
-                            a.value
-                                .partial_cmp(&b.value)
-                                .unwrap_or(std::cmp::Ordering::Equal)
-                        });
-                    }
-                });
-
-                ui.separator();
-                ui.horizontal(|ui| {
-                    if ui.button("💾 Save & apply").clicked() {
-                        save_and_apply(table, moment, settings);
-                    }
-                    if ui.button("Import .pal…").clicked() {
-                        crate::dialog::request_open(
-                            crate::dialog::ImportKind::Palette,
-                            EDITOR_TAG,
-                        );
-                    }
-                    if ui.button("Export .pal…").clicked() {
-                        export_pal(table);
-                    }
-                    if ui.button("Revert to default").clicked() {
-                        *table = crate::colormap::default_table(moment).clone();
-                    }
-                });
+                if ui.button("Sort by value").clicked() {
+                    table.stops.sort_by(|a, b| {
+                        a.value
+                            .partial_cmp(&b.value)
+                            .unwrap_or(std::cmp::Ordering::Equal)
+                    });
+                }
             });
+
+            ui.separator();
+            ui.horizontal(|ui| {
+                if ui.button("💾 Save & apply").clicked() {
+                    save_and_apply(table, moment, settings);
+                }
+                if ui.button("Import .pal…").clicked() {
+                    crate::dialog::request_open(crate::dialog::ImportKind::Palette, EDITOR_TAG);
+                }
+                if ui.button("Export .pal…").clicked() {
+                    export_pal(table);
+                }
+                if ui.button("Revert to default").clicked() {
+                    *table = crate::colormap::default_table(moment).clone();
+                }
+            });
+        });
         self.open = open;
     }
 }
@@ -217,7 +214,9 @@ fn save_and_apply(table: &ColorTable, moment: Moment, settings: &mut Settings) {
         settings
             .web_files
             .insert(name.clone(), crate::colormap::to_pal_string(table));
-        settings.palettes.insert(moment.short_name().to_string(), name);
+        settings
+            .palettes
+            .insert(moment.short_name().to_string(), name);
         return;
     };
     let path = dir.join(&name);
@@ -234,7 +233,8 @@ fn save_and_apply(table: &ColorTable, moment: Moment, settings: &mut Settings) {
 
 fn export_pal(table: &ColorTable) {
     let pal = crate::colormap::to_pal_string(table);
-    if let crate::dialog::Saved::Failed(e) = crate::dialog::save_bytes("palette.pal", "pal", pal.as_bytes())
+    if let crate::dialog::Saved::Failed(e) =
+        crate::dialog::save_bytes("palette.pal", "pal", pal.as_bytes())
     {
         log::warn!("palette export failed: {e}");
     }

--- a/crates/hookecho/src/ui/placefile_window.rs
+++ b/crates/hookecho/src/ui/placefile_window.rs
@@ -41,66 +41,66 @@ impl PlacefileWindow {
             return;
         };
         window.show(ctx, |ui| {
-                ui.label("GRLevelX placefiles (lines, polygons, text, icons at lat/lon).");
-                ui.add_space(4.0);
+            ui.label("GRLevelX placefiles (lines, polygons, text, icons at lat/lon).");
+            ui.add_space(4.0);
 
-                let mut remove: Option<usize> = None;
-                egui::ScrollArea::vertical()
-                    .max_height(200.0)
-                    .show(ui, |ui| {
-                        for (i, cfg) in settings.placefiles.iter_mut().enumerate() {
-                            let st = status.iter().find(|s| s.url == cfg.url);
-                            ui.horizontal(|ui| {
-                                ui.checkbox(&mut cfg.enabled, "");
-                                if ui.button("✖").on_hover_text("Remove").clicked() {
-                                    remove = Some(i);
-                                }
-                                ui.vertical(|ui| {
-                                    let title = st
-                                        .filter(|s| !s.title.is_empty())
-                                        .map(|s| s.title.as_str())
-                                        .unwrap_or("(untitled)");
-                                    ui.strong(title);
-                                    ui.weak(&cfg.url);
-                                    status_line(ui, st);
-                                });
+            let mut remove: Option<usize> = None;
+            egui::ScrollArea::vertical()
+                .max_height(200.0)
+                .show(ui, |ui| {
+                    for (i, cfg) in settings.placefiles.iter_mut().enumerate() {
+                        let st = status.iter().find(|s| s.url == cfg.url);
+                        ui.horizontal(|ui| {
+                            ui.checkbox(&mut cfg.enabled, "");
+                            if ui.button("✖").on_hover_text("Remove").clicked() {
+                                remove = Some(i);
+                            }
+                            ui.vertical(|ui| {
+                                let title = st
+                                    .filter(|s| !s.title.is_empty())
+                                    .map(|s| s.title.as_str())
+                                    .unwrap_or("(untitled)");
+                                ui.strong(title);
+                                ui.weak(&cfg.url);
+                                status_line(ui, st);
                             });
-                            ui.separator();
-                        }
-                    });
-                if let Some(i) = remove {
-                    settings.placefiles.remove(i);
-                }
-
-                ui.add_space(6.0);
-                ui.horizontal(|ui| {
-                    ui.label("URL:");
-                    ui.add(
-                        egui::TextEdit::singleline(&mut self.new_url)
-                            .desired_width(340.0)
-                            .hint_text("http://…/placefile.txt"),
-                    );
-                    let valid = self.new_url.starts_with("http")
-                        && !settings
-                            .placefiles
-                            .iter()
-                            .any(|c| c.url == self.new_url.trim());
-                    if ui.add_enabled(valid, egui::Button::new("Add")).clicked() {
-                        settings.placefiles.push(PlacefileConfig {
-                            url: self.new_url.trim().to_string(),
-                            enabled: true,
-                            opacity: 1.0,
                         });
-                        self.new_url.clear();
+                        ui.separator();
                     }
                 });
+            if let Some(i) = remove {
+                settings.placefiles.remove(i);
+            }
 
-                // Android can't execute a user-supplied program from app storage, so the whole
-                // section would be a form whose every entry fails. Placefile URLs still work.
-                if !cfg!(target_os = "android") {
-                    self.plugins_section(ui, settings, status);
+            ui.add_space(6.0);
+            ui.horizontal(|ui| {
+                ui.label("URL:");
+                ui.add(
+                    egui::TextEdit::singleline(&mut self.new_url)
+                        .desired_width(340.0)
+                        .hint_text("http://…/placefile.txt"),
+                );
+                let valid = self.new_url.starts_with("http")
+                    && !settings
+                        .placefiles
+                        .iter()
+                        .any(|c| c.url == self.new_url.trim());
+                if ui.add_enabled(valid, egui::Button::new("Add")).clicked() {
+                    settings.placefiles.push(PlacefileConfig {
+                        url: self.new_url.trim().to_string(),
+                        enabled: true,
+                        opacity: 1.0,
+                    });
+                    self.new_url.clear();
                 }
             });
+
+            // Android can't execute a user-supplied program from app storage, so the whole
+            // section would be a form whose every entry fails. Placefile URLs still work.
+            if !cfg!(target_os = "android") {
+                self.plugins_section(ui, settings, status);
+            }
+        });
         self.open = open;
     }
 

--- a/crates/hookecho/src/ui/sensor_window.rs
+++ b/crates/hookecho/src/ui/sensor_window.rs
@@ -15,20 +15,25 @@ pub fn show(
     drawer: &mut crate::ui::drawer::Drawer,
 ) -> bool {
     let mut open = true;
-    let Some(window) = drawer.page(ctx, "Sensors", &mut open, false, egui::Window::new("Sensors"))
-    else {
+    let Some(window) = drawer.page(
+        ctx,
+        "Sensors",
+        &mut open,
+        false,
+        egui::Window::new("Sensors"),
+    ) else {
         return open;
     };
     window.show(ctx, |ui| match data {
-            None => {
-                ui.weak("Loading nearest station…");
-            }
-            Some(Err(e)) => {
-                ui.colored_label(egui::Color32::from_rgb(220, 120, 120), "No nearby station");
-                ui.weak(e);
-            }
-            Some(Ok(station)) => dashboard(ui, station, tz),
-        });
+        None => {
+            ui.weak("Loading nearest station…");
+        }
+        Some(Err(e)) => {
+            ui.colored_label(egui::Color32::from_rgb(220, 120, 120), "No nearby station");
+            ui.weak(e);
+        }
+        Some(Ok(station)) => dashboard(ui, station, tz),
+    });
     open
 }
 

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -1124,9 +1124,7 @@ fn alerts_tab(ui: &mut egui::Ui, settings: &mut Settings) {
         });
         ui.horizontal(|ui| {
             ui.label("Topic prefix:");
-            ui.add(
-                egui::TextEdit::singleline(&mut settings.mqtt_prefix).hint_text("home/weather"),
-            );
+            ui.add(egui::TextEdit::singleline(&mut settings.mqtt_prefix).hint_text("home/weather"));
         });
         ui.weak(
             "Publishes <prefix>/status and <prefix>/nearest every five minutes, and \

--- a/crates/hookecho/src/ui/site_dialog.rs
+++ b/crates/hookecho/src/ui/site_dialog.rs
@@ -71,12 +71,11 @@ pub fn show(
             state: s.state.to_string(),
             // Which table it came from, not which letter it starts with: the old
             // `starts_with('T')` guess labelled TJUA (a WSR-88D) a terminal radar.
-            kind: if wxdata::tdwr::is_tdwr(s.id) {
-                "TDWR"
-            } else if wxdata::dwd::is_dwd(s.id) {
-                "DWD"
-            } else {
-                "WSR-88D"
+            kind: match wxdata::sites::network(s.id) {
+                wxdata::sites::Network::Tdwr => "TDWR",
+                wxdata::sites::Network::Dwd => "DWD",
+                wxdata::sites::Network::Opera => "OPERA",
+                wxdata::sites::Network::Nexrad => "WSR-88D",
             },
             dist_km: haversine_km(center, (s.longitude as f64, s.latitude as f64)),
             starred: settings.presets.iter().any(|p| p == s.id),
@@ -110,125 +109,125 @@ pub fn show(
         return open;
     };
     window.show(ctx, |ui| {
-            // Selectable label text senses clicks and drags of its own, and a row is made of
-            // nothing but labels — so every click on a row went into selecting the city name and
-            // `row.response().clicked()` never fired. Clicking a site did nothing at all.
-            ui.style_mut().interaction.selectable_labels = false;
-            ui.horizontal(|ui| {
-                ui.label("Filter:");
-                // The field's default width plus two buttons overflows a phone, pushing None/Home
-                // off the screen edge — size it from what's actually left in the row.
-                let w = (ui.available_width() - 130.0).max(80.0);
-                ui.add(egui::TextEdit::singleline(&mut dialog.filter).desired_width(w));
-                if ui.button("None").clicked() {
-                    clear = true;
-                }
-                if ui.button("Home").clicked() {
-                    go_home = true;
+        // Selectable label text senses clicks and drags of its own, and a row is made of
+        // nothing but labels — so every click on a row went into selecting the city name and
+        // `row.response().clicked()` never fired. Clicking a site did nothing at all.
+        ui.style_mut().interaction.selectable_labels = false;
+        ui.horizontal(|ui| {
+            ui.label("Filter:");
+            // The field's default width plus two buttons overflows a phone, pushing None/Home
+            // off the screen edge — size it from what's actually left in the row.
+            let w = (ui.available_width() - 130.0).max(80.0);
+            ui.add(egui::TextEdit::singleline(&mut dialog.filter).desired_width(w));
+            if ui.button("None").clicked() {
+                clear = true;
+            }
+            if ui.button("Home").clicked() {
+                go_home = true;
+            }
+        });
+        ui.separator();
+
+        // Android: `TableBuilder` row clicks don't register under touch (nested scroll eats
+        // them), so the user could never switch sites. Use a plain scrollable button list —
+        // buttons reliably take taps. Desktop keeps the sortable table.
+        if cfg!(target_os = "android") {
+            egui::ScrollArea::vertical().show(ui, |ui| {
+                for r in &rows {
+                    ui.horizontal(|ui| {
+                        let star = if r.starred { "★" } else { "☆" };
+                        if ui.button(star).clicked() {
+                            toggle_star = Some(r.id.clone());
+                        }
+                        let text = format!(
+                            "{}   {}, {}   ·   {:.0} km",
+                            r.id, r.city, r.state, r.dist_km
+                        );
+                        let btn = egui::Button::new(egui::RichText::new(text).size(15.0))
+                            .fill(egui::Color32::from_rgba_unmultiplied(255, 255, 255, 12))
+                            .corner_radius(8.0)
+                            .min_size(egui::vec2(ui.available_width(), 40.0));
+                        if ui.add(btn).clicked() {
+                            apply = Some(r.id.clone());
+                        }
+                    });
+                    ui.add_space(3.0);
                 }
             });
-            ui.separator();
+        } else {
+            let mut header_button = |ui: &mut egui::Ui, label: &str, col: SortCol| {
+                let active = dialog.sort == col;
+                let text = if active {
+                    format!("{label} {}", if dialog.desc { "▼" } else { "▲" })
+                } else {
+                    label.to_string()
+                };
+                if ui.button(text).clicked() {
+                    if active {
+                        dialog.desc = !dialog.desc;
+                    } else {
+                        dialog.sort = col;
+                        dialog.desc = false;
+                    }
+                }
+            };
 
-            // Android: `TableBuilder` row clicks don't register under touch (nested scroll eats
-            // them), so the user could never switch sites. Use a plain scrollable button list —
-            // buttons reliably take taps. Desktop keeps the sortable table.
-            if cfg!(target_os = "android") {
-                egui::ScrollArea::vertical().show(ui, |ui| {
+            TableBuilder::new(ui)
+                .striped(true)
+                .sense(egui::Sense::click())
+                .column(Column::exact(28.0)) // star
+                .column(Column::exact(56.0)) // id
+                .column(Column::remainder()) // city
+                .column(Column::exact(40.0)) // state
+                .column(Column::exact(70.0)) // kind
+                .column(Column::exact(80.0)) // distance
+                .min_scrolled_height(0.0)
+                .header(22.0, |mut h| {
+                    h.col(|ui| {
+                        ui.label("★");
+                    });
+                    h.col(|ui| header_button(ui, "ID", SortCol::Id));
+                    h.col(|ui| header_button(ui, "City", SortCol::City));
+                    h.col(|ui| header_button(ui, "St", SortCol::State));
+                    h.col(|ui| {
+                        ui.label("Type");
+                    });
+                    h.col(|ui| header_button(ui, "Dist", SortCol::Distance));
+                })
+                .body(|mut body| {
                     for r in &rows {
-                        ui.horizontal(|ui| {
-                            let star = if r.starred { "★" } else { "☆" };
-                            if ui.button(star).clicked() {
-                                toggle_star = Some(r.id.clone());
-                            }
-                            let text = format!(
-                                "{}   {}, {}   ·   {:.0} km",
-                                r.id, r.city, r.state, r.dist_km
-                            );
-                            let btn = egui::Button::new(egui::RichText::new(text).size(15.0))
-                                .fill(egui::Color32::from_rgba_unmultiplied(255, 255, 255, 12))
-                                .corner_radius(8.0)
-                                .min_size(egui::vec2(ui.available_width(), 40.0));
-                            if ui.add(btn).clicked() {
+                        body.row(20.0, |mut row| {
+                            let mut star_hit = false;
+                            row.col(|ui| {
+                                let star = if r.starred { "★" } else { "☆" };
+                                if ui.button(star).clicked() {
+                                    toggle_star = Some(r.id.clone());
+                                    star_hit = true;
+                                }
+                            });
+                            row.col(|ui| {
+                                ui.strong(&r.id);
+                            });
+                            row.col(|ui| {
+                                ui.label(&r.city);
+                            });
+                            row.col(|ui| {
+                                ui.label(&r.state);
+                            });
+                            row.col(|ui| {
+                                ui.label(r.kind);
+                            });
+                            row.col(|ui| {
+                                ui.label(format!("{:.0} km", r.dist_km));
+                            });
+                            if row.response().clicked() && !star_hit {
                                 apply = Some(r.id.clone());
                             }
                         });
-                        ui.add_space(3.0);
                     }
                 });
-            } else {
-                let mut header_button = |ui: &mut egui::Ui, label: &str, col: SortCol| {
-                    let active = dialog.sort == col;
-                    let text = if active {
-                        format!("{label} {}", if dialog.desc { "▼" } else { "▲" })
-                    } else {
-                        label.to_string()
-                    };
-                    if ui.button(text).clicked() {
-                        if active {
-                            dialog.desc = !dialog.desc;
-                        } else {
-                            dialog.sort = col;
-                            dialog.desc = false;
-                        }
-                    }
-                };
-
-                TableBuilder::new(ui)
-                    .striped(true)
-                    .sense(egui::Sense::click())
-                    .column(Column::exact(28.0)) // star
-                    .column(Column::exact(56.0)) // id
-                    .column(Column::remainder()) // city
-                    .column(Column::exact(40.0)) // state
-                    .column(Column::exact(70.0)) // kind
-                    .column(Column::exact(80.0)) // distance
-                    .min_scrolled_height(0.0)
-                    .header(22.0, |mut h| {
-                        h.col(|ui| {
-                            ui.label("★");
-                        });
-                        h.col(|ui| header_button(ui, "ID", SortCol::Id));
-                        h.col(|ui| header_button(ui, "City", SortCol::City));
-                        h.col(|ui| header_button(ui, "St", SortCol::State));
-                        h.col(|ui| {
-                            ui.label("Type");
-                        });
-                        h.col(|ui| header_button(ui, "Dist", SortCol::Distance));
-                    })
-                    .body(|mut body| {
-                        for r in &rows {
-                            body.row(20.0, |mut row| {
-                                let mut star_hit = false;
-                                row.col(|ui| {
-                                    let star = if r.starred { "★" } else { "☆" };
-                                    if ui.button(star).clicked() {
-                                        toggle_star = Some(r.id.clone());
-                                        star_hit = true;
-                                    }
-                                });
-                                row.col(|ui| {
-                                    ui.strong(&r.id);
-                                });
-                                row.col(|ui| {
-                                    ui.label(&r.city);
-                                });
-                                row.col(|ui| {
-                                    ui.label(&r.state);
-                                });
-                                row.col(|ui| {
-                                    ui.label(r.kind);
-                                });
-                                row.col(|ui| {
-                                    ui.label(format!("{:.0} km", r.dist_km));
-                                });
-                                if row.response().clicked() && !star_hit {
-                                    apply = Some(r.id.clone());
-                                }
-                            });
-                        }
-                    });
-            }
-        });
+        }
+    });
 
     if let Some(id) = toggle_star {
         if let Some(pos) = settings.presets.iter().position(|p| *p == id) {

--- a/crates/hookecho/src/ui/tropical_window.rs
+++ b/crates/hookecho/src/ui/tropical_window.rs
@@ -81,66 +81,66 @@ pub fn show(
         return None;
     };
     window.show(ctx, |ui| {
-            if storms.is_empty() {
-                ui.weak("No active tropical cyclones.");
-                ui.small("The NHC publishes these only while a storm is being advised on.");
-                return;
+        if storms.is_empty() {
+            ui.weak("No active tropical cyclones.");
+            ui.small("The NHC publishes these only while a storm is being advised on.");
+            return;
+        }
+        ui.horizontal_wrapped(|ui| {
+            for s in storms {
+                let selected = w.storm_id.as_deref() == Some(s.id.as_str());
+                if ui
+                    .selectable_label(selected, format!("{} {}", s.classification, s.name))
+                    .clicked()
+                    && !selected
+                {
+                    w.storm_id = Some(s.id.clone());
+                    want = Some((s.id.clone(), w.product));
+                }
             }
-            ui.horizontal_wrapped(|ui| {
-                for s in storms {
-                    let selected = w.storm_id.as_deref() == Some(s.id.as_str());
-                    if ui
-                        .selectable_label(selected, format!("{} {}", s.classification, s.name))
-                        .clicked()
-                        && !selected
-                    {
-                        w.storm_id = Some(s.id.clone());
-                        want = Some((s.id.clone(), w.product));
-                    }
-                }
-            });
-            ui.horizontal(|ui| {
-                for p in [Product::Discussion, Product::Advisory] {
-                    if ui.selectable_label(w.product == p, p.label()).clicked() && w.product != p {
-                        w.product = p;
-                        if let Some(id) = w.storm_id.clone() {
-                            want = Some((id, p));
-                        }
-                    }
-                }
-                if w.busy {
-                    crate::ui::loading(ui, "Fetching…");
-                } else if ui.button("⟳ Refresh").clicked() {
-                    if let Some(id) = w.storm_id.clone() {
-                        want = Some((id, w.product));
-                    }
-                }
-                if let Some(a) = &w.text {
-                    crate::ui::reader_button(ui, &a.title, w.product.label(), &a.text);
-                }
-            });
-            if let Some(e) = &w.error {
-                ui.colored_label(egui::Color32::from_rgb(230, 90, 90), e);
-            }
-            ui.separator();
-            egui::ScrollArea::vertical()
-                .auto_shrink([false, false])
-                .show(ui, |ui| match &w.text {
-                    // The products are column-formatted plain text; monospace or they lose it.
-                    Some(a) => {
-                        ui.add(
-                            egui::Label::new(egui::RichText::new(&a.text).monospace().size(12.0))
-                                .wrap(),
-                        );
-                    }
-                    None if w.busy => {
-                        ui.weak("Fetching…");
-                    }
-                    None => {
-                        ui.weak("Pick a storm to read its latest product.");
-                    }
-                });
         });
+        ui.horizontal(|ui| {
+            for p in [Product::Discussion, Product::Advisory] {
+                if ui.selectable_label(w.product == p, p.label()).clicked() && w.product != p {
+                    w.product = p;
+                    if let Some(id) = w.storm_id.clone() {
+                        want = Some((id, p));
+                    }
+                }
+            }
+            if w.busy {
+                crate::ui::loading(ui, "Fetching…");
+            } else if ui.button("⟳ Refresh").clicked() {
+                if let Some(id) = w.storm_id.clone() {
+                    want = Some((id, w.product));
+                }
+            }
+            if let Some(a) = &w.text {
+                crate::ui::reader_button(ui, &a.title, w.product.label(), &a.text);
+            }
+        });
+        if let Some(e) = &w.error {
+            ui.colored_label(egui::Color32::from_rgb(230, 90, 90), e);
+        }
+        ui.separator();
+        egui::ScrollArea::vertical()
+            .auto_shrink([false, false])
+            .show(ui, |ui| match &w.text {
+                // The products are column-formatted plain text; monospace or they lose it.
+                Some(a) => {
+                    ui.add(
+                        egui::Label::new(egui::RichText::new(&a.text).monospace().size(12.0))
+                            .wrap(),
+                    );
+                }
+                None if w.busy => {
+                    ui.weak("Fetching…");
+                }
+                None => {
+                    ui.weak("Pick a storm to read its latest product.");
+                }
+            });
+    });
     w.open = open;
     want
 }

--- a/crates/hookecho/src/ui/verify_window.rs
+++ b/crates/hookecho/src/ui/verify_window.rs
@@ -54,100 +54,100 @@ impl VerifyWindow {
             return act;
         };
         window.show(ctx, |ui| {
-                ui.horizontal_wrapped(|ui| {
-                    ui.label("Office:");
-                    ui.add(egui::TextEdit::singleline(&mut self.wfo).desired_width(56.0));
-                    ui.label("Day (UTC):");
-                    ui.add(egui::TextEdit::singleline(&mut self.day).desired_width(96.0));
-                    if ui.button("Verify").clicked() {
-                        act.refresh = true;
-                    }
-                    if self.busy {
-                        crate::ui::loading(ui, "Scoring warnings…");
-                    }
-                });
-                if let Some(e) = &self.error {
-                    ui.colored_label(egui::Color32::from_rgb(240, 120, 120), e);
+            ui.horizontal_wrapped(|ui| {
+                ui.label("Office:");
+                ui.add(egui::TextEdit::singleline(&mut self.wfo).desired_width(56.0));
+                ui.label("Day (UTC):");
+                ui.add(egui::TextEdit::singleline(&mut self.day).desired_width(96.0));
+                if ui.button("Verify").clicked() {
+                    act.refresh = true;
                 }
-                let Some(v) = &self.data else {
-                    ui.weak(
-                        "Scored against storm reports by the Iowa Environmental Mesonet's Cow \
+                if self.busy {
+                    crate::ui::loading(ui, "Scoring warnings…");
+                }
+            });
+            if let Some(e) = &self.error {
+                ui.colored_label(egui::Color32::from_rgb(240, 120, 120), e);
+            }
+            let Some(v) = &self.data else {
+                ui.weak(
+                    "Scored against storm reports by the Iowa Environmental Mesonet's Cow \
                          service — the same arbitration the published numbers use.",
-                    );
-                    return;
-                };
-                ui.separator();
-                stats_row(ui, v);
-                ui.separator();
-                ui.checkbox(&mut self.misses_only, "Unwarned reports only");
-                egui::ScrollArea::vertical().show(ui, |ui| {
-                    if !self.misses_only {
-                        ui.strong("Warnings");
-                        for w in &v.warnings {
-                            // ASCII marks, not check/cross glyphs: the monospace face the rows
-                            // use has no coverage for those and draws tofu boxes instead.
-                            let mark = if w.verified { "+" } else { "x" };
-                            let color = if w.verified {
-                                egui::Color32::from_rgb(120, 220, 140)
-                            } else {
-                                egui::Color32::from_rgb(230, 130, 130)
-                            };
-                            let lead = w
-                                .lead_min
-                                .map(|m| format!("{m} min lead"))
-                                .unwrap_or_else(|| "no verifying report".into());
-                            let label = format!(
-                                "{mark} {}-{:04}  {}  — {lead}  ({})",
-                                w.phenomena,
-                                w.eventid,
-                                crate::timefmt::fmt_clock(w.issue, tz, true),
-                                w.counties.join(", ")
-                            );
-                            if ui
-                                .add(egui::Label::new(
-                                    egui::RichText::new(label).color(color).monospace(),
-                                ))
-                                .on_hover_text("Click to fly there at the moment it was issued")
-                                .clicked()
-                            {
-                                act.goto = Some((w.lon, w.lat, Some(w.issue)));
-                            }
-                        }
-                        ui.add_space(6.0);
-                    }
-                    ui.strong("Storm reports");
-                    for r in v.reports.iter().filter(|r| !self.misses_only || !r.warned) {
-                        let color = if r.warned {
+                );
+                return;
+            };
+            ui.separator();
+            stats_row(ui, v);
+            ui.separator();
+            ui.checkbox(&mut self.misses_only, "Unwarned reports only");
+            egui::ScrollArea::vertical().show(ui, |ui| {
+                if !self.misses_only {
+                    ui.strong("Warnings");
+                    for w in &v.warnings {
+                        // ASCII marks, not check/cross glyphs: the monospace face the rows
+                        // use has no coverage for those and draws tofu boxes instead.
+                        let mark = if w.verified { "+" } else { "x" };
+                        let color = if w.verified {
                             egui::Color32::from_rgb(120, 220, 140)
                         } else {
                             egui::Color32::from_rgb(230, 130, 130)
                         };
-                        let mag = r
-                            .magnitude
-                            .map(|m| format!(" {m}"))
-                            .unwrap_or_else(String::new);
-                        let lead = match (r.warned, r.lead_min) {
-                            (true, Some(m)) => format!("warned {m} min ahead"),
-                            (true, None) => "warned".to_string(),
-                            (false, _) => "NOT WARNED".to_string(),
-                        };
+                        let lead = w
+                            .lead_min
+                            .map(|m| format!("{m} min lead"))
+                            .unwrap_or_else(|| "no verifying report".into());
                         let label = format!(
-                            "{}  {}{mag}  {} — {lead}",
-                            crate::timefmt::fmt_clock(r.valid, tz, true),
-                            r.kind,
-                            r.city
+                            "{mark} {}-{:04}  {}  — {lead}  ({})",
+                            w.phenomena,
+                            w.eventid,
+                            crate::timefmt::fmt_clock(w.issue, tz, true),
+                            w.counties.join(", ")
                         );
                         if ui
                             .add(egui::Label::new(
                                 egui::RichText::new(label).color(color).monospace(),
                             ))
+                            .on_hover_text("Click to fly there at the moment it was issued")
                             .clicked()
                         {
-                            act.goto = Some((r.lon, r.lat, Some(r.valid)));
+                            act.goto = Some((w.lon, w.lat, Some(w.issue)));
                         }
                     }
-                });
+                    ui.add_space(6.0);
+                }
+                ui.strong("Storm reports");
+                for r in v.reports.iter().filter(|r| !self.misses_only || !r.warned) {
+                    let color = if r.warned {
+                        egui::Color32::from_rgb(120, 220, 140)
+                    } else {
+                        egui::Color32::from_rgb(230, 130, 130)
+                    };
+                    let mag = r
+                        .magnitude
+                        .map(|m| format!(" {m}"))
+                        .unwrap_or_else(String::new);
+                    let lead = match (r.warned, r.lead_min) {
+                        (true, Some(m)) => format!("warned {m} min ahead"),
+                        (true, None) => "warned".to_string(),
+                        (false, _) => "NOT WARNED".to_string(),
+                    };
+                    let label = format!(
+                        "{}  {}{mag}  {} — {lead}",
+                        crate::timefmt::fmt_clock(r.valid, tz, true),
+                        r.kind,
+                        r.city
+                    );
+                    if ui
+                        .add(egui::Label::new(
+                            egui::RichText::new(label).color(color).monospace(),
+                        ))
+                        .clicked()
+                    {
+                        act.goto = Some((r.lon, r.lat, Some(r.valid)));
+                    }
+                }
             });
+        });
         self.open = open;
         act
     }

--- a/crates/hookecho/src/ui/video_window.rs
+++ b/crates/hookecho/src/ui/video_window.rs
@@ -84,40 +84,40 @@ impl VideoPlayer {
             return open;
         };
         window.vscroll(false).show(ctx, |ui| {
-                let w = ui.available_width();
-                match &self.tex {
-                    Some(tex) => {
-                        let size = tex.size_vec2();
-                        let h = if size.x > 0.0 {
-                            w * size.y / size.x
-                        } else {
-                            270.0
-                        };
-                        ui.add(egui::Image::new(tex).fit_to_exact_size(egui::vec2(w, h)));
-                    }
-                    None => {
-                        let (rect, _) =
-                            ui.allocate_exact_size(egui::vec2(w, 200.0), egui::Sense::hover());
-                        ui.painter()
-                            .rect_filled(rect, 4.0, egui::Color32::from_gray(24));
-                        ui.painter().text(
-                            rect.center(),
-                            egui::Align2::CENTER_CENTER,
-                            self.status_text(),
-                            egui::FontId::proportional(12.0),
-                            egui::Color32::from_gray(190),
-                        );
+            let w = ui.available_width();
+            match &self.tex {
+                Some(tex) => {
+                    let size = tex.size_vec2();
+                    let h = if size.x > 0.0 {
+                        w * size.y / size.x
+                    } else {
+                        270.0
+                    };
+                    ui.add(egui::Image::new(tex).fit_to_exact_size(egui::vec2(w, h)));
+                }
+                None => {
+                    let (rect, _) =
+                        ui.allocate_exact_size(egui::vec2(w, 200.0), egui::Sense::hover());
+                    ui.painter()
+                        .rect_filled(rect, 4.0, egui::Color32::from_gray(24));
+                    ui.painter().text(
+                        rect.center(),
+                        egui::Align2::CENTER_CENTER,
+                        self.status_text(),
+                        egui::FontId::proportional(12.0),
+                        egui::Color32::from_gray(190),
+                    );
+                }
+            }
+            ui.horizontal(|ui| {
+                if ui.button("Open in browser").clicked() {
+                    if let Err(e) = crate::platform::open_url(&self.url) {
+                        log::warn!("open stream URL failed: {e}");
                     }
                 }
-                ui.horizontal(|ui| {
-                    if ui.button("Open in browser").clicked() {
-                        if let Err(e) = crate::platform::open_url(&self.url) {
-                            log::warn!("open stream URL failed: {e}");
-                        }
-                    }
-                    ui.weak(&self.url);
-                });
+                ui.weak(&self.url);
             });
+        });
         open
     }
 

--- a/crates/hookecho/src/ui/volume3d_window.rs
+++ b/crates/hookecho/src/ui/volume3d_window.rs
@@ -79,90 +79,90 @@ pub fn show(
         return;
     };
     window.show(ctx, |ui| {
-            ui.weak("Drag to orbit · scroll to zoom · max-intensity projection");
-            ui.horizontal(|ui| {
-                let mut on = st.threshold_dbz.is_finite();
+        ui.weak("Drag to orbit · scroll to zoom · max-intensity projection");
+        ui.horizontal(|ui| {
+            let mut on = st.threshold_dbz.is_finite();
+            if ui
+                .checkbox(&mut on, "Only above")
+                .on_hover_text("Hide everything weaker, so cores stand alone")
+                .changed()
+            {
+                st.threshold_dbz = if on { 45.0 } else { f32::NEG_INFINITY };
+            }
+            if on {
+                let mut dbz = st.threshold_dbz;
                 if ui
-                    .checkbox(&mut on, "Only above")
-                    .on_hover_text("Hide everything weaker, so cores stand alone")
+                    .add(egui::Slider::new(&mut dbz, range.0..=range.1).suffix(" dBZ"))
                     .changed()
                 {
-                    st.threshold_dbz = if on { 45.0 } else { f32::NEG_INFINITY };
+                    st.threshold_dbz = dbz;
                 }
-                if on {
-                    let mut dbz = st.threshold_dbz;
-                    if ui
-                        .add(egui::Slider::new(&mut dbz, range.0..=range.1).suffix(" dBZ"))
-                        .changed()
-                    {
-                        st.threshold_dbz = dbz;
-                    }
-                    if ui
-                        .button("Hail core")
-                        .on_hover_text("45 dBZ — the usual floor for a hail core")
-                        .clicked()
-                    {
-                        st.threshold_dbz = 45.0;
-                    }
-                }
-            });
-            ui.horizontal(|ui| {
-                ui.label("Quality");
-                for (label, steps) in STEP_PRESETS {
-                    ui.selectable_value(&mut st.steps, steps, label)
-                        .on_hover_text(format!("{steps} samples per pixel"));
-                }
-            });
-            egui::CollapsingHeader::new("Slice")
-                .default_open(false)
-                .show(ui, |ui| {
-                    let [x0, x1, y0, y1, z0, z1] = &mut st.clip;
-                    axis_slice(ui, "E–W", x0, x1);
-                    axis_slice(ui, "N–S", y0, y1);
-                    axis_slice(ui, "Up ", z0, z1);
-                    if ui.button("Whole volume").clicked() {
-                        st.clip = [0.0, 1.0, 0.0, 1.0, 0.0, 1.0];
-                    }
-                });
-            let (rect, resp) = ui.allocate_exact_size(ui.available_size(), egui::Sense::drag());
-            if resp.dragged() {
-                let d = resp.drag_delta();
-                st.az -= d.x * 0.4;
-                st.el = (st.el + d.y * 0.3).clamp(2.0, 88.0);
-            }
-            // Wheel dollies the orbit camera; a trackpad pinch arrives as `zoom_delta` instead
-            // (scale factor, >1 is fingers apart = closer) and has to move `dist` the other way.
-            let (scroll, zoom) = ctx.input(|i| (i.smooth_scroll_delta.y, i.zoom_delta()));
-            if resp.hovered() {
-                if scroll != 0.0 {
-                    st.dist = (st.dist - scroll * 0.003).clamp(1.3, 6.0);
-                }
-                if (zoom - 1.0).abs() > f32::EPSILON {
-                    st.dist = (st.dist / zoom).clamp(1.3, 6.0);
+                if ui
+                    .button("Hail core")
+                    .on_hover_text("45 dBZ — the usual floor for a hail core")
+                    .clicked()
+                {
+                    st.threshold_dbz = 45.0;
                 }
             }
-            let aspect = rect.width() / rect.height().max(1.0);
-            // The threshold is a uniform, not a re-upload: dragging the slider never rebuilds the
-            // texture.
-            let view = View3d {
-                threshold_idx: if st.threshold_dbz.is_finite() {
-                    threshold_index(st.threshold_dbz, range)
-                } else {
-                    2.0
-                },
-                clip: st.clip,
-            };
-            let uniform = orbit_uniform(st.az, st.el, st.dist, aspect, n, nz, st.steps, view);
-            // On the window's first frame egui may hand us a zero-area rect (auto-size pass);
-            // the paint callback would be culled and the one-shot upload lost, leaving the view
-            // black until reopened. Hold the upload until the rect is real.
-            let upload = (rect.height() >= 1.0 && rect.width() >= 1.0)
-                .then(|| pending.take())
-                .flatten();
-            let cb = Volume3dCallback { upload, uniform };
-            ui.painter()
-                .add(egui_wgpu::Callback::new_paint_callback(rect, cb));
         });
+        ui.horizontal(|ui| {
+            ui.label("Quality");
+            for (label, steps) in STEP_PRESETS {
+                ui.selectable_value(&mut st.steps, steps, label)
+                    .on_hover_text(format!("{steps} samples per pixel"));
+            }
+        });
+        egui::CollapsingHeader::new("Slice")
+            .default_open(false)
+            .show(ui, |ui| {
+                let [x0, x1, y0, y1, z0, z1] = &mut st.clip;
+                axis_slice(ui, "E–W", x0, x1);
+                axis_slice(ui, "N–S", y0, y1);
+                axis_slice(ui, "Up ", z0, z1);
+                if ui.button("Whole volume").clicked() {
+                    st.clip = [0.0, 1.0, 0.0, 1.0, 0.0, 1.0];
+                }
+            });
+        let (rect, resp) = ui.allocate_exact_size(ui.available_size(), egui::Sense::drag());
+        if resp.dragged() {
+            let d = resp.drag_delta();
+            st.az -= d.x * 0.4;
+            st.el = (st.el + d.y * 0.3).clamp(2.0, 88.0);
+        }
+        // Wheel dollies the orbit camera; a trackpad pinch arrives as `zoom_delta` instead
+        // (scale factor, >1 is fingers apart = closer) and has to move `dist` the other way.
+        let (scroll, zoom) = ctx.input(|i| (i.smooth_scroll_delta.y, i.zoom_delta()));
+        if resp.hovered() {
+            if scroll != 0.0 {
+                st.dist = (st.dist - scroll * 0.003).clamp(1.3, 6.0);
+            }
+            if (zoom - 1.0).abs() > f32::EPSILON {
+                st.dist = (st.dist / zoom).clamp(1.3, 6.0);
+            }
+        }
+        let aspect = rect.width() / rect.height().max(1.0);
+        // The threshold is a uniform, not a re-upload: dragging the slider never rebuilds the
+        // texture.
+        let view = View3d {
+            threshold_idx: if st.threshold_dbz.is_finite() {
+                threshold_index(st.threshold_dbz, range)
+            } else {
+                2.0
+            },
+            clip: st.clip,
+        };
+        let uniform = orbit_uniform(st.az, st.el, st.dist, aspect, n, nz, st.steps, view);
+        // On the window's first frame egui may hand us a zero-area rect (auto-size pass);
+        // the paint callback would be culled and the one-shot upload lost, leaving the view
+        // black until reopened. Hold the upload until the rect is real.
+        let upload = (rect.height() >= 1.0 && rect.width() >= 1.0)
+            .then(|| pending.take())
+            .flatten();
+        let cb = Volume3dCallback { upload, uniform };
+        ui.painter()
+            .add(egui_wgpu::Callback::new_paint_callback(rect, cb));
+    });
     *open = keep;
 }
 

--- a/crates/hookecho/src/ui/xsection_window.rs
+++ b/crates/hookecho/src/ui/xsection_window.rs
@@ -41,85 +41,85 @@ pub fn show(
         return open;
     };
     window.show(ctx, |ui| {
-            ui.horizontal(|ui| {
-                ui.label(format!(
-                    "Length {:.0} km · top {:.0} km",
-                    xs.length_km, xs.max_height_km
-                ));
-                ui.separator();
-                // Velocity shows how a couplet leans with height; CC shows how deep the debris
-                // ball really is. Both were unreachable while this was hard-wired to REF.
-                for m in [
-                    Moment::Reflectivity,
-                    Moment::Velocity,
-                    Moment::CorrelationCoefficient,
-                ] {
-                    let info = crate::products::info(m);
-                    if ui
-                        .selectable_label(*moment == m, info.short)
-                        .on_hover_text(info.name)
-                        .clicked()
-                        && *moment != m
-                    {
-                        *moment = m;
-                        changed = true;
-                    }
-                }
-                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                    crate::ui::csv_buttons(
-                        ui,
-                        "xsection.csv",
-                        "The sampled grid, top row first",
-                        || xs.to_csv(),
-                    );
-                });
-            });
+        ui.horizontal(|ui| {
+            ui.label(format!(
+                "Length {:.0} km · top {:.0} km",
+                xs.length_km, xs.max_height_km
+            ));
             ui.separator();
-            // Draw the panel stretched to a readable size (distance wide, height tall).
-            let avail = ui.available_size();
-            let w = avail.x.max(200.0);
-            let h = (w * 0.4).clamp(120.0, 260.0);
-            let img = egui::Image::new(tex)
-                .fit_to_exact_size(egui::vec2(w, h))
-                .texture_options(egui::TextureOptions::LINEAR);
-            let resp = ui.add(img);
-            // Axis captions along the drawn rect.
-            let rect = resp.rect;
-            let cap = |ui: &egui::Ui, pos, anchor, txt: &str| {
-                ui.painter().text(
-                    pos,
-                    anchor,
-                    txt,
-                    egui::FontId::proportional(10.0),
-                    egui::Color32::from_gray(200),
+            // Velocity shows how a couplet leans with height; CC shows how deep the debris
+            // ball really is. Both were unreachable while this was hard-wired to REF.
+            for m in [
+                Moment::Reflectivity,
+                Moment::Velocity,
+                Moment::CorrelationCoefficient,
+            ] {
+                let info = crate::products::info(m);
+                if ui
+                    .selectable_label(*moment == m, info.short)
+                    .on_hover_text(info.name)
+                    .clicked()
+                    && *moment != m
+                {
+                    *moment = m;
+                    changed = true;
+                }
+            }
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                crate::ui::csv_buttons(
+                    ui,
+                    "xsection.csv",
+                    "The sampled grid, top row first",
+                    || xs.to_csv(),
                 );
-            };
-            cap(
-                ui,
-                rect.left_top() + egui::vec2(2.0, 2.0),
-                egui::Align2::LEFT_TOP,
-                &format!("{:.0} km", xs.max_height_km),
-            );
-            cap(
-                ui,
-                rect.left_bottom() + egui::vec2(2.0, -2.0),
-                egui::Align2::LEFT_BOTTOM,
-                "0 km",
-            );
-            cap(
-                ui,
-                rect.left_bottom() + egui::vec2(2.0, -14.0),
-                egui::Align2::LEFT_BOTTOM,
-                "A",
-            );
-            cap(
-                ui,
-                rect.right_bottom() + egui::vec2(-2.0, -14.0),
-                egui::Align2::RIGHT_BOTTOM,
-                "B",
-            );
-            ui.weak("A→B left to right; height increases upward. Gaps = no beam coverage.");
+            });
         });
+        ui.separator();
+        // Draw the panel stretched to a readable size (distance wide, height tall).
+        let avail = ui.available_size();
+        let w = avail.x.max(200.0);
+        let h = (w * 0.4).clamp(120.0, 260.0);
+        let img = egui::Image::new(tex)
+            .fit_to_exact_size(egui::vec2(w, h))
+            .texture_options(egui::TextureOptions::LINEAR);
+        let resp = ui.add(img);
+        // Axis captions along the drawn rect.
+        let rect = resp.rect;
+        let cap = |ui: &egui::Ui, pos, anchor, txt: &str| {
+            ui.painter().text(
+                pos,
+                anchor,
+                txt,
+                egui::FontId::proportional(10.0),
+                egui::Color32::from_gray(200),
+            );
+        };
+        cap(
+            ui,
+            rect.left_top() + egui::vec2(2.0, 2.0),
+            egui::Align2::LEFT_TOP,
+            &format!("{:.0} km", xs.max_height_km),
+        );
+        cap(
+            ui,
+            rect.left_bottom() + egui::vec2(2.0, -2.0),
+            egui::Align2::LEFT_BOTTOM,
+            "0 km",
+        );
+        cap(
+            ui,
+            rect.left_bottom() + egui::vec2(2.0, -14.0),
+            egui::Align2::LEFT_BOTTOM,
+            "A",
+        );
+        cap(
+            ui,
+            rect.right_bottom() + egui::vec2(-2.0, -14.0),
+            egui::Align2::RIGHT_BOTTOM,
+            "B",
+        );
+        ui.weak("A→B left to right; height increases upward. Gaps = no beam coverage.");
+    });
     if changed {
         // Force a rebuild on the next frame with the new moment.
         ctx.request_repaint();

--- a/crates/hookecho/src/vector_tiles.rs
+++ b/crates/hookecho/src/vector_tiles.rs
@@ -409,13 +409,7 @@ const POI_CLASSES: &[&str] = &[
 const MAX_POIS_PER_TILE: usize = 12;
 
 /// Pull the interesting subset of the `poi` layer. Present in the tiles from z11.
-fn extract_pois(
-    reader: &Reader,
-    names: &[String],
-    n: f64,
-    txf: f64,
-    tyf: f64,
-) -> Vec<PlaceLabel> {
+fn extract_pois(reader: &Reader, names: &[String], n: f64, txf: f64, tyf: f64) -> Vec<PlaceLabel> {
     let Some(i) = names.iter().position(|nm| nm == "poi") else {
         return Vec::new();
     };
@@ -728,7 +722,8 @@ impl VectorTileManager {
                     // gunzip + lyon tessellation is the heaviest CPU in the app after the volume
                     // decode; running it on the async worker starves every other fetch.
                     blocking.spawn_blocking(move || {
-                        let (vertices, indices, labels) = build_tile(&bytes, id, palette, tess_zoom);
+                        let (vertices, indices, labels) =
+                            build_tile(&bytes, id, palette, tess_zoom);
                         let _ = tx.send(FetchedVector {
                             id,
                             vertices,

--- a/crates/hookecho/src/workspace.rs
+++ b/crates/hookecho/src/workspace.rs
@@ -90,7 +90,8 @@ pub struct PaneSnap {
 impl PaneSnap {
     /// Snapshot a live pane.
     pub fn capture(v: &MapView) -> Self {
-        let (lon, lat) = crate::render::mercator::world_to_lonlat(v.camera.center.0, v.camera.center.1);
+        let (lon, lat) =
+            crate::render::mercator::world_to_lonlat(v.camera.center.0, v.camera.center.1);
         Self {
             site: v.site.clone(),
             moment: v.moment,
@@ -208,7 +209,9 @@ pub fn starters() -> Vec<Workspace> {
             name: "Analysis".into(),
             // The same storm at four heights: how a couplet leans with height, which is the
             // layout people rebuild by hand every time.
-            panes: (0..4).map(|t| pane(Moment::Reflectivity, t, false)).collect(),
+            panes: (0..4)
+                .map(|t| pane(Moment::Reflectivity, t, false))
+                .collect(),
             active: 0,
             link_cameras: true,
             overlays_on: vec!["Alerts".into(), "Cells".into(), "RangeRings".into()],
@@ -235,7 +238,10 @@ mod tests {
         v.basemap = crate::tiles::BasemapStyle::from_slug("satellite");
 
         let snap = PaneSnap::capture(&v);
-        let mut fresh = MapView::new(None, crate::render::mercator::Camera::at_lonlat(0.0, 0.0, 3.0));
+        let mut fresh = MapView::new(
+            None,
+            crate::render::mercator::Camera::at_lonlat(0.0, 0.0, 3.0),
+        );
         snap.apply(&mut fresh);
 
         assert_eq!(fresh.site.as_deref(), Some("KTLX"));
@@ -252,7 +258,10 @@ mod tests {
     #[test]
     fn per_pane_thresholds_and_layers_survive_the_round_trip() {
         use wxdata::level2::Moment;
-        let mut v = MapView::new(None, crate::render::mercator::Camera::at_lonlat(0.0, 0.0, 3.0));
+        let mut v = MapView::new(
+            None,
+            crate::render::mercator::Camera::at_lonlat(0.0, 0.0, 3.0),
+        );
         v.fields_on.insert(crate::render::FieldLayer::Mrms);
         v.thresholds[Moment::Reflectivity.index()] = Some(35.0);
         v.threshold_enabled[Moment::Reflectivity.index()] = true;
@@ -263,7 +272,10 @@ mod tests {
         assert_eq!(snap.fields_on, vec!["mrms"]);
         assert_eq!(snap.thresholds, vec![(Moment::Reflectivity, 35.0)]);
 
-        let mut fresh = MapView::new(None, crate::render::mercator::Camera::at_lonlat(0.0, 0.0, 3.0));
+        let mut fresh = MapView::new(
+            None,
+            crate::render::mercator::Camera::at_lonlat(0.0, 0.0, 3.0),
+        );
         // A leftover filter from whatever this pane was showing before must not survive a restore.
         fresh.thresholds[Moment::SpectrumWidth.index()] = Some(4.0);
         fresh.threshold_enabled[Moment::SpectrumWidth.index()] = true;

--- a/crates/hookecho/tests/flatpak_sources.rs
+++ b/crates/hookecho/tests/flatpak_sources.rs
@@ -32,11 +32,9 @@ fn locked_registry_crates(lock: &str) -> Vec<String> {
                 .find_map(|l| l.strip_prefix(key)?.split('"').nth(1))
                 .map(str::to_string)
         };
-        if let (Some(name), Some(version), Some(_)) = (
-            field("name = "),
-            field("version = "),
-            field("source = "),
-        ) {
+        if let (Some(name), Some(version), Some(_)) =
+            (field("name = "), field("version = "), field("source = "))
+        {
             out.push(format!("{name}-{version}"));
         }
     }
@@ -64,8 +62,8 @@ fn cargo_sources_covers_the_lockfile() {
         return;
     }
     let lock = std::fs::read_to_string(root.join("Cargo.lock")).expect("Cargo.lock");
-    let sources =
-        std::fs::read_to_string(root.join("packaging/flatpak/cargo-sources.json")).expect("sources");
+    let sources = std::fs::read_to_string(root.join("packaging/flatpak/cargo-sources.json"))
+        .expect("sources");
 
     let missing: Vec<String> = locked_registry_crates(&lock)
         .into_iter()

--- a/crates/wxdata/src/alerts.rs
+++ b/crates/wxdata/src/alerts.rs
@@ -565,7 +565,11 @@ mod tests {
     fn a_snow_squall_gets_its_own_color_and_its_impact_tag_escalates() {
         let (kind, rgb) = event_style("Snow Squall Warning");
         assert_eq!(kind, FeatureKind::Warning);
-        assert_ne!(rgb, event_style("Winter Storm Warning").1, "not generic red");
+        assert_ne!(
+            rgb,
+            event_style("Winter Storm Warning").1,
+            "not generic red"
+        );
 
         let mut a = AlertInfo {
             id: "urn:x".into(),
@@ -583,7 +587,11 @@ mod tests {
             motion: None,
             vtec: None,
         };
-        assert_eq!(escalation(&a), 1, "a tagged squall sorts above plain warnings");
+        assert_eq!(
+            escalation(&a),
+            1,
+            "a tagged squall sorts above plain warnings"
+        );
         a.damage_threat = None;
         assert_eq!(escalation(&a), 0);
     }

--- a/crates/wxdata/src/aviation.rs
+++ b/crates/wxdata/src/aviation.rs
@@ -178,7 +178,12 @@ pub async fn fetch_gairmet(client: &reqwest::Client) -> anyhow::Result<Vec<GeoFe
 
 /// The forecast hour back out of a feature's title, which is where [`parse_gairmet`] put it.
 fn forecast_hour(f: &GeoFeature) -> Option<i64> {
-    f.title.rsplit_once('+')?.1.trim_end_matches('h').parse().ok()
+    f.title
+        .rsplit_once('+')?
+        .1
+        .trim_end_matches('h')
+        .parse()
+        .ok()
 }
 
 /// A pilot report: what someone actually flew through, at a known altitude.
@@ -376,7 +381,11 @@ mod gairmet_tests {
           "coords":[{"lat":"40.0","lon":"-100.0"},{"lat":"41.0","lon":"-100.0"},
                     {"lat":"41.0","lon":"-99.0"}]}]"#;
         let f = parse_gairmet(json).unwrap();
-        assert!(f[0].detail.contains("FL100\u{2013}FL240"), "{}", f[0].detail);
+        assert!(
+            f[0].detail.contains("FL100\u{2013}FL240"),
+            "{}",
+            f[0].detail
+        );
 
         // Only a top: the label says so rather than inventing a floor at the surface.
         let json = json.replace(r#""base":10000,"#, "");

--- a/crates/wxdata/src/cellscore.rs
+++ b/crates/wxdata/src/cellscore.rs
@@ -128,7 +128,11 @@ mod tests {
         c.hail_in = Some(3.0);
         // Three inches of hail alongside 55 dBZ: the hail dominates its weight, and the weak
         // reflectivity component pulls the blend down only a little.
-        assert!(severity(&c, None, None) >= 85, "got {}", severity(&c, None, None));
+        assert!(
+            severity(&c, None, None) >= 85,
+            "got {}",
+            severity(&c, None, None)
+        );
         // A low probability alongside it does drag the blend down.
         assert!(severity(&c, Some(10), None) < 60);
     }

--- a/crates/wxdata/src/contour.rs
+++ b/crates/wxdata/src/contour.rs
@@ -153,15 +153,11 @@ fn stitch(segs: Vec<[(f64, f64); 2]>) -> Vec<Vec<(f64, f64)>> {
         used[start] = true;
         let mut line = vec![segs[start][0], segs[start][1]];
         // Grow the tail, then the head.
-        while let Some((si, next)) =
-            line.last().and_then(|&p| next_at(key(p), &used, &adj))
-        {
+        while let Some((si, next)) = line.last().and_then(|&p| next_at(key(p), &used, &adj)) {
             used[si] = true;
             line.push(next);
         }
-        while let Some((si, prev)) =
-            line.first().and_then(|&p| next_at(key(p), &used, &adj))
-        {
+        while let Some((si, prev)) = line.first().and_then(|&p| next_at(key(p), &used, &adj)) {
             used[si] = true;
             line.insert(0, prev);
         }

--- a/crates/wxdata/src/dealias.rs
+++ b/crates/wxdata/src/dealias.rs
@@ -113,7 +113,9 @@ pub fn dealias_with_reference(
             while let Some((caz, cg)) = stack.pop() {
                 // A labelled cell always has a velocity (that is what labelling means); skip
                 // rather than assert it, so a future labelling change degrades instead of panics.
-                let Some(cv) = vel[idx(caz, cg)] else { continue };
+                let Some(cv) = vel[idx(caz, cg)] else {
+                    continue;
+                };
                 for (naz, ng) in neighbors(caz, cg) {
                     let ni = idx(naz, ng);
                     let Some(nv) = vel[ni] else { continue };
@@ -334,9 +336,10 @@ mod tests {
         }
         let folded = fold(&truth, nyq);
         assert!(
-            folded.iter().enumerate().any(|(i, v)| {
-                (v.unwrap() - truth[i]).abs() > 1.0
-            }),
+            folded
+                .iter()
+                .enumerate()
+                .any(|(i, v)| { (v.unwrap() - truth[i]).abs() > 1.0 }),
             "fixture should actually fold"
         );
         let out = dealias(&folded, az_bins, gates, nyq);

--- a/crates/wxdata/src/derived.rs
+++ b/crates/wxdata/src/derived.rs
@@ -172,7 +172,9 @@ pub fn derive(sweeps: &[BinnedSweep], opts: &DerivedOpts) -> Option<Derived> {
             if let Some(max) = samples
                 .iter()
                 .map(|(_, dbz)| *dbz)
-                .fold(None, |acc: Option<f32>, d| Some(acc.map_or(d, |a| a.max(d))))
+                .fold(None, |acc: Option<f32>, d| {
+                    Some(acc.map_or(d, |a| a.max(d)))
+                })
             {
                 composite[i] = max;
             }
@@ -376,7 +378,10 @@ mod tests {
         let gy = ((d.composite.lat_north - 35.3) / RES_DEG) as usize;
         let v = d.composite.values[gy * d.composite.nx + gx];
         // Quantization through the u8 band costs a fraction of a dBZ.
-        assert!((v - 58.0).abs() < 0.6, "column max read {v}, wanted the 58 dBZ tilt");
+        assert!(
+            (v - 58.0).abs() < 0.6,
+            "column max read {v}, wanted the 58 dBZ tilt"
+        );
     }
 
     #[test]

--- a/crates/wxdata/src/dualpol.rs
+++ b/crates/wxdata/src/dualpol.rs
@@ -17,7 +17,7 @@
 //! All three are display-only context. They deliberately raise nothing.
 
 use crate::level2::{BinnedSweep, Moment};
-use crate::tds::{dest, decode};
+use crate::tds::{decode, dest};
 use crate::xsection::column_samples;
 
 /// Geographic cluster cell, ~4 km — the same lattice [`crate::tds`] clusters on, so a signature

--- a/crates/wxdata/src/dwd.rs
+++ b/crates/wxdata/src/dwd.rs
@@ -157,7 +157,7 @@ fn moment_url(m: &(&str, &str, &str), slug: &str, wmo: u16, tilt: u8, stamp: &st
 /// Every product of one elevation is the same scan sampled at once, so ray `i` of one file is ray
 /// `i` of the others. Callers drop any sweep whose ray count or elevation angle disagrees, which
 /// is the check that keeps that assumption honest.
-fn merge(base: &Sweep, extra: &[Sweep]) -> Sweep {
+pub(crate) fn merge(base: &Sweep, extra: &[Sweep]) -> Sweep {
     let radials = base
         .radials()
         .iter()
@@ -192,7 +192,7 @@ fn merge(base: &Sweep, extra: &[Sweep]) -> Sweep {
 ///
 /// DWD's slot numbering is not elevation order, and everything downstream — the tilt selector,
 /// cross sections, the derived grids — assumes sweep 1 is the base tilt.
-fn assemble(mut parts: Vec<(f32, Sweep)>) -> Vec<Sweep> {
+pub(crate) fn assemble(mut parts: Vec<(f32, Sweep)>) -> Vec<Sweep> {
     parts.sort_by(|a, b| a.0.total_cmp(&b.0));
     parts
         .into_iter()
@@ -293,7 +293,11 @@ pub async fn fetch_volume(
     }
     // Every file in a volume carries the same volume start time; the earliest is that time even
     // when a straggler from the next volume lands mid-fetch.
-    let time = found.iter().map(|(t, _, _)| *t).min().unwrap_or_else(Utc::now);
+    let time = found
+        .iter()
+        .map(|(t, _, _)| *t)
+        .min()
+        .unwrap_or_else(Utc::now);
     let sweeps = assemble(found.into_iter().map(|(_, a, s)| (a, s)).collect());
 
     // ODIM carries no VCP: `vol5minng01` is a free-text scan strategy. Pattern 0 says so rather
@@ -345,7 +349,11 @@ mod tests {
         for s in SITES {
             let (slug, wmo) = path_for(s.id).unwrap_or_else(|| panic!("{} has no path", s.id));
             assert_eq!(slug.len(), 3, "{} slug", s.id);
-            assert!(slug.chars().all(|c| c.is_ascii_lowercase()), "{} slug", s.id);
+            assert!(
+                slug.chars().all(|c| c.is_ascii_lowercase()),
+                "{} slug",
+                s.id
+            );
             assert!((10_000..11_000).contains(&wmo), "{} wmo {wmo}", s.id);
         }
         assert!(is_dwd("debo") && is_dwd("DEBO"));
@@ -432,7 +440,10 @@ mod tests {
         assert_eq!(angles, vec![a5, a0]);
         // Numbering must be renewed, not inherited: both files call themselves sweep 1.
         assert_eq!(
-            sweeps.iter().map(|s| s.elevation_number()).collect::<Vec<_>>(),
+            sweeps
+                .iter()
+                .map(|s| s.elevation_number())
+                .collect::<Vec<_>>(),
             vec![1, 2]
         );
     }
@@ -450,14 +461,25 @@ mod tests {
             .map(|s| s.radials()[0].elevation_angle_degrees())
             .collect();
         println!("{name} at {time}: {angles:?}");
-        assert_eq!(scan.sweeps().len(), TILTS as usize, "one sweep per elevation");
+        assert_eq!(
+            scan.sweeps().len(),
+            TILTS as usize,
+            "one sweep per elevation"
+        );
         // Velocity is reached by a name derived from the reflectivity file, not by a symlink or a
         // directory index; if DWD ever renames its timestamped files, this is what notices.
         let base = &scan.sweeps()[0].radials()[0];
         assert!(base.velocity().is_some(), "base tilt carries velocity");
         assert!(base.correlation_coefficient().is_some(), "and dual-pol");
-        assert!(angles.windows(2).all(|w| w[0] <= w[1]), "ascending: {angles:?}");
-        assert!(angles[0] < 1.0, "base tilt is 0.5 degrees, got {}", angles[0]);
+        assert!(
+            angles.windows(2).all(|w| w[0] <= w[1]),
+            "ascending: {angles:?}"
+        );
+        assert!(
+            angles[0] < 1.0,
+            "base tilt is 0.5 degrees, got {}",
+            angles[0]
+        );
         assert!(
             (Utc::now() - time).num_minutes() < 30,
             "{time} is not a live volume"

--- a/crates/wxdata/src/forecast.rs
+++ b/crates/wxdata/src/forecast.rs
@@ -45,7 +45,9 @@ fn parse_wind_mph(s: &str) -> Option<f32> {
     s.split(|c: char| !c.is_ascii_digit())
         .filter(|t| !t.is_empty())
         .filter_map(|t| t.parse::<f32>().ok())
-        .fold(None, |acc: Option<f32>, v| Some(acc.map_or(v, |a| a.max(v))))
+        .fold(None, |acc: Option<f32>, v| {
+            Some(acc.map_or(v, |a| a.max(v)))
+        })
 }
 
 /// A compass point ("NNW") as degrees the wind blows from.

--- a/crates/wxdata/src/level2.rs
+++ b/crates/wxdata/src/level2.rs
@@ -100,11 +100,11 @@ impl Moment {
     /// 0 = below-threshold (transparent), 1 = range-folded.
     pub fn value_range(&self) -> (f32, f32) {
         match self {
-            Moment::Reflectivity => (-32.0, 95.0),           // dBZ
-            Moment::Velocity => (-127.0, 127.0),             // m/s (pre-dealias)
-            Moment::SpectrumWidth => (0.0, 63.0),            // m/s
-            Moment::DifferentialReflectivity => (-7.9, 7.9), // dB
-            Moment::DifferentialPhase => (0.0, 360.0),       // deg
+            Moment::Reflectivity => (-32.0, 95.0),            // dBZ
+            Moment::Velocity => (-127.0, 127.0),              // m/s (pre-dealias)
+            Moment::SpectrumWidth => (0.0, 63.0),             // m/s
+            Moment::DifferentialReflectivity => (-7.9, 7.9),  // dB
+            Moment::DifferentialPhase => (0.0, 360.0),        // deg
             Moment::SpecificDifferentialPhase => (-2.0, 8.0), // deg/km
             Moment::CorrelationCoefficient => (0.0, 1.05),
         }
@@ -137,11 +137,10 @@ pub struct BinnedSweep {
 /// Nothing before this exists to be asked for, so it is where a date picker has to stop. The
 /// early years are legacy pre-dual-pol Type-1 messages, which decode but carry reflectivity
 /// and velocity only.
-pub const ARCHIVE_START: chrono::NaiveDate =
-    match chrono::NaiveDate::from_ymd_opt(1991, 6, 5) {
-        Some(d) => d,
-        None => panic!("1991-06-05 is a real date"),
-    };
+pub const ARCHIVE_START: chrono::NaiveDate = match chrono::NaiveDate::from_ymd_opt(1991, 6, 5) {
+    Some(d) => d,
+    None => panic!("1991-06-05 is a real date"),
+};
 
 /// What a [`BinnedSweep`] holds at one gate, and where that gate is.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -169,15 +168,11 @@ impl BinnedSweep {
     /// interpolation — the question a readout answers is "what did the radar record *here*",
     /// and a blend of neighbouring gates is a number the radar never produced.
     pub fn sample_at(&self, lon: f64, lat: f64) -> Option<GateSample> {
-        let (ground_km, bearing) = crate::xsection::dist_bearing(
-            self.radar_lon as f64,
-            self.radar_lat as f64,
-            lon,
-            lat,
-        );
+        let (ground_km, bearing) =
+            crate::xsection::dist_bearing(self.radar_lon as f64, self.radar_lat as f64, lon, lat);
         let slant = crate::xsection::slant_from_ground_km(ground_km, self.elevation_deg as f64);
-        let gate = ((slant - self.first_gate_km as f64) / self.gate_interval_km.max(1e-6) as f64)
-            .floor();
+        let gate =
+            ((slant - self.first_gate_km as f64) / self.gate_interval_km.max(1e-6) as f64).floor();
         if gate < 0.0 || gate >= self.gate_count as f64 {
             return None;
         }
@@ -288,8 +283,10 @@ fn with_previous_tail(
 ///
 /// ponytail: a flat map with a short TTL and no eviction — a session touches a handful of
 /// site/day pairs. Bound it if that ever stops being true.
-type DayListCache =
-    std::collections::HashMap<(String, chrono::NaiveDate), (crate::clock::Instant, Vec<Identifier>)>;
+type DayListCache = std::collections::HashMap<
+    (String, chrono::NaiveDate),
+    (crate::clock::Instant, Vec<Identifier>),
+>;
 static DAY_LIST_CACHE: std::sync::OnceLock<std::sync::Mutex<DayListCache>> =
     std::sync::OnceLock::new();
 
@@ -713,8 +710,13 @@ pub fn bin_sweep_opts(
             .min()
             .unwrap_or(0);
         let reference = take_dealias_reference(&key, at);
-        let unfolded =
-            crate::dealias::dealias_with_reference(&vel, AZ_BINS, gate_count, nyq, reference.as_deref());
+        let unfolded = crate::dealias::dealias_with_reference(
+            &vel,
+            AZ_BINS,
+            gate_count,
+            nyq,
+            reference.as_deref(),
+        );
         put_dealias_reference(key, at, &unfolded);
         for (i, v) in unfolded.iter().enumerate() {
             if let Some(v) = v {
@@ -800,11 +802,19 @@ mod tests {
         let ground = crate::xsection::ground_from_slant_km(slant, 0.5);
         let (lon, lat) = destination(-97.0, 35.0, want_az, ground);
 
-        let got = sweep.sample_at(lon, lat).expect("point is inside the sweep");
+        let got = sweep
+            .sample_at(lon, lat)
+            .expect("point is inside the sweep");
         assert_eq!(got.gate, want_gate, "gate index");
-        assert!((got.azimuth_deg as f64 - want_az).abs() < 0.5, "azimuth {got:?}");
+        assert!(
+            (got.azimuth_deg as f64 - want_az).abs() < 0.5,
+            "azimuth {got:?}"
+        );
         let want_value = -32.0 + (code - 2) as f32 / 253.0 * (95.0 - -32.0);
-        assert!((got.value.unwrap() - want_value).abs() < 0.01, "value {got:?}");
+        assert!(
+            (got.value.unwrap() - want_value).abs() < 0.01,
+            "value {got:?}"
+        );
     }
 
     /// The two sentinel codes are not values, and must not be reported as one.
@@ -830,7 +840,10 @@ mod tests {
 
         let (lon, lat) = destination(-97.0, 35.0, 0.0, 3.5);
         let got = sweep.sample_at(lon, lat).unwrap();
-        assert!(!got.folded && got.value.is_none(), "below threshold is not folded");
+        assert!(
+            !got.folded && got.value.is_none(),
+            "below threshold is not folded"
+        );
     }
 
     /// Past the last gate there is no reading — not a clamped one at the edge of the sweep.
@@ -859,8 +872,7 @@ mod tests {
         let (b, d) = (bearing_deg.to_radians(), km / r);
         let (p0, l0) = (lat.to_radians(), lon.to_radians());
         let p = (p0.sin() * d.cos() + p0.cos() * d.sin() * b.cos()).asin();
-        let l = l0
-            + (b.sin() * d.sin() * p0.cos()).atan2(d.cos() - p0.sin() * p.sin());
+        let l = l0 + (b.sin() * d.sin() * p0.cos()).atan2(d.cos() - p0.sin() * p.sin());
         (l.to_degrees(), p.to_degrees())
     }
 
@@ -883,14 +895,21 @@ mod tests {
     #[test]
     fn short_day_borrows_the_previous_evening() {
         let ids = |names: &[&str]| -> Vec<Identifier> {
-            names.iter().map(|n| Identifier::new(n.to_string())).collect()
+            names
+                .iter()
+                .map(|n| Identifier::new(n.to_string()))
+                .collect()
         };
         let older = ids(&["a1", "a2", "a3", "a4"]);
         let today = ids(&["b1", "b2"]);
 
         let merged = with_previous_tail(older.clone(), today.clone(), 4);
         let names: Vec<&str> = merged.iter().map(|i| i.name()).collect();
-        assert_eq!(names, ["a3", "a4", "b1", "b2"], "newest of yesterday, then today");
+        assert_eq!(
+            names,
+            ["a3", "a4", "b1", "b2"],
+            "newest of yesterday, then today"
+        );
 
         // Enough frames already: yesterday contributes nothing.
         let merged = with_previous_tail(older, today, 2);
@@ -973,8 +992,8 @@ mod tests {
                 )
             })
             .collect();
-        let binned = bin_sweep(&Sweep::new(1, radials), Moment::Reflectivity, 35.33, -97.28)
-            .unwrap();
+        let binned =
+            bin_sweep(&Sweep::new(1, radials), Moment::Reflectivity, 35.33, -97.28).unwrap();
         assert_eq!(binned.gate_count, 1);
         let empty = binned.data.iter().filter(|&&c| c == 0).count();
         assert_eq!(empty, 0, "every azimuth bin should carry the 20 dBZ value");
@@ -1123,7 +1142,10 @@ mod tests {
             ..key
         };
         assert_eq!(take_dealias_reference(&other_tilt, 400_000), None);
-        let other_site = DealiasKey { lat_e2: 4_100, ..key };
+        let other_site = DealiasKey {
+            lat_e2: 4_100,
+            ..key
+        };
         assert_eq!(take_dealias_reference(&other_site, 400_000), None);
     }
 }

--- a/crates/wxdata/src/lib.rs
+++ b/crates/wxdata/src/lib.rs
@@ -12,9 +12,9 @@ pub mod contour;
 pub mod dat;
 pub mod dealias;
 pub mod derived;
+pub mod dotcams;
 pub mod dualpol;
 pub mod dwd;
-pub mod dotcams;
 pub mod efield;
 pub mod ero;
 pub mod forecast;
@@ -38,6 +38,7 @@ pub mod nohrsc;
 pub mod obs;
 pub mod odim;
 pub mod openmeteo;
+pub mod opera;
 pub mod overlay;
 pub mod placefile;
 pub mod probsevere;
@@ -54,15 +55,15 @@ pub mod stations;
 pub mod synoptic;
 pub mod task;
 pub mod tds;
-pub mod tfr;
 pub mod tdwr;
+pub mod tfr;
 pub mod torclimo;
 pub mod towers;
 pub mod tropical;
 pub mod tz;
 pub mod verify;
-pub mod vtec;
 pub mod volume3d;
+pub mod vtec;
 /// Off-main-thread Level 2 decode in the browser.
 #[cfg(target_arch = "wasm32")]
 pub mod wasm_worker;
@@ -74,28 +75,66 @@ pub mod xsection;
 /// Radar site registry (id, city, state, lat/lon, elevation).
 ///
 /// Wraps `nexrad-model`'s WSR-88D registry so the app has one dependency surface for site data,
-/// and folds in the TDWR and DWD tables — everything that resolves a site id gets terminal and
-/// German radars for free, instead of each call site remembering there are three networks.
+/// and folds in the TDWR, DWD and OPERA tables — everything that resolves a site id gets terminal,
+/// German and European radars for free, instead of each call site remembering how many networks
+/// there are.
 pub mod sites {
     pub use nexrad_model::meta::registry::{nearest_site, sites, SiteEntry};
+
+    /// Which feed a site id belongs to.
+    ///
+    /// The fourth network is where a chain of `is_x` booleans stops paying: every call site that
+    /// wanted "not this one, not that one either" had to be edited again, and one of them was
+    /// always missed. One `match` per question instead, and adding a network makes the compiler
+    /// list the questions.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum Network {
+        /// WSR-88D — the US network, and the only one with a Level 2 stream and a volume archive.
+        Nexrad,
+        /// Terminal Doppler Weather Radar, synthesized from Level 3 tilt products.
+        Tdwr,
+        /// Germany's network, assembled from `opendata.dwd.de` ODIM files.
+        Dwd,
+        /// Europe's, from EUMETNET's OpenRadarData bucket.
+        Opera,
+    }
+
+    /// The network `id` belongs to. An id no table knows reads as [`Network::Nexrad`], which is
+    /// what every path assumed before there was more than one network.
+    pub fn network(id: &str) -> Network {
+        if crate::tdwr::is_tdwr(id) {
+            Network::Tdwr
+        } else if crate::dwd::is_dwd(id) {
+            Network::Dwd
+        } else if crate::opera::is_opera(id) {
+            Network::Opera
+        } else {
+            Network::Nexrad
+        }
+    }
 
     /// The site with this id, from any network (case-insensitive).
     pub fn site_by_id(id: &str) -> Option<&'static SiteEntry> {
         nexrad_model::meta::registry::site_by_id(id)
             .or_else(|| crate::tdwr::site_by_id(id))
             .or_else(|| crate::dwd::site_by_id(id))
+            .or_else(|| crate::opera::site_by_id(id))
     }
 
     /// Whether `id` is a WSR-88D — the only network with a Level 2 stream, a volume archive and
-    /// Level 3 algorithm products. TDWR volumes are synthesized from Level 3 tilts and DWD's are
-    /// assembled from ODIM files, so every archive/stream/algorithm path asks this instead of
+    /// Level 3 algorithm products. Every other network's volumes are assembled from ODIM files or
+    /// synthesized from Level 3 tilts, so every archive/stream/algorithm path asks this instead of
     /// assuming the site it was handed is a NEXRAD.
     pub fn is_nexrad(id: &str) -> bool {
-        !crate::tdwr::is_tdwr(id) && !crate::dwd::is_dwd(id)
+        network(id) == Network::Nexrad
     }
 
-    /// Every site the app can fetch: WSR-88Ds first, then TDWRs, then Germany's DWD network.
+    /// Every site the app can fetch: WSR-88Ds first, then TDWRs, then DWD, then OPERA.
     pub fn all() -> impl Iterator<Item = &'static SiteEntry> {
-        sites().iter().chain(crate::tdwr::SITES).chain(crate::dwd::SITES)
+        sites()
+            .iter()
+            .chain(crate::tdwr::SITES)
+            .chain(crate::dwd::SITES)
+            .chain(crate::opera::SITES)
     }
 }

--- a/crates/wxdata/src/live.rs
+++ b/crates/wxdata/src/live.rs
@@ -212,12 +212,7 @@ const SAME_PASS_MS: i64 = 90_000;
 /// sweep assembled there is missing its own beginning. Replacing wholesale threw the early
 /// radials away and drew the volume with a wedge of empty azimuths: the seam.
 fn stitch(base: &Sweep, partial: &Sweep) -> Sweep {
-    let start = |s: &Sweep| {
-        s.radials()
-            .iter()
-            .map(|r| r.collection_timestamp())
-            .min()
-    };
+    let start = |s: &Sweep| s.radials().iter().map(|r| r.collection_timestamp()).min();
     let same_pass = match (start(base), start(partial)) {
         (Some(b), Some(p)) => (p - b).abs() < SAME_PASS_MS,
         _ => false,

--- a/crates/wxdata/src/opera.rs
+++ b/crates/wxdata/src/opera.rs
@@ -1,0 +1,395 @@
+//! Europe's radars from EUMETNET's OpenRadarData feed — the fourth network, and the first that
+//! spans more than one country.
+//!
+//! ORD is an OGC EDR API on `api.meteogate.eu`, but the API only serves CoverageJSON: the ODIM
+//! files themselves live in a public S3 bucket, `openradar-24h`, one object per volume per moment,
+//! keyed `YYYY/MM/DD/CC/nod/PVOL/nod@YYYYMMDDThhmm@<elevations>@<moments>.h5`. Anonymous, no key,
+//! no registration, CC BY 4.0, and the bucket lists with a prefix — so finding the newest volume
+//! is one ~5 KB listing of the current hour rather than the megabyte of HTML DWD charges for the
+//! same question.
+//!
+//! The object is a whole volume: every elevation and (for most publishers) every moment in one
+//! ~1 MB file that [`crate::odim::decode`] already reads. That makes a European site an order of
+//! magnitude cheaper than a German one, which needs forty files. Publishers that split moments
+//! into one file per quantity are handled by fetching the rest of the group and folding them in.
+//!
+//! ponytail: a curated table of the sites that verify live, not the whole 129-radar feed. Three
+//! things disqualify a country, and all three were measured rather than assumed:
+//!
+//! * Norway (12 sites) writes HDF5 with 4-byte file offsets and Malta writes big-endian
+//!   datatypes; `hdf5lite` reads neither. Nothing in this crate can fix that.
+//! * Switzerland, Finland, France, Estonia, Lithuania and Sweden publish `SCAN/`, one file per
+//!   elevation, which is DWD's shape and a different fetch loop. Later, if ever.
+//! * Germany is already here through [`crate::dwd`], from the source rather than the aggregator.
+//!
+//! Growing the table is adding rows. Growing the machinery is not required.
+
+use chrono::{DateTime, Utc};
+use nexrad_model::data::{Scan, Sweep};
+use nexrad_model::meta::registry::SiteEntry;
+
+const BUCKET: &str = "https://s3.waw3-1.cloudferro.com/openradar-24h";
+
+const fn site(
+    id: &'static str,
+    city: &'static str,
+    state: &'static str,
+    latitude: f32,
+    longitude: f32,
+    elevation_meters: i16,
+) -> SiteEntry {
+    SiteEntry {
+        id,
+        city,
+        state,
+        latitude,
+        longitude,
+        elevation_meters,
+    }
+}
+
+/// Every OPERA radar the build offers. The id is the ODIM `NOD` code upper-cased — five letters,
+/// so it can never collide with a four-letter WSR-88D or TDWR id — and `state` carries the ISO
+/// country code, which is what the site list shows and what [`crate::tz`] keys off.
+///
+/// Coordinates and heights are the ones each radar reports in its own ODIM `/where` group, read
+/// out of a live file per site rather than transcribed from a table.
+pub const SITES: &[SiteEntry] = &[
+    site("BEHEL", "Helchteren", "BE", 51.0702, 5.4054, 144),
+    site("BEJAB", "Jabbeke", "BE", 51.1917, 3.0642, 50),
+    site("BEWID", "Wideumont", "BE", 49.9136, 5.5044, 585),
+    site("CZBRD", "Brdy", "CZ", 49.6583, 13.8178, 916),
+    site("CZSKA", "Skalky", "CZ", 49.5011, 16.7885, 767),
+    site("DKBOR", "Bornholm", "DK", 55.1127, 14.8875, 171),
+    site("DKROM", "Romo", "DK", 55.1731, 8.5520, 15),
+    site("DKSAM", "Samso", "DK", 55.8119, 10.5853, 48),
+    site("DKSIN", "Sindal", "DK", 57.4893, 10.1365, 109),
+    site("DKSTE", "Stevns", "DK", 55.3262, 12.4493, 53),
+    site("HRBIL", "Bilogora", "HR", 45.8835, 17.2005, 280),
+    site("HRDEB", "Debeljak", "HR", 44.0452, 15.3764, 208),
+    site("HRGOL", "Goli", "HR", 45.0205, 14.1223, 553),
+    site("HRGRA", "Gradiste", "HR", 45.1592, 18.7033, 110),
+    site("HRPUN", "Puntijarka", "HR", 45.9078, 15.9684, 1030),
+    site("HRULJ", "Uljenje", "HR", 42.8944, 17.4783, 463),
+    site("IESHA", "Shannon", "IE", 52.6928, -8.9200, 29),
+    site("ISBJO", "Bjolfur", "IS", 65.2659, -14.0618, 1090),
+    site("ISKEF", "Keflavik", "IS", 64.0257, -22.6354, 48),
+    site("ISSKA", "Skagi", "IS", 66.0557, -20.2680, 164),
+    site("ISX2", "Mobile 2", "IS", 63.8696, -20.2023, 42),
+    site("NLDHL", "Den Helder", "NL", 52.9528, 4.7906, 55),
+    site("NLHRW", "Herwijnen", "NL", 51.8369, 5.1381, 25),
+    site("PLBRZ", "Brzuchania", "PL", 50.3942, 20.0832, 434),
+    site("PLGDY", "Gdynia", "PL", 54.5009, 18.2718, 261),
+    site("PLGSA", "Gora Sw Anny", "PL", 50.4639, 18.1532, 433),
+    site("PLLEG", "Legionowo", "PL", 52.4053, 20.9611, 122),
+    site("PLPAS", "Pastewnik", "PL", 50.8925, 16.0395, 692),
+    site("PLPOZ", "Poznan", "PL", 52.4133, 16.7970, 123),
+    site("PLRAM", "Ramza", "PL", 50.1513, 18.7251, 357),
+    site("PLRZE", "Rzeszow", "PL", 50.1141, 22.0370, 241),
+    site("PLSWI", "Swidwin", "PL", 53.7958, 15.8368, 147),
+    site("PLUZR", "Uzranki", "PL", 53.8557, 21.4123, 237),
+    site("ROBAR", "Barnova", "RO", 47.0118, 27.5825, 454),
+    site("ROBOB", "Bobohalma", "RO", 46.3602, 24.2252, 567),
+    site("ROBUC", "Bucuresti", "RO", 44.5127, 26.0773, 133),
+    site("ROCRA", "Craiova", "RO", 44.3103, 23.8674, 218),
+    site("ROMED", "Medgidia", "RO", 44.2434, 28.2506, 112),
+    site("ROORA", "Oradea", "RO", 47.0922, 21.9429, 246),
+    site("ROTIM", "Timisoara", "RO", 45.7717, 21.2577, 145),
+    site("SILIS", "Lisca", "SI", 46.0678, 15.2849, 950),
+    site("SIPAS", "Pasja ravan", "SI", 46.0980, 14.2282, 1043),
+];
+
+/// The OPERA radar with this id, if any (case-insensitive).
+pub fn site_by_id(id: &str) -> Option<&'static SiteEntry> {
+    SITES.iter().find(|s| s.id.eq_ignore_ascii_case(id))
+}
+
+/// Whether `id` names a radar reached through the OPERA feed.
+pub fn is_opera(id: &str) -> bool {
+    site_by_id(id).is_some()
+}
+
+/// The bucket listing that names every object published for `site` in the hour containing `hour`.
+fn index_url(country: &str, nod: &str, hour: DateTime<Utc>) -> String {
+    // The `@` in the key is left as-is: S3 accepts it unescaped in a prefix, and escaping it would
+    // have to survive the proxy's path rewrite as well.
+    format!(
+        "{BUCKET}?list-type=2&prefix={}/{country}/{nod}/PVOL/{nod}@{}",
+        hour.format("%Y/%m/%d"),
+        hour.format("%Y%m%dT%H")
+    )
+}
+
+/// Every `<Key>` in an S3 `ListObjectsV2` response, in the order the bucket returned them —
+/// lexicographic, which for these keys is chronological.
+///
+/// ponytail: `split` over an XML parser. The one field wanted is a text element with no attributes
+/// and no nesting, and the feed is treated as hostile: a run-away `<Key>` with no close tag ends
+/// the scan rather than the process.
+fn keys(xml: &str) -> Vec<&str> {
+    xml.split("<Key>")
+        .skip(1)
+        .map_while(|rest| rest.split_once("</Key>").map(|(k, _)| k))
+        .collect()
+}
+
+/// The newest published volume in `xml`, as the objects that make it up.
+///
+/// A key is `nod@stamp@elevations@moments.h5`, and publishers vary: some put every moment in one
+/// object, some write one object per quantity, and some run two scan strategies whose objects
+/// share a timestamp but not an elevation list. So the choice is anchored on reflectivity — the
+/// newest object that carries `DBZH` — and its siblings are the objects agreeing with it on
+/// everything left of the moment field. Anchoring on the timestamp alone would pick a
+/// velocity-only volume whenever the velocity object of the next scan lands first, which on the
+/// Norwegian and Polish publishers is most of the time.
+fn newest_group<'a>(xml: &'a str, nod: &str) -> Vec<&'a str> {
+    let all = keys(xml);
+    let base = all
+        .iter()
+        .rev()
+        .find(|k| {
+            let name = k.rsplit('/').next().unwrap_or(k);
+            name.starts_with(nod)
+                && name
+                    .rsplit_once('@')
+                    .is_some_and(|(_, m)| m.contains("DBZH"))
+        })
+        .copied();
+    let Some(base) = base else { return Vec::new() };
+    let prefix = base.rsplit_once('@').map(|(p, _)| p).unwrap_or(base);
+    // Reflectivity first: it is the base every other moment is folded into.
+    let mut group = vec![base];
+    group.extend(
+        all.iter()
+            .filter(|k| **k != base && k.rsplit_once('@').is_some_and(|(p, _)| p == prefix))
+            .copied(),
+    );
+    group
+}
+
+/// The newest volume for `id`, assembled from the objects EUMETNET published for it.
+pub async fn fetch_volume(
+    http: &reqwest::Client,
+    id: &str,
+) -> anyhow::Result<(String, DateTime<Utc>, Scan)> {
+    let meta = site_by_id(id).ok_or_else(|| anyhow::anyhow!("{id} is not an OPERA radar"))?;
+    let nod = id.to_ascii_lowercase();
+
+    let text = |url: String| {
+        let http = http.clone();
+        async move {
+            http.get(crate::net::fetch_url(&url))
+                .send()
+                .await
+                .ok()?
+                .text()
+                .await
+                .ok()
+        }
+    };
+
+    // The listing is keyed by hour, so a volume published at :02 is alone in its hour and the one
+    // before it is in the previous one. Two listings is the worst case and they cost ~5 KB each.
+    let now = Utc::now();
+    let mut group: Vec<String> = Vec::new();
+    for back in 0..2 {
+        let index = text(index_url(
+            meta.state,
+            &nod,
+            now - chrono::Duration::hours(back),
+        ))
+        .await
+        .unwrap_or_default();
+        group = newest_group(&index, &nod)
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+        if !group.is_empty() {
+            break;
+        }
+    }
+    if group.is_empty() {
+        anyhow::bail!("no OPERA volume published for {id} in the last two hours");
+    }
+
+    let files = futures_util::future::join_all(group.iter().map(|key| {
+        let http = http.clone();
+        let url = format!("{BUCKET}/{key}");
+        async move {
+            let bytes = http
+                .get(crate::net::fetch_url(&url))
+                .send()
+                .await
+                .ok()?
+                .bytes()
+                .await
+                .ok()?;
+            match crate::odim::decode(bytes.to_vec()) {
+                Ok(v) => Some(v),
+                Err(e) => {
+                    // A moment that fails to arrive is simply absent from the volume.
+                    log::warn!("opera: skipping {url}: {e}");
+                    None
+                }
+            }
+        }
+    }))
+    .await;
+
+    let mut files = files.into_iter().flatten();
+    let (time, base) = files
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("no decodable OPERA volume for {id}"))?;
+    // Every object in the group is the same scan sampled at once, so sweep `i` of one is sweep `i`
+    // of the others; a file that disagrees about the scan it describes is dropped rather than
+    // smeared across it.
+    let extras: Vec<Scan> = files
+        .map(|(_, s)| s)
+        .filter(|s| {
+            s.sweeps().len() == base.sweeps().len()
+                && std::iter::zip(s.sweeps(), base.sweeps()).all(|(a, b)| angle(a) == angle(b))
+        })
+        .collect();
+    let merged: Vec<Sweep> = base
+        .sweeps()
+        .iter()
+        .enumerate()
+        .map(|(i, sweep)| {
+            let siblings: Vec<Sweep> = extras
+                .iter()
+                .filter_map(|s| s.sweeps().get(i).cloned())
+                .collect();
+            crate::dwd::merge(sweep, &siblings)
+        })
+        .collect();
+
+    // Some publishers concatenate two scan strategies into one volume, which leaves an elevation
+    // appearing more than once. The map draws tilts in angle order, so the duplicates would stack
+    // invisibly on top of each other; the first one wins.
+    let mut seen = Vec::new();
+    let ordered: Vec<(f32, Sweep)> = merged
+        .into_iter()
+        .filter_map(|s| {
+            let a = angle(&s);
+            (!seen.contains(&a.to_bits())).then(|| {
+                seen.push(a.to_bits());
+                (a, s)
+            })
+        })
+        .collect();
+
+    let name = format!("{id}-{}", time.format("%Y%m%d%H%M%S"));
+    Ok((
+        name,
+        time,
+        // The decoder already built the pattern-0 placeholder ODIM's free-text scan strategy
+        // deserves; there is nothing better to say about it here.
+        Scan::with_site(
+            meta.to_site(),
+            base.coverage_pattern().clone(),
+            crate::dwd::assemble(ordered),
+        ),
+    ))
+}
+
+/// The elevation a sweep was cut at, or `NaN` for an empty one — which no decoded sweep is.
+fn angle(sweep: &Sweep) -> f32 {
+    sweep
+        .radials()
+        .first()
+        .map_or(f32::NAN, |r| r.elevation_angle_degrees())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LISTING: &str = "<ListBucketResult>\
+        <Contents><Key>2026/08/29/PL/plgsa/PVOL/plgsa@20260829T1531@0.5_1.5@DBZH.h5</Key></Contents>\
+        <Contents><Key>2026/08/29/PL/plgsa/PVOL/plgsa@20260829T1531@0.5_1.5@TH.h5</Key></Contents>\
+        <Contents><Key>2026/08/29/PL/plgsa/PVOL/plgsa@20260829T1531@0.5_1.5@VRADH.h5</Key></Contents>\
+        <Contents><Key>2026/08/29/PL/plgsa/PVOL/plgsa@20260829T1536@0.5_1.5@VRADH.h5</Key></Contents>\
+        </ListBucketResult>";
+
+    /// The reason the volume is chosen by reflectivity and not by timestamp: the newest object in
+    /// the bucket is routinely the velocity half of a volume whose reflectivity has not landed.
+    #[test]
+    fn the_newest_complete_volume_wins_over_the_newest_object() {
+        let g = newest_group(LISTING, "plgsa");
+        assert_eq!(g.len(), 3, "{g:?}");
+        assert!(
+            g[0].ends_with("plgsa@20260829T1531@0.5_1.5@DBZH.h5"),
+            "{g:?}"
+        );
+        assert!(g.iter().all(|k| k.contains("T1531")), "{g:?}");
+    }
+
+    /// Objects of a different scan strategy share the timestamp but not the elevation list, and
+    /// merging is by sweep index — so they must not be mistaken for siblings.
+    #[test]
+    fn a_second_scan_strategy_is_not_a_sibling() {
+        let xml = LISTING.replace("T1531@0.5_1.5@TH", "T1531@0.3_0.9@TH");
+        let g = newest_group(&xml, "plgsa");
+        assert_eq!(g.len(), 2, "{g:?}");
+        assert!(g.iter().all(|k| k.contains("@0.5_1.5@")), "{g:?}");
+    }
+
+    /// The feed is hostile input: a truncated listing must end the scan, not the process.
+    #[test]
+    fn an_unterminated_key_ends_the_scan() {
+        assert_eq!(keys("<Key>a</Key><Key>b"), ["a"]);
+        assert!(newest_group("<Key>", "plgsa").is_empty());
+    }
+
+    /// One digit out in the prefix and the listing comes back empty.
+    #[test]
+    fn the_index_url_names_one_hour_of_one_site() {
+        let hour = chrono::DateTime::parse_from_rfc3339("2026-08-29T15:36:30Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(
+            index_url("PL", "plgsa", hour),
+            "https://s3.waw3-1.cloudferro.com/openradar-24h\
+             ?list-type=2&prefix=2026/08/29/PL/plgsa/PVOL/plgsa@20260829T15"
+        );
+    }
+
+    /// The ids must not collide with the US networks — the site tables are separate and
+    /// `site_by_id` resolves them in order, so a collision would silently shadow a radar — and
+    /// every site must carry the two-letter country code the bucket path and the timezone table
+    /// are built from.
+    #[test]
+    fn ids_are_five_letter_nod_codes_under_a_country() {
+        for s in SITES {
+            assert!(
+                nexrad_model::meta::registry::site_by_id(s.id).is_none()
+                    && crate::tdwr::site_by_id(s.id).is_none(),
+                "{} collides with a US site id",
+                s.id
+            );
+            assert!(s.id.starts_with(s.state), "{} is not in {}", s.id, s.state);
+            assert_eq!(s.state.len(), 2, "{} is not an ISO country code", s.state);
+            assert!(
+                crate::sites::site_by_id(s.id).is_some(),
+                "{} is unreachable",
+                s.id
+            );
+        }
+    }
+
+    /// Costs real network and a live feed; run with `--ignored`.
+    #[tokio::test]
+    #[ignore]
+    async fn live_opera_volume_assembles() {
+        let http = reqwest::Client::new();
+        let (name, _, scan) = fetch_volume(&http, "HRBIL").await.expect("volume");
+        assert!(name.starts_with("HRBIL-"), "{name}");
+        assert!(scan.sweeps().len() >= 5, "{} sweeps", scan.sweeps().len());
+        let base = &scan.sweeps()[0].radials()[0];
+        assert!(
+            base.reflectivity().is_some(),
+            "base tilt carries reflectivity"
+        );
+        assert!(base.velocity().is_some(), "and velocity");
+    }
+}

--- a/crates/wxdata/src/placefile.rs
+++ b/crates/wxdata/src/placefile.rs
@@ -430,9 +430,7 @@ mod tests {
     /// to survive both without producing an item.
     #[test]
     fn a_polygon_with_no_usable_ring_is_dropped() {
-        let pf = parse(
-            "Color: 255 0 0\nPolygon:\n\n 35.0, -97.0\n 35.1, -97.0\nEnd:\n",
-        );
+        let pf = parse("Color: 255 0 0\nPolygon:\n\n 35.0, -97.0\n 35.1, -97.0\nEnd:\n");
         assert!(pf.items.is_empty(), "two points is not a polygon");
     }
 

--- a/crates/wxdata/src/sounding.rs
+++ b/crates/wxdata/src/sounding.rs
@@ -12,9 +12,7 @@ const BUCKET: &str = "https://noaa-hrrr-bdp-pds.s3.amazonaws.com";
 /// top two are above the tropopause on purpose: an uncapped plains parcel is still buoyant at
 /// 200 hPa, and without an equilibrium level the effective-layer shear and STP have nothing to
 /// measure against and come back absent.
-const LEVELS_HPA: &[u32] = &[
-    1000, 925, 850, 700, 600, 500, 400, 300, 250, 200, 150, 100,
-];
+const LEVELS_HPA: &[u32] = &[1000, 925, 850, 700, 600, 500, 400, 300, 250, 200, 150, 100];
 
 /// One level of the sounding.
 #[derive(Debug, Clone, Copy)]
@@ -694,9 +692,14 @@ mod tests {
         let (top, bottom) = csv.split_once("\n\n").expect("two blocks");
         assert!(top.starts_with("index,value\n"));
         assert!(top.lines().any(|l| l.starts_with("stp,")));
-        assert!(top.lines().any(|l| l.starts_with("ebwd_kt,") && l != "ebwd_kt,"));
+        assert!(top
+            .lines()
+            .any(|l| l.starts_with("ebwd_kt,") && l != "ebwd_kt,"));
         let mut rows = bottom.lines();
-        assert_eq!(rows.next().unwrap(), "pressure_hpa,height_m,temp_c,dewpt_c,u_ms,v_ms");
+        assert_eq!(
+            rows.next().unwrap(),
+            "pressure_hpa,height_m,temp_c,dewpt_c,u_ms,v_ms"
+        );
         assert_eq!(rows.next().unwrap(), "1000,0,30.0,22.0,0.0,8.0");
         assert_eq!(rows.count(), s.levels.len() - 1);
     }

--- a/crates/wxdata/src/spc.rs
+++ b/crates/wxdata/src/spc.rs
@@ -393,7 +393,10 @@ mod tests {
             Some("https://www.spc.noaa.gov/products/md/md2032.txt")
         );
         assert_eq!(md_text_url(""), None);
-        assert_eq!(md_text_url("www.spc.noaa.gov/products/md/md2032.html"), None);
+        assert_eq!(
+            md_text_url("www.spc.noaa.gov/products/md/md2032.html"),
+            None
+        );
         assert_eq!(
             md_text_url("https://www.spc.noaa.gov/products/md/md2032"),
             None

--- a/crates/wxdata/src/stations.rs
+++ b/crates/wxdata/src/stations.rs
@@ -529,7 +529,10 @@ mod tests {
             .expect("synoptic answered");
         assert!(!obs.is_empty(), "no stations came back");
         for o in obs.iter().take(10) {
-            println!("{} {} temp={:?} gust={:?}", o.id, o.name, o.temp_c, o.gust_kt);
+            println!(
+                "{} {} temp={:?} gust={:?}",
+                o.id, o.name, o.temp_c, o.gust_kt
+            );
         }
     }
 }

--- a/crates/wxdata/src/synoptic.rs
+++ b/crates/wxdata/src/synoptic.rs
@@ -45,7 +45,8 @@ fn station(s: &serde_json::Value) -> Option<StationOb> {
     };
     let str_num = |key: &str| -> Option<f64> {
         let v = s.get(key)?;
-        v.as_f64().or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+        v.as_f64()
+            .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
     };
     let temp_c = num("air_temp");
     let dewp_c = num("dew_point_temperature");

--- a/crates/wxdata/src/towers.rs
+++ b/crates/wxdata/src/towers.rs
@@ -187,7 +187,10 @@ mod tests {
 
     #[test]
     fn the_table_is_sorted_and_plausible() {
-        assert!(TOWERS.windows(2).all(|w| w[0].0 < w[1].0), "binary_search needs sorted ids");
+        assert!(
+            TOWERS.windows(2).all(|w| w[0].0 < w[1].0),
+            "binary_search needs sorted ids"
+        );
         for (id, h) in TOWERS {
             assert!(*h > 5.0 && *h < 80.0, "{id}: {h} m is not a radar tower");
         }

--- a/crates/wxdata/src/tropical.rs
+++ b/crates/wxdata/src/tropical.rs
@@ -396,8 +396,8 @@ pub async fn fetch_advisory(
         .error_for_status()?
         .text()
         .await?;
-    let text = advisory_text(&body)
-        .ok_or_else(|| anyhow::anyhow!("no product text in the NHC page"))?;
+    let text =
+        advisory_text(&body).ok_or_else(|| anyhow::anyhow!("no product text in the NHC page"))?;
     Ok(Advisory {
         title: title.to_string(),
         text,

--- a/crates/wxdata/src/tz.rs
+++ b/crates/wxdata/src/tz.rs
@@ -118,7 +118,23 @@ pub fn site_tz(id: &str) -> Option<Tz> {
         // asked, or every German radar falls through to `None` and reads UTC.
         _ if crate::dwd::is_dwd(id) => Europe__Berlin,
 
-        _ => return None,
+        // OPERA sites carry an ISO country code instead of a state, and every country in the
+        // table is a single zone, so the zone is a property of the country and not of the radar.
+        // `every_site_has_a_timezone` fails the moment the site table grows a country this match
+        // does not answer for.
+        _ => match crate::opera::site_by_id(id)?.state {
+            "BE" => Europe__Brussels,
+            "CZ" => Europe__Prague,
+            "DK" => Europe__Copenhagen,
+            "HR" => Europe__Zagreb,
+            "IE" => Europe__Dublin,
+            "IS" => Atlantic__Reykjavik,
+            "NL" => Europe__Amsterdam,
+            "PL" => Europe__Warsaw,
+            "RO" => Europe__Bucharest,
+            "SI" => Europe__Ljubljana,
+            _ => return None,
+        },
     })
 }
 

--- a/crates/wxdata/src/verify.rs
+++ b/crates/wxdata/src/verify.rs
@@ -343,7 +343,10 @@ mod tests {
         let blocks: Vec<&str> = csv.split("\n\n").collect();
         assert_eq!(blocks.len(), 3, "stats, warnings, reports");
         assert!(blocks[0].contains("OUN,2013-05-20T00:00:00+00:00"));
-        assert!(blocks[1].contains("OUN,TO,24,"), "the verified tornado warning");
+        assert!(
+            blocks[1].contains("OUN,TO,24,"),
+            "the verified tornado warning"
+        );
         assert!(
             blocks[1].contains("Cleveland OK;Oklahoma OK"),
             "counties keep out of the comma columns"

--- a/crates/wxdata/src/wasm_worker.rs
+++ b/crates/wxdata/src/wasm_worker.rs
@@ -52,7 +52,11 @@ pub async fn decode_volume(bytes: Vec<u8>) -> Result<Vec<u8>, Error> {
         Err(e) => {
             let msg = e
                 .as_string()
-                .or_else(|| js_sys::Reflect::get(&e, &"message".into()).ok()?.as_string())
+                .or_else(|| {
+                    js_sys::Reflect::get(&e, &"message".into())
+                        .ok()?
+                        .as_string()
+                })
                 .unwrap_or_else(|| "worker rejected".into());
             // The bridge rejects with this exact string once it has terminated a dead worker, so
             // the caller falls back inline instead of reporting a broken volume.

--- a/crates/wxdata/src/wfigs.rs
+++ b/crates/wxdata/src/wfigs.rs
@@ -121,11 +121,7 @@ async fn pages(
 ) -> anyhow::Result<Vec<String>> {
     let mut out = Vec::new();
     for page in 0..MAX_PAGES {
-        let url = format!(
-            "{base}{}&resultOffset={}",
-            bbox_query(bbox),
-            page * LIMIT
-        );
+        let url = format!("{base}{}&resultOffset={}", bbox_query(bbox), page * LIMIT);
         let body = get(client, url).await?;
         let more = crate::dat::exceeded_limit(&body);
         out.push(body);

--- a/crates/wxdata/src/xsection.rs
+++ b/crates/wxdata/src/xsection.rs
@@ -87,7 +87,10 @@ pub fn slant_from_ground_km(ground_km: f64, elev_deg: f64) -> f64 {
 pub fn ground_from_slant_km(slant_km: f64, elev_deg: f64) -> f64 {
     let h = beam_height_km(slant_km, elev_deg);
     let e = elev_deg.to_radians();
-    R_EFF_KM * (slant_km * e.cos() / (R_EFF_KM + h)).clamp(-1.0, 1.0).asin()
+    R_EFF_KM
+        * (slant_km * e.cos() / (R_EFF_KM + h))
+            .clamp(-1.0, 1.0)
+            .asin()
 }
 
 /// Great-circle distance (km) and initial bearing (deg from north) from `(lon0,lat0)` to `(lon,lat)`.
@@ -272,7 +275,10 @@ mod tests {
         // one — at 4.3° and 230 km the old formula was two gates out, so the cross-section read
         // the wrong gate *and* drew it at the wrong height.
         let err = (slant_from_ground_km(230.0, 4.3) - flat(230.0, 4.3)).abs();
-        assert!(err > 0.5, "expected a multi-gate error at long range, got {err} km");
+        assert!(
+            err > 0.5,
+            "expected a multi-gate error at long range, got {err} km"
+        );
         // And still under a gate where most interrogation happens.
         assert!((slant_from_ground_km(100.0, 0.5) - flat(100.0, 0.5)).abs() < 0.25);
     }

--- a/scripts/web/build.sh
+++ b/scripts/web/build.sh
@@ -91,7 +91,7 @@ gz_bytes="$(gzip -9 -c "web/dist/hookecho_bg-$wasm_hash.wasm" | wc -c)"
 # cutting fonts (~1.9 MB of TTF) or a wgpu backend, and neither is free. Raise it deliberately.
 # The number tracks CI's build, which runs ~15 KB above a local one, so a local build has that
 # much slack; CI is the gate that matters.
-budget="${HOOKECHO_WASM_BUDGET:-4902000}"
+budget="${HOOKECHO_WASM_BUDGET:-4915000}"
 printf 'wasm: %s raw, %s gzipped (budget %s)\n' \
   "$(stat -c%s "web/dist/hookecho_bg-$wasm_hash.wasm")" "$gz_bytes" "$budget"
 if [ "$gz_bytes" -gt "$budget" ]; then

--- a/web/_worker.js/proxy-core.js
+++ b/web/_worker.js/proxy-core.js
@@ -50,6 +50,9 @@ export const ALLOWED_HOSTS = [
   "gibs.earthdata.nasa.gov",
   // European radar.
   "opendata.dwd.de",
+  // EUMETNET OpenRadarData: the ODIM volumes the OPERA network publishes, plus the
+  // bucket listing that names the newest one.
+  "s3.waw3-1.cloudferro.com",
   // Basemap and imagery tiles.
   "api.mapbox.com",
   "api.maptiler.com",


### PR DESCRIPTION
Fourth radar network: 42 European radars across ten countries, from EUMETNET's OpenRadarData feed. Anonymous, no key, no registration, CC BY 4.0.

## Pre-coding check (plan item 4) overturned the premise again

The plan budgeted for MeteoGate ORD as the data source. It is an OGC EDR API, and **it only serves CoverageJSON** — `Formats` enum has exactly one value. The actual ODIM files are in a public S3 bucket the API links to, `s3.waw3-1.cloudferro.com/openradar-24h`, which lists with a prefix. So:

| | measured |
|---|---|
| finding the newest volume | one `list-type=2` prefix listing of the current hour, ~2.4–9.6 KB |
| the volume itself | **one object**, every elevation and (mostly) every moment, ~0.5–1.4 MB |
| API key / quota | none; anonymous, CC BY 4.0, 24 h retention |
| CORS | none on the bucket, so `/proxy/` as usual; the EDR API sends `*` but isn't used |

A European volume is roughly **1–4 MB against Germany's ~18 MB**, because ORD publishes a whole PVOL where DWD publishes forty single-sweep files.

## Which countries, and why not the rest

Curated to what verifies live — all 129 sites were listed, classified and decoded with this crate's own decoder before any code:

**In (42):** BE 3, CZ 2, DK 5, HR 6, IE 1, IS 4, NL 2, PL 10, RO 7, SI 2.

**Out, measured not assumed:**
- **NO (12 sites)** — `hdf5lite: Unsupported("4-byte file offsets")`. **MT (1)** — `Unsupported("big-endian datatype")`. Nothing in `wxdata` can fix either.
- **CH, FI, FR, EE, LT, SE** — publish `SCAN/`, one file per elevation. That is DWD's shape and a different fetch loop. Later, if ever.
- **DE** — already here through `dwd`, from the source rather than the aggregator.

Growing the table is adding rows.

## `sites::Network`

The fourth network is where `!is_tdwr(id) && !is_dwd(id)` stopped paying. `pub enum Network { Nexrad, Tdwr, Dwd, Opera }` plus `network(id)`; `is_nexrad` is now `network(id) == Network::Nexrad`, and the fetch dispatch, the site-list label and the attribution line are all one `match`. Adding a fifth network makes the compiler list the questions.

## Two feed quirks that needed handling

- **Volume choice is anchored on reflectivity, not on the newest timestamp.** Split-moment publishers write `@DBZH.h5`, `@TH.h5`, `@VRADH.h5` separately, and the newest object in the bucket is usually the velocity half of a volume whose reflectivity has not landed. Picking by timestamp gives a velocity-only volume most of the time on PL and NO. Test: `the_newest_complete_volume_wins_over_the_newest_object`.
- **Belgium and Norway run two scan strategies at the same timestamp**, distinguished only by the elevation list in the key. Merging is by sweep index, so siblings must agree on everything left of the moment field. Test: `a_second_scan_strategy_is_not_a_sibling`.
- **Netherlands concatenates both strategies into one file** — 16 datasets, `0.30` three times, out of order. Duplicates dropped before sorting, or they stack invisibly on the map.

Listing XML is treated as hostile: `keys()` is a bounded `split` that stops at an unterminated `<Key>` rather than panicking (`an_unterminated_key_ends_the_scan`).

## Verified live

`live_opera_volume_assembles` (HRBIL) is the shipped `--ignored` test. Also run by hand across publisher shapes, all with reflectivity, all but BEHEL with velocity:

```
PLGSA  8 sweeps  z=true v=true   (3 objects merged)
NLDHL 14 sweeps  z=true v=true   (16 datasets deduped to 14)
ROBUC 12 sweeps  z=true v=true   (3 objects)
CZBRD 12 sweeps  z=true v=true   (3 objects)
ISKEF 12 sweeps  z=true v=true   (3 objects)
BEHEL 12 sweeps  z=true v=false  (BE published no velocity at that stamp)
```

## Also

- `tz.rs` keys off the ISO country code in `state`; ten arms, no per-site exceptions (ES and PT are not in ORD at all, so the Canaries/Azores question the plan raised does not arise).
- Attribution arm credits `EUMETNET OPERA / OpenRadarData (CC BY 4.0)`.
- `s3.waw3-1.cloudferro.com` in both allowlists; drift check green locally. Not in `LIVE_HOSTS` — the listing already gets 15 s via the existing `list-type=` rule, and the `.h5` objects are immutable by name.
- Wasm budget 4902000 → 4915000 (local 4894999, CI runs ~16 KB above).

## Gate

clippy `-D warnings` · `cargo test --workspace` · wasm32 check · `shoot.sh check` · `build.sh` — all green locally.

Worth loading a European site (HRBIL, PLGSA) on the deployed app by eye; CI's headless smoke never picks one, same gap as DWD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)