### PR TITLE
feat(render): warnings + chrome in headless renders

### DIFF
--- a/crates/hookecho/src/chrome.rs
+++ b/crates/hookecho/src/chrome.rs
@@ -1,0 +1,281 @@
+//! Caption, color bar and city labels painted into a finished render, on the CPU.
+//!
+//! A shared image has to say what it is looking at and when — a radar picture with no site, no
+//! time and no scale is a pretty texture. The app draws all three with egui over the map; this
+//! does the same thing for the off-screen renders the server serves, without a window.
+//!
+//! Why the CPU and not a second `egui_wgpu` pass over the same target: the renders are produced on
+//! whatever adapter the box has, including lavapipe, and a text pass through the GPU is the part
+//! most likely to differ between them. Laying glyphs out with epaint and blitting the atlas by
+//! hand is a few dozen lines, has no adapter in it at all, and is byte-identical everywhere.
+//!
+//! Native only — nothing here is reachable from the wasm build, which draws its chrome the normal
+//! egui way.
+
+use crate::colormap::ColorTable;
+use egui::epaint::text::{FontId, Fonts, TextOptions};
+use egui::Color32;
+
+/// Distance from the image edge to anything drawn here.
+const INSET: f32 = 14.0;
+/// Caption size in pixels, at the reference width below. Everything scales off this.
+const CAPTION_PX: f32 = 15.0;
+/// The width the sizes above are tuned for; a bigger render gets proportionally bigger text.
+const REFERENCE_W: f32 = 1000.0;
+
+/// The color bar to draw, if the render has a moment to explain.
+pub struct Bar {
+    pub table: ColorTable,
+    /// e.g. `"dBZ"`.
+    pub unit: &'static str,
+}
+
+/// Everything painted on top of a finished render.
+#[derive(Default)]
+pub struct Stamp {
+    /// One line, bottom left: `KTLX · REF 0.5° · 2026-08-29 20:32Z · hookecho.io`.
+    pub caption: String,
+    pub bar: Option<Bar>,
+    /// City labels, already projected to pixels by the caller — this module knows nothing about
+    /// cameras, and the caller is the only place the projection exists.
+    pub labels: Vec<(f32, f32, String)>,
+}
+
+/// The buffer being painted into: an RGBA8 image and its dimensions, kept together so the
+/// drawing helpers take one argument for "where" instead of three.
+struct Canvas<'a> {
+    rgba: &'a mut [u8],
+    w: u32,
+    h: u32,
+}
+
+/// Paint `stamp` into an RGBA8 buffer of `w`x`h` pixels, in place.
+pub fn draw(rgba: &mut [u8], w: u32, h: u32, stamp: &Stamp) {
+    if rgba.len() < (w as usize * h as usize * 4) {
+        return;
+    }
+    let canvas = &mut Canvas { rgba, w, h };
+    let mut fonts = Fonts::new(
+        TextOptions {
+            max_texture_side: 2048,
+            ..Default::default()
+        },
+        crate::fonts::base(),
+    );
+    let scale = (w as f32 / REFERENCE_W).clamp(0.7, 2.0);
+
+    // Labels first: the caption and the bar are the frame, and nothing may cover them.
+    let label_px = 12.0 * scale;
+    let mut taken: Vec<[f32; 4]> = Vec::new();
+    for (x, y, name) in &stamp.labels {
+        let size = text_size(&mut fonts, name, label_px);
+        let (x0, y0) = (x - size.0 / 2.0, y - size.1 / 2.0);
+        let box_ = [x0, y0, x0 + size.0, y0 + size.1];
+        // Greedy: first label in wins its space, later ones that would collide are dropped. A
+        // proper label solver is a different project; ten names on a radar picture is the job.
+        if taken.iter().any(|t| overlaps(t, &box_)) {
+            continue;
+        }
+        taken.push(box_);
+        text(
+            canvas,
+            &mut fonts,
+            name,
+            label_px,
+            x0,
+            y0,
+            Color32::from_rgb(235, 235, 240),
+        );
+    }
+
+    let caption_px = CAPTION_PX * scale;
+    let inset = INSET * scale;
+    if !stamp.caption.is_empty() {
+        let size = text_size(&mut fonts, &stamp.caption, caption_px);
+        text(
+            canvas,
+            &mut fonts,
+            &stamp.caption,
+            caption_px,
+            inset,
+            h as f32 - inset - size.1,
+            Color32::from_rgb(240, 240, 245),
+        );
+    }
+
+    if let Some(bar) = &stamp.bar {
+        draw_bar(canvas, &mut fonts, bar, scale);
+    }
+}
+
+/// The moment's color scale as a horizontal ramp above the bottom-right corner, with its ends
+/// labelled. Sampled from the same [`ColorTable`] the shader's LUT is baked from, so the picture
+/// and its key cannot drift apart.
+fn draw_bar(c: &mut Canvas<'_>, fonts: &mut Fonts, bar: &Bar, scale: f32) {
+    let (w, h) = (c.w, c.h);
+    let (Some(first), Some(last)) = (bar.table.stops.first(), bar.table.stops.last()) else {
+        return;
+    };
+    let (vmin, vmax) = (first.value, last.value);
+    let span = (vmax - vmin).max(f32::EPSILON);
+
+    let inset = INSET * scale;
+    let bar_h = 10.0 * scale;
+    let bar_w = (w as f32 * 0.32).min(360.0 * scale);
+    let x1 = w as f32 - inset;
+    let x0 = x1 - bar_w;
+    let y1 = h as f32 - inset;
+    let y0 = y1 - bar_h;
+
+    for px in 0..bar_w as u32 {
+        let value = vmin + (px as f32 / bar_w) * span;
+        let Some(color) = bar.table.sample(value) else {
+            continue;
+        };
+        for py in y0 as u32..y1 as u32 {
+            c.blend(x0 as u32 + px, py, [color[0], color[1], color[2]], 255);
+        }
+    }
+
+    let tick_px = 11.0 * scale;
+    let low = format!("{vmin:.0}");
+    let high = format!("{vmax:.0} {}", bar.unit);
+    let low_size = text_size(fonts, &low, tick_px);
+    let high_size = text_size(fonts, &high, tick_px);
+    let ty = y0 - low_size.1 - 2.0 * scale;
+    let dim = Color32::from_rgb(215, 215, 220);
+    text(c, fonts, &low, tick_px, x0, ty, dim);
+    text(c, fonts, &high, tick_px, x1 - high_size.0, ty, dim);
+}
+
+fn overlaps(a: &[f32; 4], b: &[f32; 4]) -> bool {
+    a[0] < b[2] && b[0] < a[2] && a[1] < b[3] && b[1] < a[3]
+}
+
+fn text_size(fonts: &mut Fonts, s: &str, px: f32) -> (f32, f32) {
+    let galley = fonts.with_pixels_per_point(1.0).layout_no_wrap(
+        s.to_owned(),
+        FontId::proportional(px),
+        Color32::WHITE,
+    );
+    (galley.rect.width(), galley.rect.height())
+}
+
+/// Blit one line of text with its top-left at (`x`, `y`).
+///
+/// Drawn twice: once in black one pixel down-right, then in `color`. The halo is what makes a
+/// caption readable over a bright echo and over an empty dark map both.
+fn text(c: &mut Canvas<'_>, fonts: &mut Fonts, s: &str, px: f32, x: f32, y: f32, color: Color32) {
+    let galley = fonts.with_pixels_per_point(1.0).layout_no_wrap(
+        s.to_owned(),
+        FontId::proportional(px),
+        color,
+    );
+    // The atlas has to be read after layout: laying the text out is what allocates its glyphs.
+    let atlas = fonts.image();
+    let [aw, _ah] = atlas.size;
+    for (dx, dy, ink) in [(1.0, 1.0, Color32::BLACK), (0.0, 0.0, color)] {
+        for row in &galley.rows {
+            for glyph in &row.row.glyphs {
+                if glyph.uv_rect.is_nothing() {
+                    continue;
+                }
+                let left = row.pos.x + glyph.pos.x + glyph.uv_rect.offset.x + x + dx;
+                let top = row.pos.y + glyph.pos.y + glyph.uv_rect.offset.y + y + dy;
+                let gw = (glyph.uv_rect.max[0] - glyph.uv_rect.min[0]) as u32;
+                let gh = (glyph.uv_rect.max[1] - glyph.uv_rect.min[1]) as u32;
+                for gy in 0..gh {
+                    for gx in 0..gw {
+                        let tx = glyph.uv_rect.min[0] as usize + gx as usize;
+                        let ty = glyph.uv_rect.min[1] as usize + gy as usize;
+                        let Some(texel) = atlas.pixels.get(ty * aw + tx) else {
+                            continue;
+                        };
+                        let alpha = texel.a();
+                        if alpha == 0 {
+                            continue;
+                        }
+                        let (px_x, px_y) = (left + gx as f32, top + gy as f32);
+                        if px_x < 0.0 || px_y < 0.0 {
+                            continue;
+                        }
+                        c.blend(
+                            px_x as u32,
+                            px_y as u32,
+                            [ink.r(), ink.g(), ink.b()],
+                            alpha,
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Source-over one pixel. Out-of-bounds writes are dropped rather than wrapped — a label near the
+/// edge is clipped, never smeared onto the opposite side.
+impl Canvas<'_> {
+    fn blend(&mut self, x: u32, y: u32, color: [u8; 3], alpha: u8) {
+        if x >= self.w || y >= self.h {
+            return;
+        }
+        let i = (y as usize * self.w as usize + x as usize) * 4;
+        let a = alpha as u32;
+        for (k, &c) in color.iter().enumerate() {
+            let dst = self.rgba[i + k] as u32;
+            self.rgba[i + k] = ((c as u32 * a + dst * (255 - a)) / 255) as u8;
+        }
+        self.rgba[i + 3] = 255;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Text lands inside the buffer, changes pixels where it is drawn, and leaves the rest alone.
+    /// This is the test that catches an epaint atlas API change — the only thing here that can
+    /// silently start producing nothing.
+    #[test]
+    fn a_caption_marks_the_bottom_left_and_nothing_else() {
+        let (w, h) = (400u32, 200u32);
+        let mut rgba = vec![0u8; (w * h * 4) as usize];
+        draw(
+            &mut rgba,
+            w,
+            h,
+            &Stamp {
+                caption: "KTLX · REF · hookecho.io".to_string(),
+                ..Default::default()
+            },
+        );
+        let lit = |x0: u32, y0: u32, x1: u32, y1: u32| {
+            let mut n = 0;
+            for y in y0..y1 {
+                for x in x0..x1 {
+                    let i = ((y * w + x) * 4) as usize;
+                    if rgba[i] > 0 || rgba[i + 1] > 0 || rgba[i + 2] > 0 {
+                        n += 1;
+                    }
+                }
+            }
+            n
+        };
+        assert!(lit(0, h - 40, w / 2, h) > 50, "no caption was drawn");
+        assert_eq!(lit(0, 0, w, h / 2), 0, "something was drawn off-caption");
+    }
+
+    /// Blending stays in bounds: a glyph hanging off the edge is clipped, not wrapped.
+    #[test]
+    fn out_of_bounds_pixels_are_dropped() {
+        let mut rgba = vec![0u8; 4 * 4 * 4];
+        let mut canvas = Canvas {
+            rgba: &mut rgba,
+            w: 4,
+            h: 4,
+        };
+        canvas.blend(9, 1, [255, 255, 255], 255);
+        canvas.blend(1, 9, [255, 255, 255], 255);
+        assert!(rgba.iter().all(|&b| b == 0));
+    }
+}

--- a/crates/hookecho/src/headless.rs
+++ b/crates/hookecho/src/headless.rs
@@ -24,6 +24,22 @@ fn size() -> u32 {
     SIZE_PX.load(std::sync::atomic::Ordering::Relaxed)
 }
 
+/// Whether the renders that follow carry warning polygons, a caption, a color bar and city
+/// labels. Off for the CLI verifiers and the golden tests, which want the bare pipeline; on for
+/// the server, whose renders are shared as pictures and have to say what they are.
+///
+/// Process-global for the same reason as the two knobs above, and set under the same lock.
+static EXTRAS: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Ask for warnings + chrome (or not) on the renders that follow.
+pub fn set_extras(on: bool) {
+    EXTRAS.store(on, std::sync::atomic::Ordering::Relaxed);
+}
+
+fn extras() -> bool {
+    EXTRAS.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 /// Ask for a different output size (256..=2048 px) and/or zoom for the renders that follow.
 /// `None` leaves that knob where it was.
 pub fn set_output(px: Option<u32>, zoom: Option<f64>) {
@@ -113,6 +129,79 @@ fn national_basemap(
     }
 }
 
+/// The active warning polygons, tessellated for the overlay layer — or `None` when nothing is
+/// warned and there is nothing to draw.
+///
+/// Only the three polygon warnings the app leads with: watches and advisories are county-sized
+/// wash that hides the radar underneath, which is the thing the picture is of.
+fn warnings_overlay(
+    rt: &tokio::runtime::Runtime,
+    client: &reqwest::Client,
+    zoom: f64,
+) -> Option<OverlayUpload> {
+    let features = rt.block_on(wxdata::alerts::fetch_polygon_alerts(client));
+    let features = match features {
+        Ok(f) => f,
+        // A picture with no warnings on it is worth more than no picture.
+        Err(e) => {
+            log::warn!("alerts for render unavailable: {e}");
+            return None;
+        }
+    };
+    let warned: Vec<_> = features.into_iter().filter(is_lead_warning).collect();
+    if warned.is_empty() {
+        return None;
+    }
+    let geom = overlay_build::build(&warned, zoom);
+    Some(OverlayUpload {
+        vertices: geom.vertices,
+        indices: geom.indices,
+    })
+}
+
+/// Tornado, severe thunderstorm and flash flood warnings — the three the app's overlay leads with.
+fn is_lead_warning(f: &wxdata::overlay::GeoFeature) -> bool {
+    f.kind == wxdata::overlay::FeatureKind::Warning
+        && matches!(
+            f.title.as_str(),
+            "Tornado Warning" | "Severe Thunderstorm Warning" | "Flash Flood Warning"
+        )
+}
+
+/// The one line under the picture: what radar, what product, what tilt, when, and whose render.
+fn caption(site: &str, moment: Moment, elevation_deg: f32, at: Option<&str>) -> String {
+    let when = at.unwrap_or("latest");
+    format!(
+        "{site} · {} {elevation_deg:.1}° · {when} · hookecho.io",
+        moment.short_name()
+    )
+}
+
+/// City names, projected to pixels, biggest places first so the collision pass keeps those.
+fn screen_labels(
+    labels: &[crate::vector_tiles::PlaceLabel],
+    camera: &Camera,
+    vp: (f32, f32),
+) -> Vec<(f32, f32, String)> {
+    let mut cities: Vec<_> = labels.iter().filter(|l| l.city).collect();
+    cities.sort_by_key(|l| l.rank);
+    cities
+        .iter()
+        .map(|l| {
+            let (x, y) =
+                camera.world_to_screen((l.world[0] as f64, l.world[1] as f64), vp);
+            (x, y, l.name.clone())
+        })
+        .filter(|(x, y, _)| *x > 0.0 && *y > 0.0 && *x < vp.0 && *y < vp.1)
+        .take(10)
+        .collect()
+}
+
+/// A volume time as it appears in a caption: `2026-08-29 20:32Z`, always UTC.
+fn stamp_time(t: &chrono::DateTime<chrono::Utc>) -> String {
+    t.format("%Y-%m-%d %H:%MZ").to_string()
+}
+
 /// Render one real radar sweep for `site` to a PNG.
 ///
 /// `pal` optionally overrides the moment's colormap with a GRLevelX `.pal` file (verifies the
@@ -140,7 +229,9 @@ pub fn run(
         None => crate::colormap::default_table(moment).clone(),
     };
 
-    let sweep = rt.block_on(async {
+    // The volume's own time, formatted, for the caption — carried as a string because each
+    // network hands back a different chrono type for it and the caption is all any of them feed.
+    let (sweep, scan_time) = rt.block_on(async {
         // Only NEXRAD has a volume archive to scrub; every other network publishes its current
         // volume and nothing else. Saying so is better than quietly rendering "now" for a request
         // that asked for last Tuesday.
@@ -161,10 +252,13 @@ pub fn run(
                 }
                 wxdata::sites::Network::Nexrad => unreachable!("guarded above"),
             }?;
-            let (name, _time, scan) =
+            let (name, time, scan) =
                 fetched.ok_or_else(|| anyhow::anyhow!("no current volume for {site}"))?;
             eprintln!("live volume: {name}");
-            return level2::bin_scan_opts(&scan, moment, tilt, dealias);
+            return Ok((
+                level2::bin_scan_opts(&scan, moment, tilt, dealias)?,
+                Some(stamp_time(&time)),
+            ));
         }
         // Archive mode: list a specific UTC day and pick the volume nearest `hhmm` — the exact
         // path the timeline uses when scrubbing (list_volumes -> download_scan by identifier).
@@ -190,16 +284,27 @@ pub fn run(
                 None => frames.into_iter().next_back().unwrap(),
             };
             eprintln!("archive frame: {}", id.name());
+            let at = id.date_time().map(|t| stamp_time(&t));
             let scan = level2::download_scan(id, None).await?;
-            return level2::bin_scan_opts(&scan, moment, tilt, dealias);
+            return Ok((level2::bin_scan_opts(&scan, moment, tilt, dealias)?, at));
         }
 
         let mut day = chrono::Utc::now().date_naive();
         for _ in 0..3 {
-            match level2::download_latest_scan(site, day).await {
-                Ok(scan) => return level2::bin_scan_opts(&scan, moment, tilt, dealias),
-                Err(e) => {
-                    eprintln!("{day}: {e}");
+            // `download_latest_scan` throws the volume identifier away, and the identifier is
+            // where the volume's time lives — so the same two calls are made here by hand.
+            let latest = level2::list_volumes(site, day)
+                .await
+                .map(|mut v| v.pop())
+                .unwrap_or_default();
+            match latest {
+                Some(id) => {
+                    let at = id.date_time().map(|t| stamp_time(&t));
+                    let scan = level2::download_scan(id, None).await?;
+                    return Ok((level2::bin_scan_opts(&scan, moment, tilt, dealias)?, at));
+                }
+                None => {
+                    eprintln!("{day}: no volumes");
                     day = day.pred_opt().unwrap();
                 }
             }
@@ -246,6 +351,7 @@ pub fn run(
     } else {
         (Vec::new(), Vec::new())
     };
+    let mut place_labels: Vec<crate::vector_tiles::PlaceLabel> = Vec::new();
     let (new_vector_tiles, visible_vector) = if is_vector {
         let dark = basemap == BasemapStyle::Dark;
         let tess_zoom = camera.zoom;
@@ -282,10 +388,24 @@ pub fn run(
             println!("  label: {} (rank {}, city {})", l.name, l.rank, l.city);
         }
         let ids: Vec<crate::render::TileId> = vis.iter().map(|v| v.id).collect();
+        place_labels = labels;
         (tiles, ids)
     } else {
         (Vec::new(), Vec::new())
     };
+
+    // Warnings and chrome, when the caller asked for them (the server does; the verifiers do not).
+    let overlay = extras()
+        .then(|| warnings_overlay(&rt, &client, camera.zoom))
+        .flatten();
+    let stamp = extras().then(|| crate::chrome::Stamp {
+        caption: caption(site, moment, sweep.elevation_deg, scan_time.as_deref()),
+        bar: Some(crate::chrome::Bar {
+            table: table.clone(),
+            unit: moment.units(),
+        }),
+        labels: screen_labels(&place_labels, &camera, vp),
+    });
 
     let cb = MapCallback {
         pane: 0,
@@ -299,8 +419,8 @@ pub fn run(
             &sweep, &table, None, smooth, storm_uv, None, false,
         )),
         draw_radar: true,
-        overlay_upload: None,
-        draw_overlay: false,
+        draw_overlay: overlay.is_some(),
+        overlay_upload: overlay,
         field_uploads: Vec::new(),
         field_draws: Vec::new(),
         clear_tiles: false,
@@ -312,7 +432,7 @@ pub fn run(
         wind_upload: None,
         wind: None,
     };
-    render_to_png(&rt, cb, out_path)
+    render_to_png_stamped(&rt, cb, out_path, stamp.as_ref())
 }
 
 /// Verify the multi-pane render path: prepare two panes with different cameras (pane 1 last),
@@ -1249,6 +1369,23 @@ pub fn run_mrms(out_path: &str) -> anyhow::Result<()> {
     let camera = cam_or_env(-97.0, 38.0, 4.0);
     let (new_tiles, visible, new_vector_tiles, visible_vector) = national_basemap(&rt, &camera);
     let (center, scale) = camera.world_to_clip_uniform((size() as f32, size() as f32));
+    // Same opt-in as the site renders: bare mosaic for the CLI verifier, warnings and a caption
+    // for the one the server publishes.
+    let client = reqwest::Client::new();
+    let overlay = extras()
+        .then(|| warnings_overlay(&rt, &client, camera.zoom))
+        .flatten();
+    let stamp = extras().then(|| crate::chrome::Stamp {
+        caption: format!(
+            "MRMS composite reflectivity · {} · hookecho.io",
+            stamp_time(&field.time)
+        ),
+        bar: Some(crate::chrome::Bar {
+            table: table.clone(),
+            unit: Moment::Reflectivity.units(),
+        }),
+        labels: Vec::new(),
+    });
     let cb = MapCallback {
         pane: 0,
         camera_center: center,
@@ -1259,8 +1396,8 @@ pub fn run_mrms(out_path: &str) -> anyhow::Result<()> {
         visible,
         radar_upload: None,
         draw_radar: false,
-        overlay_upload: None,
-        draw_overlay: false,
+        draw_overlay: overlay.is_some(),
+        overlay_upload: overlay,
         field_uploads: vec![(crate::render::FieldLayer::Mrms, upload)],
         field_draws: vec![(crate::render::FieldLayer::Mrms, 1.0)],
         clear_tiles: false,
@@ -1272,7 +1409,7 @@ pub fn run_mrms(out_path: &str) -> anyhow::Result<()> {
         wind_upload: None,
         wind: None,
     };
-    render_to_png(&rt, cb, out_path)
+    render_to_png_stamped(&rt, cb, out_path, stamp.as_ref())
 }
 
 /// Fetch the latest MRMS lightning-density mosaic, print stats, and render it over CONUS.
@@ -2777,6 +2914,18 @@ fn render_to_png(
     cb: MapCallback,
     out_path: &str,
 ) -> anyhow::Result<()> {
+    render_to_png_stamped(rt, cb, out_path, None)
+}
+
+/// As [`render_to_png`], with `stamp` painted onto the pixels after readback and before the file
+/// is written. The chrome is drawn on the CPU precisely so it cannot vary with the adapter — see
+/// `chrome.rs`.
+fn render_to_png_stamped(
+    rt: &tokio::runtime::Runtime,
+    cb: MapCallback,
+    out_path: &str,
+    stamp: Option<&crate::chrome::Stamp>,
+) -> anyhow::Result<()> {
     let (device, queue, adapter) = init_gpu(rt)?;
     println!("adapter: {}", adapter.get_info().name);
 
@@ -2863,6 +3012,9 @@ fn render_to_png(
     drop(mapped);
     buffer.unmap();
 
+    if let Some(stamp) = stamp {
+        crate::chrome::draw(&mut rgba, size(), size(), stamp);
+    }
     image::save_buffer(out_path, &rgba, size(), size(), image::ColorType::Rgba8)?;
     println!("wrote {out_path}");
     Ok(())

--- a/crates/hookecho/src/lib.rs
+++ b/crates/hookecho/src/lib.rs
@@ -19,6 +19,9 @@ pub mod cam;
 /// Dead reckoning ahead of the car, for the next radar handoff.
 pub mod chase;
 pub mod chaselog;
+/// Caption, color bar and city labels blitted onto an off-screen render.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod chrome;
 pub mod cloud;
 pub mod colormap;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/hookecho/src/serve.rs
+++ b/crates/hookecho/src/serve.rs
@@ -573,6 +573,9 @@ fn render_png(
         let _one_at_a_time = server.render.lock().unwrap();
         // Global knobs on the renderer, set under the same lock that serializes the render.
         crate::headless::set_output(Some(f.px), f.zoom);
+        // Anything this server hands out is a picture someone will look at away from the app, so
+        // it carries its warnings, its caption and its scale. The CLI verifiers do not.
+        crate::headless::set_extras(true);
         crate::headless::run(
             out.to_string_lossy().as_ref(),
             &f.site,

--- a/crates/wxdata/src/alerts.rs
+++ b/crates/wxdata/src/alerts.rs
@@ -426,6 +426,15 @@ const MAX_POINTS: usize = 8;
 ///
 /// `// ponytail: capped at MAX_POINTS queries; a state or bbox query if someone saves more
 /// locations than that and misses advisories at the ones past the cap.`
+/// The active alerts that carry their own polygon, and nothing else.
+///
+/// [`fetch_active`] follows every zone-only alert to the zone geometry service, which is dozens of
+/// extra requests for shapes a rendered picture does not use — the warnings worth drawing over
+/// radar all ship a polygon in the feed itself.
+pub async fn fetch_polygon_alerts(client: &reqwest::Client) -> anyhow::Result<Vec<GeoFeature>> {
+    parse_alerts(&get_alerts(client, ALERTS_URL).await?)
+}
+
 pub async fn fetch_active(
     client: &reqwest::Client,
     points: &[(f64, f64)],


### PR DESCRIPTION
Third of five behind "our radar on our pages". Before the site points at our renders, the renders have to be worth pointing at: today a snapshot is basemap + sweep and nothing else — no site, no time, no scale, no warnings — and the city labels are fetched and then discarded.

## What

**`chrome.rs`** (new, native-only): caption, color bar and city labels painted into the RGBA readback buffer on the CPU. epaint does the layout; the font atlas is blitted by hand with a 1px black halo.

Why CPU and not a second `egui_wgpu` pass over the same target: renders come off whatever adapter the box has, including lavapipe, and a text pass through the GPU is the part most likely to differ between them. This has no adapter in it. The bar samples the same `ColorTable` the shader's LUT is baked from, so the key cannot drift from the picture.

**Warnings** reuse the pipeline `--headless-overlay` already proves: `fetch_polygon_alerts` → `overlay_build::build` → `OverlayUpload`, filtered to Tornado / Severe Thunderstorm / Flash Flood. Watches and advisories are county-sized wash over the thing the picture is of. New `wxdata::alerts::fetch_polygon_alerts` is `get_alerts` + `parse_alerts` without the zone-geometry pass — dozens of requests for shapes a render never uses.

**Volume time**: the NEXRAD live path lists and downloads by identifier instead of calling `download_latest_scan`, which throws away the identifier the time lives on.

**All opt-in** behind `headless::set_extras`, a process-global set under the same render lock as the existing size/zoom knobs (same precedent, same serialization). CLI verifiers, the golden test and `shoot.sh check` render exactly what they rendered before, by construction. `serve` turns it on for everything it hands out; `run_mrms` honours it too, ready for `/national.png`.

## Verify

By eye, through a local `--serve` on 8099:
- `?site=KTLX` — caption `KTLX · REF 0.5° · 2026-08-30 02:23Z · hookecho.io`, dBZ bar bottom-right, "Oklahoma City" and "Dallas" labelled
- `?site=KABR` during live SD warnings — two warning polygons drawn over the cells that earned them

Gate: clippy `-D warnings` clean · `cargo test --workspace` 658 passed (two new `chrome` tests: a caption marks the bottom-left and nothing else — this is what catches an epaint atlas API change — and out-of-bounds blends are dropped) · wasm check, no growth (module is `cfg(not(target_arch = "wasm32"))`) · `shoot.sh check` · `scripts/web/build.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)