### PR TITLE
perf(data): conditional requests, and the DWD probe stops sending bytes

### DIFF
--- a/crates/wxdata/src/dwd.rs
+++ b/crates/wxdata/src/dwd.rs
@@ -241,15 +241,15 @@ pub async fn fetch_volume(
     // that behaved differently per platform would be a second code path to be wrong in. The bytes
     // are handed to the sweep job below rather than thrown away, so when the volume *has* moved
     // on, the probe costs nothing at all.
-    let probe = get(sweep_url(slug, wmo, 0)).await;
-    if let Some((_, bytes)) = &probe {
-        if let Ok((time, _)) = crate::odim::decode(bytes.clone()) {
-            if current_name == Some(volume_name(id, time).as_str()) {
-                crate::stats::bump(crate::stats::Counter::FetchSkipped);
-                return Ok(None);
-            }
+    let probe_url = sweep_url(slug, wmo, 0);
+    let probe = match probe_sweep(http, &probe_url, id, current_name).await {
+        Probe::UpToDate => {
+            crate::stats::bump(crate::stats::Counter::FetchSkipped);
+            return Ok(None);
         }
-    }
+        Probe::Fresh(bytes) => Some((probe_url, bytes)),
+        Probe::Unreadable => None,
+    };
     let mut probe = probe;
 
     let jobs = (0..TILTS).map(|tilt| {
@@ -351,6 +351,97 @@ pub async fn fetch_volume(
         time,
         Scan::with_site(meta.to_site(), vcp, sweeps),
     )))
+}
+
+/// What the probe learned about the newest volume.
+enum Probe {
+    /// The feed still holds the volume the caller is already showing.
+    UpToDate,
+    /// A newer volume — here are the reflectivity bytes for its lowest tilt, already paid for.
+    Fresh(Vec<u8>),
+    /// The probe could not be fetched or could not be decoded. Not an answer; carry on and let
+    /// the full fetch report whatever is really wrong.
+    Unreadable,
+}
+
+/// Ask the feed whether the volume has moved on, as cheaply as it can be asked.
+///
+/// Two layers, and the second is why the first is safe. `opendata.dwd.de` honours both `ETag` and
+/// `If-Modified-Since` on these files, so an unchanged poll can be a header exchange with no body
+/// at all — but a 304 says only "this file has not changed since *you* last read it", which means
+/// "you are up to date" only if what the caller holds is what that read produced. So the volume
+/// name is remembered next to the validators and checked against the caller's; when they disagree
+/// the request is reissued unconditionally, which is exactly the behaviour of not having the
+/// store at all.
+///
+/// Without a 304 the probe still pays for one ~190 KB file rather than a ~2 MB volume, and those
+/// bytes are handed back to be used as the tilt-0 sweep.
+async fn probe_sweep(
+    http: &reqwest::Client,
+    url: &str,
+    id: &str,
+    current_name: Option<&str>,
+) -> Probe {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        // Only ever conditional when the caller has something to be up to date *with*.
+        if current_name.is_some() {
+            let remembered = crate::net::validators::get(url);
+            let req = crate::net::validators::apply(http.get(crate::net::fetch_url(url)), url);
+            if let Ok(resp) = req.send().await {
+                if resp.status() == reqwest::StatusCode::NOT_MODIFIED {
+                    crate::stats::bump(crate::stats::Counter::NetNotModified);
+                    crate::stats::net(0);
+                    // The file is unchanged; is it the volume the caller holds?
+                    if remembered.and_then(|e| e.tag).as_deref() == current_name {
+                        return Probe::UpToDate;
+                    }
+                    // It is not — fall through and fetch it for real, unconditionally.
+                } else if resp.status().is_success() {
+                    return finish_probe(url, id, current_name, resp).await;
+                } else {
+                    return Probe::Unreadable;
+                }
+            } else {
+                return Probe::Unreadable;
+            }
+        }
+    }
+    match http.get(crate::net::fetch_url(url)).send().await {
+        Ok(resp) if resp.status().is_success() => finish_probe(url, id, current_name, resp).await,
+        _ => Probe::Unreadable,
+    }
+}
+
+/// Read a probe response's body, remember its validators against the volume it turned out to be,
+/// and say whether the caller already has that volume.
+async fn finish_probe(
+    url: &str,
+    id: &str,
+    current_name: Option<&str>,
+    resp: reqwest::Response,
+) -> Probe {
+    #[cfg(not(target_arch = "wasm32"))]
+    let validators = (resp.headers().clone(), url.to_string());
+    let Ok(bytes) = resp.bytes().await else {
+        return Probe::Unreadable;
+    };
+    crate::stats::net(bytes.len());
+    let bytes = bytes.to_vec();
+    let Ok((time, _)) = crate::odim::decode(bytes.clone()) else {
+        return Probe::Unreadable;
+    };
+    let name = volume_name(id, time);
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let (headers, url) = validators;
+        crate::net::validators::remember_headers(&url, &headers, Some(name.clone()));
+    }
+    let _ = url;
+    if current_name == Some(name.as_str()) {
+        return Probe::UpToDate;
+    }
+    Probe::Fresh(bytes)
 }
 
 /// The name a DWD volume is known by: the site and the volume's start time.
