### PR TITLE
perf(wxdata): decode-path allocations

### DIFF
--- a/crates/wxdata/src/dwd.rs
+++ b/crates/wxdata/src/dwd.rs
@@ -262,9 +262,9 @@ pub async fn fetch_volume(
                 None => get(sweep_url(slug, wmo, tilt)).await?,
             };
             // The stamp has to come off the reflectivity file before anything else is asked for:
-            // it is the only name the other moments answer to.
-            let stamp = crate::odim::end_stamp(bytes.clone());
-            let (time, scan) = match crate::odim::decode(bytes) {
+            // it is the only name the other moments answer to — and it comes out of the same
+            // decode, rather than a second open and parse of the same ~190 KB.
+            let (time, scan, stamp) = match crate::odim::decode_with_stamp(bytes) {
                 Ok(v) => v,
                 Err(e) => {
                     // One unreadable elevation shouldn't cost the whole volume.
@@ -428,7 +428,8 @@ async fn finish_probe(
     };
     crate::stats::net(bytes.len());
     let bytes = bytes.to_vec();
-    let Ok((time, _)) = crate::odim::decode(bytes.clone()) else {
+    // Header only: the probe asks which volume this is, not what is in it.
+    let Ok(time) = crate::odim::start_time(bytes.clone()) else {
         return Probe::Unreadable;
     };
     let name = volume_name(id, time);
@@ -517,6 +518,11 @@ mod tests {
     #[test]
     fn the_end_stamp_names_the_sibling_files() {
         let stamp = crate::odim::end_stamp(fixture("00")).expect("end stamp");
+        // The decode reads it out of the file it is already holding; the two must agree, or a
+        // volume's dual-pol moments would be asked for under a name that does not exist.
+        let (_, _, from_decode) =
+            crate::odim::decode_with_stamp(fixture("00")).expect("decode with stamp");
+        assert_eq!(from_decode.as_deref(), Some(stamp.as_str()));
         assert_eq!(stamp.len(), 16, "{stamp}");
         assert!(stamp.chars().all(|c| c.is_ascii_digit()), "{stamp}");
         assert!(stamp.ends_with("00"), "centiseconds: {stamp}");

--- a/crates/wxdata/src/glm.rs
+++ b/crates/wxdata/src/glm.rs
@@ -163,10 +163,19 @@ impl GlmFeed {
     /// has to be cheap, so it's an extend and a re-sort rather than a re-poll.
     pub fn absorb(&mut self, other: GlmFeed) {
         self.last_keys.extend(other.last_keys);
+        // Both sides are already in time order, and a granule that just landed is normally newer
+        // than everything held — so the usual merge is an append. Only an out-of-order granule
+        // pays for a re-sort of the whole 15-minute window, under the painter's mutex.
+        let ordered = match (self.flashes.back(), other.flashes.front()) {
+            (Some(last), Some(first)) => first.time >= last.time,
+            _ => true,
+        };
         self.flashes.extend(other.flashes);
-        self.flashes
-            .make_contiguous()
-            .sort_by_key(|f| f.time.timestamp_millis());
+        if !ordered {
+            self.flashes
+                .make_contiguous()
+                .sort_by_key(|f| f.time.timestamp_millis());
+        }
         self.expire(Utc::now());
     }
 
@@ -474,6 +483,42 @@ mod density_tests {
 
 #[cfg(test)]
 mod tests {
+    /// A merge must leave the window in time order — that is what lets `expire` pop the front —
+    /// but the ordinary case (a granule newer than everything held) has to reach it without
+    /// re-sorting a quarter-hour of flashes under the painter's mutex.
+    #[test]
+    fn absorbing_keeps_the_window_in_time_order() {
+        use chrono::Utc;
+        // Inside the window: `absorb` expires as it goes, and a fixed epoch would be dropped.
+        let base = Utc::now() - chrono::Duration::seconds(120);
+        let flash = |secs: i64| super::Flash {
+            lon: -97.0,
+            lat: 35.0,
+            energy: 1.0,
+            time: base + chrono::Duration::seconds(secs),
+        };
+        let offsets = |f: &super::GlmFeed| -> Vec<i64> {
+            f.flashes()
+                .iter()
+                .map(|x| (x.time - base).num_seconds())
+                .collect()
+        };
+
+        let mut held = super::GlmFeed::new(15);
+        held.flashes.extend([flash(10), flash(20)]);
+
+        let mut newer = super::GlmFeed::new(15);
+        newer.flashes.extend([flash(30), flash(40)]);
+        held.absorb(newer);
+        assert_eq!(offsets(&held), vec![10, 20, 30, 40]);
+
+        // A granule that arrives late still lands in the right place.
+        let mut late = super::GlmFeed::new(15);
+        late.flashes.extend([flash(25), flash(50)]);
+        held.absorb(late);
+        assert_eq!(offsets(&held), vec![10, 20, 25, 30, 40, 50]);
+    }
+
     use super::*;
 
     fn flash(min_ago: i64) -> Flash {

--- a/crates/wxdata/src/level2.rs
+++ b/crates/wxdata/src/level2.rs
@@ -281,8 +281,8 @@ fn with_previous_tail(
 /// Recent day listings, so a site switch doesn't LIST the same S3 prefix two or three times over
 /// (the head poll and the timeline listing both want today's).
 ///
-/// ponytail: a flat map with a short TTL and no eviction — a session touches a handful of
-/// site/day pairs. Bound it if that ever stops being true.
+/// ponytail: a flat map with a short TTL, swept of expired entries on insert — a session touches
+/// a handful of site/day pairs at a time. Bound it by count if that ever stops being true.
 type DayListCache = std::collections::HashMap<
     (String, chrono::NaiveDate),
     (crate::clock::Instant, Vec<Identifier>),
@@ -324,6 +324,9 @@ async fn list_day(site: &str, date: chrono::NaiveDate) -> anyhow::Result<Vec<Ide
     ids.retain(|id| is_volume(id.name()));
     ids.sort_by_key(|id| id.date_time());
     if let Ok(mut map) = cache.lock() {
+        // Scrubbing a week of dates across a few sites left every one of those listings here for
+        // the life of the process; an expired entry can never be read, so drop it as we pass.
+        map.retain(|_, (at, _)| at.elapsed() < DAY_LIST_TTL);
         map.insert(key, (crate::clock::Instant::now(), ids.clone()));
     }
     Ok(ids)
@@ -555,21 +558,25 @@ const DEALIAS_REF_MAX_AGE_MS: i64 = 15 * 60 * 1000;
 /// ~7 MB field, and one of them is cheap where six would not be. Key it into a small map if
 /// flipping tilts on a folded storm turns out to matter.
 #[allow(clippy::type_complexity)]
-static DEALIAS_REF: std::sync::Mutex<Option<(DealiasKey, i64, Vec<Option<f32>>)>> =
+// The field is shared, never edited: an `Arc` so keeping it and handing it back both cost a
+// pointer instead of a ~10 MB copy each.
+static DEALIAS_REF: std::sync::Mutex<Option<(DealiasKey, i64, DealiasField)>> =
     std::sync::Mutex::new(None);
+
+type DealiasField = std::sync::Arc<Vec<Option<f32>>>;
 
 /// The previous pass over this tilt, if there is one and it is recent enough to mean anything.
 /// A reference from *later* than this sweep is a scrub backwards through the timeline: skipped,
 /// because "previous" is the only relationship the dealiaser can use.
-fn take_dealias_reference(key: &DealiasKey, at: i64) -> Option<Vec<Option<f32>>> {
+fn take_dealias_reference(key: &DealiasKey, at: i64) -> Option<DealiasField> {
     let guard = DEALIAS_REF.lock().ok()?;
     let (k, t, field) = guard.as_ref()?;
     (k == key && at > *t && at - *t <= DEALIAS_REF_MAX_AGE_MS).then(|| field.clone())
 }
 
-fn put_dealias_reference(key: DealiasKey, at: i64, field: &[Option<f32>]) {
+fn put_dealias_reference(key: DealiasKey, at: i64, field: DealiasField) {
     if let Ok(mut guard) = DEALIAS_REF.lock() {
-        *guard = Some((key, at, field.to_vec()));
+        *guard = Some((key, at, field));
     }
 }
 
@@ -719,9 +726,10 @@ pub fn bin_sweep_opts(
             AZ_BINS,
             gate_count,
             nyq,
-            reference.as_deref(),
+            reference.as_ref().map(|r| r.as_slice()),
         );
-        put_dealias_reference(key, at, &unfolded);
+        let unfolded: DealiasField = std::sync::Arc::new(unfolded);
+        put_dealias_reference(key, at, unfolded.clone());
         for (i, v) in unfolded.iter().enumerate() {
             if let Some(v) = v {
                 data[i] = normalize(*v);
@@ -1131,7 +1139,8 @@ mod tests {
             gate_count: 2,
         };
         let field = vec![Some(1.0), Some(2.0)];
-        put_dealias_reference(key, 100_000, &field);
+        let field = std::sync::Arc::new(field);
+        put_dealias_reference(key, 100_000, field.clone());
 
         assert_eq!(take_dealias_reference(&key, 400_000), Some(field.clone()));
         assert_eq!(take_dealias_reference(&key, 100_000), None, "same instant");

--- a/crates/wxdata/src/meteoalarm.rs
+++ b/crates/wxdata/src/meteoalarm.rs
@@ -75,16 +75,30 @@ pub async fn fetch_in_view(
     client: &reqwest::Client,
     bounds: (f64, f64, f64, f64),
 ) -> anyhow::Result<Vec<GeoFeature>> {
-    let mut out = Vec::new();
-    for slug in countries_in_view(bounds) {
+    // Up to eleven countries can be in view, and they were fetched one after another — eleven
+    // round trips deep instead of one wide, on a 120 s refresh.
+    let bodies = futures_util::future::join_all(countries_in_view(bounds).into_iter().map(|slug| {
         let url = crate::net::fetch_url(&format!("{FEED}{slug}"));
-        match client.get(&url).send().await {
-            Ok(resp) => match resp.text().await {
-                Ok(body) => out.extend(parse(&body)),
-                Err(e) => log::warn!("meteoalarm {slug}: body read failed ({e})"),
-            },
-            Err(e) => log::warn!("meteoalarm {slug}: fetch failed ({e})"),
+        async move {
+            match client.get(&url).send().await {
+                Ok(resp) => match resp.text().await {
+                    Ok(body) => Some(body),
+                    Err(e) => {
+                        log::warn!("meteoalarm {slug}: body read failed ({e})");
+                        None
+                    }
+                },
+                Err(e) => {
+                    log::warn!("meteoalarm {slug}: fetch failed ({e})");
+                    None
+                }
+            }
         }
+    }))
+    .await;
+    let mut out = Vec::new();
+    for body in bodies.into_iter().flatten() {
+        out.extend(parse(&body));
     }
     Ok(out)
 }

--- a/crates/wxdata/src/odim.rs
+++ b/crates/wxdata/src/odim.rs
@@ -81,7 +81,12 @@ struct Moment {
 /// a moment with no `-LATEST-` symlink is otherwise reachable only by downloading a megabyte of
 /// directory index to learn one name.
 pub fn end_stamp(bytes: Vec<u8>) -> Option<String> {
-    let f = hdf5lite::File::open(bytes).ok()?;
+    stamp_of(&hdf5lite::File::open(bytes).ok()?)
+}
+
+/// The sweep end stamp from an already-open file, so a caller that is decoding anyway does not
+/// open and parse the same ~190 KB a second time to read two attributes.
+fn stamp_of(f: &hdf5lite::File) -> Option<String> {
     let what = f.attributes("dataset1/what").ok()?;
     let (d, t) = (text(&what, "enddate")?, text(&what, "endtime")?);
     // Anything else would name a file that cannot exist; better no velocity than a wild URL.
@@ -93,7 +98,28 @@ pub fn end_stamp(bytes: Vec<u8>) -> Option<String> {
 ///
 /// Sweeps come out in file order, which ODIM requires to be ascending elevation.
 pub fn decode(bytes: Vec<u8>) -> anyhow::Result<(DateTime<Utc>, Scan)> {
+    let (time, scan, _) = decode_with_stamp(bytes)?;
+    Ok((time, scan))
+}
+
+/// The volume's nominal start time, without decoding a single ray.
+///
+/// The DWD probe only wants to know *which* volume a file belongs to; reading the root `what`
+/// group answers that for the cost of an open, where a full decode allocates a `Vec` per ray per
+/// moment for a scan it is about to throw away.
+pub fn start_time(bytes: Vec<u8>) -> anyhow::Result<DateTime<Utc>> {
     let f = hdf5lite::File::open(bytes).map_err(|e| anyhow::anyhow!("odim: {e}"))?;
+    let root_what = f.attributes("what").map_err(|e| anyhow::anyhow!("{e}"))?;
+    timestamp(&root_what, "date", "time")
+        .ok_or_else(|| anyhow::anyhow!("odim: no usable /what/date and /what/time"))
+}
+
+/// [`decode`], plus the sweep end stamp the DWD feed names its dual-pol files by.
+pub fn decode_with_stamp(
+    bytes: Vec<u8>,
+) -> anyhow::Result<(DateTime<Utc>, Scan, Option<String>)> {
+    let f = hdf5lite::File::open(bytes).map_err(|e| anyhow::anyhow!("odim: {e}"))?;
+    let stamp = stamp_of(&f);
 
     let root_what = f.attributes("what").map_err(|e| anyhow::anyhow!("{e}"))?;
     let object = text(&root_what, "object").unwrap_or_default();
@@ -152,7 +178,7 @@ pub fn decode(bytes: Vec<u8>) -> anyhow::Result<(DateTime<Utc>, Scan)> {
         false,
         Vec::new(),
     );
-    Ok((time, Scan::with_site(site, vcp, sweeps)))
+    Ok((time, Scan::with_site(site, vcp, sweeps), stamp))
 }
 
 /// The four-letter id from an ODIM `source` string, which is comma-separated `KEY:value` pairs.


### PR DESCRIPTION
W11 of the performance plan (#214 was W10). Five contained fixes on the decode path, plus one finding that turned out not to be ours to fix.

## Measured

Committed DWD fixture, release, 20 iterations, per call:

| path | before | after |
| --- | --- | --- |
| DWD probe | full decode **1.340 ms** | `start_time` **2.3 µs** |
| DWD tilt | `end_stamp` + `decode` **1.121 ms** | `decode_with_stamp` **1.029 ms** |
| dealias reference (6.9 MB, twice per binned velocity sweep) | `clone` + `to_vec` **501 µs** | two `Arc` clones **6 ns** |

## What changed

1. **DWD probe** decoded the whole ~190 KB file — every ray of every moment — to read two attributes and throw the scan away. `odim::start_time` opens the file and reads the root `what` group instead.
2. **DWD tilt** opened and parsed the same file twice: once for the sweep end stamp that names the dual-pol siblings, once for the data. `odim::decode_with_stamp` returns both from one parse, and the 190 KB clone feeding the second open is gone. `decode` stays as the wrapper everything else calls. A test pins the two stamps equal — they name URLs, and a disagreement would ask for files that do not exist.
3. **Dealias reference** is a ~7 MB `Vec<Option<f32>>` copied in and copied out once per binned velocity sweep. Shared, never edited, so it is an `Arc`.
4. **GLM `absorb`** re-sorted the whole 15-minute window under the painter's mutex. Both sides are already in time order and a fresh granule is normally newer than everything held, so the ordinary merge is an append; only an out-of-order granule pays for the sort. Test covers both.
5. **MeteoAlarm** fetched up to eleven countries serially on a 120 s refresh. `join_all`, like level3 and dwd already do.
6. **`DAY_LIST_CACHE`** never dropped expired entries; swept on insert.

## Not done

ODIM's per-ray `Vec` per moment (finding #9). `MomentData::from_fixed_point` takes an owned `Vec<u8>` per radial, so that allocation belongs to nexrad-model's API rather than to this decoder — removing it means changing that crate, which is not this wave.

## Gate

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 652 passed, 34 ignored
- wasm32 check — clean
- `./scripts/shots/shoot.sh check` — passed
- `./scripts/web/build.sh` — 4,096,608 gz against a 4,125,000 budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)