### PR TITLE
feat(serve): /national.png + --public preset gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,7 @@ and you get the full app there.
 | `/snapshot.png?site=KTLX` | a radar render — `&product=VEL`, `&basemap=none`, `&size=512` (256–2048), `&zoom=6.5`, `&tilt=1` |
 | `/loop.gif?site=KTLX` | the last half hour animating — same render knobs, plus `&frames=6` (2–12) and `&fps=2` |
 | `/loop.mp4?site=KTLX` | the same loop as H.264, if ffmpeg is installed |
+| `/national.png` | the MRMS national mosaic, rendered here rather than hotlinked |
 
 JSON answers are cached for a minute, snapshots and loops for five, so polling it
 every 30 seconds costs the upstream services nothing extra. A loop reuses the
@@ -583,6 +584,40 @@ curl 'http://boxname:8080/snapshot.png?site=KTLX&token=hunter2'
 Every route is behind it, `/metrics` and the CORS proxy included. The
 `?token=` form is there for dashboards that can only fetch a URL and have no
 place to put a header.
+
+#### Publishing the pictures and nothing else
+
+`--public` is the middle setting between "token or nothing" and an open image
+API: callers with no token get exactly the frames hookecho.io embeds —
+`/snapshot.png?site=`, `/loop.gif?site=` for NEXRAD sites, `/national.png` and
+`/health.json`, each with no other parameter — and a `403 {"error":"presets
+only"}` for everything else. The site registry is the allowlist, so there is no
+preset file to maintain. A valid token still opens the full surface, which is
+how the owner keeps `&size=2048` and `/status.json` on the same process.
+
+Those renders carry warning polygons, a caption with the volume's own time, the
+colour scale and city labels — a picture that travels to somebody else's timeline
+has to say what it is.
+
+This is what serves the imagery on hookecho.io. The origin stays on loopback and
+Cloudflare reaches it through a tunnel, so nothing is exposed on the box itself:
+
+```sh
+# on the box: the origin, loopback only, presets public
+hookecho --serve 8080 --public --serve-token "$(cat ~/.config/hookecho/img-token)"
+
+# the tunnel, once
+cloudflared tunnel create hookecho-img
+cloudflared tunnel route dns hookecho-img img.hookecho.io
+# ingress: img.hookecho.io -> http://127.0.0.1:8080
+cloudflared tunnel run hookecho-img
+```
+
+The images ship `Cache-Control: public, max-age=300`, so Cloudflare answers the
+repeat views and the box renders roughly one frame per site per five minutes.
+`HOOKECHO_GPU_FALLBACK=1` forces the lavapipe software renderer, for a box with
+no usable Vulkan device; leave it off where there's a GPU, the national mosaic is
+7000×3500 and notices.
 
 For a desktop widget rather than a server, `--snapshot` writes the same render
 straight to a file:

--- a/crates/hookecho/src/headless.rs
+++ b/crates/hookecho/src/headless.rs
@@ -139,16 +139,7 @@ fn warnings_overlay(
     client: &reqwest::Client,
     zoom: f64,
 ) -> Option<OverlayUpload> {
-    let features = rt.block_on(wxdata::alerts::fetch_polygon_alerts(client));
-    let features = match features {
-        Ok(f) => f,
-        // A picture with no warnings on it is worth more than no picture.
-        Err(e) => {
-            log::warn!("alerts for render unavailable: {e}");
-            return None;
-        }
-    };
-    let warned: Vec<_> = features.into_iter().filter(is_lead_warning).collect();
+    let warned = cached_warnings(rt, client)?;
     if warned.is_empty() {
         return None;
     }
@@ -157,6 +148,37 @@ fn warnings_overlay(
         vertices: geom.vertices,
         indices: geom.indices,
     })
