### PR TITLE
feat(headless): every network renders

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -9716,18 +9716,17 @@ impl HookEchoApp {
             if vol.elevations.is_empty() {
                 return (None, true);
             }
-            vol.binned(moment, tilt, dealias)
-                .map(|s| {
-                    to_upload(
-                        s,
-                        table,
-                        threshold,
-                        smooth,
-                        storm_uv,
-                        precip.as_deref(),
-                        lut_only,
-                    )
-                })
+            vol.binned(moment, tilt, dealias).map(|s| {
+                to_upload(
+                    s,
+                    table,
+                    threshold,
+                    smooth,
+                    storm_uv,
+                    precip.as_deref(),
+                    lut_only,
+                )
+            })
         };
         match upload {
             Ok(up) => {
@@ -11110,19 +11109,14 @@ impl HookEchoApp {
                             painter.layout_no_wrap(text, font.clone(), egui::Color32::WHITE);
                         let anchor = egui::pos2(prect.left() + 8.0, y);
                         let size = galley.size();
-                        let bg =
-                            egui::Rect::from_min_size(anchor, size + egui::vec2(10.0, 4.0));
+                        let bg = egui::Rect::from_min_size(anchor, size + egui::vec2(10.0, 4.0));
                         painter.rect_filled(
                             bg,
                             3.0,
                             egui::Color32::from_rgba_unmultiplied(150, 30, 30, 210),
                         );
                         // The galley just measured, drawn — one layout, not two.
-                        painter.galley(
-                            anchor + egui::vec2(5.0, 2.0),
-                            galley,
-                            egui::Color32::WHITE,
-                        );
+                        painter.galley(anchor + egui::vec2(5.0, 2.0), galley, egui::Color32::WHITE);
                         y += size.y + 6.0;
                     }
                 }
@@ -11957,8 +11951,7 @@ impl HookEchoApp {
                         .map(|a| a.event.as_str())
                         .unwrap_or_default();
                     let line = format!("⚠ {} — {} in {:.0} min", mk.name, event, t);
-                    let galley =
-                        painter.layout_no_wrap(line, font.clone(), egui::Color32::WHITE);
+                    let galley = painter.layout_no_wrap(line, font.clone(), egui::Color32::WHITE);
                     let anchor = egui::pos2(prect.left() + 8.0, y);
                     let bg =
                         egui::Rect::from_min_size(anchor, galley.size() + egui::vec2(10.0, 4.0));
@@ -13622,10 +13615,9 @@ impl HookEchoApp {
                 .find(|m| m.home)
                 .map(|m| (m.lon, m.lat))
         });
-        let line =
-            here.and_then(|(lon, lat)| {
-                widget_storm_line(self.active_storm_cells(), lon, lat, self.metric())
-            });
+        let line = here.and_then(|(lon, lat)| {
+            widget_storm_line(self.active_storm_cells(), lon, lat, self.metric())
+        });
         match line {
             Some(line) => {
                 if let Err(e) = std::fs::write(&path, line) {
@@ -13908,7 +13900,11 @@ pub(crate) fn to_upload(
     }
     let (precip_flag, flag_nx, flag_ny, flag_w, flag_n, flag_e, flag_s) = match tint {
         Some(g) => (
-            if lut_only { Vec::new() } else { g.classes.clone() },
+            if lut_only {
+                Vec::new()
+            } else {
+                g.classes.clone()
+            },
             g.nx,
             g.ny,
             g.west,
@@ -13972,10 +13968,7 @@ fn sites_in_world() -> &'static [(&'static wxdata::sites::SiteEntry, (f64, f64))
             .map(|s| {
                 (
                     s,
-                    crate::render::mercator::lonlat_to_world(
-                        s.longitude as f64,
-                        s.latitude as f64,
-                    ),
+                    crate::render::mercator::lonlat_to_world(s.longitude as f64, s.latitude as f64),
                 )
             })
             .collect()
@@ -16608,14 +16601,20 @@ mod tests {
     #[test]
     fn a_pinch_defers_the_retessellation_but_new_geometry_never_waits() {
         use super::should_retess;
-        assert!(should_retess(false, false, true), "quiet: rebuild on a bucket change");
+        assert!(
+            should_retess(false, false, true),
+            "quiet: rebuild on a bucket change"
+        );
         assert!(!should_retess(true, false, true), "mid-gesture: wait");
         assert!(
             should_retess(true, true, true),
             "new geometry mid-gesture is data arriving, not the camera moving"
         );
         assert!(!should_retess(true, false, false));
-        assert!(!should_retess(false, false, false), "nothing changed, nothing to do");
+        assert!(
+            !should_retess(false, false, false),
+            "nothing changed, nothing to do"
+        );
     }
 
     /// A palette change must not re-send the sweep. Everything the GPU keeps (the gate bytes,

--- a/crates/hookecho/src/fonts.rs
+++ b/crates/hookecho/src/fonts.rs
@@ -11,9 +11,9 @@
 //! and then applies the app's own two faces on top the same way [`base`] does. What differs is
 //! only *when* the fallbacks arrive.
 
-use egui::{FontData, FontDefinitions, FontFamily};
 #[cfg(target_arch = "wasm32")]
 use egui::FontTweak;
+use egui::{FontData, FontDefinitions, FontFamily};
 use std::sync::Arc;
 
 /// Inter, subsetted (SIL OFL, see `data/fonts/Inter-LICENSE.txt`) — ~26 KB gzipped, and the face
@@ -39,10 +39,9 @@ pub fn base() -> FontDefinitions {
 /// egui's defaults that yields `[Inter, Ubuntu-Light, phosphor, …]`, which is what native has had
 /// all along — so the web build reaching the same list is a matter of feeding this the same input.
 fn decorate(mut fonts: FontDefinitions) -> FontDefinitions {
-    fonts.font_data.insert(
-        "Inter".to_owned(),
-        Arc::new(FontData::from_static(INTER)),
-    );
+    fonts
+        .font_data
+        .insert("Inter".to_owned(), Arc::new(FontData::from_static(INTER)));
     let prop = fonts.families.entry(FontFamily::Proportional).or_default();
     prop.insert(0, "Inter".to_owned());
     // `add_to_fonts` does `insert(1, …)`, which panics on a list shorter than that — on the web,
@@ -93,9 +92,10 @@ pub fn full(fetched: Fetched) -> FontDefinitions {
     fonts
         .font_data
         .insert("NotoEmoji-Regular".to_owned(), tweaked(noto, 0.81));
-    fonts
-        .font_data
-        .insert("Ubuntu-Light".to_owned(), Arc::new(FontData::from_owned(ubuntu)));
+    fonts.font_data.insert(
+        "Ubuntu-Light".to_owned(),
+        Arc::new(FontData::from_owned(ubuntu)),
+    );
     fonts
         .font_data
         .insert("emoji-icon-font".to_owned(), tweaked(emoji, 0.90));

--- a/crates/hookecho/src/headless.rs
+++ b/crates/hookecho/src/headless.rs
@@ -141,6 +141,31 @@ pub fn run(
     };
 
     let sweep = rt.block_on(async {
+        // Only NEXRAD has a volume archive to scrub; every other network publishes its current
+        // volume and nothing else. Saying so is better than quietly rendering "now" for a request
+        // that asked for last Tuesday.
+        if !wxdata::sites::is_nexrad(site) && (date.is_some() || hhmm.is_some()) {
+            anyhow::bail!("{site} has no volume archive — only the current scan is available");
+        }
+        // The live path for those networks: one call assembles the newest volume from the site's
+        // own files, and it feeds the same binner the Level 2 path uses.
+        if !wxdata::sites::is_nexrad(site) {
+            let http = reqwest::Client::builder()
+                .user_agent(wxdata::alerts::USER_AGENT)
+                .build()?;
+            let fetched = match wxdata::sites::network(site) {
+                wxdata::sites::Network::Tdwr => wxdata::tdwr::fetch_volume(&http, site, None).await,
+                wxdata::sites::Network::Dwd => wxdata::dwd::fetch_volume(&http, site, None).await,
+                wxdata::sites::Network::Opera => {
+                    wxdata::opera::fetch_volume(&http, site, None).await
+                }
+                wxdata::sites::Network::Nexrad => unreachable!("guarded above"),
+            }?;
+            let (name, _time, scan) =
+                fetched.ok_or_else(|| anyhow::anyhow!("no current volume for {site}"))?;
+            eprintln!("live volume: {name}");
+            return level2::bin_scan_opts(&scan, moment, tilt, dealias);
+        }
         // Archive mode: list a specific UTC day and pick the volume nearest `hhmm` — the exact
         // path the timeline uses when scrubbing (list_volumes -> download_scan by identifier).
         if let Some(day) = date {
@@ -2960,7 +2985,10 @@ mod golden_tests {
         let built = counter(Counter::RadarTexturesBuilt) - before.0;
         let quads = counter(Counter::TileQuadsBuilt) - before.1;
         println!("radar_textures_built={built} tile_quads_built={quads} over 15 frames");
-        assert_eq!(built, 1, "same-shaped sweeps write into the retained textures");
+        assert_eq!(
+            built, 1,
+            "same-shaped sweeps write into the retained textures"
+        );
         assert_eq!(quads, 1, "a still camera keeps its tile quads");
     }
 

--- a/crates/hookecho/src/loopexport.rs
+++ b/crates/hookecho/src/loopexport.rs
@@ -7,9 +7,9 @@
 // before it ever reached here. Compiling the codec in anyway was pure bundle weight.
 #[cfg(not(target_arch = "wasm32"))]
 use image::codecs::gif::{GifEncoder, Repeat};
+use image::RgbaImage;
 #[cfg(not(target_arch = "wasm32"))]
 use image::{Delay, Frame};
-use image::RgbaImage;
 use std::path::Path;
 
 /// Output container for a loop export.

--- a/crates/hookecho/src/serve.rs
+++ b/crates/hookecho/src/serve.rs
@@ -604,7 +604,12 @@ fn snapshot_dir() -> anyhow::Result<std::path::PathBuf> {
 /// Anything unreadable, empty, or without a usable modified time is treated as absent — a missing
 /// cache entry is a re-render, never an error.
 fn fresh_on_disk(path: &std::path::Path) -> Option<Vec<u8>> {
-    let age = std::fs::metadata(path).ok()?.modified().ok()?.elapsed().ok()?;
+    let age = std::fs::metadata(path)
+        .ok()?
+        .modified()
+        .ok()?
+        .elapsed()
+        .ok()?;
     if age >= SNAPSHOT_TTL {
         return None;
     }
@@ -804,7 +809,9 @@ fn metrics(server: &Server) -> String {
     out.push_str("# TYPE hookecho_stats_total counter\n");
     for (label, n) in wxdata::stats::snapshot() {
         let label = escape_label(label);
-        out.push_str(&format!("hookecho_stats_total{{counter=\"{label}\"}} {n}\n"));
+        out.push_str(&format!(
+            "hookecho_stats_total{{counter=\"{label}\"}} {n}\n"
+        ));
     }
 
     // What the proxy cache is actually saving: a hit is an upstream fetch that did not happen.
@@ -814,7 +821,10 @@ fn metrics(server: &Server) -> String {
     );
     let (entries, bytes) = {
         let cache = server.proxy_cache.lock().unwrap();
-        (cache.len(), cache.iter().map(|(_, h)| h.body.len()).sum::<usize>())
+        (
+            cache.len(),
+            cache.iter().map(|(_, h)| h.body.len()).sum::<usize>(),
+        )
     };
     out.push_str("# HELP hookecho_proxy_cache_hits_total Proxied responses served without an upstream fetch.\n");
     out.push_str("# TYPE hookecho_proxy_cache_hits_total counter\n");
@@ -1403,7 +1413,10 @@ mod tests {
             render: Mutex::new(()),
         };
         let Reply {
-            status, ctype, body, ..
+            status,
+            ctype,
+            body,
+            ..
         } = route(&server, "/etc/passwd", "", None);
         assert_eq!(status, "404 Not Found");
         assert_eq!(ctype, "application/json");
@@ -1505,8 +1518,9 @@ mod tests {
     fn the_proxy_cache_evicts_on_bytes_not_just_entries() {
         let mut cache =
             lru::LruCache::new(std::num::NonZeroUsize::new(PROXY_CACHE_ENTRIES).unwrap());
-        let held =
-            |c: &lru::LruCache<String, ProxyHit>| c.iter().map(|(_, h)| h.body.len()).sum::<usize>();
+        let held = |c: &lru::LruCache<String, ProxyHit>| {
+            c.iter().map(|(_, h)| h.body.len()).sum::<usize>()
+        };
         // Ten entries of 64 MB: well inside the entry cap, well past the byte cap.
         for i in 0..10 {
             cache.put(

--- a/crates/hookecho/src/tiles.rs
+++ b/crates/hookecho/src/tiles.rs
@@ -1792,7 +1792,8 @@ fn janitor_delay() -> std::time::Duration {
 struct SweepJob(std::path::PathBuf, &'static str, u64);
 
 #[cfg(not(target_arch = "wasm32"))]
-static JANITOR: std::sync::Mutex<(Vec<SweepJob>, bool)> = std::sync::Mutex::new((Vec::new(), false));
+static JANITOR: std::sync::Mutex<(Vec<SweepJob>, bool)> =
+    std::sync::Mutex::new((Vec::new(), false));
 
 /// Queue a cache sweep for the shared janitor: one thread, started once, running every queued
 /// sweep in turn after [`janitor_delay`].

--- a/crates/hookecho/src/ui/marker_window.rs
+++ b/crates/hookecho/src/ui/marker_window.rs
@@ -160,7 +160,11 @@ pub fn marker_grid(
                 } else {
                     m.alert_radius_mi
                 };
-                let (max, suffix) = if metric { (320.0, " km") } else { (200.0, " mi") };
+                let (max, suffix) = if metric {
+                    (320.0, " km")
+                } else {
+                    (200.0, " mi")
+                };
                 if ui
                     .add(
                         egui::DragValue::new(&mut shown)

--- a/crates/hookecho/src/view.rs
+++ b/crates/hookecho/src/view.rs
@@ -387,23 +387,43 @@ mod tests {
 
         view.show_volume(scan_at(&[0.5, 1.5]), "a".into(), now);
         let before = binned();
-        view.volume.as_mut().unwrap().binned(Moment::Reflectivity, 0, false).unwrap();
+        view.volume
+            .as_mut()
+            .unwrap()
+            .binned(Moment::Reflectivity, 0, false)
+            .unwrap();
         assert_eq!(binned() - before, 1, "the first look has to do the work");
 
         // The playhead moves on, then comes back round.
         view.show_volume(scan_at(&[0.5, 1.5]), "b".into(), now);
-        view.volume.as_mut().unwrap().binned(Moment::Reflectivity, 0, false).unwrap();
+        view.volume
+            .as_mut()
+            .unwrap()
+            .binned(Moment::Reflectivity, 0, false)
+            .unwrap();
         let after_b = binned();
         view.show_volume(scan_at(&[0.5, 1.5]), "a".into(), now);
         assert_eq!(view.volume.as_ref().unwrap().name, "a");
-        view.volume.as_mut().unwrap().binned(Moment::Reflectivity, 0, false).unwrap();
-        assert_eq!(binned(), after_b, "the second lap re-binned a sweep it already had");
+        view.volume
+            .as_mut()
+            .unwrap()
+            .binned(Moment::Reflectivity, 0, false)
+            .unwrap();
+        assert_eq!(
+            binned(),
+            after_b,
+            "the second lap re-binned a sweep it already had"
+        );
 
         // A site change is a different piece of sky: nothing kept is worth keeping.
         view.forget_recent();
         view.show_volume(scan_at(&[0.5, 1.5]), "b".into(), now);
         let before = binned();
-        view.volume.as_mut().unwrap().binned(Moment::Reflectivity, 0, false).unwrap();
+        view.volume
+            .as_mut()
+            .unwrap()
+            .binned(Moment::Reflectivity, 0, false)
+            .unwrap();
         assert_eq!(binned() - before, 1);
 
         // A volume still being written must never be kept: half its tilts may not have arrived,
@@ -434,7 +454,11 @@ mod tests {
                 vol.binned(Moment::Reflectivity, 0, false).unwrap();
             }
         }
-        assert_eq!(binned() - before, 30, "the old path re-bins every frame, every lap");
+        assert_eq!(
+            binned() - before,
+            30,
+            "the old path re-bins every frame, every lap"
+        );
 
         let mut view = MapView::new(
             Some("KTLX".into()),

--- a/crates/hookecho/src/wind_gpu.rs
+++ b/crates/hookecho/src/wind_gpu.rs
@@ -433,29 +433,25 @@ impl WindGpu {
             .get(&pane)
             .is_none_or(|t| t.size != (size.0.max(1), size.1.max(1)));
         if stale {
-            self.trails.insert(
-                pane,
-                {
-                    let tex = [
-                        rgba8_target(device, "wind_trail_a", size.0, size.1),
-                        rgba8_target(device, "wind_trail_b", size.0, size.1),
-                    ];
-                    let view: [wgpu::TextureView; 2] =
-                        std::array::from_fn(|i| tex[i].create_view(&Default::default()));
-                    let src_bg =
-                        std::array::from_fn(|i| src_bind_group(device, &self.src_bgl, &view[i]));
-                    Trails {
-                        tex,
-                        view,
-                        src_bg,
-                        cur: 0,
-                        size: (size.0.max(1), size.1.max(1)),
-                    }
-                },
-            );
+            self.trails.insert(pane, {
+                let tex = [
+                    rgba8_target(device, "wind_trail_a", size.0, size.1),
+                    rgba8_target(device, "wind_trail_b", size.0, size.1),
+                ];
+                let view: [wgpu::TextureView; 2] =
+                    std::array::from_fn(|i| tex[i].create_view(&Default::default()));
+                let src_bg =
+                    std::array::from_fn(|i| src_bind_group(device, &self.src_bgl, &view[i]));
+                Trails {
+                    tex,
+                    view,
+                    src_bg,
+                    cur: 0,
+                    size: (size.0.max(1), size.1.max(1)),
+                }
+            });
         }
     }
-
 }
 
 /// The single-texture bind group both the fade and the composite passes read through.


### PR DESCRIPTION
Second of five behind "our radar on our pages". The per-site `/radar/` pages for TDWR and international radars have never carried an image, because RIDGE does not serve them — and neither did our own renderer.

## What

`headless::run` assumed NEXRAD: it called `level2::download_latest_scan` and, failing that, walked back three days of a Level 2 archive that does not exist for TDWR/DWD/OPERA.

Now it branches on `wxdata::sites::network`:
- non-NEXRAD → `{tdwr,dwd,opera}::fetch_volume(&http, site, None)`, which assembles the current volume and returns the same `Scan` type. `level2::bin_scan_opts` and everything downstream are untouched.
- `--date`/`--time` on a non-NEXRAD site → clear error (`"TOKC has no volume archive — only the current scan is available"`) instead of quietly rendering "now" for a request that asked for last Tuesday.

Consequence, by design: loops stay NEXRAD-only — a loop steps the archive. Other networks get a live still.

## Verify

- `--headless out.png <site>` produces a real image for **KTLX** (NEXRAD), **TOKC** (TDWR), **DEES** (DWD, Essen), **BEHEL** (OPERA, Helchteren) — all four exit 0 with plausible echo
- archive rejection checked by hand on TOKC, message above
- gate: clippy `-D warnings` clean · `cargo test --workspace` 656 passed · wasm check · `shoot.sh check` · `scripts/web/build.sh` — goldens untouched, no wasm growth

🤖 Generated with [Claude Code](https://claude.com/claude-code)