### PR TITLE
feat(perf): counters + perf readout (native)

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -12,6 +12,8 @@ mod mobile;
 use crate::colormap::{ColorTable, Palettes};
 use crate::hotkeys::{self, BindableAction};
 use crate::overlay_build;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::perf::PerfReadout;
 use crate::render::{mercator::Camera, MapCallback, OverlayUpload, RadarUpload, RenderResources};
 use crate::settings::Settings;
 use crate::tiles::TileManager;
@@ -2491,6 +2493,10 @@ pub struct HookEchoApp {
     embed: bool,
     /// Set by the first interaction with an embedded map: from then on it repaints normally.
     embed_live: bool,
+    /// Perf readout state: whether `HOOKECHO_PERF=1` asked for the window, the frame count and
+    /// mark the frames-per-minute number is derived from, and the last idle interval requested.
+    #[cfg(not(target_arch = "wasm32"))]
+    perf: PerfReadout,
     /// Last pane state posted to the parent frame, so only real changes cross the boundary.
     #[cfg(target_arch = "wasm32")]
     last_posted: Option<crate::workspace::PaneSnap>,
@@ -3185,6 +3191,8 @@ impl HookEchoApp {
             obs_mode: false,
             embed: is_embed(),
             embed_live: false,
+            #[cfg(not(target_arch = "wasm32"))]
+            perf: PerfReadout::new(),
             #[cfg(target_arch = "wasm32")]
             last_posted: None,
             obs_tour: false,
@@ -9404,6 +9412,7 @@ impl HookEchoApp {
                 let shown = self.views[idx].volume.as_ref().map(|v| v.name.clone());
                 if shown.as_deref() != Some(name.as_str()) {
                     if let Some(scan) = self.scan_cache.get(&name).map(Arc::clone) {
+                        wxdata::stats::bump(wxdata::stats::Counter::ScanCacheHits);
                         let v = &mut self.views[idx];
                         v.volume = Some(Volume::new(scan, name, time));
                         v.loading = false;
@@ -9412,6 +9421,7 @@ impl HookEchoApp {
                         v.clamp_moment();
                         self.pane_shown.remove(&idx);
                     } else if !self.views[idx].loading {
+                        wxdata::stats::bump(wxdata::stats::Counter::ScanCacheMisses);
                         let s = self.views[idx].site.clone().unwrap_or_default();
                         self.views[idx].loading = true;
                         self.spawn_frame_fetch(idx, s, id, ctx.clone());
@@ -14447,6 +14457,9 @@ impl eframe::App for HookEchoApp {
         // `platform::activity`). A frame that follows a gap means the app just came back, so
         // force one refresh rather than making the user wait out the poll interval.
         self.frame_nr = self.frame_nr.wrapping_add(1);
+        wxdata::stats::bump(wxdata::stats::Counter::FramesDrawn);
+        #[cfg(not(target_arch = "wasm32"))]
+        self.perf.tick(ctx);
         #[cfg(debug_assertions)]
         self.frame_time_overlay(ctx);
         let focused = ctx.input(|i| i.viewport().focused.unwrap_or(true));
@@ -16212,6 +16225,10 @@ impl eframe::App for HookEchoApp {
         } else {
             100
         };
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            self.perf.idle_ms = idle;
+        }
         ctx.request_repaint_after(std::time::Duration::from_millis(idle));
     }
 }

--- a/crates/hookecho/src/lib.rs
+++ b/crates/hookecho/src/lib.rs
@@ -47,6 +47,9 @@ pub mod notify;
 pub mod nwr;
 pub mod overlay_build;
 pub mod paths;
+/// The perf counters' readout — native only, see the module docs.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod perf;
 pub mod platform;
 /// External-process placefile plugins — a browser cannot spawn a process.
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/hookecho/src/perf.rs
+++ b/crates/hookecho/src/perf.rs
@@ -1,0 +1,112 @@
+//! The measuring stick the performance work is judged by.
+//!
+//! `wxdata::stats` does the counting; this turns those counters into something readable: an egui
+//! window when `HOOKECHO_PERF=1` is set, and a line in the log once a minute, which is the only
+//! readout `--headless` and `--serve` runs have. Rates are per minute over the last window rather
+//! than process-lifetime averages, because the question every wave asks is "what is it doing
+//! *now*, idle" — a lifetime average of a session that spent ten minutes scrubbing hides it.
+//!
+//! Native only. The browser build shares these code paths but carries no counters (see
+//! `wxdata::stats`), so a native number stands in for the wasm one.
+//!
+// ponytail: env var, not a menu item — turning the readout on is a developer action, and a new
+// window in the UI is a user-visible change this work is not allowed to make.
+
+use std::time::{Duration, Instant};
+
+/// How often the rates are recomputed and the log line printed.
+const WINDOW: Duration = Duration::from_secs(60);
+
+pub struct PerfReadout {
+    /// `HOOKECHO_PERF=1`: draw the window as well as logging.
+    show: bool,
+    /// Start of the current window, and the counter values it began with.
+    since: Instant,
+    base: Vec<(&'static str, u64)>,
+    /// Per-minute rates from the last completed window, ready to draw.
+    rates: Vec<(&'static str, f64)>,
+    /// The idle repaint interval the app last asked for, in ms — the number the heartbeat work
+    /// moves, and the one that explains the frame rate above it.
+    pub idle_ms: u64,
+    /// Process start, for the startup line.
+    start: Instant,
+    first_frame: Option<Duration>,
+}
+
+impl Default for PerfReadout {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PerfReadout {
+    pub fn new() -> Self {
+        Self {
+            show: std::env::var("HOOKECHO_PERF").is_ok_and(|v| v != "0"),
+            since: Instant::now(),
+            base: wxdata::stats::snapshot(),
+            rates: Vec::new(),
+            idle_ms: 0,
+            start: Instant::now(),
+            first_frame: None,
+        }
+    }
+
+    /// Call once per frame, early. Rolls the window when it is up and draws the window if asked.
+    pub fn tick(&mut self, ctx: &egui::Context) {
+        if self.first_frame.is_none() {
+            let dt = self.start.elapsed();
+            self.first_frame = Some(dt);
+            log::info!("perf: first frame after {} ms", dt.as_millis());
+        }
+        if self.since.elapsed() >= WINDOW {
+            self.roll();
+        }
+        if self.show {
+            self.window(ctx);
+        }
+    }
+
+    /// Close the window: turn the deltas into per-minute rates and log them.
+    fn roll(&mut self) {
+        let now = wxdata::stats::snapshot();
+        let per_min = 60.0 / self.since.elapsed().as_secs_f64().max(0.001);
+        self.rates = now
+            .iter()
+            .zip(&self.base)
+            .map(|((label, n), (_, was))| (*label, n.saturating_sub(*was) as f64 * per_min))
+            .collect();
+        let line = self
+            .rates
+            .iter()
+            .map(|(l, r)| format!("{l}={r:.0}/min"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        log::info!("perf: idle={}ms {line}", self.idle_ms);
+        self.since = Instant::now();
+        self.base = now;
+    }
+
+    fn window(&self, ctx: &egui::Context) {
+        egui::Window::new("Perf")
+            .default_pos(egui::pos2(12.0, 60.0))
+            .resizable(false)
+            .show(ctx, |ui| {
+                ui.monospace(format!("idle repaint  {} ms", self.idle_ms));
+                if let Some(dt) = self.first_frame {
+                    ui.monospace(format!("first frame   {} ms", dt.as_millis()));
+                }
+                ui.separator();
+                if self.rates.is_empty() {
+                    ui.monospace(format!(
+                        "measuring… {}s",
+                        WINDOW.saturating_sub(self.since.elapsed()).as_secs()
+                    ));
+                    return;
+                }
+                for (label, rate) in &self.rates {
+                    ui.monospace(format!("{label:<21}{rate:>9.0}/min"));
+                }
+            });
+    }
+}

--- a/crates/hookecho/src/profiling.rs
+++ b/crates/hookecho/src/profiling.rs
@@ -93,7 +93,55 @@ impl Pacing {
             Self::over(&self.gap_us, 20_000),
             self.gap_us.len(),
         );
+        #[cfg(all(feature = "profiling", not(target_arch = "wasm32")))]
+        log::info!(
+            "perf: allocs {:.0}/frame | rss {} MB",
+            counting_alloc::ALLOCS.swap(0, std::sync::atomic::Ordering::Relaxed) as f64
+                / self.cost_us.len().max(1) as f64,
+            rss_mb().unwrap_or(0),
+        );
     }
+}
+
+/// Resident set size in MB, from `/proc/self/statm` — "did that wave actually free anything" in
+/// one number. Linux only; anywhere else the report simply omits it.
+#[cfg(all(feature = "profiling", not(target_arch = "wasm32")))]
+fn rss_mb() -> Option<u64> {
+    let statm = std::fs::read_to_string("/proc/self/statm").ok()?;
+    let pages: u64 = statm.split_whitespace().nth(1)?.parse().ok()?;
+    Some(pages * 4096 / (1024 * 1024))
+}
+
+/// A `System` allocator that counts allocations, so a per-frame allocation count is a number and
+/// not a guess. Behind the `profiling` feature: every allocation in the process pays for the
+/// counter, which is exactly the kind of cost the default build must not carry.
+#[cfg(all(feature = "profiling", not(target_arch = "wasm32")))]
+pub mod counting_alloc {
+    use std::alloc::{GlobalAlloc, Layout, System};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// Allocations since the last pacing report, which resets it.
+    pub static ALLOCS: AtomicU64 = AtomicU64::new(0);
+
+    pub struct Counting;
+
+    // Safety: every method forwards to `System` unchanged; the counter is the only addition.
+    unsafe impl GlobalAlloc for Counting {
+        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+            ALLOCS.fetch_add(1, Ordering::Relaxed);
+            unsafe { System.alloc(layout) }
+        }
+        unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+            unsafe { System.dealloc(ptr, layout) }
+        }
+        unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+            ALLOCS.fetch_add(1, Ordering::Relaxed);
+            unsafe { System.realloc(ptr, layout, new_size) }
+        }
+    }
+
+    #[global_allocator]
+    static ALLOC: Counting = Counting;
 }
 
 /// How many frames a pacing report covers. `HOOKECHO_PERF_EVERY=0` turns the reports off and

--- a/crates/hookecho/src/render/mod.rs
+++ b/crates/hookecho/src/render/mod.rs
@@ -897,6 +897,7 @@ impl RenderResources {
     }
 
     fn build_radar(&self, device: &wgpu::Device, queue: &wgpu::Queue, r: &RadarUpload) -> RadarGpu {
+        wxdata::stats::bump(wxdata::stats::Counter::RadarTexturesBuilt);
         let size = wgpu::Extent3d {
             width: r.gate_count,
             height: r.az_bins,

--- a/crates/hookecho/src/serve.rs
+++ b/crates/hookecho/src/serve.rs
@@ -698,6 +698,13 @@ fn metrics(server: &Server) -> String {
         ));
     }
 
+    out.push_str("# HELP hookecho_stats_total Perf counters (wxdata::stats).\n");
+    out.push_str("# TYPE hookecho_stats_total counter\n");
+    for (label, n) in wxdata::stats::snapshot() {
+        let label = escape_label(label);
+        out.push_str(&format!("hookecho_stats_total{{counter=\"{label}\"}} {n}\n"));
+    }
+
     let Ok(body) = cached_json(server, "/status.json") else {
         // A feed being down is not a reason to fail the scrape — the counters above still answer.
         return out;

--- a/crates/wxdata/src/alerts.rs
+++ b/crates/wxdata/src/alerts.rs
@@ -324,6 +324,7 @@ async fn fetch_zone_geometry(client: &reqwest::Client, url: &str) -> Vec<Vec<Vec
             .text()
             .await
             .ok()?;
+        crate::stats::net(body.len());
         let out = rings(&body)?;
         if let Some(p) = &file {
             if let Some(dir) = p.parent() {
@@ -398,7 +399,7 @@ async fn resolve_zone_alerts(
 
 /// GET an api.weather.gov alerts endpoint as a GeoJSON body.
 async fn get_alerts(client: &reqwest::Client, url: &str) -> anyhow::Result<String> {
-    Ok(client
+    let body = client
         .get(crate::net::fetch_url(url))
         .header("User-Agent", USER_AGENT)
         .header("Accept", "application/geo+json")
@@ -406,7 +407,9 @@ async fn get_alerts(client: &reqwest::Client, url: &str) -> anyhow::Result<Strin
         .await?
         .error_for_status()?
         .text()
-        .await?)
+        .await?;
+    crate::stats::net(body.len());
+    Ok(body)
 }
 
 /// How many `?point=` queries one refresh may make. Each is a round trip plus its zone

--- a/crates/wxdata/src/dwd.rs
+++ b/crates/wxdata/src/dwd.rs
@@ -225,6 +225,7 @@ pub async fn fetch_volume(
                 .bytes()
                 .await
                 .ok()?;
+            crate::stats::net(bytes.len());
             Some((url, bytes.to_vec()))
         }
     };

--- a/crates/wxdata/src/level2.rs
+++ b/crates/wxdata/src/level2.rs
@@ -312,10 +312,12 @@ async fn list_day(site: &str, date: chrono::NaiveDate) -> anyhow::Result<Vec<Ide
     if let Ok(map) = cache.lock() {
         if let Some((at, ids)) = map.get(&key) {
             if at.elapsed() < DAY_LIST_TTL {
+                crate::stats::bump(crate::stats::Counter::DayListHits);
                 return Ok(ids.clone());
             }
         }
     }
+    crate::stats::bump(crate::stats::Counter::DayListMisses);
     let mut ids = archive::list_files(site, &date)
         .await
         .map_err(|e| anyhow::anyhow!("list_files({site}, {date}): {e}"))?;
@@ -392,6 +394,7 @@ pub async fn download_scan(id: Identifier, cache_dir: Option<PathBuf>) -> anyhow
             let f = archive::download_file(id)
                 .await
                 .map_err(|e| anyhow::anyhow!("download_file: {e}"))?;
+            crate::stats::net(f.data().len());
             if let Some(p) = &cache_file {
                 if let Some(dir) = p.parent() {
                     let _ = std::fs::create_dir_all(dir);
@@ -498,6 +501,7 @@ pub fn bin_scan_opts(
     tilt: usize,
     dealias: bool,
 ) -> anyhow::Result<BinnedSweep> {
+    crate::stats::bump(crate::stats::Counter::SweepsBinned);
     let target = *elevation_angles(scan)
         .get(tilt)
         .ok_or_else(|| anyhow::anyhow!("tilt {tilt} out of range"))?;

--- a/crates/wxdata/src/level3.rs
+++ b/crates/wxdata/src/level3.rs
@@ -666,10 +666,12 @@ async fn fetch_latest(
             continue;
         };
         let Ok(xml) = resp.text().await else { continue };
+        crate::stats::net(xml.len());
         if let Some(key) = last_key(&xml) {
             let obj_url = format!("{BUCKET}/{key}");
             if let Ok(resp) = http.get(crate::net::fetch_url(&obj_url)).send().await {
                 if let Ok(bytes) = resp.bytes().await {
+                    crate::stats::net(bytes.len());
                     match decode(&bytes) {
                         Ok(p) => return Some((p, key_time(&key))),
                         Err(e) => log::warn!("level3 decode {key}: {e}"),
@@ -817,6 +819,7 @@ async fn fetch_tgftp(http: &reqwest::Client, site: &str, ds: &str) -> Option<Lev
         .bytes()
         .await
         .ok()?;
+    crate::stats::net(bytes.len());
     match decode(&bytes) {
         Ok(p) => Some(p),
         Err(e) => {

--- a/crates/wxdata/src/lib.rs
+++ b/crates/wxdata/src/lib.rs
@@ -54,6 +54,7 @@ pub mod spc;
 pub mod spoken;
 pub mod spotters;
 pub mod stations;
+pub mod stats;
 pub mod synoptic;
 pub mod task;
 pub mod tds;

--- a/crates/wxdata/src/opera.rs
+++ b/crates/wxdata/src/opera.rs
@@ -185,6 +185,7 @@ pub async fn fetch_volume(
                 .text()
                 .await
                 .ok()
+                .inspect(|t: &String| crate::stats::net(t.len()))
         }
     };
 
@@ -224,6 +225,7 @@ pub async fn fetch_volume(
                 .bytes()
                 .await
                 .ok()?;
+            crate::stats::net(bytes.len());
             match crate::odim::decode(bytes.to_vec()) {
                 Ok(v) => Some(v),
                 Err(e) => {

--- a/crates/wxdata/src/stats.rs
+++ b/crates/wxdata/src/stats.rs
@@ -1,0 +1,120 @@
+//! Process-lifetime counters for the numbers the perf work is judged on.
+//!
+//! Every later optimization has to show a before/after, and "how many requests did that poll
+//! actually make" is not a question a profiler answers — it needs a count at the fetch site. The
+//! counters are read by the app's Perf window, by `--serve`'s `/metrics`, and by a once-a-minute
+//! log line in headless runs.
+//!
+//! On wasm every function here is an empty inline body, so the browser build carries no counters
+//! and no bytes: the shared code paths are the same ones, and a native measurement of a shared
+//! path stands in for the wasm one.
+//!
+// ponytail: flat atomics, no labels, no histograms — the ceiling is "which wave moved which
+// number". A per-host or per-feed breakdown wants a real metrics crate, not more statics here.
+
+/// One counter each, in [`Snapshot`] order.
+#[cfg(not(target_arch = "wasm32"))]
+static COUNTERS: [std::sync::atomic::AtomicU64; Counter::COUNT] =
+    [const { std::sync::atomic::AtomicU64::new(0) }; Counter::COUNT];
+
+/// What can be counted. Adding one means adding its label to [`Counter::LABELS`].
+#[derive(Copy, Clone, Debug)]
+#[repr(usize)]
+pub enum Counter {
+    /// HTTP requests issued by an instrumented feed path.
+    NetRequests,
+    /// Response bytes received by an instrumented feed path.
+    NetBytes,
+    /// Requests an upstream answered `304 Not Modified`.
+    NetNotModified,
+    /// Volume fetches skipped because the feed had not published a new one.
+    FetchSkipped,
+    /// Decoded volumes served from the app's scan cache.
+    ScanCacheHits,
+    ScanCacheMisses,
+    /// Bucket listings served from the day-list cache.
+    DayListHits,
+    DayListMisses,
+    /// Frames the app drew.
+    FramesDrawn,
+    /// Sweeps run through `bin_scan_opts`.
+    SweepsBinned,
+    /// Radar GPU textures built from scratch.
+    RadarTexturesBuilt,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Counter {
+    const COUNT: usize = Self::LABELS.len();
+
+    /// Prometheus/log names, in declaration order.
+    pub const LABELS: [&'static str; 11] = [
+        "net_requests",
+        "net_bytes",
+        "net_not_modified",
+        "fetch_skipped",
+        "scan_cache_hits",
+        "scan_cache_misses",
+        "day_list_hits",
+        "day_list_misses",
+        "frames_drawn",
+        "sweeps_binned",
+        "radar_textures_built",
+    ];
+}
+
+/// Add `n` to `c`.
+#[cfg(not(target_arch = "wasm32"))]
+#[inline]
+pub fn add(c: Counter, n: u64) {
+    COUNTERS[c as usize].fetch_add(n, std::sync::atomic::Ordering::Relaxed);
+}
+
+#[cfg(target_arch = "wasm32")]
+#[inline]
+pub fn add(_c: Counter, _n: u64) {}
+
+/// Add one to `c`.
+#[inline]
+pub fn bump(c: Counter) {
+    add(c, 1);
+}
+
+/// Count one instrumented HTTP response of `bytes`.
+#[inline]
+pub fn net(bytes: usize) {
+    bump(Counter::NetRequests);
+    add(Counter::NetBytes, bytes as u64);
+}
+
+/// Every counter's current value, paired with its label, in [`Counter::LABELS`] order.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn snapshot() -> Vec<(&'static str, u64)> {
+    Counter::LABELS
+        .iter()
+        .zip(&COUNTERS)
+        .map(|(l, c)| (*l, c.load(std::sync::atomic::Ordering::Relaxed)))
+        .collect()
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+
+    /// A label per counter, and a count that lands on the right one — an off-by-one here would
+    /// silently report every wave's before/after against the wrong number.
+    #[test]
+    fn labels_line_up_with_counters() {
+        assert_eq!(Counter::LABELS.len(), Counter::COUNT);
+        let before = snapshot();
+        net(1234);
+        let after = snapshot();
+        let delta = |name: &str| {
+            let f = |v: &Vec<(&'static str, u64)>| v.iter().find(|(l, _)| *l == name).unwrap().1;
+            f(&after) - f(&before)
+        };
+        assert_eq!(delta("net_requests"), 1);
+        assert_eq!(delta("net_bytes"), 1234);
+        assert_eq!(delta("frames_drawn"), 0);
+    }
+}

--- a/crates/wxdata/src/tdwr.rs
+++ b/crates/wxdata/src/tdwr.rs
@@ -136,6 +136,7 @@ async fn newest_key(http: &reqwest::Client, prefix: &str) -> Option<String> {
         .text()
         .await
         .ok()?;
+    crate::stats::net(xml.len());
     // Keys sort by their embedded timestamp, so the last one listed is the newest.
     let (i, _) = xml.rmatch_indices("<Key>").next()?;
     let rest = &xml[i + 5..];
@@ -248,6 +249,7 @@ pub async fn fetch_volume(
                 .await
                 .ok()?;
             let bytes = resp.bytes().await.ok()?;
+            crate::stats::net(bytes.len());
             let p = match nexrad_level3::decode(&bytes) {
                 Ok(p) => p,
                 Err(e) => {


### PR DESCRIPTION
Wave 1 of the efficiency push: the measuring stick. Every later wave's PR quotes a counter from this one, before and after.

## What

`wxdata::stats` — a flat array of atomics behind `add`/`bump`/`net`, incremented where the later waves will land:

- feed paths: level2 volume downloads + its day-list cache hit/miss, dwd, opera, tdwr, alerts, level3
- `bin_scan_opts` (sweeps binned), `build_radar` (radar textures built)
- the app's scan cache hit/miss and its frame loop

**Zero on wasm**: every function is an empty inline body there and the label table is cfg'd out. The shared code paths are the same ones, so a native number stands in for the wasm one.

## Readouts — existing surfaces only

- `HOOKECHO_PERF=1` draws a small egui window of per-minute rates. An env var rather than a menu item: a new window in the UI is the kind of user-visible change this work is not allowed to make.
- Same rates to the log once a minute (the only readout `--headless` has), plus a one-shot first-frame timing line — that one feeds the startup wave.
- `/metrics` gains `hookecho_stats_total` beside the request counters already there.
- Behind the existing `profiling` feature: a counting global allocator (allocs/frame) and RSS from `/proc/self/statm`, reported by the pacing sink that already prints frame quantiles.

## Gate

- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace` — 638 passed, 32 ignored (includes a new `stats` test that the labels line up with the counters)
- wasm32 `cargo check` clean
- `./scripts/shots/shoot.sh check` passed (no pixel change, as expected)
- `./scripts/web/build.sh`: **4904486 gzipped, budget 4930000**, +764 vs main. The raw wasm is 29 bytes *smaller* — the delta is gzip noise from code layout, not counters. The next wave takes ~776 KB back out.