### PR TITLE
feat(site): the weather on these pages moves

### DIFF
--- a/site/src/components/LiveMosaic.astro
+++ b/site/src/components/LiveMosaic.astro
@@ -10,6 +10,9 @@
 // preloading, no fade. The server updates roughly every 10 minutes; we ask every 5.
 interface Props {
   src?: string;
+  /// An MP4 of the same view. Shown instead of the still where it plays; the <img> below is the
+  /// poster, the reduced-motion answer and the fallback, so nothing depends on the video.
+  video?: string;
   alt?: string;
   caption?: string;
   fallback?: string;
@@ -17,6 +20,7 @@ interface Props {
 
 const {
   src = "https://img.hookecho.io/national.png",
+  video,
   alt = "The national radar mosaic across the United States, updated live",
   caption =
     "Live national mosaic. HookEcho draws this from MRMS at full resolution, warnings and all.",
@@ -26,6 +30,11 @@ const everyMs = 5 * 60 * 1000;
 ---
 
 <figure class="mosaic" data-src={src} data-every={everyMs} data-fallback={fallback}>
+  {
+    video && (
+      <video class="clip" src={video} poster={src} autoplay muted loop playsinline hidden />
+    )
+  }
   <img src={src} alt={alt} />
   <figcaption>{caption}</figcaption>
 </figure>
@@ -33,6 +42,7 @@ const everyMs = 5 * 60 * 1000;
 <script>
   const fig = document.querySelector<HTMLElement>(".mosaic");
   const img = fig?.querySelector("img");
+  const clip = fig?.querySelector<HTMLVideoElement>(".clip");
   const src = fig?.dataset.src;
   const every = Number(fig?.dataset.every ?? 0);
 
@@ -54,6 +64,23 @@ const everyMs = 5 * 60 * 1000;
     );
   }
 
+  // The video is opt-in twice over: the visitor has to not have asked for less motion, and the
+  // origin has to actually answer. Either no and the still stays exactly as it is today.
+  if (clip && img && !matchMedia("(prefers-reduced-motion: reduce)").matches) {
+    clip.addEventListener(
+      "error",
+      () => {
+        clip.remove();
+        img.hidden = false;
+      },
+      { once: true },
+    );
+    clip.addEventListener("loadeddata", () => {
+      clip.hidden = false;
+      img.hidden = true;
+    });
+  }
+
   if (img && src && every > 0) {
     setInterval(() => {
       // Only while the tab is visible: a backgrounded tab refreshing a national radar image all
@@ -67,7 +94,9 @@ const everyMs = 5 * 60 * 1000;
         // refreshing whatever is actually on the page.
         const url = fig?.dataset.src ?? src;
         const join = url.includes("?") ? "&" : "?";
-        img.src = `${url}${join}t=${Math.floor(Date.now() / every)}`;
+        const t = Math.floor(Date.now() / every);
+        img.src = `${url}${join}t=${t}`;
+        if (clip && !clip.hidden) clip.src = `${clip.src.split("?")[0]}?t=${t}`;
       }
     }, every);
   }
@@ -75,7 +104,8 @@ const everyMs = 5 * 60 * 1000;
 
 <style>
   .mosaic { margin: 0; }
-  .mosaic img {
+  .mosaic img,
+  .mosaic video {
     display: block;
     width: 100%;
     border: 1px solid var(--stroke);

--- a/site/src/components/StormCard.astro
+++ b/site/src/components/StormCard.astro
@@ -15,6 +15,7 @@ import Icon from "./Icon.astro";
   </p>
   <h3 class="where">Watching the country…</h3>
   <p class="sub">Ranking the active warnings by the radar that can see them.</p>
+  <video class="loop clip" width="600" height="550" autoplay muted loop playsinline hidden></video>
   <img class="loop" alt="" width="600" height="550" hidden />
   <p class="links" hidden>
     <a class="here" href="/radar/">See this radar</a> ·
@@ -37,7 +38,8 @@ import Icon from "./Icon.astro";
           ? `${site.id} · ${warnings} in range right now.`
           : `${site.id} · quiet right now, so here is the radar nearest you.`;
 
-        const loop = card.querySelector<HTMLImageElement>(".loop")!;
+        const loop = card.querySelector<HTMLImageElement>("img.loop")!;
+        const clip = card.querySelector<HTMLVideoElement>("video.loop")!;
         loop.addEventListener(
           "error",
           () => {
@@ -48,9 +50,30 @@ import Icon from "./Icon.astro";
         // Quantized to five minutes: every visitor in a window asks for the same URL, so the
         // second one is an edge hit rather than another render.
         const t = Math.floor(Date.now() / (5 * 60 * 1000));
-        loop.src = `https://img.hookecho.io/loop.gif?site=${site.id}&t=${t}`;
         loop.alt = `Live radar loop from ${site.id}, ${site.city}, ${site.state}`;
-        loop.hidden = false;
+        // The MP4 is about 40% smaller than the GIF for the same half hour (measured on KTLX:
+        // 230 KB against 375 KB). If it does not play — reduced motion, an origin that is down —
+        // the image chain underneath is untouched.
+        if (matchMedia("(prefers-reduced-motion: reduce)").matches) {
+          clip.remove();
+          loop.src = `https://img.hookecho.io/loop.gif?site=${site.id}&t=${t}`;
+          loop.hidden = false;
+        } else {
+          clip.addEventListener("loadeddata", () => {
+            clip.hidden = false;
+            loop.hidden = true;
+          });
+          clip.addEventListener(
+            "error",
+            () => {
+              clip.remove();
+              loop.src = `https://img.hookecho.io/loop.gif?site=${site.id}&t=${t}`;
+              loop.hidden = false;
+            },
+            { once: true },
+          );
+          clip.src = `https://img.hookecho.io/loop.mp4?site=${site.id}&t=${t}`;
+        }
 
         const links = card.querySelector<HTMLElement>(".links")!;
         links.querySelector<HTMLAnchorElement>(".here")!.href =

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -156,7 +156,7 @@ const jsonld = {
           <p class="tile-copy">NEXRAD sites, plus 44 terminal radars, archived back to 1991 — for $0.</p>
         </div>
         <div class="tile mosaic-tile" data-span="2" data-reveal data-reveal-delay="160">
-          <LiveMosaic />
+          <LiveMosaic video="https://img.hookecho.io/national.mp4" />
         </div>
       </Bento>
     </div>


### PR DESCRIPTION
The landing page has been showing a still of the country and a GIF of one radar. Both play video from the same origin now: measured on KTLX, **230 KB of H.264 against 375 KB of GIF** for the same half hour, and an hour of national mosaic where there used to be one frozen minute.

Nothing depends on it. The still is the poster, the reduced-motion answer and the fallback, so a visitor whose browser refuses the video or whose origin is down sees exactly the page they saw yesterday — one swap, never a retry loop. The quantized `?t=` refresh follows whichever element is actually on screen.

## Verification
- `npm run build` + `npm run linkcheck` (737 links)
- Origin killed mid-session: single swap to `national.png` → CONUS GIF → hidden, no retry storm
- `prefers-reduced-motion: reduce` forced: video removed, GIF path taken

🤖 Generated with [Claude Code](https://claude.com/claude-code)