### PR TITLE
feat(app): auto-by-region distance units

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -4106,6 +4106,7 @@ impl HookEchoApp {
     /// Detect warning-tier alerts whose id we haven't seen, raising a banner + audible cue for
     /// each new one. The first fetch only seeds the known set (no alert on already-active warnings).
     fn detect_new_warnings(&mut self, feats: &[GeoFeature]) {
+        let metric = self.metric();
         let mut alerted = false;
         let mut max_esc = 0u8; // highest escalation among newly-seen warnings this pass
                                // Only banner warnings within the selected radar's coverage — a warning covering a saved
@@ -4237,7 +4238,7 @@ impl HookEchoApp {
                         let where_ = if km <= 0.05 {
                             format!("covers {name}")
                         } else {
-                            format!("{:.0} mi from {name}", km / crate::geo::KM_PER_MILE)
+                            format!("{} from {name}", crate::geo::fmt_distance(km, metric, 0))
                         };
                         (format!("⚠ {}", a.event), where_)
                     }
@@ -6129,6 +6130,7 @@ impl HookEchoApp {
     /// Same shape as the lightning alarm: a per-location cooldown, so a couplet that persists over
     /// six volumes is one alert, not six.
     fn rotation_near_you(&mut self, hits: &[wxdata::rotation::CoupletHit]) {
+        let metric = self.metric();
         const COOLDOWN: std::time::Duration = std::time::Duration::from_secs(600);
         if hits.is_empty() {
             return;
@@ -6159,14 +6161,14 @@ impl HookEchoApp {
             }
             self.rotation_alerted.insert(id, Instant::now());
             let kt = vrot_ms as f64 * 1.943_844;
-            let mi = km / crate::geo::KM_PER_MILE;
+            let away = crate::geo::fmt_distance(km, metric, 0);
             self.banner(
                 format!("\u{21bb} Rotation near {name}"),
-                format!("{kt:.0} kt couplet, {mi:.0} mi away"),
+                format!("{kt:.0} kt couplet, {away} away"),
             );
             self.notify_alert(
                 &format!("\u{21bb} Rotation near {name}"),
-                &format!("{kt:.0} kt rotational velocity, {mi:.0} mi from {name}"),
+                &format!("{kt:.0} kt rotational velocity, {away} from {name}"),
                 true,
             );
             fired = true;
@@ -6684,6 +6686,29 @@ impl HookEchoApp {
         }
     }
 
+    /// Whether distances should read in kilometres: they should everywhere the US networks do not
+    /// reach, which the active pane's radar tells us for free. No setting, because a setting here
+    /// is one more thing to get wrong — someone watching Hamburg wants kilometres, and someone
+    /// watching Oklahoma wants miles, and the pane already knows which one they are looking at.
+    ///
+    /// A pane with no site loaded reads as the US, which is what every path assumed before there
+    /// was more than one network.
+    fn metric(&self) -> bool {
+        self.metric_in(self.active)
+    }
+
+    /// The same question for a specific pane, which is what a per-pane drawing (the measure tool)
+    /// wants: split panes can show Oklahoma beside Bavaria.
+    fn metric_in(&self, idx: usize) -> bool {
+        !matches!(
+            self.views[idx]
+                .site
+                .as_deref()
+                .map_or(wxdata::sites::Network::Nexrad, wxdata::sites::network),
+            wxdata::sites::Network::Nexrad | wxdata::sites::Network::Tdwr
+        )
+    }
+
     /// Lon/lat box `±radius_km` around the active pane's radar site (its coverage area), or `None`
     /// when no site is selected. Used to scope new-warning banners to the viewed radar.
     fn active_site_bounds(&self, radius_km: f64) -> Option<(f64, f64, f64, f64)> {
@@ -6897,6 +6922,7 @@ impl HookEchoApp {
     /// is, how close it will come and when, and which way to drive to get off its path. Display
     /// only; the arrival cones and NWS warnings already own the alarms.
     fn chase_hud(&mut self, ctx: &egui::Context) {
+        let metric = self.metric();
         if !self.chase_mode {
             return;
         }
@@ -6920,12 +6946,16 @@ impl HookEchoApp {
         // changed, and never more than once a minute — a voice that repeats itself is a voice the
         // user turns off. Reported in whole miles, so a storm parked in place says nothing.
         if self.settings.speak_position && !self.settings.mute_alerts {
-            let miles = (km * 0.621_371).round() as i32;
+            let whole = if metric {
+                km.round() as i32
+            } else {
+                (km / crate::geo::KM_PER_MILE).round() as i32
+            };
             let fresh = self.spoke_pos.is_none_or(|(t, m)| {
-                m != miles && t.elapsed() >= std::time::Duration::from_secs(60)
+                m != whole && t.elapsed() >= std::time::Duration::from_secs(60)
             });
             if fresh {
-                self.spoke_pos = Some((Instant::now(), miles));
+                self.spoke_pos = Some((Instant::now(), whole));
                 crate::speech::speak(&wxdata::spoken::position_script(
                     // "Cell O7", not the bare id — a synthesizer reading "O7" alone is a noise.
                     &if c.id.is_empty() {
@@ -6936,12 +6966,13 @@ impl HookEchoApp {
                     bearing as f32,
                     km,
                     c.mvt_deg,
+                    metric,
                 ));
             }
         }
-        let mi = |km: f64| km * 0.621_371;
-        // Urgent when the storm will be on top of you soon.
-        let urgent = mi(close_km) < 5.0 && close_min < 20.0;
+        // Urgent when the storm will be on top of you soon. The threshold stays in kilometres
+        // whatever the card reads in: five miles of warning is five miles of warning in Bavaria.
+        let urgent = close_km < 8.05 && close_min < 20.0;
         let accent = crate::theme::accent(self.settings.theme);
         let red = egui::Color32::from_rgb(230, 70, 70);
         let inset_bottom = (ctx.viewport_rect().bottom() - ctx.content_rect().bottom()).max(0.0);
@@ -7002,13 +7033,21 @@ impl HookEchoApp {
                     row(
                         ui,
                         "Now",
-                        format!("{:.1} mi {} ({:.0}°)", mi(km), cardinal(bearing), bearing),
+                        format!(
+                            "{} {} ({:.0}°)",
+                            crate::geo::fmt_distance(km, metric, 1),
+                            cardinal(bearing),
+                            bearing
+                        ),
                     );
                     if kt > 1.0 {
                         row(
                             ui,
                             "Closest",
-                            format!("{:.1} mi in {close_min:.0} min", mi(close_km)),
+                            format!(
+                                "{} in {close_min:.0} min",
+                                crate::geo::fmt_distance(close_km, metric, 1)
+                            ),
                         );
                         row(
                             ui,
@@ -12557,8 +12596,10 @@ impl HookEchoApp {
                 let (a, b) = (screen(self.measure[0]), screen(self.measure[1]));
                 painter.line_segment([a, b], egui::Stroke::new(2.0, col));
                 let (km, brg) = crate::geo::great_circle(self.measure[0], self.measure[1]);
-                let mi = km * 0.621_371; // statute miles
-                let mut txt = format!("{mi:.1} mi  @ {brg:.0}°");
+                let mut txt = format!(
+                    "{}  @ {brg:.0}°",
+                    crate::geo::fmt_distance(km, self.metric_in(idx), 1)
+                );
                 // How high the beam is over the far end of the line. The number that decides
                 // whether "there's nothing on radar there" means the storm is weak or means the
                 // scan is looking over its head, and until now it lived only in the cross-section.
@@ -12901,6 +12942,7 @@ impl HookEchoApp {
     /// have no place in the action registry: view toggles, chase, capture, settings bundles.
     /// Rendered inside the drawer, and (for one more commit) inside the old More popup.
     fn app_rows(&mut self, ui: &mut egui::Ui) {
+        let metric = self.metric();
         {
             ui.label(egui::RichText::new("View").strong());
             {
@@ -12962,9 +13004,9 @@ impl HookEchoApp {
                 );
             if self.settings.chase_log && !self.chase_track.points.is_empty() {
                 ui.weak(format!(
-                    "{} points · {:.0} mi",
+                    "{} points · {}",
                     self.chase_track.points.len(),
-                    self.chase_track.miles()
+                    crate::geo::fmt_distance(self.chase_track.km(), metric, 0)
                 ));
                 ui.horizontal(|ui| {
                     if ui
@@ -13500,7 +13542,9 @@ impl HookEchoApp {
                 .map(|m| (m.lon, m.lat))
         });
         let line =
-            here.and_then(|(lon, lat)| widget_storm_line(self.active_storm_cells(), lon, lat));
+            here.and_then(|(lon, lat)| {
+                widget_storm_line(self.active_storm_cells(), lon, lat, self.metric())
+            });
         match line {
             Some(line) => {
                 if let Err(e) = std::fs::write(&path, line) {
@@ -14242,16 +14286,16 @@ fn nearest_cell(cells: &[Cell], lon: f64, lat: f64, max_km: f64) -> Option<&Cell
 /// read — "R3 12 mi SSW, moving NE 35 mph". `None` when nothing is being tracked nearby, which
 /// the widget renders as no line at all rather than as "no storms" (the app may simply have been
 /// looking at another part of the country).
-fn widget_storm_line(cells: &[Cell], lon: f64, lat: f64) -> Option<String> {
+fn widget_storm_line(cells: &[Cell], lon: f64, lat: f64, metric: bool) -> Option<String> {
     let c = nearest_cell(cells, lon, lat, 300.0)?;
     let (km, bearing) = crate::geo::great_circle([c.lon, c.lat], [lon, lat]);
     // Bearing is measured from the cell to you, so the compass point is the side of you the storm
     // sits on once it is flipped back.
     let from = crate::geo::compass(((bearing + 180.0) % 360.0) as f32);
     let mut line = format!(
-        "{} {:.0} mi {from}",
+        "{} {} {from}",
         if c.id.is_empty() { &c.title } else { &c.id },
-        km * 0.621_371
+        crate::geo::fmt_distance(km, metric, 0)
     );
     if let (Some(dir), Some(kt)) = (c.mvt_deg, c.mvt_kt) {
         if kt >= 1.0 {
@@ -15346,11 +15390,13 @@ impl eframe::App for HookEchoApp {
                 Err(e) => self.marker_window.status = Some(e),
             }
         }
+        let metric = self.metric();
         let query = self.marker_window.show(
             ctx,
             &mut self.settings,
             &self.marker_icon_tex,
             &mut self.drawer,
+            metric,
         );
         // The map popup indexes into the same list: a delete above it leaves it describing the
         // wrong marker, which is the one way this UI can lie about which place you are editing.
@@ -15634,9 +15680,10 @@ impl eframe::App for HookEchoApp {
             }
         }
 
+        let metric = self.metric();
         if let Some(act) = self
             .chase_replay
-            .show(ctx, &self.chase_track, &mut self.drawer)
+            .show(ctx, &self.chase_track, &mut self.drawer, metric)
         {
             use ui::chase_replay::ReplayAction;
             match act {
@@ -15698,11 +15745,13 @@ impl eframe::App for HookEchoApp {
                 .collect(),
             _ => std::collections::HashSet::new(),
         };
+        let metric = self.metric();
         if ui::rules_window::show(
             &mut self.rules_window,
             ctx,
             &mut self.settings,
             &mut self.drawer,
+            metric,
         ) {
             self.settings.save();
         }
@@ -16280,13 +16329,16 @@ mod follow_tests {
         let mut c = cell("R3", -97.72, 35.30);
         c.mvt_deg = Some(45.0);
         c.mvt_kt = Some(30.0);
-        let line = widget_storm_line(&[c], -97.5, 35.3).unwrap();
+        let line = widget_storm_line(&[c.clone()], -97.5, 35.3, false).unwrap();
         // West of you: the compass point names the side the storm is on, not the bearing to it.
         assert!(line.starts_with("R3 12 mi W"), "{line}");
         assert!(line.ends_with("moving NE 35 mph"), "{line}");
+        // Same cell on a German pane: the distance turns over, the speed does not.
+        let km_line = widget_storm_line(&[c], -97.5, 35.3, true).unwrap();
+        assert!(km_line.starts_with("R3 20 km W"), "{km_line}");
         // Nothing within 300 km is no line at all.
-        assert!(widget_storm_line(&[cell("Z1", -80.0, 35.3)], -97.5, 35.3).is_none());
-        assert!(widget_storm_line(&[], -97.5, 35.3).is_none());
+        assert!(widget_storm_line(&[cell("Z1", -80.0, 35.3)], -97.5, 35.3, false).is_none());
+        assert!(widget_storm_line(&[], -97.5, 35.3, false).is_none());
     }
 
     #[test]

--- a/crates/hookecho/src/chaselog.rs
+++ b/crates/hookecho/src/chaselog.rs
@@ -65,13 +65,18 @@ impl Track {
         self.waypoints.clear();
     }
 
-    /// Distance travelled along the track, in miles.
-    pub fn miles(&self) -> f64 {
+    /// Distance travelled along the track, in kilometres.
+    pub fn km(&self) -> f64 {
         self.points
             .windows(2)
             .map(|w| haversine_m(w[0].lon, w[0].lat, w[1].lon, w[1].lat))
             .sum::<f64>()
-            / 1609.344
+            / 1000.0
+    }
+
+    /// The same distance in miles.
+    pub fn miles(&self) -> f64 {
+        self.km() * 1000.0 / 1609.344
     }
 
     /// GPX 1.1: the waypoints first (that is the order the schema wants), then one track.

--- a/crates/hookecho/src/geo.rs
+++ b/crates/hookecho/src/geo.rs
@@ -18,6 +18,20 @@ pub fn great_circle(a: [f64; 2], b: [f64; 2]) -> (f64, f64) {
 /// describe how far away weather is.
 pub const KM_PER_MILE: f64 = 1.609_344;
 
+/// A distance written in the units the region on screen uses: kilometres everywhere except the
+/// two US radar networks, which is what `metric` decides (see `App::metric`). `decimals` is the
+/// precision the call site wants — most read better whole, the measure tool wants a tenth.
+///
+/// ponytail: a formatter, not a units system. Nothing here converts back, because nothing but
+/// the marker watch radius is stored in miles, and that one converts at its own editor.
+pub fn fmt_distance(km: f64, metric: bool, decimals: usize) -> String {
+    if metric {
+        format!("{km:.*} km", decimals)
+    } else {
+        format!("{:.*} mi", decimals, km / KM_PER_MILE)
+    }
+}
+
 /// Kilometers to nautical miles.
 pub fn km_to_nmi(km: f64) -> f64 {
     km / 1.852
@@ -203,5 +217,13 @@ mod tests {
         assert!(arrival_eta_min([-97.0, 35.0], 90.0, 30.0, [-98.0, 35.0], 20.0, 240.0).is_none());
         // Stationary storm.
         assert!(arrival_eta_min([-97.0, 35.0], 90.0, 0.5, [-96.0, 35.0], 20.0, 240.0).is_none());
+    }
+
+    #[test]
+    fn distances_read_in_the_units_of_the_region() {
+        assert_eq!(fmt_distance(32.18688, false, 0), "20 mi");
+        assert_eq!(fmt_distance(32.18688, true, 0), "32 km");
+        assert_eq!(fmt_distance(1.609_344, false, 1), "1.0 mi");
+        assert_eq!(fmt_distance(0.0, true, 1), "0.0 km");
     }
 }

--- a/crates/hookecho/src/ui/chase_replay.rs
+++ b/crates/hookecho/src/ui/chase_replay.rs
@@ -108,6 +108,7 @@ impl ChaseReplay {
         ctx: &egui::Context,
         live: &Track,
         drawer: &mut crate::ui::drawer::Drawer,
+        metric: bool,
     ) -> Option<ReplayAction> {
         let mut open = self.open;
         let mut action = None;
@@ -150,10 +151,10 @@ impl ChaseReplay {
             }
             ui.add_space(6.0);
             ui.weak(format!(
-                "{} \u{2014} {} points, {:.0} miles",
+                "{} \u{2014} {} points, {}",
                 self.source,
                 self.track.points.len(),
-                self.track.miles()
+                crate::geo::fmt_distance(self.track.km(), metric, 0)
             ));
             ui.add_space(6.0);
             ui.horizontal(|ui| {

--- a/crates/hookecho/src/ui/marker_window.rs
+++ b/crates/hookecho/src/ui/marker_window.rs
@@ -36,6 +36,7 @@ impl MarkerWindow {
         settings: &mut Settings,
         icon_tex: &IconTextures,
         drawer: &mut crate::ui::drawer::Drawer,
+        metric: bool,
     ) -> Option<String> {
         let mut open = self.open;
         let mut go: Option<String> = None;
@@ -82,7 +83,8 @@ impl MarkerWindow {
                      Ctrl+K ▸ \"Tool: Drop marker\". Tap a marker on the map to rename or remove it.",
                 );
                 ui.add_space(4.0);
-                self.removed = marker_grid(ui, &mut settings.markers, icon_tex).or(self.removed);
+                self.removed =
+                    marker_grid(ui, &mut settings.markers, icon_tex, metric).or(self.removed);
                 ui.add_space(6.0);
                 if ui.button("➕ Add blank marker").clicked() {
                     let n = settings.markers.len() + 1;
@@ -110,6 +112,7 @@ pub fn marker_grid(
     ui: &mut egui::Ui,
     markers: &mut Vec<Marker>,
     icon_tex: &IconTextures,
+    metric: bool,
 ) -> Option<usize> {
     let mut remove: Option<usize> = None;
     let mut make_home: Option<usize> = None;
@@ -122,8 +125,11 @@ pub fn marker_grid(
             ui.strong("Name");
             ui.strong("Lat");
             ui.strong("Lon");
-            ui.strong("Watch")
-                .on_hover_text("Alert when a warning comes within this many miles");
+            ui.strong("Watch").on_hover_text(if metric {
+                "Alert when a warning comes within this many kilometres"
+            } else {
+                "Alert when a warning comes within this many miles"
+            });
             ui.strong("Video")
                 .on_hover_text("Live stream URL for this place (HLS/MJPEG plays in-app)");
             ui.strong("Icon");
@@ -146,14 +152,34 @@ pub fn marker_grid(
                         .speed(0.01)
                         .max_decimals(4),
                 );
-                ui.add(
-                    egui::DragValue::new(&mut m.alert_radius_mi)
-                        .range(0.0..=200.0)
-                        .speed(1.0)
-                        .max_decimals(0)
-                        .suffix(" mi"),
-                )
-                .on_hover_text("0 = only alert when the warning polygon actually covers this spot");
+                // ponytail: the field stays `alert_radius_mi` on disk whatever this box reads
+                // in — a stored unit that changes with the pane on screen is a config file that
+                // means something different tomorrow. Convert in, convert back out.
+                let mut shown = if metric {
+                    m.alert_radius_mi * crate::geo::KM_PER_MILE
+                } else {
+                    m.alert_radius_mi
+                };
+                let (max, suffix) = if metric { (320.0, " km") } else { (200.0, " mi") };
+                if ui
+                    .add(
+                        egui::DragValue::new(&mut shown)
+                            .range(0.0..=max)
+                            .speed(1.0)
+                            .max_decimals(0)
+                            .suffix(suffix),
+                    )
+                    .on_hover_text(
+                        "0 = only alert when the warning polygon actually covers this spot",
+                    )
+                    .changed()
+                {
+                    m.alert_radius_mi = if metric {
+                        shown / crate::geo::KM_PER_MILE
+                    } else {
+                        shown
+                    };
+                }
                 ui.add(
                     egui::TextEdit::singleline(&mut m.video_url)
                         .desired_width(160.0)

--- a/crates/hookecho/src/ui/rules_window.rs
+++ b/crates/hookecho/src/ui/rules_window.rs
@@ -35,6 +35,7 @@ pub fn show(
     ctx: &egui::Context,
     settings: &mut Settings,
     drawer: &mut crate::ui::drawer::Drawer,
+    metric: bool,
 ) -> bool {
     if !state.open {
         return false;
@@ -72,7 +73,7 @@ pub fn show(
         );
         ui.separator();
 
-        let places = place_options(settings);
+        let places = place_options(settings, metric);
         let mut remove: Option<usize> = None;
         egui::Grid::new("rules_grid")
             .num_columns(7)
@@ -181,12 +182,16 @@ pub fn show(
 }
 
 /// Every place a rule can name: anywhere, each marker, each drawn zone.
-fn place_options(settings: &Settings) -> Vec<(RulePlace, String)> {
+fn place_options(settings: &Settings, metric: bool) -> Vec<(RulePlace, String)> {
     let mut out = vec![(RulePlace::Anywhere, "Anywhere".to_string())];
     for m in &settings.markers {
         out.push((
             RulePlace::Marker { id: m.id.clone() },
-            format!("{} ({:.0} mi)", m.name, m.alert_radius_mi),
+            format!(
+                "{} ({})",
+                m.name,
+                crate::geo::fmt_distance(m.alert_radius_mi * crate::geo::KM_PER_MILE, metric, 0)
+            ),
         ));
     }
     for z in &settings.alert_polygons {
@@ -467,7 +472,7 @@ mod tests {
             name: "The valley".into(),
             ring: vec![[-98.0, 35.0], [-97.0, 35.0], [-97.0, 36.0], [-98.0, 35.0]],
         });
-        let places = place_options(&s);
+        let places = place_options(&s, false);
         assert_eq!(places[0].0, RulePlace::Anywhere);
         assert_eq!(
             places[1].0,

--- a/crates/wxdata/src/spoken.rs
+++ b/crates/wxdata/src/spoken.rs
@@ -170,12 +170,15 @@ pub fn position_script(
     bearing_deg: f32,
     km: f64,
     moving_toward_deg: Option<f32>,
+    metric: bool,
 ) -> String {
-    let miles = (km * 0.621_371).round() as i32;
-    let mut s = format!(
-        "{name} is {miles} miles to your {}",
-        spoken_compass(bearing_deg)
-    );
+    // Spelled out, not abbreviated: a synthesizer reading "km" says "kay em".
+    let (n, unit) = if metric {
+        (km.round() as i32, "kilometers")
+    } else {
+        ((km * 0.621_371).round() as i32, "miles")
+    };
+    let mut s = format!("{name} is {n} {unit} to your {}", spoken_compass(bearing_deg));
     if let Some(d) = moving_toward_deg {
         s.push_str(&format!(", moving {}", spoken_compass(d)));
     }
@@ -254,7 +257,9 @@ mod tests {
     #[test]
     fn a_position_update_names_the_side_it_is_on() {
         // 225 here is a heading, not a from-bearing: cell tables give direction of travel.
-        let s = position_script("The storm", 90.0, 32.2, Some(225.0));
+        let s = position_script("The storm", 90.0, 32.2, Some(225.0), false);
         assert_eq!(s, "The storm is 20 miles to your east, moving southwest.");
+        let s = position_script("The storm", 90.0, 32.2, Some(225.0), true);
+        assert_eq!(s, "The storm is 32 kilometers to your east, moving southwest.");
     }
 }


### PR DESCRIPTION
Wave G11 of the going-global plan. Every distance the app spoke or drew was in statute miles — right for the WSR-88D network it started as, wrong everywhere the DWD, OPERA and ECCC waves have since taken it.

**No setting.** The active pane's radar already knows its network, and that answers it better than a preference could — one pane can be on Oklahoma while the pane beside it is on Bavaria, and each reads in its own units. `App::metric` asks for the active pane, `metric_in(idx)` for a specific one (the measure tool draws per pane), and every call site is one `geo::fmt_distance(km, metric, decimals)`.

Converted: new-warning banner distance, rotation banner + phone push, spoken storm-position update (including the whole-unit gate deciding whether to speak again), the chase card's "Now"/"Closest" rows, measure tool, chase-track length in the drawer and the replay window, the desktop widget's storm line, the marker watch-radius editor, and the rules-window place labels.

**Storage keeps its unit.** `Marker::alert_radius_mi` stays miles on disk — a stored unit that follows the pane on screen is a config file that means something different tomorrow. The editor converts in and back out, with a `ponytail:` comment saying so.

Two notes:
- Speeds (kt, mph) untouched. This wave is distances; a mixed card is the price, and mixing them into the same diff makes the units question harder to review, not easier.
- The chase card's urgency test was `mi(close_km) < 5.0` and is now `close_km < 8.05` — the same distance, no longer routed through a display conversion.

Gates: clippy `-D warnings` clean, 637 tests pass, wasm target checks, shots check passes, web build 4903722 gzipped against a 4930000 budget (+614 bytes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)