### PR TITLE
feat(site): it knows you came back, and whether the sky is falling

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -6,5 +6,8 @@ import sitemap from "@astrojs/sitemap";
 // is a separate deploy (project `hookecho`) and lives at app.hookecho.io — nothing here bundles it.
 export default defineConfig({
   site: "https://hookecho.io",
+  // Hover-prefetch every internal link. The pages are a few kB of static HTML, so the next one is
+  // already there by the time the click lands; lists opt into viewport prefetching by hand.
+  prefetch: true,
   integrations: [sitemap()],
 });

--- a/site/src/components/Ticker.astro
+++ b/site/src/components/Ticker.astro
@@ -50,6 +50,14 @@ const events = [
           watchCount(slot as HTMLElement);
         }
         slot.parentElement?.classList.toggle("hot", n > 0);
+        // Storm mode: the page already knows whether the country is under warnings, so say so
+        // in the palette. Tornado outranks severe; the CSS does the rest.
+        if (n > 0 && event !== "Flash Flood Warning") {
+          const storm = event === "Tornado Warning" ? "tor" : "svr";
+          if (storm === "tor" || !document.documentElement.dataset.storm) {
+            document.documentElement.dataset.storm = storm;
+          }
+        }
       })
       // A blocked or failing fetch leaves the em dash: the row still reads as a list of the
       // warning types the app tracks, which is the point of it being on the page.

--- a/site/src/pages/radar/index.astro
+++ b/site/src/pages/radar/index.astro
@@ -47,6 +47,12 @@ const countrySlug = (code: string) =>
         link that opens that radar in HookEcho at full resolution.
       </p>
 
+      <div class="yours" hidden>
+        <h2>Start here</h2>
+        <ul class="near" hidden />
+        <ul class="recent" hidden />
+      </div>
+
       {
         states.map((state) => (
           <div class="state">
@@ -117,6 +123,67 @@ const countrySlug = (code: string) =>
       }
     </div>
   </section>
+<script>
+  import sites from "../../data/nexrad-sites.json";
+  import { milesBetween } from "../../data/geo";
+
+  // Two questions a 600-link index cannot answer on its own: which radar covers me, and which one
+  // was I just looking at. Both are answered in the browser — the page stays static.
+  const box = document.querySelector<HTMLElement>(".yours");
+  const link = (id: string, tail: string) => {
+    const site = sites.find((s) => s.id === id);
+    if (!site) return null;
+    const li = document.createElement("li");
+    const a = document.createElement("a");
+    a.href = `/radar/${site.id.toLowerCase()}/`;
+    a.setAttribute("data-astro-prefetch", "viewport");
+    a.innerHTML = `<strong>${site.id}</strong> ${site.city}`;
+    const note = document.createElement("span");
+    note.className = "note";
+    note.textContent = tail;
+    a.append(note);
+    li.append(a);
+    return li;
+  };
+
+  if (box) {
+    try {
+      const recent: string[] = JSON.parse(localStorage.getItem("hookecho:recent") ?? "[]");
+      const list = box.querySelector<HTMLElement>(".recent")!;
+      for (const id of recent) {
+        const li = link(id, "recently viewed");
+        if (li) list.append(li);
+      }
+      if (list.children.length) {
+        list.hidden = false;
+        box.hidden = false;
+      }
+    } catch {}
+
+    // /geo.json is the edge worker reading request.cf — no permission prompt, no coordinates
+    // leaving the page.
+    fetch("/geo.json")
+      .then((r) => (r.ok ? r.json() : Promise.reject(r.status)))
+      .then((geo) => {
+        if (typeof geo?.lat !== "number" || typeof geo?.lon !== "number") return;
+        const near = sites
+          .map((s) => ({ s, miles: Math.round(milesBetween(geo, s)) }))
+          .sort((a, b) => a.miles - b.miles)
+          .slice(0, 3);
+        const list = box.querySelector<HTMLElement>(".near")!;
+        for (const { s, miles } of near) {
+          const li = link(s.id, `${miles} mi away`);
+          if (li) list.append(li);
+        }
+        if (list.children.length) {
+          list.hidden = false;
+          box.hidden = false;
+        }
+      })
+      .catch(() => {});
+  }
+</script>
+
 </Base>
 
 <style>
@@ -148,5 +215,7 @@ const countrySlug = (code: string) =>
     font-size: 0.95rem;
   }
   li a:hover { border-color: var(--accent); color: var(--text); }
+  .yours ul { list-style: none; padding: 0; display: flex; gap: 0.6rem; flex-wrap: wrap; }
+  .yours .note { color: var(--text-dim); margin-left: 0.5rem; font-size: 0.85rem; }
   li strong { color: var(--text); margin-right: 0.4rem; }
 </style>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -268,3 +268,24 @@ section { padding: clamp(3rem, 8vw, 5.5rem) 0; }
 @media (prefers-reduced-motion: reduce) {
   [data-reveal] { opacity: 1; transform: none; }
 }
+
+/* Storm mode. The ticker's own fetch sets data-storm on <html> when the country is under
+   warnings, and the page warms to match: the wash takes the hot end of the ramp and the storm
+   card is outlined rather than merely present. Colour only — nothing here moves, so
+   prefers-reduced-motion has nothing to switch off. */
+:root[data-storm="svr"] {
+  --mesh:
+    radial-gradient(60% 45% at 15% 0%, color-mix(in srgb, var(--ramp-4) 18%, transparent), transparent 70%),
+    radial-gradient(55% 40% at 85% 10%, color-mix(in srgb, var(--ramp-3) 14%, transparent), transparent 70%);
+}
+:root[data-storm="tor"] {
+  --mesh:
+    radial-gradient(60% 45% at 15% 0%, color-mix(in srgb, var(--ramp-5) 22%, transparent), transparent 70%),
+    radial-gradient(55% 40% at 85% 10%, color-mix(in srgb, var(--ramp-4) 16%, transparent), transparent 70%);
+}
+:root[data-storm] .storm { border-color: color-mix(in srgb, var(--ramp-4) 55%, var(--stroke)); }
+:root[data-storm="tor"] .storm { box-shadow: var(--glow-hot); }
+
+/* Cross-document view transitions: a browser that has them cross-fades between pages, and one
+   that does not ignores the rule. No JavaScript either way. */
+@view-transition { navigation: auto; }


### PR DESCRIPTION
Three small things that make the site feel like it is paying attention.

- **Start here** on `/radar/` — a six-hundred-link index now opens with the radars nearest you (the edge worker already knew where the request came from, so no permission prompt and no coordinates leaving the page) and the ones you were just looking at.
- **Storm mode** — the palette warms when the country is actually under warnings, driven by counts the ticker was already fetching. Colour rather than motion, so nobody has to opt out of it; tornado outranks severe.
- **Instant nav** — every internal link prefetched on hover, with a native cross-document view transition between pages. One config line and one CSS rule, no router, no JS.

## Verification
- `npm run build` + `npm run linkcheck`
- Storm mode forced via `document.documentElement.dataset.storm` in both palettes
- Prefetch requests visible in devtools; recents survive navigation; no geo and no recents leaves the strip hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)