### PR TITLE
fix(serve): a busy renderer serves stale rather than queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,6 +619,22 @@ repeat views and the box renders roughly one frame per site per five minutes.
 no usable Vulkan device; leave it off where there's a GPU, the national mosaic is
 7000×3500 and notices.
 
+A request that arrives while a render is already running does not queue behind
+it — it serves the copy on disk, however old, and returns immediately. That is
+what a crawler walking a few hundred site pages does to a machine that renders
+one frame at a time, and waiting politely in line is how one crawl becomes an
+error page for everyone. The one case that has no answer is a frame that has
+never been rendered, so warm the disk once after a deploy:
+
+```sh
+scripts/warm-presets.sh                       # ~255 stills, serial, ~20 minutes
+scripts/warm-presets.sh https://img.hookecho.io
+```
+
+A four-minute timer re-fetching `/national.png` keeps the landing image warm at
+the edge; the per-site frames are left to render on demand, which is one render
+per site per five minutes at worst.
+
 For a desktop widget rather than a server, `--snapshot` writes the same render
 straight to a file:
 

--- a/crates/hookecho/src/serve.rs
+++ b/crates/hookecho/src/serve.rs
@@ -638,7 +638,9 @@ fn render_png(
     // through to "the latest volume" — which is a loop of the same frame six times.
     let hhmm = at.map(|t| t.format("%H:%M").to_string());
     {
-        let _one_at_a_time = server.render.lock().unwrap();
+        let Some(_one_at_a_time) = try_render(server, out)? else {
+            return Ok(std::fs::read(out)?);
+        };
         // Global knobs on the renderer, set under the same lock that serializes the render.
         crate::headless::set_output(Some(f.px), f.zoom);
         // Anything this server hands out is a picture someone will look at away from the app, so
@@ -659,6 +661,27 @@ fn render_png(
         )?;
     }
     Ok(std::fs::read(out)?)
+}
+
+/// The render lock, or `None` when somebody else has it and this frame already exists on disk.
+///
+/// A crawler walking the site directory asks for a few hundred renders at once. Queued on one
+/// mutex the last of them waits an hour — long past the point where the CDN in front gives up, so
+/// one crawl turns into an error page for everybody. A request that finds the renderer busy
+/// therefore does not wait: it serves whatever is on disk, however old, and is fast about it. A
+/// frame that has never been rendered at all is the only case left that can fail.
+fn try_render<'a>(
+    server: &'a Server,
+    out: &std::path::Path,
+) -> anyhow::Result<Option<std::sync::MutexGuard<'a, ()>>> {
+    match server.render.try_lock() {
+        Ok(guard) => Ok(Some(guard)),
+        Err(_) if out.is_file() => {
+            log::debug!("renderer busy; serving stale {}", out.display());
+            Ok(None)
+        }
+        Err(_) => anyhow::bail!("renderer busy, and this frame has never been rendered"),
+    }
 }
 
 /// Where rendered frames are kept between requests.
@@ -737,13 +760,15 @@ fn national(server: &Server) -> anyhow::Result<Vec<u8>> {
     let out = snapshot_dir()?.join("national.png");
     let png = match fresh_on_disk(&out) {
         Some(bytes) => bytes,
-        None => {
-            let _one_at_a_time = server.render.lock().unwrap();
-            crate::headless::set_output(Some(NATIONAL_PX), Some(NATIONAL_ZOOM));
-            crate::headless::set_extras(true);
-            crate::headless::run_mrms(out.to_string_lossy().as_ref())?;
-            std::fs::read(&out)?
-        }
+        None => match try_render(server, &out)? {
+            Some(_one_at_a_time) => {
+                crate::headless::set_output(Some(NATIONAL_PX), Some(NATIONAL_ZOOM));
+                crate::headless::set_extras(true);
+                crate::headless::run_mrms(out.to_string_lossy().as_ref())?;
+                std::fs::read(&out)?
+            }
+            None => std::fs::read(&out)?,
+        },
     };
     server
         .cache

--- a/scripts/warm-presets.sh
+++ b/scripts/warm-presets.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Warm the origin's disk cache: the national mosaic, then one still per radar on every network.
+#
+# Serial on purpose — the renderer is one frame at a time anyway, and asking in parallel only
+# fills a queue. Run it once after a deploy so no preset is ever "never rendered" (that is the one
+# case the server cannot answer from a stale file), and on a slow timer to keep the frames a
+# crawler asks for recent rather than absent.
+#
+# Usage: scripts/warm-presets.sh [origin]   # default http://127.0.0.1:8087
+set -u
+host="${1:-http://127.0.0.1:8087}"
+here="$(cd "$(dirname "$0")/.." && pwd)"
+
+curl -s -o /dev/null -w "national %{http_code} %{time_total}s\n" "$host/national.png"
+python3 -c '
+import json, sys
+sites = json.load(open(sys.argv[1]))
+print("\n".join(s["id"] for s in sites))
+' "$here/site/src/data/nexrad-sites.json" | while read -r id; do
+  curl -s -o /dev/null -w "$id %{http_code} %{time_total}s\n" "$host/snapshot.png?site=$id"
+done


### PR DESCRIPTION
Found while verifying the origin for PR5: I pointed the site's own link checker at it and got **392 broken links, all 502/524** — from a server that was working correctly and simply queueing.

## What happened

The checker asked for a few hundred frames at once. Every one queued on the render mutex, the tail waited tens of minutes, and Cloudflare's 100 s origin timeout fired long before. One crawl → an error page for every real visitor.

## The fix

A request that finds the renderer busy no longer waits: it serves whatever copy is on disk, however old, and returns immediately. For a picture that is plainly the right trade — a frame from ten minutes ago beats a timeout, and whoever asks next gets a fresh one.

The only case with nothing to fall back on is a frame that has never been rendered at all, so `scripts/warm-presets.sh` renders every preset once (serial — the renderer is one-at-a-time anyway, and parallel asking only refills the queue). ~5 s per site, ~20 minutes for all 255. README documents it as a post-deploy step, along with the four-minute timer that keeps `/national.png` warm.

## Verify

- gate: clippy `-D warnings` clean · `cargo test --workspace` 659 passed · `shoot.sh check`
- warming pass running against the live origin: 49/255 so far, every one 200, ~5.1 s each
- the queue-collapse is re-tested against the live origin in the site PR that follows

🤖 Generated with [Claude Code](https://claude.com/claude-code)