@@ -504,7 +595,8 @@ mod tests {
     /// feed pollable at all. Run with `--ignored` when a German site stops updating.
     /// The point of the probe, against the live feed: a second poll that is already showing the
     /// newest volume must cost one request instead of ~50, and must say so rather than handing
-    /// back a volume the caller then throws away.
+    /// back a volume the caller then throws away. With validators remembered from the first
+    /// fetch, that one request carries no body at all.
     #[tokio::test]
     #[ignore = "network"]
     async fn a_second_poll_of_an_unchanged_volume_costs_one_request() {
@@ -519,11 +611,18 @@ mod tests {
         let requests = |v: &Vec<(&'static str, u64)>| {
             v.iter().find(|(l, _)| *l == "net_requests").unwrap().1
         };
+        let bytes =
+            |v: &Vec<(&'static str, u64)>| v.iter().find(|(l, _)| *l == "net_bytes").unwrap().1;
         assert!(again.is_none(), "unchanged volume should be skipped");
         assert_eq!(
             requests(&after) - requests(&before),
             1,
             "the probe is one request, not a whole volume"
+        );
+        assert_eq!(
+            bytes(&after) - bytes(&before),
+            0,
+            "an unchanged probe is answered 304, with no body"
         );
     }
 

--- a/crates/wxdata/src/net.rs
+++ b/crates/wxdata/src/net.rs
@@ -67,6 +67,168 @@ pub fn install_s3_proxy_rewriter() {
     nexrad_data::aws::client::set_url_rewriter(fetch_url);
 }
 
+/// Remembered HTTP validators, so a feed that has not changed can answer in a header instead of a
+/// body.
+///
+/// One store, keyed by URL, holding whatever the last response offered (`ETag`, `Last-Modified`)
+/// plus a caller's own tag for *what those bytes were* — a 304 says "the file has not changed
+/// since you last read it", which only means "you are up to date" if what you hold is what that
+/// read produced.
+///
+/// Native only. In a browser the same job is already done, better, by the HTTP cache and by the
+/// edge in front of `/proxy/`; adding a second layer inside the wasm would cost bundle size to
+/// re-implement what the platform does for free.
+///
+// ponytail: one adopter today (the DWD volume probe, where it turns a 201 KB poll into a
+// header exchange). It lives here rather than in `dwd.rs` because the next feed that wants it
+// should not write a second one — but it is deliberately small, and it is not a cache: it stores
+// validators, never bodies.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod validators {
+    use std::num::NonZeroUsize;
+    use std::sync::Mutex;
+
+    /// What we remember about one URL.
+    #[derive(Clone, Default)]
+    pub struct Entry {
+        pub etag: Option<String>,
+        pub last_modified: Option<String>,
+        /// The caller's name for the bytes that response carried.
+        pub tag: Option<String>,
+    }
+
+    /// Bounded because the keys are URLs and a long session touches many. 256 covers every feed
+    /// URL the app polls, several times over.
+    fn store() -> &'static Mutex<lru::LruCache<String, Entry>> {
+        static STORE: std::sync::OnceLock<Mutex<lru::LruCache<String, Entry>>> =
+            std::sync::OnceLock::new();
+        STORE.get_or_init(|| {
+            Mutex::new(lru::LruCache::new(NonZeroUsize::new(256).unwrap()))
+        })
+    }
+
+    /// What is remembered for `url`, if anything.
+    pub fn get(url: &str) -> Option<Entry> {
+        store().lock().ok()?.get(url).cloned()
+    }
+
+    /// Add `If-None-Match` / `If-Modified-Since` for `url`, if anything is remembered for it.
+    ///
+    /// Nothing remembered means the request goes out exactly as it would have.
+    pub fn apply(req: reqwest::RequestBuilder, url: &str) -> reqwest::RequestBuilder {
+        let Some(e) = get(url) else { return req };
+        let req = match &e.etag {
+            Some(v) => req.header(reqwest::header::IF_NONE_MATCH, v),
+            None => req,
+        };
+        match &e.last_modified {
+            Some(v) => req.header(reqwest::header::IF_MODIFIED_SINCE, v),
+            None => req,
+        }
+    }
+
+    /// Remember what a response offered for `url`, tagged with the caller's name for those bytes.
+    /// Headers rather than the response itself, because the caller needs the body.
+    ///
+    /// A response with no validators clears the entry rather than leaving a stale one: sending a
+    /// condition the server never issued is how a feed that stopped publishing them starts
+    /// answering 304 to a request that should have been unconditional.
+    pub fn remember_headers(url: &str, headers: &reqwest::header::HeaderMap, tag: Option<String>) {
+        let header = |name: reqwest::header::HeaderName| {
+            headers
+                .get(name)
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_owned)
+        };
+        let entry = Entry {
+            etag: header(reqwest::header::ETAG),
+            last_modified: header(reqwest::header::LAST_MODIFIED),
+            tag,
+        };
+        if let Ok(mut s) = store().lock() {
+            if entry.etag.is_none() && entry.last_modified.is_none() {
+                s.pop(url);
+            } else {
+                s.put(url.to_owned(), entry);
+            }
+        }
+    }
+
+    /// Forget everything. Tests only — the store is process-wide.
+    #[cfg(test)]
+    pub fn clear() {
+        if let Ok(mut s) = store().lock() {
+            s.clear();
+        }
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod validator_tests {
+    use super::validators;
+
+    fn headers(pairs: &[(&str, &str)]) -> reqwest::header::HeaderMap {
+        let mut h = reqwest::header::HeaderMap::new();
+        for (k, v) in pairs {
+            h.insert(
+                reqwest::header::HeaderName::from_bytes(k.as_bytes()).unwrap(),
+                v.parse().unwrap(),
+            );
+        }
+        h
+    }
+
+    /// What is remembered is what comes back, tagged with the caller's name for those bytes —
+    /// the tag is the whole reason a 304 can be trusted to mean "you are up to date".
+    #[test]
+    fn remembers_validators_and_the_tag() {
+        validators::clear();
+        let url = "https://example.invalid/one";
+        validators::remember_headers(
+            url,
+            &headers(&[("etag", "\"abc\""), ("last-modified", "Sat, 29 Aug 2026 10:00:00 GMT")]),
+            Some("VOL-1".into()),
+        );
+        let e = validators::get(url).expect("remembered");
+        assert_eq!(e.etag.as_deref(), Some("\"abc\""));
+        assert_eq!(e.last_modified.as_deref(), Some("Sat, 29 Aug 2026 10:00:00 GMT"));
+        assert_eq!(e.tag.as_deref(), Some("VOL-1"));
+    }
+
+    /// A response that carries no validators must clear what was remembered, not leave it.
+    /// Otherwise a feed that stops issuing them starts answering 304 to a request that should
+    /// have been unconditional — and the app stops seeing new data with nothing to show for it.
+    #[test]
+    fn a_response_without_validators_forgets_the_old_ones() {
+        validators::clear();
+        let url = "https://example.invalid/two";
+        validators::remember_headers(url, &headers(&[("etag", "\"abc\"")]), Some("VOL-1".into()));
+        assert!(validators::get(url).is_some());
+        validators::remember_headers(url, &headers(&[("content-type", "text/plain")]), None);
+        assert!(
+            validators::get(url).is_none(),
+            "a validator-less response must clear the entry"
+        );
+    }
+
+    /// Nothing remembered means the request goes out exactly as it would have.
+    #[test]
+    fn an_unknown_url_adds_no_headers() {
+        validators::clear();
+        let client = reqwest::Client::new();
+        let req = validators::apply(
+            client.get("https://example.invalid/three"),
+            "https://example.invalid/three",
+        );
+        let built = req.build().unwrap();
+        assert!(built.headers().get(reqwest::header::IF_NONE_MATCH).is_none());
+        assert!(built
+            .headers()
+            .get(reqwest::header::IF_MODIFIED_SINCE)
+            .is_none());
+    }
+}
+
 #[cfg(test)]
 mod tests {
     /// A keyed tile URL must never be rewritten to `/proxy/…`: the proxy is a shared edge cache


### PR DESCRIPTION
Wave 5. Stacked on #208 (merged).

Wave 4 made an unchanged DWD poll cost one ~190 KB request instead of ~50 requests / ~2 MB. `opendata.dwd.de` honours both `ETag` and `If-Modified-Since` on those files, so that request can carry **no body at all**.

## `net::validators`

A small store keyed by URL: whatever the last response offered, plus the caller's own name for what those bytes were. Native only — in a browser the HTTP cache and the edge in front of `/proxy/` already do this better, and re-implementing it inside the wasm would spend bundle size to buy nothing.

**The tag is what makes a 304 safe to act on.** A 304 says "this file has not changed since *you* last read it" — that only means "you are up to date" if what the caller holds is what that read produced. After a site switch, or after a volume aged out of the cache, those are different things. So the volume name is remembered beside the validators; when it disagrees with the caller's, the request is reissued unconditionally — exactly the behaviour of not having the store at all. A response carrying no validators clears the entry rather than leaving a stale one (otherwise a feed that stops issuing them starts answering 304 to requests that should be unconditional, and the app quietly stops seeing new data).

Three unit tests pin those rules; the live network test from wave 4 now asserts the result:

```
a second poll of an unchanged volume: 1 request, 0 bytes
```

## Two planned adopters I checked and skipped

- **api.weather.gov `alerts/active`** — the biggest prize on paper (1–5 MB per refresh) **gains nothing**. Its ETag is weak and changes on every response; three consecutive revalidations with a freshly-read ETag all returned 200 with a full body. Conditional requests there would add a header and save zero bytes.
- **tgftp Level 3** does answer 304, but payloads are ~1.6 KB and `fetch_tgftp` returns `Option<Level3Product>` where `None` already means "no product" — a 304 needs a third state or a layer clears itself on an unchanged poll. Not worth that change for 1.6 KB.

Both were measured with curl before writing any code, which is why this wave is smaller than planned and lands where the bytes actually are.

## Gate

- clippy `-D warnings` clean · `cargo test --workspace` 645 passed, 33 ignored
- wasm32 check clean · `./scripts/shots/shoot.sh check` passed
- `./scripts/web/build.sh`: 4090300 gz, budget 4125000