### PR TITLE
feat(serve): mp4 loops and velocity join the presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,8 +589,9 @@ place to put a header.
 
 `--public` is the middle setting between "token or nothing" and an open image
 API: callers with no token get exactly the frames hookecho.io embeds —
-`/snapshot.png?site=`, `/loop.gif?site=` for NEXRAD sites, `/national.png` and
-`/health.json`, each with no other parameter — and a `403 {"error":"presets
+`/snapshot.png?site=`, `/loop.gif?site=` and `/loop.mp4?site=` for NEXRAD sites,
+`/national.png` and `/health.json`, each with no parameter but an optional
+`&product=REF|VEL` on the renders — and a `403 {"error":"presets
 only"}` for everything else. The site registry is the allowlist, so there is no
 preset file to maintain. A valid token still opens the full surface, which is
 how the owner keeps `&size=2048` and `/status.json` on the same process.

--- a/crates/hookecho/src/serve.rs
+++ b/crates/hookecho/src/serve.rs
@@ -248,9 +248,16 @@ fn is_preset(path: &str, query: &str) -> bool {
         .collect();
     match path {
         "/health.json" | "/national.png" => keys.is_empty(),
-        "/snapshot.png" | "/loop.gif" => {
-            if keys != ["site"] {
+        "/snapshot.png" | "/loop.gif" | "/loop.mp4" => {
+            // `product` is the one knob the site actually turns, and only between the two
+            // moments a viewer reads: what it looks like, and which way it's moving.
+            if keys != ["site"] && keys != ["site", "product"] && keys != ["product", "site"] {
                 return false;
+            }
+            if let Some(product) = crate::cloud::param(query, "product") {
+                if !matches!(product.as_str(), "REF" | "VEL") {
+                    return false;
+                }
             }
             let Some(site) = crate::cloud::param(query, "site") else {
                 return false;
@@ -259,7 +266,7 @@ fn is_preset(path: &str, query: &str) -> bool {
                 return false;
             }
             // A loop steps the volume archive, which only NEXRAD has.
-            if path == "/loop.gif" && !wxdata::sites::is_nexrad(&site) {
+            if path.starts_with("/loop.") && !wxdata::sites::is_nexrad(&site) {
                 return false;
             }
             true
@@ -1823,13 +1830,17 @@ mod preset_gate_tests {
         assert!(is_preset("/snapshot.png", "site=KTLX&t=123"));
         assert!(is_preset("/snapshot.png", "site=TOKC")); // TDWR — a still, not a loop
         assert!(is_preset("/loop.gif", "site=KTLX"));
+        assert!(is_preset("/loop.mp4", "site=KTLX"));
+        assert!(is_preset("/snapshot.png", "site=KTLX&product=VEL"));
+        assert!(is_preset("/loop.mp4", "product=VEL&site=KTLX"));
         assert!(is_preset("/national.png", ""));
         assert!(is_preset("/national.png", "t=99"));
         assert!(is_preset("/health.json", ""));
 
         // Refused: any other knob, however harmless it looks.
         assert!(!is_preset("/snapshot.png", "site=KTLX&size=2048"));
-        assert!(!is_preset("/snapshot.png", "site=KTLX&product=VEL"));
+        assert!(!is_preset("/snapshot.png", "site=KTLX&product=CC"));
+        assert!(!is_preset("/snapshot.png", "product=VEL"));
         assert!(!is_preset("/snapshot.png", "site=KTLX&zoom=12"));
         assert!(!is_preset("/snapshot.png", "site=KTLX&basemap=satellite"));
         assert!(!is_preset("/loop.gif", "site=KTLX&frames=12"));
@@ -1838,11 +1849,11 @@ mod preset_gate_tests {
         // Refused: a site nobody has heard of, and a loop of a radar with no archive to step.
         assert!(!is_preset("/snapshot.png", "site=ZZZZ"));
         assert!(!is_preset("/loop.gif", "site=TOKC"));
+        assert!(!is_preset("/loop.mp4", "site=TOKC"));
         assert!(!is_preset("/snapshot.png", ""));
 
         // Refused: everything that is not an image the site embeds.
         assert!(!is_preset("/status.json", ""));
-        assert!(!is_preset("/loop.mp4", "site=KTLX"));
         assert!(!is_preset("/metrics", ""));
         assert!(!is_preset("/proxy/https://example.invalid/x", ""));
         assert!(!is_preset("/", ""));


### PR DESCRIPTION
Two things the renderer has always been able to do were locked behind a token for no reason a visitor would recognise. `/loop.mp4` has existed since ffmpeg export landed and is meaningfully smaller than the GIF for the same half hour, and `product=` already parses VEL — velocity answers "is it rotating", which is the question a warning raises and a reflectivity still cannot settle.

Both are public on a `--public` server now, under exactly the rule the other presets follow: a known site and no other knob. `product` is admitted with two values (REF, VEL) and refuses the rest, so the surface grows by one enum — no size, no zoom, no arbitrary product by guessing a URL.

## Verification
Against the live origin, unauthenticated:

| request | result |
|---|---|
| `snapshot.png?site=KTLX&product=VEL` | 200, 495 KB |
| `snapshot.png?site=KTLX&product=CC` | **403** |
| `snapshot.png?site=KTLX&size=2048` | **403** |
| `loop.mp4?site=KTLX` | 200, 236 KB (GIF: 385 KB) |
| `loop.mp4?site=TOKC` (no archive) | **403** |
| `status.json` | **403** |

`only_the_site_frames_are_public` extended with those rows. Full gate green: clippy `-D warnings`, `cargo test --workspace`, wasm check, `scripts/shots/shoot.sh check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)