### PR TITLE
perf(data): ask before downloading on the DWD, OPERA and TDWR feeds

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -8717,21 +8717,33 @@ impl HookEchoApp {
             let http = self.http.clone();
             self.spawner.spawn(async move {
                 use wxdata::sites::Network;
+                // Each of these asks its feed what the newest volume is *before* downloading it,
+                // and answers `None` when that is what we are already showing. The NEXRAD path
+                // below has always worked this way — it lists, then compares, then downloads;
+                // these three used to download the whole volume and compare afterwards, which on
+                // DWD meant ~50 requests and ~2 MB discarded on nine polls out of ten.
+                let cur = current_name.as_deref();
                 let fetched = match network {
-                    Network::Dwd => wxdata::dwd::fetch_volume(&http, &site).await,
-                    Network::Opera => wxdata::opera::fetch_volume(&http, &site).await,
+                    Network::Dwd => wxdata::dwd::fetch_volume(&http, &site, cur).await,
+                    Network::Opera => wxdata::opera::fetch_volume(&http, &site, cur).await,
                     Network::Tdwr | Network::Nexrad => {
-                        wxdata::tdwr::fetch_volume(&http, &site).await
+                        wxdata::tdwr::fetch_volume(&http, &site, cur).await
                     }
                 };
                 let msg = match fetched {
-                    Ok((name, _, _)) if current_name.as_deref() == Some(name.as_str()) => {
+                    Ok(None) => DataMsg::UpToDate {
+                        view: view_idx,
+                        site,
+                    },
+                    // A feed that hands back the name we already hold anyway — a probe that could
+                    // not decode, say — is still up to date.
+                    Ok(Some((name, _, _))) if current_name.as_deref() == Some(name.as_str()) => {
                         DataMsg::UpToDate {
                             view: view_idx,
                             site,
                         }
                     }
-                    Ok((name, time, scan)) => DataMsg::Volume {
+                    Ok(Some((name, time, scan))) => DataMsg::Volume {
                         view: view_idx,
                         site,
                         name,

--- a/crates/wxdata/src/dwd.rs
+++ b/crates/wxdata/src/dwd.rs
@@ -210,7 +210,8 @@ pub(crate) fn assemble(mut parts: Vec<(f32, Sweep)>) -> Vec<Sweep> {
 pub async fn fetch_volume(
     http: &reqwest::Client,
     id: &str,
-) -> anyhow::Result<(String, DateTime<Utc>, Scan)> {
+    current_name: Option<&str>,
+) -> anyhow::Result<Option<(String, DateTime<Utc>, Scan)>> {
     let meta = site_by_id(id).ok_or_else(|| anyhow::anyhow!("{id} is not a DWD radar"))?;
     let (slug, wmo) = path_for(id).ok_or_else(|| anyhow::anyhow!("{id} has no DWD path"))?;
 
@@ -230,10 +231,36 @@ pub async fn fetch_volume(
         }
     };
 
+    // Is there anything new? DWD republishes every `-LATEST-` sweep on a five-minute cycle at a
+    // URL that never changes, so there is nothing to list and nothing to compare but the data
+    // itself. The lowest tilt's reflectivity is the cheapest thing that answers: ~190 KB against
+    // the ~2 MB and ~50 requests a whole volume costs, and every file in a volume carries the
+    // same start time, so its stamp names the volume.
+    //
+    // A GET and not a HEAD: the proxies the browser build goes through are GET-only, and a probe
+    // that behaved differently per platform would be a second code path to be wrong in. The bytes
+    // are handed to the sweep job below rather than thrown away, so when the volume *has* moved
+    // on, the probe costs nothing at all.
+    let probe = get(sweep_url(slug, wmo, 0)).await;
+    if let Some((_, bytes)) = &probe {
+        if let Ok((time, _)) = crate::odim::decode(bytes.clone()) {
+            if current_name == Some(volume_name(id, time).as_str()) {
+                crate::stats::bump(crate::stats::Counter::FetchSkipped);
+                return Ok(None);
+            }
+        }
+    }
+    let mut probe = probe;
+
     let jobs = (0..TILTS).map(|tilt| {
         let get = &get;
+        // Tilt 0 was already fetched by the probe above; the rest go over the wire now.
+        let prefetched = (tilt == 0).then(|| probe.take()).flatten();
         async move {
-            let (url, bytes) = get(sweep_url(slug, wmo, tilt)).await?;
+            let (url, bytes) = match prefetched {
+                Some(pair) => pair,
+                None => get(sweep_url(slug, wmo, tilt)).await?,
+            };
             // The stamp has to come off the reflectivity file before anything else is asked for:
             // it is the only name the other moments answer to.
             let stamp = crate::odim::end_stamp(bytes.clone());
@@ -319,13 +346,37 @@ pub async fn fetch_volume(
         false,
         Vec::new(),
     );
-    let name = format!("{id}-{}", time.format("%Y%m%d%H%M%S"));
-    Ok((name, time, Scan::with_site(meta.to_site(), vcp, sweeps)))
+    Ok(Some((
+        volume_name(id, time),
+        time,
+        Scan::with_site(meta.to_site(), vcp, sweeps),
+    )))
+}
+
+/// The name a DWD volume is known by: the site and the volume's start time.
+///
+/// One function because the probe above has to predict exactly what a full fetch would return —
+/// two spellings of this format that drifted apart would mean a volume that never looks up to
+/// date, and a poll that downloads two megabytes every thirty seconds forever.
+fn volume_name(id: &str, time: DateTime<Utc>) -> String {
+    format!("{id}-{}", time.format("%Y%m%d%H%M%S"))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The probe skips a poll by predicting the name a full fetch would return. If the two ever
+    /// spell it differently, every poll downloads a whole volume forever and nothing looks wrong
+    /// — so the format lives in one function, and this is the check that it is the one the caller
+    /// compares against.
+    #[test]
+    fn volume_name_is_the_site_and_the_volume_time() {
+        let t = chrono::DateTime::parse_from_rfc3339("2026-08-29T15:31:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(volume_name("DEBO", t), "DEBO-20260829153100");
+    }
 
     /// Two real sweeps of Boostedt, saved from the live feed: publication slot 0 is 5.5° and slot
     /// 5 is the 0.5° base tilt, which is the ordering [`assemble`] exists to fix.
@@ -451,11 +502,39 @@ mod tests {
 
     /// The `-LATEST-` symlinks are DWD's convention, not a standard, and they are what makes this
     /// feed pollable at all. Run with `--ignored` when a German site stops updating.
+    /// The point of the probe, against the live feed: a second poll that is already showing the
+    /// newest volume must cost one request instead of ~50, and must say so rather than handing
+    /// back a volume the caller then throws away.
+    #[tokio::test]
+    #[ignore = "network"]
+    async fn a_second_poll_of_an_unchanged_volume_costs_one_request() {
+        let client = reqwest::Client::new();
+        let (name, _, _) = fetch_volume(&client, "DEBO", None)
+            .await
+            .unwrap()
+            .expect("first fetch returns a volume");
+        let before = crate::stats::snapshot();
+        let again = fetch_volume(&client, "DEBO", Some(&name)).await.unwrap();
+        let after = crate::stats::snapshot();
+        let requests = |v: &Vec<(&'static str, u64)>| {
+            v.iter().find(|(l, _)| *l == "net_requests").unwrap().1
+        };
+        assert!(again.is_none(), "unchanged volume should be skipped");
+        assert_eq!(
+            requests(&after) - requests(&before),
+            1,
+            "the probe is one request, not a whole volume"
+        );
+    }
+
     #[tokio::test]
     #[ignore]
     async fn live_dwd_volume_assembles() {
         let client = reqwest::Client::new();
-        let (name, time, scan) = fetch_volume(&client, "DEBO").await.unwrap();
+        let (name, time, scan) = fetch_volume(&client, "DEBO", None)
+            .await
+            .unwrap()
+            .expect("a fresh fetch is never up to date");
         let angles: Vec<f32> = scan
             .sweeps()
             .iter()

--- a/crates/wxdata/src/opera.rs
+++ b/crates/wxdata/src/opera.rs
@@ -171,7 +171,8 @@ fn newest_group<'a>(xml: &'a str, nod: &str) -> Vec<&'a str> {
 pub async fn fetch_volume(
     http: &reqwest::Client,
     id: &str,
-) -> anyhow::Result<(String, DateTime<Utc>, Scan)> {
+    current_name: Option<&str>,
+) -> anyhow::Result<Option<(String, DateTime<Utc>, Scan)>> {
     let meta = site_by_id(id).ok_or_else(|| anyhow::anyhow!("{id} is not an OPERA radar"))?;
     let nod = id.to_ascii_lowercase();
 
@@ -213,7 +214,7 @@ pub async fn fetch_volume(
         anyhow::bail!("no OPERA volume published for {id} in the last two hours");
     }
 
-    let files = futures_util::future::join_all(group.iter().map(|key| {
+    let fetch = |key: String| {
         let http = http.clone();
         let url = format!("{BUCKET}/{key}");
         async move {
@@ -235,13 +236,24 @@ pub async fn fetch_volume(
                 }
             }
         }
-    }))
-    .await;
+    };
 
-    let mut files = files.into_iter().flatten();
-    let (time, base) = files
-        .next()
+    // Reflectivity first, alone, and then ask whether the rest is worth fetching. The key carries
+    // a timestamp, but only to the minute, and the name this returns is built from the decoded
+    // volume time — so comparing keys would be comparing something subtly different from what the
+    // caller holds. Decoding the one object the volume is anchored on answers exactly, and it is
+    // the object every other moment gets folded into, so nothing is wasted when the answer is
+    // "yes, this is new".
+    let (time, base) = fetch(group[0].clone())
+        .await
         .ok_or_else(|| anyhow::anyhow!("no decodable OPERA volume for {id}"))?;
+    if current_name == Some(volume_name(id, time).as_str()) {
+        crate::stats::bump(crate::stats::Counter::FetchSkipped);
+        return Ok(None);
+    }
+
+    let files = futures_util::future::join_all(group[1..].iter().cloned().map(&fetch)).await;
+    let files = files.into_iter().flatten();
     // Every object in the group is the same scan sampled at once, so sweep `i` of one is sweep `i`
     // of the others; a file that disagrees about the scan it describes is dropped rather than
     // smeared across it.
@@ -280,9 +292,8 @@ pub async fn fetch_volume(
         })
         .collect();
 
-    let name = format!("{id}-{}", time.format("%Y%m%d%H%M%S"));
-    Ok((
-        name,
+    Ok(Some((
+        volume_name(id, time),
         time,
         // The decoder already built the pattern-0 placeholder ODIM's free-text scan strategy
         // deserves; there is nothing better to say about it here.
@@ -291,7 +302,13 @@ pub async fn fetch_volume(
             base.coverage_pattern().clone(),
             crate::dwd::assemble(ordered),
         ),
-    ))
+    )))
+}
+
+/// The name an OPERA volume is known by. Same shape as the DWD one and for the same reason: the
+/// probe above has to predict exactly what a full fetch returns.
+fn volume_name(id: &str, time: DateTime<Utc>) -> String {
+    format!("{id}-{}", time.format("%Y%m%d%H%M%S"))
 }
 
 /// The elevation a sweep was cut at, or `NaN` for an empty one — which no decoded sweep is.
@@ -305,6 +322,16 @@ fn angle(sweep: &Sweep) -> f32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Same contract as the DWD one: the probe's predicted name and the fetched volume's name are
+    /// the same function, or the "already showing it" comparison never fires.
+    #[test]
+    fn volume_name_is_the_site_and_the_volume_time() {
+        let t = chrono::DateTime::parse_from_rfc3339("2026-08-29T15:31:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(volume_name("HRBIL", t), "HRBIL-20260829153100");
+    }
 
     const LISTING: &str = "<ListBucketResult>\
         <Contents><Key>2026/08/29/PL/plgsa/PVOL/plgsa@20260829T1531@0.5_1.5@DBZH.h5</Key></Contents>\
@@ -384,7 +411,10 @@ mod tests {
     #[ignore]
     async fn live_opera_volume_assembles() {
         let http = reqwest::Client::new();
-        let (name, _, scan) = fetch_volume(&http, "HRBIL").await.expect("volume");
+        let (name, _, scan) = fetch_volume(&http, "HRBIL", None)
+            .await
+            .expect("volume")
+            .expect("a fresh fetch is never up to date");
         assert!(name.starts_with("HRBIL-"), "{name}");
         assert!(scan.sweeps().len() >= 5, "{} sweeps", scan.sweeps().len());
         let base = &scan.sweeps()[0].radials()[0];

--- a/crates/wxdata/src/tdwr.rs
+++ b/crates/wxdata/src/tdwr.rs
@@ -230,19 +230,40 @@ fn sweep_from(
 pub async fn fetch_volume(
     http: &reqwest::Client,
     id: &str,
-) -> anyhow::Result<(String, DateTime<Utc>, Scan)> {
+    current_name: Option<&str>,
+) -> anyhow::Result<Option<(String, DateTime<Utc>, Scan)>> {
     let meta = site_by_id(id).ok_or_else(|| anyhow::anyhow!("{id} is not a TDWR"))?;
     let short = &meta.id[1..];
     let day = Utc::now().format("%Y_%m_%d").to_string();
 
-    // Six products, twelve round trips. Serially that was most of the wait for a TDWR site;
-    // they're independent, so fetch and decode them all at once.
-    let mut jobs = Vec::new();
-    for (n, (product, gate_len)) in PRODUCTS.iter().enumerate() {
+    // The listings first, on their own. This volume's name *is* the newest contributing key, so
+    // six listings of a few KB each answer "has anything been published since last time?" exactly
+    // — and answering it before the six product bodies is the difference between a poll that
+    // costs a few KB and one that costs megabytes, on a feed that turns over every few minutes.
+    let keys = futures_util::future::join_all(PRODUCTS.iter().map(|(product, _)| {
         let (http, prefix) = (http.clone(), format!("{short}_{product}_{day}"));
+        async move { newest_key(&http, &prefix).await }
+    }))
+    .await;
+    let newest_listed = keys
+        .iter()
+        .flatten()
+        .filter_map(|k| key_time(k).map(|t| (k, t)))
+        .max_by_key(|(_, t)| *t)
+        .map(|(k, _)| k.clone());
+    if newest_listed.is_some() && current_name == newest_listed.as_deref() {
+        crate::stats::bump(crate::stats::Counter::FetchSkipped);
+        return Ok(None);
+    }
+
+    // Six products. Serially that was most of the wait for a TDWR site; they're independent, so
+    // fetch and decode them all at once.
+    let mut jobs = Vec::new();
+    for ((n, (product, gate_len)), key) in PRODUCTS.iter().enumerate().zip(keys) {
+        let http = http.clone();
         let (product, gate_len) = (*product, *gate_len);
         jobs.push(async move {
-            let key = newest_key(&http, &prefix).await?;
+            let key = key?;
             let resp = http
                 .get(crate::net::fetch_url(&format!("{BUCKET}/{key}")))
                 .send()
@@ -309,7 +330,7 @@ pub async fn fetch_volume(
         false,
         Vec::new(),
     );
-    Ok((name, time, Scan::with_site(site, vcp, sweeps)))
+    Ok(Some((name, time, Scan::with_site(site, vcp, sweeps))))
 }
 
 #[cfg(test)]
@@ -340,6 +361,25 @@ mod tests {
         let t = key_time("OKC_TZ0_2026_08_01_17_27_13").unwrap();
         assert_eq!(t.to_rfc3339(), "2026-08-01T17:27:13+00:00");
         assert!(key_time("OKC_TZ0_garbage").is_none());
+    }
+
+    /// The name a TDWR volume is known by is the newest contributing key, and that is exactly
+    /// what the listings hand back — which is what lets six cheap listings decide whether the six
+    /// product bodies are worth fetching at all. This pins the "newest wins" rule that decision
+    /// rests on: keys sort by their embedded timestamp, not lexically and not by product order.
+    #[test]
+    fn the_newest_listed_key_is_the_volume_name() {
+        let keys = [
+            "OKC_TZ0_2026_08_01_17_27_13",
+            "OKC_TV0_2026_08_01_17_28_02",
+            "OKC_TZ1_2026_08_01_17_26_44",
+        ];
+        let newest = keys
+            .iter()
+            .filter_map(|k| key_time(k).map(|t| (*k, t)))
+            .max_by_key(|(_, t)| *t)
+            .map(|(k, _)| k);
+        assert_eq!(newest, Some("OKC_TV0_2026_08_01_17_28_02"));
     }
 
     /// A synthetic tilt product round-trips through the fixed-point packing back to its own dBZ.
@@ -411,7 +451,10 @@ mod tests {
     #[ignore = "network"]
     async fn fetches_a_live_tdwr_volume() {
         let http = reqwest::Client::new();
-        let (name, _time, scan) = fetch_volume(&http, "TOKC").await.expect("TOKC volume");
+        let (name, _time, scan) = fetch_volume(&http, "TOKC", None)
+            .await
+            .expect("TOKC volume")
+            .expect("a fresh fetch is never up to date");
         assert!(name.starts_with("OKC_"), "{name}");
         let tilts = crate::level2::elevation_angles(&scan);
         assert!(!tilts.is_empty(), "at least one tilt");


### PR DESCRIPTION
Wave 4 — the biggest network win in the plan. Stacked on #207 (merged).

## The problem

The NEXRAD path has always listed first, compared the newest volume's name against what is on screen, and downloaded only on a difference. The other three downloaded the whole volume and compared *afterwards*. On DWD that is ~50 requests and ~2 MB every 30-second poll against a feed that publishes every five minutes — roughly nine polls in ten threw away everything they fetched.

## The fix

`fetch_volume` on all three takes the caller's `current_name` and returns `Ok(None)` for "you already have it", which the app turns into the `UpToDate` message it already had.

Each probe is the cheapest thing that answers *exactly*:

- **DWD** republishes every `-LATEST-` sweep at a URL that never changes — nothing to list, nothing to compare but the data. Probe = a GET of the lowest tilt's reflectivity (~190 KB); every file in a volume carries the same start time, so its stamp names the volume. When the volume *has* moved on those bytes go straight to the tilt-0 sweep job, so the probe then costs nothing at all.
- **OPERA** fetches the reflectivity object alone and decodes it, then fetches the rest of the group only if it is new. Its key carries a timestamp but only to the minute, while the name comes from the decoded volume time — comparing keys would compare something subtly different from what the caller holds. Reflectivity is the object every other moment folds into, so it is not wasted either way.
- **TDWR**'s volume name *is* its newest contributing key, so six listings of a few KB decide whether the six product bodies are worth fetching.

A GET and not a HEAD: the browser build's proxies are GET-only, and a probe that behaved differently per platform would be a second code path to be wrong in.

## The failure mode I designed against

If the name a probe predicts and the name a full fetch returns ever drift apart, every poll downloads a whole volume forever and *nothing looks wrong*. So each feed has one `volume_name` function used by both, with unit tests pinning the format, plus a test for the "newest key wins" rule the TDWR probe rests on.

## Measured

New `#[ignore = "network"]` test against the live DWD feed, which asserts the result: a second poll of an unchanged volume costs **1 request / 201 KB**, against ~50 requests / ~2 MB before. Wave 1's `fetch_skipped` counter counts them in the app.

```
test dwd::tests::a_second_poll_of_an_unchanged_volume_costs_one_request ... ok
```

## Not included

The same-site pane dedup this wave was planned to carry. Sharing one download between two panes on one site needs the fetch task to reach the app's scan cache — a different mechanism with its own failure modes. It belongs in its own change rather than hidden behind this one; I'll bring it separately.

## Gate

- clippy `-D warnings` clean · `cargo test --workspace` 642 passed, 32 ignored
- wasm32 check clean · `./scripts/shots/shoot.sh check` passed
- `./scripts/web/build.sh`: 4089254 gz, budget 4125000