### PR TITLE
perf(lite): a refresh fetches what it does not already have

### DIFF
--- a/crates/hookecho/src/serve.rs
+++ b/crates/hookecho/src/serve.rs
@@ -296,7 +296,12 @@ fn static_file(server: &Server, path: &str) -> (&'static str, &'static str, Vec<
         log::warn!("refused traversal attempt: {path}");
         return not_found();
     }
-    let file = root.join(rel);
+    // A directory has an index.html or it has nothing — `--web-root web` could not serve /lite/
+    // at all before this, because reading a directory is an error and that read as a 404.
+    let file = match rel.is_empty() || rel.ends_with('/') {
+        true => root.join(rel).join("index.html"),
+        false => root.join(rel),
+    };
     match std::fs::read(&file) {
         Ok(body) => ("200 OK", content_type(&file), body),
         Err(_) => not_found(),
@@ -1416,6 +1421,36 @@ mod tests {
     /// the values in `cacheSeconds` (web/_worker.js/proxy-core.js) written out — if that table
     /// moves, this fails and says so, instead of two deployments quietly disagreeing about how
     /// long a volume is good for.
+    /// `--web-root web` has to be able to serve `/lite/`, which is a directory. Reading one is an
+    /// error, and that error read as a 404 — the lite viewer was simply unreachable this way.
+    #[test]
+    fn a_directory_is_served_as_its_index() {
+        let dir = std::env::temp_dir().join(format!("hookecho-serve-{}", std::process::id()));
+        std::fs::create_dir_all(dir.join("lite")).unwrap();
+        std::fs::write(dir.join("lite/index.html"), b"<!doctype html>lite").unwrap();
+        let server = Server {
+            token: String::new(),
+            spots: Vec::new(),
+            web_root: Some(dir.clone()),
+            rt: tokio::runtime::Builder::new_current_thread()
+                .build()
+                .unwrap(),
+            http: reqwest::Client::new(),
+            cache: Mutex::new(lru::LruCache::new(
+                std::num::NonZeroUsize::new(ANSWER_CACHE).unwrap(),
+            )),
+            proxy_cache: Mutex::new(lru::LruCache::new(
+                std::num::NonZeroUsize::new(PROXY_CACHE_ENTRIES).unwrap(),
+            )),
+            render: Mutex::new(()),
+        };
+        let body = route(&server, "/lite/", "", None).body;
+        assert_eq!(String::from_utf8_lossy(&body), "<!doctype html>lite");
+        // Still no way out of the root, trailing slash or not.
+        assert_eq!(route(&server, "/../", "", None).status, "404 Not Found");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
     #[test]
     fn cache_ttls_match_the_edge_worker() {
         assert_eq!(cache_seconds(ARCHIVE_BUCKET, ""), 3600);

--- a/web/lite/app.js
+++ b/web/lite/app.js
@@ -43,10 +43,16 @@ const state = {
   zoom: clampZoom(Number(params.get("zoom")) || 9),
   frame: 0,
   times: [],
+  keys: [], // the loop's S3 keys, so a refresh can tell what it already has
   playing: true,
   loading: false,
   warnings: [], // [{ event, rings }] already filtered to the current view
 };
+
+// The bytes behind `state.keys`. A new scan lands every four to six minutes and the loop
+// refreshes every two, so five of the six frames a refresh wants are the five it is already
+// holding — refetching all of them was most of this page's traffic.
+const held = new Map(); // key -> Uint8Array
 
 let allSites = [];
 let viewer = null;
@@ -71,27 +77,45 @@ function canvasSize() {
   return [Math.max(w, 1), Math.max(h, 1)];
 }
 
+// The tile grid is diffed rather than rebuilt. Emptying the host dropped every loaded <img> on
+// the floor, so a resize, a fullscreen toggle or the same zoom returned to refetched the lot; the
+// tiles that are still wanted are almost always the ones already on screen.
 function drawTiles(w, h) {
   const z = state.zoom;
   const host = el("tiles");
-  host.textContent = "";
   const cx = lonToX(state.site.lon, z);
   const cy = latToY(state.site.lat, z);
   const left = cx - w / 2;
   const top = cy - h / 2;
   const n = 2 ** z;
+  const want = new Map(); // src -> [left, top]
   for (let ty = Math.floor(top / 256); ty <= Math.floor((top + h) / 256); ty++) {
     for (let tx = Math.floor(left / 256); tx <= Math.floor((left + w) / 256); tx++) {
       if (ty < 0 || ty >= n) continue;
-      const img = new Image();
-      img.loading = "lazy";
-      img.alt = "";
       // ArcGIS tile URLs are z/y/x, not z/x/y.
-      img.src = `${TILES}/${z}/${ty}/${((tx % n) + n) % n}`;
-      img.style.left = `${tx * 256 - left}px`;
-      img.style.top = `${ty * 256 - top}px`;
-      host.append(img);
+      const src = `${TILES}/${z}/${ty}/${((tx % n) + n) % n}`;
+      want.set(src, [`${tx * 256 - left}px`, `${ty * 256 - top}px`]);
     }
+  }
+  // `getAttribute`, not `.src`: the property resolves to an absolute URL and would never match
+  // the same-origin path written above.
+  for (const img of [...host.children]) {
+    const pos = want.get(img.getAttribute("src"));
+    if (!pos) {
+      img.remove();
+      continue;
+    }
+    [img.style.left, img.style.top] = pos;
+    want.delete(img.getAttribute("src"));
+  }
+  for (const [src, [x, y]] of want) {
+    const img = new Image();
+    img.loading = "lazy";
+    img.alt = "";
+    img.src = src;
+    img.style.left = x;
+    img.style.top = y;
+    host.append(img);
   }
 }
 
@@ -230,21 +254,35 @@ async function loadLoop() {
   showTime();
   try {
     const keys = await listKeys();
-    // All six at once. Fetched one after another this was six round trips deep, which is most of
-    // the wait on a slow link; the decode below is the same work either way.
+    // Nothing new has landed and every frame is still in hand: the loop already shows this.
+    if (
+      keys.length &&
+      keys.length === state.keys.length &&
+      keys.every((k, i) => k === state.keys[i] && held.has(k))
+    ) {
+      return;
+    }
+    // A frame already held is not fetched again. All the rest at once: fetched one after another
+    // this was six round trips deep, which is most of the wait on a slow link; the decode below is
+    // the same work either way.
     const inflight = keys.map((key) =>
-      fetch(`${S3}/${key}`)
-        .then((r) => (r.ok ? r.arrayBuffer() : null))
-        .then((buf) => (buf ? { key, bytes: new Uint8Array(buf) } : null))
-        .catch(() => null),
+      held.has(key)
+        ? Promise.resolve({ key, bytes: held.get(key) })
+        : fetch(`${S3}/${key}`)
+            .then((r) => (r.ok ? r.arrayBuffer() : null))
+            .then((buf) => (buf ? { key, bytes: new Uint8Array(buf) } : null))
+            .catch(() => null),
     );
     viewer.clear_frames();
     const times = [];
+    const loaded = [];
     // Awaited in order, not with Promise.all: the requests are already all in flight, and waiting
     // for the slowest one before decoding any of them is how the first frame ends up last.
     for (const pending of inflight) {
       const item = await pending;
       if (!item || !viewer.add_frame(item.bytes)) continue;
+      held.set(item.key, item.bytes);
+      loaded.push(item.key);
       times.push(keyTime(item.key));
       // Paint the oldest frame the moment it decodes rather than sitting on a blank map for the
       // length of five more decodes.
@@ -260,6 +298,12 @@ async function loadLoop() {
       await new Promise((r) => setTimeout(r, 0));
     }
     state.times = times;
+    state.keys = loaded;
+    // Anything that slid out of the window, or belongs to the site or product just switched away
+    // from, stops being held — six scans is the whole budget.
+    for (const key of [...held.keys()]) {
+      if (!loaded.includes(key)) held.delete(key);
+    }
     state.frame = Math.max(0, times.length - 1);
     if (ctx) viewer.render(ctx, state.frame);
   } finally {


### PR DESCRIPTION
Wave 8 of the performance plan.

## The gap

The lite viewer discarded all six loop frames every 120 s and refetched them. A new N0B lands every four to six minutes, so five of the six were already in hand — most of this page's traffic was rebuying bytes it had just thrown away.

## Measured

Local `--serve --web-root web`, headless Chrome, requests counted at the network layer:

| refresh | frame GETs | bytes |
|---|---|---|
| before | 6 | 1,660,843 |
| **after** | **0** | **0** |

The listing still goes out every refresh — that is how the page learns whether anything new landed, and at ~5 KB it is the cheap half. When a new scan has landed, only that scan is fetched; when the key list is unchanged and every frame is still held, `loadLoop` returns without touching the wire.

`held` is a `Map` of key → bytes, pruned after each load to exactly the keys on display, so a site or product switch drops the old ones rather than accumulating them. The decode is still redone from held bytes — `add_frame` is the wasm's only entry point and frames are one product's data levels — so this is a change in what is *fetched*, nothing else.

## Behaviour checks

- Six frames decode, toolbar reaches **6/6**
- A refresh leaves the map painted — 60,163 non-transparent pixels
- Product toggle still fetches its six velocity frames and paints — 436,214 pixels
- `smoke-lite.mjs` passes against the local server

## Tile grid

`drawTiles` diffs instead of emptying the host. `host.textContent = ""` dropped every loaded `<img>` on the floor, so a resize or fullscreen toggle rebuilt the whole grid; tiles still wanted are now moved rather than recreated.

**No network delta to report for this one.** Since #210 and #211 those tiles carry a `Cache-Control` and the browser was already answering the refetches from its own cache — I could not reproduce a request-count difference, with or without the HTTP cache enabled. So this is DOM churn and the flash of an empty map, not bytes. Flagging that rather than quoting the ~36-tile figure from the plan, which no longer holds now that the transport waves have landed.

## Also

`--web-root DIR` could not serve `/lite/` at all: reading a directory is an error and that error read as a 404, so the lite viewer was unreachable from the native server — which is what this wave needed to be measured against. A trailing-slash path now resolves to `index.html`. The traversal guard runs before it, unchanged, and `a_directory_is_served_as_its_index` checks both halves.

## Gate

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 649 passed, 33 ignored
- wasm32 `cargo check` — clean
- `./scripts/shots/shoot.sh check` — passed
- `./scripts/web/build.sh` — 4090300 gz against a 4125000 budget
- `node --test web/_worker.js/proxy-core.test.mjs` — 8 passed
- `scripts/web/smoke-lite.mjs` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)