+}
+
+/// How long one alerts fetch serves every render that follows. A server rendering a wall of
+/// sites otherwise asks api.weather.gov once per picture for a feed that changes once a minute.
+const WARNING_TTL: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// The lead warnings, from cache when they are fresh enough. `None` means "nothing to draw",
+/// whether that is because nothing is warned or because the feed could not be reached — a picture
+/// with no warnings on it is worth more than no picture.
+fn cached_warnings(
+    rt: &tokio::runtime::Runtime,
+    client: &reqwest::Client,
+) -> Option<Vec<wxdata::overlay::GeoFeature>> {
+    static CACHE: std::sync::Mutex<
+        Option<(std::time::Instant, Vec<wxdata::overlay::GeoFeature>)>,
+    > = std::sync::Mutex::new(None);
+    let mut slot = CACHE.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some((at, warned)) = slot.as_ref() {
+        if at.elapsed() < WARNING_TTL {
+            return (!warned.is_empty()).then(|| warned.clone());
+        }
+    }
+    let warned = match rt.block_on(wxdata::alerts::fetch_polygon_alerts(client)) {
+        Ok(f) => f.into_iter().filter(is_lead_warning).collect::<Vec<_>>(),
+        Err(e) => {
+            log::warn!("alerts for render unavailable: {e}");
+            return None;
+        }
+    };
+    *slot = Some((std::time::Instant::now(), warned.clone()));
+    (!warned.is_empty()).then_some(warned)
 }
 
 /// Tornado, severe thunderstorm and flash flood warnings — the three the app's overlay leads with.

