### PR TITLE
chore: clippy 1.98 wants as_chunks

### DIFF
--- a/crates/hookecho/src/headless.rs
+++ b/crates/hookecho/src/headless.rs
@@ -2575,7 +2575,9 @@ pub fn run_3d(site: &str, out_path: &str, threshold_dbz: Option<f32>) -> anyhow:
     image::save_buffer(out_path, &rgba, size(), size(), image::ColorType::Rgba8)?;
     // Echo pixels = those differing from the uniform sRGB background clear (~48,48,63).
     let echo = rgba
-        .chunks_exact(4)
+        .as_chunks::<4>()
+        .0
+        .iter()
         .filter(|p| {
             (p[0] as i16 - 48).abs() + (p[1] as i16 - 48).abs() + (p[2] as i16 - 63).abs() > 30
         })
@@ -3265,8 +3267,10 @@ mod golden_tests {
         // letting a real render regression through.
         let bad = expected
             .as_raw()
-            .chunks_exact(4)
-            .zip(actual.chunks_exact(4))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .zip(actual.as_chunks::<4>().0)
             .filter(|(e, a)| {
                 e.iter()
                     .zip(a.iter())

--- a/crates/hookecho/src/render/field_ramps.rs
+++ b/crates/hookecho/src/render/field_ramps.rs
@@ -590,7 +590,7 @@ const fn ramp_smoke() -> FieldRamp {
 /// Shared by the GPU upload path and the headless verifiers.
 pub fn bake_ramp_lut(stops: &[(f32, [u8; 3])], alpha: u8) -> Vec<u8> {
     let mut lut = vec![0u8; 256 * 4];
-    for (i, slot) in lut.chunks_exact_mut(4).enumerate().skip(2) {
+    for (i, slot) in lut.as_chunks_mut::<4>().0.iter_mut().enumerate().skip(2) {
         let t = (i - 2) as f32 / 253.0;
         let mut rgb = stops[0].1;
         for w in stops.windows(2) {

--- a/crates/hookecho/src/tray.rs
+++ b/crates/hookecho/src/tray.rs
@@ -61,7 +61,7 @@ mod imp {
     fn logo_icon() -> ksni::Icon {
         let size = 64usize;
         let mut data = crate::icon::rgba(size); // RGBA
-        for px in data.chunks_exact_mut(4) {
+        for px in data.as_chunks_mut::<4>().0 {
             px.rotate_right(1); // RGBA -> ARGB
         }
         ksni::Icon {

--- a/crates/hookecho/src/wind_gpu.rs
+++ b/crates/hookecho/src/wind_gpu.rs
@@ -727,7 +727,7 @@ mod tests {
         let mut out = Vec::with_capacity((SIDE * SIDE) as usize);
         for row in 0..SIDE {
             let start = (row * padded) as usize;
-            for px in mapped[start..start + (SIDE * 4) as usize].chunks_exact(4) {
+            for px in mapped[start..start + (SIDE * 4) as usize].as_chunks::<4>().0 {
                 out.push((
                     px[0] as f32 / 255.0 + px[1] as f32 / 255.0 / 255.0,
                     px[2] as f32 / 255.0 + px[3] as f32 / 255.0 / 255.0,


### PR DESCRIPTION
Rust 1.98's clippy flags `chunks_exact` with a constant size in favour of `as_chunks`, and CI tracks `@stable`, so six call sites fail `-D warnings` on any branch that changed none of them. Mechanical swap, same iteration, no behaviour change.

Base of the round-2 stack — everything after it is red on clippy until this lands.

## Verification
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` — 656 passed
- `RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check --target wasm32-unknown-unknown -p hookecho --lib`

🤖 Generated with [Claude Code](https://claude.com/claude-code)