### PR TITLE
feat(site): our radar on every page

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -8,7 +8,7 @@
     "build": "npm run shots && astro build",
     "preview": "astro preview",
     "shots": "mkdir -p public/shots && cp ../docs/shots/reflectivity.jpg ../docs/shots/alltilts.jpg ../docs/shots/layers.jpg ../docs/shots/velocity.jpg public/shots/",
-    "linkcheck": "linkinator dist --recurse --skip \"radar.weather.gov|api.weather.gov|https://hookecho.io/\"",
+    "linkcheck": "linkinator dist --recurse --skip \"radar.weather.gov|api.weather.gov|img.hookecho.io|https://hookecho.io/\"",
     "postbuild": "pagefind --site dist"
   },
   "dependencies": {

--- a/site/src/components/LiveMosaic.astro
+++ b/site/src/components/LiveMosaic.astro
@@ -1,24 +1,31 @@
 ---
-// The national mosaic, hotlinked live from the NWS's own RIDGE image server and re-fetched on a
-// timer. It is the cheapest possible proof that the page is looking at real weather right now.
+// A live radar image, re-fetched on a timer. It is the cheapest possible proof that the page is
+// looking at real weather right now.
+//
+// The source is our own origin (img.hookecho.io), which renders the frame the way the app does.
+// `fallback` is where to go if that render is not there: the NWS's RIDGE image for the frames it
+// publishes, and nothing at all for the ones it never did (TDWR, DWD, OPERA) — an empty fallback
+// hides the figure rather than leaving a broken image on the page.
 // ponytail: a cache-busting query on an <img> is the whole refresh mechanism — no canvas, no
 // preloading, no fade. The server updates roughly every 10 minutes; we ask every 5.
 interface Props {
   src?: string;
   alt?: string;
   caption?: string;
+  fallback?: string;
 }
 
 const {
-  src = "https://radar.weather.gov/ridge/standard/CONUS_0.gif",
+  src = "https://img.hookecho.io/national.png",
   alt = "The national radar mosaic across the United States, updated live",
   caption =
-    "Live national mosaic, straight from the NWS. HookEcho draws this from MRMS at full resolution.",
+    "Live national mosaic. HookEcho draws this from MRMS at full resolution, warnings and all.",
+  fallback = "https://radar.weather.gov/ridge/standard/CONUS_0.gif",
 } = Astro.props;
 const everyMs = 5 * 60 * 1000;
 ---
 
-<figure class="mosaic" data-src={src} data-every={everyMs}>
+<figure class="mosaic" data-src={src} data-every={everyMs} data-fallback={fallback}>
   <img src={src} alt={alt} />
   <figcaption>{caption}</figcaption>
 </figure>
@@ -28,6 +35,25 @@ const everyMs = 5 * 60 * 1000;
   const img = fig?.querySelector("img");
   const src = fig?.dataset.src;
   const every = Number(fig?.dataset.every ?? 0);
+
+  // One swap, never a loop: if our origin is down the NWS image takes over, and if there is no
+  // NWS image for this radar the figure leaves the page. A second failure is left alone.
+  if (fig && img) {
+    img.addEventListener(
+      "error",
+      () => {
+        const fallback = fig.dataset.fallback;
+        if (fallback) {
+          fig.dataset.src = fallback;
+          img.src = fallback;
+        } else {
+          fig.hidden = true;
+        }
+      },
+      { once: true },
+    );
+  }
+
   if (img && src && every > 0) {
     setInterval(() => {
       // Only while the tab is visible: a backgrounded tab refreshing a national radar image all
@@ -37,7 +63,11 @@ const everyMs = 5 * 60 * 1000;
       // every five minutes. Every tab in a cycle now asks for the same URL, and the second one
       // is a cache hit.
       if (document.visibilityState === "visible") {
-        img.src = `${src}?t=${Math.floor(Date.now() / every)}`;
+        // The current source, not the prop: after a fallback swap the timer has to keep
+        // refreshing whatever is actually on the page.
+        const url = fig?.dataset.src ?? src;
+        const join = url.includes("?") ? "&" : "?";
+        img.src = `${url}${join}t=${Math.floor(Date.now() / every)}`;
       }
     }, every);
   }

--- a/site/src/components/StormCard.astro
+++ b/site/src/components/StormCard.astro
@@ -1,7 +1,11 @@
 ---
 // Storm of the day: whichever radar is watching the most active weather in the country, with its
-// live RIDGE loop and a way straight into it. Same ranking as the hero — activeSite() memoizes
-// the query, so this costs no extra request.
+// live loop and a way straight into it. Same ranking as the hero — activeSite() memoizes the
+// query, so this costs no extra request.
+//
+// The loop is our own render (img.hookecho.io), warnings and caption included; the NWS's RIDGE
+// GIF is the one-shot fallback, which always exists here because activeSite() only ever returns
+// WSR-88Ds.
 import Icon from "./Icon.astro";
 ---
 
@@ -34,7 +38,17 @@ import Icon from "./Icon.astro";
           : `${site.id} · quiet right now, so here is the radar nearest you.`;
 
         const loop = card.querySelector<HTMLImageElement>(".loop")!;
-        loop.src = `https://radar.weather.gov/ridge/standard/${site.id}_loop.gif`;
+        loop.addEventListener(
+          "error",
+          () => {
+            loop.src = `https://radar.weather.gov/ridge/standard/${site.id}_loop.gif`;
+          },
+          { once: true },
+        );
+        // Quantized to five minutes: every visitor in a window asks for the same URL, so the
+        // second one is an edge hit rather than another render.
+        const t = Math.floor(Date.now() / (5 * 60 * 1000));
+        loop.src = `https://img.hookecho.io/loop.gif?site=${site.id}&t=${t}`;
         loop.alt = `Live radar loop from ${site.id}, ${site.city}, ${site.state}`;
         loop.hidden = false;
 

--- a/site/src/pages/radar/[id].astro
+++ b/site/src/pages/radar/[id].astro
@@ -65,13 +65,21 @@ const appLink = site ? `https://app.hookecho.io/#goto=${site.id},${site.lon},${s
 // would open an empty loop.
 const liteLink =
   site && site.network === "nexrad" ? `https://app.hookecho.io/lite/?site=${site.id}` : "";
-// RIDGE standard loops exist for WSR-88D ids only — TOKC/TDFW/TDAL all 404 there, and it serves no
-// European site — so every other page carries the facts and the deep link and skips the loop
-// rather than ship a broken image.
+// Every network gets an image now: we render them ourselves. This is the first radar imagery
+// these pages have ever carried for TDWR and for Europe, where RIDGE publishes nothing at all.
+//
+// A still rather than a loop, on every network including NEXRAD: a loop is six renders, and a
+// crawler walking six hundred site pages would ask this box for a few thousand of them at once.
+// The loop lives on the landing page, where it is one site at a time, and in the app.
 const isTdwr = site?.network === "tdwr";
 const network = site?.network ?? "nexrad";
-const loop =
-  site && network === "nexrad" ? `https://radar.weather.gov/ridge/standard/${site.id}_loop.gif` : "";
+const loop = site ? `https://img.hookecho.io/snapshot.png?site=${site.id}` : "";
+// Where to go if our origin is not answering. RIDGE has a loop for WSR-88Ds and nothing for
+// anyone else, and an empty fallback tells LiveMosaic to hide the figure instead.
+const loopFallback =
+  site && network === "nexrad"
+    ? `https://radar.weather.gov/ridge/standard/${site.id}_loop.gif`
+    : "";
 // Distances, warnings and the units below all turn on this one question, the same one the app
 // asks of the pane on screen.
 const metric = site ? site.country !== "US" : props.country !== "US";
@@ -116,7 +124,7 @@ const net = NETWORKS[network];
             ? `Live NEXRAD radar for ${site.id}, the WSR-88D at ${place}: the current loop, active warnings near the site, and every tilt of the Level 2 volume in HookEcho.`
             : `Live weather radar for ${site.id} at ${place}, ${net.blurb} — every elevation angle of the volume, opened in HookEcho.`
       }
