### PR TITLE
perf(site): landing and docs delivery

### DIFF
--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -50,6 +50,7 @@ const LITE = "https://app.hookecho.io/lite/";
   if (backdrop && lite) {
     activeSite()
       .then((site) => {
+        if (!site) return;
         const frame = document.createElement("iframe");
         frame.src = `${lite}?site=${site.id}&hero=1`;
         frame.title = "";

--- a/site/src/components/LiveMosaic.astro
+++ b/site/src/components/LiveMosaic.astro
@@ -32,7 +32,13 @@ const everyMs = 5 * 60 * 1000;
     setInterval(() => {
       // Only while the tab is visible: a backgrounded tab refreshing a national radar image all
       // day is exactly the kind of thing that gets a hotlink blocked.
-      if (document.visibilityState === "visible") img.src = `${src}?t=${Date.now()}`;
+      // Quantized to the refresh cycle rather than `Date.now()`: a unique URL per tab per
+      // refresh is uncacheable by construction, so every tab pulled the whole GIF from the NWS
+      // every five minutes. Every tab in a cycle now asks for the same URL, and the second one
+      // is a cache hit.
+      if (document.visibilityState === "visible") {
+        img.src = `${src}?t=${Math.floor(Date.now() / every)}`;
+      }
     }, every);
   }
 </script>

--- a/site/src/components/StormCard.astro
+++ b/site/src/components/StormCard.astro
@@ -25,6 +25,7 @@ import Icon from "./Icon.astro";
   if (card) {
     activeSite()
       .then((site) => {
+        if (!site) return;
         const warnings =
           site.warnings === 1 ? "1 active warning" : `${site.warnings} active warnings`;
         card.querySelector(".where")!.textContent = `${site.city}, ${site.state}`;

--- a/site/src/layouts/Docs.astro
+++ b/site/src/layouts/Docs.astro
@@ -55,7 +55,15 @@ const next = at >= 0 && at < pages.length - 1 ? pages[at + 1] : undefined;
 <!-- Pagefind builds its bundle from dist after astro build (the postbuild script), so these two
      files do not exist during dev and 404 there. is:inline keeps Vite from trying to resolve a
      path that is not on disk yet. Failing quietly is right: the sidebar is the fallback. -->
-<link rel="stylesheet" href="/pagefind/pagefind-ui.css" />
+<!-- Loaded without blocking the render: the search box is one widget on a documentation page,
+     and its stylesheet was holding up the text people came for. `media="print"` makes it a
+     non-blocking fetch; onload flips it back to every medium. -->
+<link
+  rel="stylesheet"
+  href="/pagefind/pagefind-ui.css"
+  media="print"
+  onload="this.media='all'"
+/>
 <script is:inline type="module">
   import("/pagefind/pagefind-ui.js")
     .then(({ PagefindUI }) => {

--- a/site/src/pages/nexrad-sites.json.ts
+++ b/site/src/pages/nexrad-sites.json.ts
@@ -1,0 +1,24 @@
+/*
+  The site list the landing page's hero ranking needs, and nothing else.
+
+  It used to be an `import` in `active-site.ts`, which meant the whole 52 KB registry — every
+  network, every field — was bundled into the landing page's JavaScript and parsed before the
+  page could do anything with it. Prerendered here instead and fetched when the ranking actually
+  runs: five fields, US radars only, because that is all the ranking reads.
+*/
+import sites from "../data/nexrad-sites.json";
+
+export const prerender = true;
+
+export function GET() {
+  const slim = sites
+    .filter((s) => s.network === "nexrad")
+    .map(({ id, city, state, lat, lon }) => ({ id, city, state, lat, lon }));
+  return new Response(JSON.stringify(slim), {
+    headers: {
+      "content-type": "application/json",
+      // The registry changes when the app ships a new one, which is a new deploy.
+      "cache-control": "public, max-age=3600",
+    },
+  });
+}

--- a/site/src/scripts/active-site.ts
+++ b/site/src/scripts/active-site.ts
@@ -6,7 +6,6 @@
   Everything is client-side and unauthenticated against api.weather.gov, which is CORS-open and
   public. No key, no proxy, no backend.
 */
-import sites from "../data/nexrad-sites.json";
 import { milesBetween } from "../data/geo";
 
 export interface ActiveSite {
@@ -28,13 +27,31 @@ const WEIGHT: Record<string, number> = {
   "Flash Flood Warning": 1,
 };
 
+interface Site {
+  id: string;
+  city: string;
+  state: string;
+  lat: number;
+  lon: number;
+}
+
 // TDWR sites are terminal radars with a short range and no RIDGE loop; they never lead the page.
 // The international rows are out for a different reason: the ranking below is driven entirely by
-// api.weather.gov, so pairing a German radar with a US warning count would be a lie.
-const NEXRAD = sites.filter((s) => s.network === "nexrad");
-type Site = (typeof NEXRAD)[number];
+// api.weather.gov, so pairing a German radar with a US warning count would be a lie. Both filters
+// happen where the file is built (`/nexrad-sites.json`), so no page ships the rows it cannot use.
+//
+// Fetched rather than imported: bundling the registry put 52 KB of JSON — 38 KB of generated
+// JavaScript — in front of every landing page, for a list only the hero ranking reads.
+let registry: Promise<Site[]> | null = null;
+function nexrad(): Promise<Site[]> {
+  registry ??= fetch("/nexrad-sites.json")
+    .then((r) => (r.ok ? r.json() : []))
+    .catch(() => [] as Site[]);
+  return registry;
+}
 
-const fallback = () => NEXRAD.find((s) => s.id === "KTLX") ?? NEXRAD[0];
+const fallback = (list: Site[]) =>
+  list.find((s) => s.id === "KTLX") ?? list[0] ?? null;
 
 /** Mean of a polygon's outer ring — close enough to "where the warning is" for ranking. */
 function centroid(feature: any): { lat: number; lon: number } | null {
@@ -49,10 +66,10 @@ function centroid(feature: any): { lat: number; lon: number } | null {
   return { lat: lat / ring.length, lon: lon / ring.length };
 }
 
-function nearest(point: { lat: number; lon: number }) {
-  let best: Site = NEXRAD[0];
+function nearest(list: Site[], point: { lat: number; lon: number }) {
+  let best: Site | null = list[0] ?? null;
   let bestMiles = Infinity;
-  for (const site of NEXRAD) {
+  for (const site of list) {
     const miles = milesBetween(point, site);
     if (miles < bestMiles) {
       bestMiles = miles;
@@ -62,20 +79,23 @@ function nearest(point: { lat: number; lon: number }) {
   return best;
 }
 
-async function visitorSite(): Promise<ActiveSite> {
+async function visitorSite(list: Site[]): Promise<ActiveSite | null> {
   // The site's own edge worker (site/public/_worker.js) hands back the visitor's rough location.
   try {
     const geo = await fetch("/geo.json").then((r) => (r.ok ? r.json() : null));
     if (typeof geo?.lat === "number" && typeof geo?.lon === "number") {
-      return { ...nearest({ lat: geo.lat, lon: geo.lon }), warnings: 0 };
+      const near = nearest(list, { lat: geo.lat, lon: geo.lon });
+      if (near) return { ...near, warnings: 0 };
     }
   } catch {
     // fall through
   }
-  return { ...fallback(), warnings: 0 };
+  const back = fallback(list);
+  return back ? { ...back, warnings: 0 } : null;
 }
 
-async function pick(): Promise<ActiveSite> {
+async function pick(): Promise<ActiveSite | null> {
+  const list = await nexrad();
   try {
     const url =
       "https://api.weather.gov/alerts/active?status=actual&event=" +
@@ -87,7 +107,8 @@ async function pick(): Promise<ActiveSite> {
     for (const feature of data?.features ?? []) {
       const at = centroid(feature);
       if (!at) continue;
-      const site = nearest(at);
+      const site = nearest(list, at);
+      if (!site) continue;
       const weight = WEIGHT[feature?.properties?.event] ?? 1;
       const row = scores.get(site.id) ?? { score: 0, count: 0 };
       row.score += weight;
@@ -103,19 +124,25 @@ async function pick(): Promise<ActiveSite> {
       }
     }
     if (bestId) {
-      const site = NEXRAD.find((s) => s.id === bestId)!;
+      const site = list.find((s) => s.id === bestId)!;
       return { ...site, warnings: scores.get(bestId)!.count };
     }
   } catch {
     // A quiet map or a blocked fetch both land on the visitor's own radar, which is never wrong.
   }
-  return visitorSite();
+  return visitorSite(list);
 }
 
-let cached: Promise<ActiveSite> | null = null;
+let cached: Promise<ActiveSite | null> | null = null;
 
-/** The most-active radar site right now, or the visitor's nearest when the country is quiet. */
-export function activeSite(): Promise<ActiveSite> {
+/**
+ * The most-active radar site right now, or the visitor's nearest when the country is quiet.
+ *
+ * `null` only when the registry itself could not be fetched — callers already had to handle a
+ * failed ranking, and a hero with no backdrop is better than one built from a site that is not
+ * in the list.
+ */
+export function activeSite(): Promise<ActiveSite | null> {
   cached ??= pick();
   return cached;
 }


### PR DESCRIPTION
W16 of the performance plan (#219 was W15) — **the last wave**. Three delivery fixes on the marketing site; no app code.

## Measured

From `site/dist`, before and after:

| | before | after |
| --- | --- | --- |
| `active-site` chunk | 37.4 KB | **1.6 KB** |
| total `/_astro` JS | 60,041 B | **23,435 B** (−61%) |

## What changed

1. **The registry left the landing bundle.** `active-site.ts` imported the 52 KB site registry, so every landing page shipped and parsed 37 KB of generated JavaScript for a list only the hero ranking reads. It is a prerendered `/nexrad-sites.json` now — five fields, US radars only, 11.2 KB raw / 3.5 KB gzipped — fetched when the ranking runs. Both filters (TDWR out, international out) moved to where the file is built, so no page ships rows it cannot use.

   `activeSite()` can now answer `null`, when the registry itself fails to arrive. Callers already had to handle a failed ranking, and a hero with no backdrop beats one built from a site that is not in the list.

2. **LiveMosaic stopped defeating the cache.** `?t=${Date.now()}` is a unique URL per tab per refresh — uncacheable by construction, so every tab pulled the whole GIF from the NWS every five minutes. The stamp is quantized to the refresh cycle: every tab in a cycle asks for the same URL, and the second one is a cache hit. Same freshness, same cadence.

3. **Pagefind CSS no longer blocks the docs render.** `media="print"` + `onload` makes it a non-blocking fetch for a search box that is one widget on the page.

## Gate

- `npm run build` — clean
- `npm run linkcheck` — 736 links, no failures
- Rust workspace untouched and still green: clippy clean, `cargo test --workspace` 654 passed / 34 ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)