### PR TITLE
perf(render): reuse radar GPU state, palette-only LUT, tile-quad skip

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1600,15 +1600,16 @@ impl DataMsg {
 }
 
 /// What is currently uploaded to the GPU, so we only re-bin/re-upload on a real change.
-/// The `u64` is the palette generation (a color-table reload forces a re-bake); the trailing
-/// option is the storm-motion (east, north) m/s for storm-relative velocity.
+/// The trailing option is the storm-motion (east, north) m/s for storm-relative velocity.
+///
+/// The palette generation is deliberately *not* in here — it rides alongside in `pane_lut`, so
+/// a color-table change re-bakes the 3 KB LUT without re-binning or re-uploading the sweep.
 type ShownKey = (
     String,
     Moment,
     usize,
     Option<f32>,
     bool,
-    u64,
     Option<(u32, u32)>,
     bool,
     // Precipitation-tint generation: `None` when the tint is off, else the grid revision, so a
@@ -1890,6 +1891,8 @@ pub struct HookEchoApp {
     chasepack: Option<ChasePack>,
     /// Per-pane "what's uploaded" key, so each pane re-bins/re-uploads only on a real change.
     pane_shown: std::collections::HashMap<usize, ShownKey>,
+    /// Palette generation currently baked into each pane's LUT (see [`ShownKey`]).
+    pane_lut: std::collections::HashMap<usize, u64>,
     /// Last `(theme, system_dark, density, accent)` handed to `theme::apply`.
     theme_applied: Option<(
         crate::settings::Theme,
@@ -2841,6 +2844,7 @@ impl HookEchoApp {
             ipgeo_rx,
             chasepack: None,
             pane_shown: std::collections::HashMap::new(),
+            pane_lut: std::collections::HashMap::new(),
             theme_applied: None,
             settings_checked: None,
             frame_nr: 0,
@@ -9616,6 +9620,7 @@ impl HookEchoApp {
         let has_volume = self.views[data].volume.is_some();
         if !self.views[idx].show_radar || !has_volume {
             self.pane_shown.remove(&idx);
+            self.pane_lut.remove(&idx);
             return (None, false);
         }
         let count = self.views[data].elevation_count();
@@ -9669,12 +9674,15 @@ impl HookEchoApp {
             tilt,
             threshold,
             smooth,
-            self.palettes.gen,
             uv_key,
             dealias,
             self.settings.precip_tint.then_some(self.precip_flag_gen),
         );
-        if self.pane_shown.get(&idx) == Some(&key) {
+        let lut_gen = self.palettes.gen;
+        // Same sweep already up: the only thing left that can differ is the color table, and
+        // that is a 3 KB write into the texture already bound.
+        let lut_only = self.pane_shown.get(&idx) == Some(&key);
+        if lut_only && self.pane_lut.get(&idx) == Some(&lut_gen) {
             return (None, true);
         }
         let table = self.palettes.table(moment);
@@ -9694,11 +9702,22 @@ impl HookEchoApp {
                 return (None, true);
             }
             vol.binned(moment, tilt, dealias)
-                .map(|s| to_upload(s, table, threshold, smooth, storm_uv, precip.as_deref()))
+                .map(|s| {
+                    to_upload(
+                        s,
+                        table,
+                        threshold,
+                        smooth,
+                        storm_uv,
+                        precip.as_deref(),
+                        lut_only,
+                    )
+                })
         };
         match upload {
             Ok(up) => {
                 self.pane_shown.insert(idx, key);
+                self.pane_lut.insert(idx, lut_gen);
                 (Some(up), true)
             }
             Err(e) => {
@@ -13818,6 +13837,9 @@ pub(crate) fn to_upload(
     smooth: bool,
     storm_uv: Option<(f32, f32)>,
     precip: Option<&PrecipGrid>,
+    // Only the color table changed, so the sweep and precipitation-flag bytes the GPU already
+    // holds are still correct and are not copied.
+    lut_only: bool,
 ) -> RadarUpload {
     use crate::render::mercator::lonlat_to_world;
     let max_range_km = s.first_gate_km + s.gate_count as f32 * s.gate_interval_km;
@@ -13854,7 +13876,7 @@ pub(crate) fn to_upload(
     }
     let (precip_flag, flag_nx, flag_ny, flag_w, flag_n, flag_e, flag_s) = match tint {
         Some(g) => (
-            g.classes.clone(),
+            if lut_only { Vec::new() } else { g.classes.clone() },
             g.nx,
             g.ny,
             g.west,
@@ -13868,7 +13890,7 @@ pub(crate) fn to_upload(
     RadarUpload {
         az_bins: s.az_bins as u32,
         gate_count: s.gate_count as u32,
-        data: s.data.clone(),
+        data: if lut_only { Vec::new() } else { s.data.clone() },
         uniform: [
             s.radar_lat,
             s.radar_lon,
@@ -13895,6 +13917,7 @@ pub(crate) fn to_upload(
         precip_flag,
         world_min: [wx0 as f32, wy0 as f32],
         world_max: [wx1 as f32, wy1 as f32],
+        lut_only,
     }
 }
 
@@ -16517,6 +16540,35 @@ mod field_lut_tests {
 
 #[cfg(test)]
 mod tests {
+
+    /// A palette change must not re-send the sweep. Everything the GPU keeps (the gate bytes,
+    /// the precipitation-flag grid) is left out of a LUT-only upload; the color table and the
+    /// uniform, which are what a re-bake changes, are still there in full.
+    #[test]
+    fn a_palette_change_uploads_the_table_and_nothing_else() {
+        let sweep = wxdata::level2::BinnedSweep {
+            moment: wxdata::level2::Moment::Reflectivity,
+            az_bins: 360,
+            gate_count: 200,
+            data: vec![7u8; 360 * 200],
+            first_gate_km: 2.125,
+            gate_interval_km: 0.25,
+            radar_lat: 35.0,
+            radar_lon: -97.0,
+            elevation_deg: 0.5,
+            value_min: -32.0,
+            value_max: 95.0,
+        };
+        let table = crate::colormap::default_table(wxdata::level2::Moment::Reflectivity);
+        let full = super::to_upload(&sweep, table, None, false, None, None, false);
+        let lut = super::to_upload(&sweep, table, None, false, None, None, true);
+        assert_eq!(full.data.len(), 360 * 200);
+        assert!(lut.data.is_empty(), "the gate texture is already uploaded");
+        assert_eq!(lut.lut, full.lut, "the color table is what changed");
+        assert_eq!(lut.uniform, full.uniform);
+        assert_eq!((lut.az_bins, lut.gate_count), (360, 200));
+        assert!(lut.lut_only);
+    }
 
     /// The DWD arm exists because DL-DE/BY-2.0 requires the credit; the NOAA sites must stay
     /// uncredited so the corner is empty on the maps most users open.

--- a/crates/hookecho/src/headless.rs
+++ b/crates/hookecho/src/headless.rs
@@ -271,7 +271,7 @@ pub fn run(
         basemap_key: basemap.key(),
         vector_over_raster: false,
         radar_upload: Some(crate::app::to_upload(
-            &sweep, &table, None, smooth, storm_uv, None,
+            &sweep, &table, None, smooth, storm_uv, None, false,
         )),
         draw_radar: true,
         overlay_upload: None,
@@ -325,7 +325,7 @@ pub fn run_multipane(site: &str, out_a: &str, out_b: &str) -> anyhow::Result<()>
             new_tiles: Vec::new(),
             visible: Vec::new(),
             radar_upload: Some(crate::app::to_upload(
-                &sweep, &table, None, false, None, None,
+                &sweep, &table, None, false, None, None, false,
             )),
             draw_radar: true,
             overlay_upload: None,
@@ -989,7 +989,7 @@ pub fn run_live(out_path: &str, site: &str, moment: Moment) -> anyhow::Result<()
         new_tiles: Vec::new(),
         visible: Vec::new(),
         radar_upload: Some(crate::app::to_upload(
-            &sweep, &table, None, false, None, None,
+            &sweep, &table, None, false, None, None, false,
         )),
         draw_radar: true,
         overlay_upload: None,
@@ -2887,6 +2887,83 @@ mod golden_tests {
         }
     }
 
+    /// A loop frame and a palette drag must not rebuild GPU state that only ever changes shape.
+    ///
+    /// Ten renders of the same-shaped sweep plus five palette generations: one texture set and
+    /// one tile-quad list, not fifteen of each. Run under lavapipe like the golden below.
+    #[test]
+    #[ignore = "gpu"]
+    fn a_loop_and_a_palette_drag_rebuild_nothing() {
+        use wxdata::stats::Counter;
+        let sweep = synthetic_sweep();
+        let table = crate::colormap::default_table(Moment::Reflectivity).clone();
+        let camera = Camera::at_lonlat(sweep.radar_lon as f64, sweep.radar_lat as f64, 8.5);
+        let (center, scale) =
+            camera.world_to_clip_uniform((GOLDEN_SIZE as f32, GOLDEN_SIZE as f32));
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let Ok((device, queue, _adapter)) = init_gpu(&rt) else {
+            println!("SKIP: no wgpu adapter");
+            return;
+        };
+        let format = wgpu::TextureFormat::Rgba8UnormSrgb;
+        let mut res = RenderResources::new(&device, format);
+        let target = new_target(&device, format, GOLDEN_SIZE);
+        let view = target.create_view(&wgpu::TextureViewDescriptor::default());
+
+        let counter = |c: Counter| {
+            let label = wxdata::stats::Counter::LABELS[c as usize];
+            wxdata::stats::snapshot()
+                .into_iter()
+                .find(|(l, _)| *l == label)
+                .expect("counter")
+                .1
+        };
+        let before = (
+            counter(Counter::RadarTexturesBuilt),
+            counter(Counter::TileQuadsBuilt),
+        );
+
+        // Ten loop frames (a new sweep each time, same shape), then five LUT-only uploads.
+        for i in 0..15 {
+            let lut_only = i >= 10;
+            let mut cb = MapCallback {
+                pane: 0,
+                camera_center: center,
+                camera_scale: scale,
+                basemap_key: 0,
+                vector_over_raster: false,
+                new_tiles: Vec::new(),
+                visible: Vec::new(),
+                radar_upload: Some(crate::app::to_upload(
+                    &sweep, &table, None, false, None, None, lut_only,
+                )),
+                draw_radar: true,
+                overlay_upload: None,
+                draw_overlay: false,
+                field_uploads: Vec::new(),
+                field_draws: Vec::new(),
+                clear_tiles: false,
+                drop_tiles: Vec::new(),
+                new_vector_tiles: Vec::new(),
+                visible_vector: Vec::new(),
+                clear_vector: false,
+                drop_vector_tiles: Vec::new(),
+                wind_upload: None,
+                wind: None,
+            };
+            cb.draw_radar = true;
+            res.render_once(&device, &queue, &view, &cb, wgpu::Color::BLACK);
+        }
+        let built = counter(Counter::RadarTexturesBuilt) - before.0;
+        let quads = counter(Counter::TileQuadsBuilt) - before.1;
+        println!("radar_textures_built={built} tile_quads_built={quads} over 15 frames");
+        assert_eq!(built, 1, "same-shaped sweeps write into the retained textures");
+        assert_eq!(quads, 1, "a still camera keeps its tile quads");
+    }
+
     /// Golden-image test for the radar render pipeline. Run with
     /// `HOOKECHO_GPU_FALLBACK=1 cargo test -p hookecho -- --ignored gpu` so the
     /// software (lavapipe) adapter is used — the golden is authored under lavapipe.
@@ -2907,7 +2984,7 @@ mod golden_tests {
             new_tiles: Vec::new(),
             visible: Vec::new(),
             radar_upload: Some(crate::app::to_upload(
-                &sweep, &table, None, false, None, None,
+                &sweep, &table, None, false, None, None, false,
             )),
             draw_radar: true,
             overlay_upload: None,

--- a/crates/hookecho/src/render/mod.rs
+++ b/crates/hookecho/src/render/mod.rs
@@ -57,6 +57,10 @@ pub struct RadarUpload {
     /// World-space quad corners covering the disk (min/max box).
     pub world_min: [f32; 2],
     pub world_max: [f32; 2],
+    /// Only the color table changed: `data` and `precip_flag` are empty and the retained
+    /// textures keep their contents. A palette drag writes 3 KB instead of re-uploading the
+    /// ~1.3 MB gate texture it was already showing.
+    pub lut_only: bool,
 }
 
 /// A national gridded field layer (all share the MRMS warp pipeline; they differ only in data,
@@ -373,11 +377,15 @@ struct TileGpu {
 }
 
 struct RadarGpu {
-    _tex: wgpu::Texture,
-    _flag: wgpu::Texture,
-    _lut: wgpu::Texture,
-    _uni: wgpu::Buffer,
+    tex: wgpu::Texture,
+    flag: wgpu::Texture,
+    lut: wgpu::Texture,
+    uni: wgpu::Buffer,
     bind_group: wgpu::BindGroup,
+    /// (gate_count, az_bins) and the precipitation-flag grid size, so a later upload of the same
+    /// shape writes into these textures instead of building new ones with a new bind group.
+    dims: (u32, u32),
+    flag_dims: (u32, u32),
 }
 
 struct OverlayGpu {
@@ -407,6 +415,12 @@ struct PaneGpu {
     /// Ids of the tiles this frame's quads draw, in quad order. Not the same as the visible list:
     /// a missing tile is stood in for by resident children or an ancestor.
     frame_visible: Vec<TileKey>,
+    /// What the tile quads in `tile_vbuf` were built from: tile-cache generation, basemap, camera
+    /// and visible count. Unchanged means the quads are still the right ones, so a still map
+    /// re-uploads nothing.
+    // ponytail: the visible *count* rather than the list — camera plus generation already decide
+    // which tiles are asked for; compare the ids if a case ever shows a stale quad.
+    quads_key: Option<(u64, u8, u32, u32, u32, u32, usize)>,
     frame_visible_vector: Vec<TileId>,
     vector_over_raster: bool,
     frame_draw_radar: bool,
@@ -440,6 +454,9 @@ pub struct RenderResources {
     fields: HashMap<FieldLayer, MrmsGpu>,
     // One entry per live pane.
     panes: HashMap<u32, PaneGpu>,
+    /// Bumped whenever the shared tile cache gains or loses a texture, so a pane can tell that
+    /// its quad list is still current.
+    tiles_gen: u64,
     /// GPU wind particles, built on first use. `None` when the CPU path is in charge.
     wind: Option<crate::wind_gpu::WindGpu>,
     target_format: wgpu::TextureFormat,
@@ -741,6 +758,7 @@ impl RenderResources {
             overlay: None,
             fields: HashMap::new(),
             panes: HashMap::new(),
+            tiles_gen: 0,
             wind: None,
             target_format,
         }
@@ -783,6 +801,7 @@ impl RenderResources {
                 radar_vbuf,
                 radar: None,
                 frame_visible: Vec::new(),
+                quads_key: None,
                 frame_visible_vector: Vec::new(),
                 vector_over_raster: false,
                 frame_draw_radar: false,
@@ -896,7 +915,35 @@ impl RenderResources {
         );
     }
 
-    fn build_radar(&self, device: &wgpu::Device, queue: &wgpu::Queue, r: &RadarUpload) -> RadarGpu {
+    /// Upload one sweep for a pane, reusing `existing` when it is the same shape.
+    ///
+    /// Returns `None` only for a LUT-only upload with nothing retained to write into — which
+    /// the app does not ask for (it only sends one when the same key is already shown), but is
+    /// answered by leaving the pane's radar alone rather than by a panic.
+    fn build_radar(
+        &self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        r: &RadarUpload,
+        existing: Option<RadarGpu>,
+    ) -> Option<RadarGpu> {
+        let flag_dims = flag_dims(r);
+        // Same shape: write into the retained textures and keep the bind group. Dimensions are
+        // the only thing a bind group depends on here, so nothing else can go stale.
+        if let Some(g) = existing {
+            if g.dims == (r.gate_count, r.az_bins) && g.flag_dims == flag_dims {
+                if !r.lut_only {
+                    write_r8(queue, &g.tex, g.dims, &r.data);
+                    write_r8(queue, &g.flag, g.flag_dims, &flag_bytes(r, g.flag_dims));
+                }
+                queue.write_buffer(&g.uni, 0, bytemuck::cast_slice(&r.uniform));
+                write_lut(queue, &g.lut, &r.lut);
+                return Some(g);
+            }
+        }
+        if r.lut_only {
+            return None;
+        }
         wxdata::stats::bump(wxdata::stats::Counter::RadarTexturesBuilt);
         let size = wgpu::Extent3d {
             width: r.gate_count,
@@ -931,7 +978,7 @@ impl RenderResources {
         let uni = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("radar_uniform"),
             contents: bytemuck::cast_slice(&r.uniform),
-            usage: wgpu::BufferUsages::UNIFORM,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
 
         // 256×3 color LUT, indexed by the sweep u8 across and the precipitation type down.
@@ -971,12 +1018,8 @@ impl RenderResources {
 
         // Precipitation-type grid. One byte per cell; 1×1 of zeroes when the tint is off, which
         // the shader never reads because the tint flag in the uniform is zero too.
-        let (fnx, fny) = (r.uniform[11] as u32, r.uniform[12] as u32);
-        let (fnx, fny, flag_data) = if r.precip_flag.len() == (fnx * fny) as usize && fnx > 0 {
-            (fnx, fny, r.precip_flag.clone())
-        } else {
-            (1, 1, vec![0u8])
-        };
+        let (fnx, fny) = flag_dims;
+        let flag_data = flag_bytes(r, flag_dims);
         let flag_size = wgpu::Extent3d {
             width: fnx,
             height: fny,
@@ -1031,13 +1074,15 @@ impl RenderResources {
                 },
             ],
         });
-        RadarGpu {
-            _tex: tex,
-            _flag: flag_tex,
-            _lut: lut_tex,
-            _uni: uni,
+        Some(RadarGpu {
+            tex,
+            flag: flag_tex,
+            lut: lut_tex,
+            uni,
             bind_group,
-        }
+            dims: (r.gate_count, r.az_bins),
+            flag_dims,
+        })
     }
 
     /// Upload camera/tiles/radar for `cb` and stage its pane's draw list. Shared caches (tiles,
@@ -1068,57 +1113,9 @@ impl RenderResources {
         }
     }
 
-    fn upload_frame(&mut self, device: &wgpu::Device, queue: &wgpu::Queue, cb: &MapCallback) {
-        // --- Shared caches ---
-        if cb.clear_tiles {
-            self.tiles.clear();
-        }
-        if cb.clear_vector {
-            self.vector_tiles.clear();
-        }
-        for id in &cb.drop_vector_tiles {
-            self.vector_tiles.remove(id);
-        }
-        for t in &cb.new_vector_tiles {
-            self.upload_vector_tile(device, t);
-        }
-        for t in &cb.new_tiles {
-            self.upload_tile(device, queue, t);
-        }
-        if let Some(o) = &cb.overlay_upload {
-            self.upload_overlay(device, o);
-        }
-        // Grow to fit the frame before touching anything. A zoomed-out view can need more tiles
-        // than the resting cap, and promoting a visible tile into a full cache evicts another
-        // visible one — which showed up as a band of basemap with the rest of the map bare.
-        // The cap is a resting size, not a limit on what one frame may hold.
-        for id in &cb.drop_tiles {
-            self.tiles.remove(id);
-        }
-        // Touch everything this frame draws so the LRU evicts what is off screen, not what is in
-        // front of the user. Visible entries can't be evicted mid-frame: the caches only shrink
-        // here, before any drawing.
-        for (layer, up) in &cb.field_uploads {
-            let gpu = self.build_field_layer(device, queue, up);
-            self.fields.insert(*layer, gpu);
-        }
-        // Draw only the requested layers that actually have GPU data. Opacity rides in the grid
-        // uniform's first pad word, so it costs one 4-byte write per drawn layer — no LUT re-bake.
-        let mut field_draws = Vec::new();
-        for (layer, opacity) in &cb.field_draws {
-            if let Some(f) = self.fields.get(layer) {
-                queue.write_buffer(&f.uni, 24, &opacity.to_le_bytes());
-                field_draws.push(*layer);
-            }
-        }
-
-        // --- Per-pane state ---
-        let new_radar = cb
-            .radar_upload
-            .as_ref()
-            .map(|r| self.build_radar(device, queue, r));
-        // Build the tile quad list against the shared tile cache before mutably borrowing the pane
-        // — a tile with no texture yet borrows one from the tiles around it (see `tile_quads`).
+    /// The tile quads for this frame, and the tile ids they draw in quad order.
+    fn tile_verts(&self, cb: &MapCallback) -> (Vec<TileVertex>, Vec<TileKey>) {
+        wxdata::stats::bump(wxdata::stats::Counter::TileQuadsBuilt);
         let mut tverts: Vec<TileVertex> = Vec::new();
         let mut visible: Vec<TileKey> = Vec::new();
         for v in &cb.visible {
@@ -1157,6 +1154,79 @@ impl RenderResources {
                 visible.push(id);
             }
         }
+        (tverts, visible)
+    }
+
+    fn upload_frame(&mut self, device: &wgpu::Device, queue: &wgpu::Queue, cb: &MapCallback) {
+        // --- Shared caches ---
+        if cb.clear_tiles {
+            self.tiles.clear();
+        }
+        if cb.clear_vector {
+            self.vector_tiles.clear();
+        }
+        for id in &cb.drop_vector_tiles {
+            self.vector_tiles.remove(id);
+        }
+        for t in &cb.new_vector_tiles {
+            self.upload_vector_tile(device, t);
+        }
+        for t in &cb.new_tiles {
+            self.upload_tile(device, queue, t);
+        }
+        if let Some(o) = &cb.overlay_upload {
+            self.upload_overlay(device, o);
+        }
+        // Grow to fit the frame before touching anything. A zoomed-out view can need more tiles
+        // than the resting cap, and promoting a visible tile into a full cache evicts another
+        // visible one — which showed up as a band of basemap with the rest of the map bare.
+        // The cap is a resting size, not a limit on what one frame may hold.
+        for id in &cb.drop_tiles {
+            self.tiles.remove(id);
+        }
+        if cb.clear_tiles || !cb.new_tiles.is_empty() || !cb.drop_tiles.is_empty() {
+            self.tiles_gen = self.tiles_gen.wrapping_add(1);
+        }
+        // Touch everything this frame draws so the LRU evicts what is off screen, not what is in
+        // front of the user. Visible entries can't be evicted mid-frame: the caches only shrink
+        // here, before any drawing.
+        for (layer, up) in &cb.field_uploads {
+            let gpu = self.build_field_layer(device, queue, up);
+            self.fields.insert(*layer, gpu);
+        }
+        // Draw only the requested layers that actually have GPU data. Opacity rides in the grid
+        // uniform's first pad word, so it costs one 4-byte write per drawn layer — no LUT re-bake.
+        let mut field_draws = Vec::new();
+        for (layer, opacity) in &cb.field_draws {
+            if let Some(f) = self.fields.get(layer) {
+                queue.write_buffer(&f.uni, 24, &opacity.to_le_bytes());
+                field_draws.push(*layer);
+            }
+        }
+
+        // --- Per-pane state ---
+        let new_radar = match cb.radar_upload.as_ref() {
+            Some(r) => {
+                let existing = self.panes.get_mut(&cb.pane).and_then(|p| p.radar.take());
+                self.build_radar(device, queue, r, existing)
+            }
+            None => None,
+        };
+        // Build the tile quad list against the shared tile cache before mutably borrowing the pane
+        // — a tile with no texture yet borrows one from the tiles around it (see `tile_quads`).
+        // Skipped outright when nothing it depends on moved: a still map rebuilt up to 512 tiles
+        // worth of vertices and re-uploaded them every heartbeat frame.
+        let quads_key = (
+            self.tiles_gen,
+            cb.basemap_key,
+            cb.camera_center[0].to_bits(),
+            cb.camera_center[1].to_bits(),
+            cb.camera_scale[0].to_bits(),
+            cb.camera_scale[1].to_bits(),
+            cb.visible.len(),
+        );
+        let quads = (self.panes.get(&cb.pane).map(|p| p.quads_key) != Some(Some(quads_key)))
+            .then(|| self.tile_verts(cb));
         let overlay_present = self.overlay.is_some();
 
         let pane = self.pane_mut(device, cb.pane);
@@ -1184,10 +1254,13 @@ impl RenderResources {
         if let Some(radar) = new_radar {
             pane.radar = Some(radar);
         }
-        if !tverts.is_empty() {
-            queue.write_buffer(&pane.tile_vbuf, 0, bytemuck::cast_slice(&tverts));
+        if let Some((tverts, visible)) = quads {
+            if !tverts.is_empty() {
+                queue.write_buffer(&pane.tile_vbuf, 0, bytemuck::cast_slice(&tverts));
+            }
+            pane.frame_visible = visible;
+            pane.quads_key = Some(quads_key);
         }
-        pane.frame_visible = visible;
         pane.frame_visible_vector = cb.visible_vector.clone();
         pane.vector_over_raster = cb.vector_over_raster;
         pane.frame_draw_radar = cb.draw_radar && pane.radar.is_some();
@@ -1561,4 +1634,69 @@ mod tests {
         assert_eq!(min, [0.875, 0.875]);
         assert_eq!(max, [1.0, 1.0]);
     }
+}
+
+/// The precipitation-flag grid size for an upload: the grid the uniform declares when the tint
+/// is on and the bytes match it, else the 1×1 dummy every binding needs whether or not it is read.
+fn flag_dims(r: &RadarUpload) -> (u32, u32) {
+    let (nx, ny) = (r.uniform[11] as u32, r.uniform[12] as u32);
+    match r.precip_flag.len() == (nx * ny) as usize && nx > 0 {
+        true => (nx, ny),
+        false => (1, 1),
+    }
+}
+
+/// The precipitation-flag bytes to write for `dims` (the dummy grid is a single zero).
+fn flag_bytes(r: &RadarUpload, dims: (u32, u32)) -> Vec<u8> {
+    match dims == (1, 1) && r.precip_flag.len() != 1 {
+        true => vec![0u8],
+        false => r.precip_flag.clone(),
+    }
+}
+
+/// Write a full R8 texture of `dims`.
+fn write_r8(queue: &wgpu::Queue, tex: &wgpu::Texture, dims: (u32, u32), data: &[u8]) {
+    let (width, height) = dims;
+    queue.write_texture(
+        wgpu::TexelCopyTextureInfo {
+            texture: tex,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        data,
+        wgpu::TexelCopyBufferLayout {
+            offset: 0,
+            bytes_per_row: Some(width),
+            rows_per_image: Some(height),
+        },
+        wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+    );
+}
+
+/// Write the 256×3 RGBA color LUT.
+fn write_lut(queue: &wgpu::Queue, tex: &wgpu::Texture, lut: &[u8]) {
+    queue.write_texture(
+        wgpu::TexelCopyTextureInfo {
+            texture: tex,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        lut,
+        wgpu::TexelCopyBufferLayout {
+            offset: 0,
+            bytes_per_row: Some(256 * 4),
+            rows_per_image: Some(3),
+        },
+        wgpu::Extent3d {
+            width: 256,
+            height: 3,
+            depth_or_array_layers: 1,
+        },
+    );
 }

--- a/crates/wxdata/src/stats.rs
+++ b/crates/wxdata/src/stats.rs
@@ -41,6 +41,8 @@ pub enum Counter {
     SweepsBinned,
     /// Radar GPU textures built from scratch.
     RadarTexturesBuilt,
+    /// Tile-quad vertex lists rebuilt and re-uploaded.
+    TileQuadsBuilt,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -48,7 +50,7 @@ impl Counter {
     const COUNT: usize = Self::LABELS.len();
 
     /// Prometheus/log names, in declaration order.
-    pub const LABELS: [&'static str; 11] = [
+    pub const LABELS: [&'static str; 12] = [
         "net_requests",
         "net_bytes",
         "net_not_modified",
@@ -60,6 +62,7 @@ impl Counter {
         "frames_drawn",
         "sweeps_binned",
         "radar_textures_built",
+        "tile_quads_built",
     ];
 }
 


### PR DESCRIPTION
W10 of the performance plan (#213 was W9). Three things the renderer rebuilt every frame it had no reason to.

## Measured

15 renders of a same-shaped sweep — 10 loop frames plus 5 palette generations — under lavapipe, both paths in one test (`a_loop_and_a_palette_drag_rebuild_nothing`, `#[ignore = "gpu"]`):

| counter | before | after |
| --- | --- | --- |
| `radar_textures_built` | 15 | **1** |
| `tile_quads_built` | 15 | **1** |

## What changed

1. **Retained radar textures.** `build_radar` created four textures, a uniform buffer and a bind group per upload. It now writes into the retained ones when the shape matches — dimensions are the only thing the bind group depends on, so nothing else can go stale — and builds from scratch only on a dimension change.

2. **Palette-only uploads.** `palettes.gen` leaves `ShownKey` for a sibling `pane_lut` map. Same sweep, new color table now sends a `lut_only` upload: 3 KB of LUT plus the uniform, with `data` and `precip_flag` left empty rather than a ~1.3 MB gate-texture copy in `to_upload` and a second copy into a new texture. A LUT-only upload with nothing retained to write into leaves the pane's radar alone instead of panicking — the app only sends one when the same key is already shown.

3. **Tile quads.** The up-to-512-tile vertex list was rebuilt and re-uploaded every heartbeat frame, camera still or not. Now keyed on tile-cache generation, basemap, camera and visible count, and skipped when unchanged. `tiles_gen` is bumped in the one place the shared tile cache is mutated.

New `tile_quads_built` counter, so the skip shows up in the Perf window and `/metrics` the way the texture builds do.

## Gate

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 651 passed, 34 ignored
- wasm32 check — clean
- `./scripts/shots/shoot.sh check` — passed (pixel identity is this wave's contract)
- `./scripts/web/build.sh` — 4,094,866 gz against a 4,125,000 budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)