-      image={`/og/radar/${site.id.toLowerCase()}.png`}
+      image={`https://img.hookecho.io/snapshot.png?site=${site.id}`}
     >
       <section>
         <div class="wrap">
@@ -172,8 +180,9 @@ const net = NETWORKS[network];
           {loop && (
             <LiveMosaic
               src={loop}
-              alt={`The current radar loop from ${site.id} at ${place}`}
-              caption={`${site.id} base reflectivity, refreshed live from the NWS.`}
+              fallback={loopFallback}
+              alt={`The current radar scan from ${site.id} at ${place}`}
+              caption={`${site.id} base reflectivity, the current volume, rendered by HookEcho.`}
             />
           )}
 
@@ -211,16 +220,16 @@ const net = NETWORKS[network];
               <h2>Where to see this radar</h2>
               <p>
                 {isTdwr
-                  ? `The National Weather Service publishes no standard web loop for terminal radars, so there is nothing to show here. HookEcho reads the ${site.id} products straight from the NOAA archive: reflectivity, velocity and dual-pol at the TDWR's own resolution, with warnings, storm reports and lightning drawn over the same map.`
-                  : `There is no public web loop for this radar to embed, so this page carries the facts and the link. HookEcho fetches the ${site.id} volume itself and renders it locally — every elevation angle, velocity and dual-pol — with the warnings in force drawn over the same map.`}
+                  ? `The National Weather Service publishes no web loop for terminal radars, so the image above is ours: HookEcho reads the ${site.id} products straight from the NOAA archive and renders them at the TDWR's own resolution. In the app you get the rest — reflectivity, velocity and dual-pol at every tilt, with warnings, storm reports and lightning drawn over the same map.`
+                  : `No public web loop exists for this radar, so the image above is ours: HookEcho fetches the ${site.id} volume itself and renders it. In the app you get every elevation angle, velocity and dual-pol, with the warnings in force drawn over the same map.`}
               </p>
               {net.credit && <p class="credit">{net.credit}</p>}
             </>
           ) : (
             <>
-              <h2>What HookEcho shows that the loop above does not</h2>
+              <h2>What HookEcho shows that the image above does not</h2>
               <p>
-                That GIF is one product at one tilt, rendered on someone else's server. HookEcho
+                That is one product at one tilt, one volume old. HookEcho
                 reads the Level 2 volume from {site.id} directly: every elevation angle,
                 storm-relative velocity with dealiasing, correlation coefficient for debris
                 signatures, and the warnings, storm reports and lightning drawn over the same map.

--- a/site/src/scripts/motion.ts
+++ b/site/src/scripts/motion.ts
@@ -39,7 +39,10 @@ function format(value: number, template: string): string {
 
 function countUp(el: HTMLElement): void {
   const text = el.textContent ?? "";
-  const target = Number(el.dataset.countup ?? text.replace(/[^0-9.]/g, ""));
+  // `||`, not `??`: a bare `data-countup` is the empty string, which is present as far as `??`
+  // is concerned and `Number("")` is 0 — so the tile animated 0 -> 0 over the number in the
+  // markup. Every bare user wants the number it already shipped with.
+  const target = Number(el.dataset.countup || text.replace(/[^0-9.]/g, ""));
   if (!Number.isFinite(target)) return;
   const start = performance.now();
   const step = (now: number) => {


### PR DESCRIPTION
The last of the five. "This should be our radar" — it is now.

Every radar image on the site was a hotlink to `radar.weather.gov`, including the national mosaic sitting under a caption that said *"HookEcho draws this from MRMS at full resolution"*. All of it now comes from `hookecho --serve --public` on the box, through `img.hookecho.io`, with warning polygons, the volume's own timestamp, the colour scale and city labels rendered into every frame.

## What changed

- **Landing**: storm-of-the-day animates `loop.gif?site=`; the mosaic is `national.png` — the caption is now true.
- **All ~600 /radar/ pages** carry an image, including TDWR, DWD and OPERA. RIDGE publishes nothing for any of those, so roughly 90 of these pages have never had radar imagery at all.
- **Stills, not loops, on the site pages.** A loop is six renders; a crawler walking six hundred pages would ask this box for a few thousand at once. The loop stays on the landing card, where it is one site at a time.
- **`og:image`** is a live render of the site, so a shared radar link unfurls as that radar right now. `og/[...route].ts` stays for `storms/*`.
- **One-shot fallback**, no retry loops: RIDGE where it exists, and where it never did the figure removes itself rather than showing a broken image.
- **Copy**: "There is no public web loop for this radar to embed" was true when written and is not any more.
- **Bug**: bare `data-countup` → `Number("")` → 0, so "The whole network" animated 0 → 0 over the 152 in the markup. `??` → `||` fixes every bare user.
- `img.hookecho.io` is skipped by linkinator — a live render origin is not a link, and a radar with no volumes upstream shouldn't fail a build.

## Verify

Site gate: `npm run build` + `npm run linkcheck` — 736 links clean.

Against the live origin, before and after `fix(serve): a busy renderer serves stale rather than queue` (#225):

| | links | time | broken |
| --- | --- | --- | --- |
| before | 1144 | 626 s | **392** (502/524 — queue collapse) |
| after | 992 | 6.3 s | 6 |

The remaining 6 are genuine upstream gaps, not our failure: KGLD and KLIX have published no volumes for three days, and TPBI/TPHL/TSDF/TTUL are TDWRs with no products right now. Those are exactly the pages where the fallback fires — RIDGE for the two WSR-88Ds, figure hidden for the four TDWRs.

Origin ops (already live, documented in the README): loopback `--serve 8087 --public`, token in `settings.json` not on the command line, `cloudflared` tunnel with metrics pinned off 8080, a four-minute timer keeping `/national.png` warm, and `scripts/warm-presets.sh` run once — 249 of 255 presets on disk, the other six being the sites above.

**Merge #225 first**; without it a crawl of this site takes the origin down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)