--- a/crates/hookecho/src/main.rs
+++ b/crates/hookecho/src/main.rs
@@ -94,7 +94,10 @@ fn main() -> eframe::Result<()> {
         // A headless box on a shelf is exactly where MQTT earns its keep — this is the process
         // that is always up.
         hookecho::mqtt::spawn(&saved);
-        if let Err(e) = hookecho::serve::run(spots, bind, port, web_root, token) {
+        // `--public` serves the site's preset frames to callers with no token, and 403s
+        // everything else. Without it a token still means "all or nothing".
+        let public = args.iter().any(|a| a == "--public");
+        if let Err(e) = hookecho::serve::run(spots, bind, port, web_root, token, public) {
             eprintln!("serve failed: {e}");
             std::process::exit(1);
         }

--- a/crates/hookecho/src/serve.rs
+++ b/crates/hookecho/src/serve.rs
@@ -23,6 +23,12 @@ use std::time::{Duration, Instant};
 const JSON_TTL: Duration = Duration::from_secs(60);
 /// How long a rendered radar PNG is reused. A volume is ~5 minutes wide, so is this.
 const SNAPSHOT_TTL: Duration = Duration::from_secs(300);
+/// Edge length of the national mosaic. Wider than a site frame because it carries the whole
+/// country, and it is the one image on the landing page.
+const NATIONAL_PX: u32 = 1400;
+/// Zoom for that frame. The verifier's 4.0 frames CONUS at 1000 px; a wider image at the same
+/// zoom just adds ocean, so this buys the extra pixels back as detail.
+const NATIONAL_ZOOM: f64 = 4.5;
 /// How many built answers are kept. The snapshot key carries `px` and `zoom`, which the client
 /// picks, so this cannot be a map that only grows — a poller walking zoom levels would otherwise
 /// pin every render it ever asked for.
@@ -38,6 +44,9 @@ struct Server {
     /// Bearer token every request must carry, or empty for the open behaviour. A user secret:
     /// it lives in settings.json (or the flag) and is never committed.
     token: String,
+    /// Whether unauthenticated callers may have the preset frames (`--public`). Off by default:
+    /// a server with a token answers nothing without it.
+    public: bool,
     /// Directory of static files to serve (the browser build), if this was started with one.
     web_root: Option<std::path::PathBuf>,
     rt: tokio::runtime::Runtime,
@@ -58,12 +67,14 @@ pub fn run(
     port: u16,
     web_root: Option<std::path::PathBuf>,
     token: String,
+    public: bool,
 ) -> anyhow::Result<()> {
     let _ = STARTED.set(Instant::now());
     let listener = TcpListener::bind((bind, port))?;
     let server = Arc::new(Server {
         spots,
         token,
+        public,
         web_root,
         // One runtime and one client for the process, not one per request like the headless
         // verifiers build — this one stays up.
@@ -147,6 +158,21 @@ fn handle(server: &Server, mut stream: TcpStream) -> anyhow::Result<()> {
     }
     let reply = if authorized {
         route(server, path, query, if_none_match.as_deref())
+    } else if server.public {
+        // The public hostname serves the fixed frames the site embeds and nothing else. Anything
+        // else — another size, another product, a status page — needs the token, which is how the
+        // owner keeps the full parameter surface without handing it to the internet.
+        if is_preset(path, query) {
+            route(server, path, query, if_none_match.as_deref())
+        } else {
+            count("denied");
+            (
+                "403 Forbidden",
+                "application/json",
+                br#"{"error":"presets only"}"#.to_vec(),
+            )
+                .into()
+        }
     } else {
         count("denied");
         (
@@ -205,6 +231,43 @@ impl From<(&'static str, &'static str, Vec<u8>)> for Reply {
     }
 }
 
+/// Whether an unauthenticated request on a `--public` server is one of the frames the site
+/// embeds.
+///
+/// The site registry is the allowlist: one default frame per known radar, plus the national
+/// mosaic and the health page. There is no preset file to keep in step, and no way to ask for a
+/// 2048 px render of an arbitrary product by guessing a URL — every knob but `site` has to be
+/// absent, and `site` has to be a radar we know.
+fn is_preset(path: &str, query: &str) -> bool {
+    // `t=` is the cache-buster the page appends; it changes no pixel and is ignored everywhere.
+    let keys: Vec<&str> = query
+        .split('&')
+        .filter(|p| !p.is_empty())
+        .map(|p| p.split_once('=').map_or(p, |(k, _)| k))
+        .filter(|k| *k != "t")
+        .collect();
+    match path {
+        "/health.json" | "/national.png" => keys.is_empty(),
+        "/snapshot.png" | "/loop.gif" => {
+            if keys != ["site"] {
+                return false;
+            }
+            let Some(site) = crate::cloud::param(query, "site") else {
+                return false;
+            };
+            if wxdata::sites::site_by_id(&site).is_none() {
+                return false;
+            }
+            // A loop steps the volume archive, which only NEXRAD has.
+            if path == "/loop.gif" && !wxdata::sites::is_nexrad(&site) {
+                return false;
+            }
+            true
+        }
+        _ => false,
+    }
+}
+
 /// A rendered image, with the one header that lets a CDN in front of this server do its job.
 ///
 /// The default is `no-cache` (see `respond`), which is right for the JSON routes and wrong for a
@@ -228,6 +291,7 @@ fn route(server: &Server, path: &str, query: &str, if_none_match: Option<&str>) 
         "/status.json" | "/alerts.json" | "/obs.json" | "/health.json" => "json",
         "/cells.json" => "cells",
         "/snapshot.png" => "snapshot",
+        "/national.png" => "national",
         "/loop.gif" | "/loop.mp4" => "loop",
         "/metrics" => "metrics",
         _ if path.starts_with("/proxy/") => "proxy",
@@ -254,6 +318,10 @@ fn route(server: &Server, path: &str, query: &str, if_none_match: Option<&str>) 
             Err(e) => error_json(e).into(),
         },
         "/snapshot.png" => match snapshot(server, query) {
+            Ok(png) => image_reply("image/png", png),
+            Err(e) => error_json(e).into(),
+        },
+        "/national.png" => match national(server) {
             Ok(png) => image_reply("image/png", png),
             Err(e) => error_json(e).into(),
         },
@@ -641,6 +709,41 @@ fn snapshot(server: &Server, query: &str) -> anyhow::Result<Vec<u8>> {
     let png = match fresh_on_disk(&out) {
         Some(bytes) => bytes,
         None => render_png(server, &f, None, &out)?,
+    };
+    server
+        .cache
+        .lock()
+        .unwrap()
+        .put(key, (Instant::now(), png.clone()));
+    Ok(png)
+}
+
+/// The MRMS national mosaic, rendered here rather than hotlinked from the NWS.
+///
+/// One frame for everybody — there is nothing to vary — so the key, the file and the TTL are all
+/// fixed. MRMS publishes every couple of minutes and this holds a render for five, which is still
+/// fresher than the ten-minute GIF it replaces.
+fn national(server: &Server) -> anyhow::Result<Vec<u8>> {
+    let key = "/national.png".to_string();
+    if let Some(hit) = server
+        .cache
+        .lock()
+        .unwrap()
+        .get(&key)
+        .filter(|(when, _)| when.elapsed() < SNAPSHOT_TTL)
+    {
+        return Ok(hit.1.clone());
+    }
+    let out = snapshot_dir()?.join("national.png");
+    let png = match fresh_on_disk(&out) {
+        Some(bytes) => bytes,
+        None => {
+            let _one_at_a_time = server.render.lock().unwrap();
+            crate::headless::set_output(Some(NATIONAL_PX), Some(NATIONAL_ZOOM));
+            crate::headless::set_extras(true);
+            crate::headless::run_mrms(out.to_string_lossy().as_ref())?;
+            std::fs::read(&out)?
+        }
     };
     server
         .cache
@@ -1367,6 +1470,7 @@ mod tests {
     fn the_dashboard_points_at_the_radar_nearest_home() {
         let server = Server {
             token: String::new(),
+            public: false,
             spots: vec![Spot {
                 name: "home".to_string(),
                 lat: 35.22,
@@ -1401,6 +1505,7 @@ mod tests {
         // A server with no spots: routing is independent of what it would report.
         let server = Server {
             token: String::new(),
+            public: false,
             spots: Vec::new(),
             web_root: None,
             rt: tokio::runtime::Builder::new_current_thread()
@@ -1433,6 +1538,7 @@ mod tests {
     fn static_serving_refuses_to_walk_out_of_the_web_root() {
         let server = Server {
             token: String::new(),
+            public: false,
             spots: Vec::new(),
             web_root: Some(std::path::PathBuf::from("/var/empty")),
             rt: tokio::runtime::Builder::new_current_thread()
@@ -1481,6 +1587,7 @@ mod tests {
         std::fs::write(dir.join("lite/index.html"), b"<!doctype html>lite").unwrap();
         let server = Server {
             token: String::new(),
+            public: false,
             spots: Vec::new(),
             web_root: Some(dir.clone()),
             rt: tokio::runtime::Builder::new_current_thread()
@@ -1567,6 +1674,7 @@ mod tests {
     fn proxy_refuses_hosts_that_are_not_on_the_list() {
         let server = Server {
             token: String::new(),
+            public: false,
             spots: Vec::new(),
             web_root: None,
             rt: tokio::runtime::Builder::new_current_thread()
@@ -1608,6 +1716,7 @@ mod tests {
     fn requests_are_counted_by_route() {
         let server = Server {
             token: String::new(),
+            public: false,
             spots: Vec::new(),
             web_root: None,
             rt: tokio::runtime::Builder::new_current_thread()
@@ -1673,5 +1782,44 @@ mod cache_hygiene_tests {
         assert!(fresh_on_disk(&path).is_none(), "stale file was reused");
 
         std::fs::remove_dir_all(&dir).ok();
+    }
+}
+
+#[cfg(test)]
+mod preset_gate_tests {
+    use super::*;
+
+    /// The frames the site embeds are served without a token; everything else is not. This is the
+    /// whole public surface of the origin, so it is worth spelling out.
+    #[test]
+    fn only_the_site_frames_are_public() {
+        // Allowed: a known radar's default frame, with or without the page's cache-buster.
+        assert!(is_preset("/snapshot.png", "site=KTLX"));
+        assert!(is_preset("/snapshot.png", "site=KTLX&t=123"));
+        assert!(is_preset("/snapshot.png", "site=TOKC")); // TDWR — a still, not a loop
+        assert!(is_preset("/loop.gif", "site=KTLX"));
+        assert!(is_preset("/national.png", ""));
+        assert!(is_preset("/national.png", "t=99"));
+        assert!(is_preset("/health.json", ""));
+
+        // Refused: any other knob, however harmless it looks.
+        assert!(!is_preset("/snapshot.png", "site=KTLX&size=2048"));
+        assert!(!is_preset("/snapshot.png", "site=KTLX&product=VEL"));
+        assert!(!is_preset("/snapshot.png", "site=KTLX&zoom=12"));
+        assert!(!is_preset("/snapshot.png", "site=KTLX&basemap=satellite"));
+        assert!(!is_preset("/loop.gif", "site=KTLX&frames=12"));
+        assert!(!is_preset("/national.png", "size=2048"));
+
+        // Refused: a site nobody has heard of, and a loop of a radar with no archive to step.
+        assert!(!is_preset("/snapshot.png", "site=ZZZZ"));
+        assert!(!is_preset("/loop.gif", "site=TOKC"));
+        assert!(!is_preset("/snapshot.png", ""));
+
+        // Refused: everything that is not an image the site embeds.
+        assert!(!is_preset("/status.json", ""));
+        assert!(!is_preset("/loop.mp4", "site=KTLX"));
+        assert!(!is_preset("/metrics", ""));
+        assert!(!is_preset("/proxy/https://example.invalid/x", ""));
+        assert!(!is_preset("/", ""));
     }
 }


### PR DESCRIPTION
Fourth of five. The origin side is finished here: after this, `hookecho --serve --public` is safe to put behind a hostname, and PR5 flips the site onto it.

## What

**`/national.png`** — the MRMS national mosaic through the same off-screen renderer, 1400 px at zoom 4.5 (the verifier's 4.0 frames CONUS at 1000 px; a wider image at the same zoom is just more ocean). One frame for everybody, so the LRU key, the disk file and the TTL are all fixed. Five-minute TTL against a mosaic that publishes every ~2 minutes — strictly fresher than the ~10-minute GIF the landing page hotlinks today, and it makes that page's existing caption true.

**`--public`** — the middle setting between "token or nothing" and an open image API. Unauthenticated callers get exactly the frames the site embeds and `403 {"error":"presets only"}` for anything else. The site registry is the allowlist: `site` must name a radar we know, every other knob must be absent, and `/loop.gif` additionally requires NEXRAD (a loop steps the volume archive). No preset file to maintain. A valid token bypasses the gate entirely, so the owner keeps `&size=2048` and `/status.json` on the same process.

**One alerts fetch per 60 s** shared by every render, instead of one per picture — this is what stops a crawler walking the site directory from hammering api.weather.gov.

**README**: the flag, the endpoint, and the loopback + `cloudflared` shape the origin runs in.

## Verify

Local `--serve 8099 --public --serve-token localtest`, no token on the request:

| request | code |
| --- | --- |
| `/snapshot.png?site=KTLX` | 200 |
| `/snapshot.png?site=TOKC` (TDWR still) | 200 |
| `/national.png`, `/health.json` | 200 |
| `/snapshot.png?site=KTLX&size=2048` | 403 |
| `/snapshot.png?site=ZZZZ` | 403 |
| `/loop.gif?site=TOKC` (no archive) | 403 |
| `/status.json`, `/metrics` | 403 |

With the token: `&size=2048` → 200, `/status.json` → 200. `Cache-Control: public, max-age=300` present on the images.

Cold `/national.png` render on this box (RTX 4080, warm MRMS): **9.5 s** including the fetch and basemap; repeat requests are instant off memory, then off disk after a restart. Rendered image checked by eye — CONUS framed, caption `MRMS composite reflectivity · 2026-08-30 02:46Z · hookecho.io`, scale bottom-right.

Gate: clippy `-D warnings` clean · `cargo test --workspace` 659 passed (new `only_the_site_frames_are_public` spells out the entire public surface) · wasm check · `shoot.sh check` · `scripts/web/build.sh`

## Not done here

The tunnel and systemd unit on the box are an outward-facing change — I'll ask before creating `img.hookecho.io`, and it happens before PR5 flips any page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)