### PR TITLE
perf(app): one janitor thread, after the launch

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -2683,6 +2683,10 @@ impl HookEchoApp {
         // 4096. Field grids (MRMS rotation/AzShear reach 14000 px) are decimated to fit this.
         let max_texture_dim = render_state.device.limits().max_texture_dimension_2d;
         {
+            // Shaders and pipelines are compiled here, synchronously, before the first paint —
+            // the suspected dominant term in a cold launch. Timed so the guess is a number.
+            #[cfg(not(target_arch = "wasm32"))]
+            let pipelines_at = std::time::Instant::now();
             let mut w = render_state.renderer.write();
             w.callback_resources.insert(RenderResources::new(
                 &render_state.device,
@@ -2693,6 +2697,11 @@ impl HookEchoApp {
                     &render_state.device,
                     render_state.target_format,
                 ));
+            #[cfg(not(target_arch = "wasm32"))]
+            log::info!(
+                "perf: pipelines compiled in {} ms",
+                pipelines_at.elapsed().as_millis()
+            );
         }
 
         let mut settings = Settings::load();
@@ -2737,31 +2746,19 @@ impl HookEchoApp {
         // Archived volumes are kept on disk forever within a cap; same startup sweep the tile
         // caches get, for the same reason (mid-session deletion would race the fetch tasks).
         if let Some(root) = crate::paths::cache_dir().map(|d| d.join("volumes")) {
-            std::thread::spawn(move || {
-                crate::tiles::sweep_cache_dir(
-                    &root,
-                    "volume cache",
-                    crate::tiles::volume_cache_bytes(),
-                )
-            });
+            crate::tiles::sweep_later(root, "volume cache", crate::tiles::volume_cache_bytes());
         }
         // The small caches had no sweep at all: zone geometry and archived RAOB soundings grew
         // for the life of the install. They are small enough that the cap is a tripwire.
         if let Some(dir) = crate::paths::cache_dir() {
-            std::thread::spawn(move || {
-                for (sub, label) in [
-                    ("zones", "zone cache"),
-                    ("raob", "RAOB cache"),
-                    ("snapshots", "snapshot cache"),
-                    ("pficons", "placefile icon cache"),
-                ] {
-                    crate::tiles::sweep_cache_dir(
-                        &dir.join(sub),
-                        label,
-                        crate::tiles::SMALL_CACHE_BYTES,
-                    );
-                }
-            });
+            for (sub, label) in [
+                ("zones", "zone cache"),
+                ("raob", "RAOB cache"),
+                ("snapshots", "snapshot cache"),
+                ("pficons", "placefile icon cache"),
+            ] {
+                crate::tiles::sweep_later(dir.join(sub), label, crate::tiles::SMALL_CACHE_BYTES);
+            }
         }
         let mut tiles = TileManager::new(spawner.clone());
         let mut vtiles = crate::vector_tiles::VectorTileManager::new(spawner.clone());

--- a/crates/hookecho/src/elevation.rs
+++ b/crates/hookecho/src/elevation.rs
@@ -69,7 +69,7 @@ pub fn tile_url(x: u32, y: u32) -> String {
 }
 
 /// Disk path a DEM tile caches at. Mirrors the basemap layout (`<root>/<provider>/default/z/x/y`)
-/// so `sweep_tile_cache` and the chase-pack downloader need no special case.
+/// so the tile-cache sweep and the chase-pack downloader need no special case.
 pub fn tile_path(root: &std::path::Path, x: u32, y: u32) -> std::path::PathBuf {
     root.join(DEM_PROVIDER)
         .join("default")

--- a/crates/hookecho/src/main.rs
+++ b/crates/hookecho/src/main.rs
@@ -34,6 +34,7 @@ fn main() -> eframe::Result<()> {
         );
     }
 
+    hookecho::perf::mark_start();
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
     // A panic on the desktop goes to a terminal nobody launched the app from; leave a report the
     // next start can offer back instead.

--- a/crates/hookecho/src/perf.rs
+++ b/crates/hookecho/src/perf.rs
@@ -28,9 +28,26 @@ pub struct PerfReadout {
     /// The idle repaint interval the app last asked for, in ms — the number the heartbeat work
     /// moves, and the one that explains the frame rate above it.
     pub idle_ms: u64,
-    /// Process start, for the startup line.
+    /// Process start, for the startup line — the real one when `mark_start` was called, else
+    /// this struct's construction, which is as early as a library-only build can see.
     start: Instant,
     first_frame: Option<Duration>,
+}
+
+/// Process start, for the startup line.
+///
+/// Set from `main` before anything else runs. Without it the startup number would begin at app
+/// construction and miss the window, the adapter and the pipeline compile — which is most of what
+/// a launch costs and the whole reason to measure it.
+static START: std::sync::OnceLock<Instant> = std::sync::OnceLock::new();
+
+/// Stamp the start of the process. Idempotent; the first call wins.
+pub fn mark_start() {
+    let _ = START.set(Instant::now());
+}
+
+fn process_start() -> Instant {
+    *START.get_or_init(Instant::now)
 }
 
 impl Default for PerfReadout {
@@ -47,7 +64,7 @@ impl PerfReadout {
             base: wxdata::stats::snapshot(),
             rates: Vec::new(),
             idle_ms: 0,
-            start: Instant::now(),
+            start: process_start(),
             first_frame: None,
         }
     }

--- a/crates/hookecho/src/tiles.rs
+++ b/crates/hookecho/src/tiles.rs
@@ -1189,7 +1189,7 @@ impl TileManager {
                 .expect("build reqwest client");
         let cache_root = crate::paths::cache_dir().map(|d| d.join("tiles"));
         if let Some(root) = cache_root.clone() {
-            std::thread::spawn(move || sweep_tile_cache(&root));
+            sweep_later(root, "tile cache", tile_cache_bytes());
         }
         Self {
             spawner,
@@ -1682,7 +1682,7 @@ pub async fn fetch_visible(
 /// Read-through disk cache: return the cached PNG if present, else fetch and store it.
 ///
 /// A corrupt/partial cache file just fails to decode upstream and gets re-fetched next view,
-/// so no locking or temp-rename dance is needed. Bounded by [`sweep_tile_cache`] at startup.
+/// so no locking or temp-rename dance is needed. Bounded by the startup sweep (see [`sweep_later`]).
 pub(crate) async fn load_tile_bytes(
     client: &reqwest::Client,
     url: &str,
@@ -1735,11 +1735,6 @@ pub(crate) const DISK_CACHE_BYTES: u64 = if cfg!(target_os = "android") {
     500 * 1024 * 1024
 };
 
-/// Trim the on-disk tile cache to [`tile_cache_bytes`], oldest-touched first.
-pub(crate) fn sweep_tile_cache(root: &std::path::Path) {
-    sweep_cache_dir(root, "tile cache", tile_cache_bytes());
-}
-
 /// User overrides for the two disk caps, in bytes; 0 means "use the platform default".
 ///
 /// Globals because the sweeps run from three places that construct before — and without — the
@@ -1777,6 +1772,68 @@ pub(crate) fn volume_cache_bytes() -> u64 {
 /// writing into it, and a file deleted out from under a read just gets re-fetched anyway. Chase
 /// packs live under the tile root and are deliberately not spared — they are re-downloadable, and
 /// a pack the user still cares about is a pack they have been looking at recently.
+/// How long a cache sweep waits before it starts.
+///
+/// Four janitor threads used to walk four cache trees while the app was still opening its window,
+/// reading its settings and asking for its first tiles — competing for the same disk with the
+/// reads a launch is actually waiting on. Nothing here is urgent: these caps are tripwires
+/// against a cache that grew for weeks.
+#[cfg(not(target_arch = "wasm32"))]
+fn janitor_delay() -> std::time::Duration {
+    // Tests want the same thread, spawn and drain, not the wait.
+    match cfg!(test) {
+        true => std::time::Duration::from_millis(50),
+        false => std::time::Duration::from_secs(20),
+    }
+}
+
+/// One sweep job: the directory, what to call it in the log, and its cap.
+#[cfg(not(target_arch = "wasm32"))]
+struct SweepJob(std::path::PathBuf, &'static str, u64);
+
+#[cfg(not(target_arch = "wasm32"))]
+static JANITOR: std::sync::Mutex<(Vec<SweepJob>, bool)> = std::sync::Mutex::new((Vec::new(), false));
+
+/// Queue a cache sweep for the shared janitor: one thread, started once, running every queued
+/// sweep in turn after [`janitor_delay`].
+///
+/// ponytail: a `Vec` and a `bool` rather than a channel — the queue is four entries deep at
+/// startup and empty forever after.
+pub(crate) fn sweep_later(root: std::path::PathBuf, label: &'static str, cap: u64) {
+    // The browser has no cache directory to sweep and no threads to sweep it with; the callers
+    // are the same on both targets so the caps have one definition, not two.
+    #[cfg(target_arch = "wasm32")]
+    let _ = (root, label, cap);
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let Ok(mut j) = JANITOR.lock() else { return };
+        j.0.push(SweepJob(root, label, cap));
+        if j.1 {
+            return;
+        }
+        j.1 = true;
+        std::thread::spawn(|| {
+            std::thread::sleep(janitor_delay());
+            loop {
+                // The flag is cleared under the same lock the queue is popped from, so a sweep
+                // queued after this thread gives up starts a new one rather than being forgotten.
+                let job = {
+                    let Ok(mut j) = JANITOR.lock() else { return };
+                    match j.0.pop() {
+                        Some(job) => job,
+                        None => {
+                            j.1 = false;
+                            return;
+                        }
+                    }
+                };
+                sweep_cache_dir(&job.0, job.1, job.2);
+            }
+        });
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn sweep_cache_dir(root: &std::path::Path, label: &str, cap: u64) {
     fn walk(
         dir: &std::path::Path,
@@ -2001,6 +2058,26 @@ mod tests {
             pack_tile_ids(-99.0, 34.0, -96.0, 36.0, 7, 9).len() as u64,
             pack_tile_count(-99.0, 34.0, -96.0, 36.0, 7, 9)
         );
+    }
+
+    /// The janitor really does run: one thread, spawned once, sweeping every queued directory
+    /// after its delay. Without this the sweeps could stop happening and nothing would say so —
+    /// `sweep_cache_dir` is silent when a cache is under its cap.
+    #[test]
+    fn the_janitor_thread_sweeps_what_is_queued() {
+        let root = std::env::temp_dir().join(format!("hookecho-janitor-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&root);
+        let file = root.join("big.bin");
+        std::fs::write(&file, vec![0u8; 4096]).expect("write");
+        super::sweep_later(root.clone(), "janitor test", 1024);
+        for _ in 0..100 {
+            if !file.exists() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        assert!(!file.exists(), "the queued sweep never ran");
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/crates/hookecho/src/vector_tiles.rs
+++ b/crates/hookecho/src/vector_tiles.rs
@@ -583,7 +583,7 @@ impl VectorTileManager {
         let cache_root = crate::paths::cache_dir().map(|d| d.join("vector"));
         // The vector cache grew forever; the raster one has been swept at startup all along.
         if let Some(root) = cache_root.clone() {
-            std::thread::spawn(move || crate::tiles::sweep_tile_cache(&root));
+            crate::tiles::sweep_later(root, "vector tile cache", crate::tiles::tile_cache_bytes());
         }
         Self {
             spawner,


### PR DESCRIPTION
W15 of the performance plan (#218 was W14). Four threads walked four cache trees at launch; they are one thread now, and it waits 20 seconds first.

## Measured first — and two of the findings go against the plan

| | |
| --- | --- |
| pipelines compiled | **2 ms** (the plan's "suspected dominant term") |
| first frame, 3 cold launches, before | 284 / 257 / 256 ms |
| first frame, 3 cold launches, after | 241 / 254 / 254 ms |

**The synchronous pipeline compile is not what a cold launch costs**, so the async-pipeline follow-up the plan held in reserve is not warranted — at least on this box (RTX 4080, Vulkan).

**Nor is the stagger a measurable startup win here.** The four janitors ran in parallel with a 250 ms launch on an NVMe with a warm dentry cache. What they were doing during it, measured against this machine's 3.1 GB cache: **21,000 `stat` calls over five directories, ~80 ms of walking**, all of it concurrent with the reads a launch is waiting on. That is what moved off the launch window; on a phone or a cold cache it is not 80 ms. I am not claiming a first-frame number this change did not produce.

## The startup line had to be fixed before it could say any of that

It measured from `PerfReadout::new`, which is inside app construction — 1 ms, and blind to the window, the adapter and the pipelines. `perf::mark_start` is called first thing in `main` now, and the pipeline compile is timed and logged.

## The janitor

`sweep_later` queues; one thread drains serially after the delay, clearing its running flag under the same lock the queue is popped from, so a sweep queued after it gives up starts a new one rather than being forgotten. A test covers that path — `sweep_cache_dir` is silent when a cache is under its cap, so "the sweeps quietly stopped happening" is exactly the regression nothing else would catch.

## Gate

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 654 passed, 34 ignored
- wasm32 check — clean, no new warnings
- `./scripts/shots/shoot.sh check` — passed
- `./scripts/web/build.sh` — 4,097,941 gz against a 4,125,000 budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)