### PR TITLE
fix(site): a hidden video is not a black box

### DIFF
--- a/site/src/components/LiveMosaic.astro
+++ b/site/src/components/LiveMosaic.astro
@@ -115,6 +115,10 @@ const everyMs = 5 * 60 * 1000;
 
 <style>
   .mosaic { margin: 0; }
+  /* Same trap as the storm card: this `display: block` outranks the browser's
+     `[hidden] { display: none }`, and the pair takes turns being hidden. */
+  .mosaic img[hidden],
+  .mosaic video[hidden] { display: none; }
   .mosaic img,
   .mosaic video {
     display: block;

--- a/site/src/components/StormCard.astro
+++ b/site/src/components/StormCard.astro
@@ -59,10 +59,11 @@ import Icon from "./Icon.astro";
           loop.src = `https://img.hookecho.io/loop.gif?site=${site.id}&t=${t}`;
           loop.hidden = false;
         } else {
-          clip.addEventListener("loadeddata", () => {
-            clip.hidden = false;
-            loop.hidden = true;
-          });
+          // The poster is the current still, already rendered and cached, so the card shows this
+          // radar straight away rather than an empty box while a cold /loop.mp4 spends its twenty
+          // seconds rendering six frames.
+          clip.poster = `https://img.hookecho.io/snapshot.png?site=${site.id}&t=${t}`;
+          clip.hidden = false;
           clip.addEventListener(
             "error",
             () => {
@@ -102,6 +103,10 @@ import Icon from "./Icon.astro";
   .storm .eyebrow { display: inline-flex; align-items: center; gap: 0.4rem; margin: 0; }
   .storm h3 { margin: 0; }
   .sub { color: var(--text-dim); font-size: var(--text-sm); margin: 0; }
+  /* Author `display: block` beats the browser's `[hidden] { display: none }`, so without this
+     the hidden element of the pair is still painted: a black video box, or the image's alt text
+     in an empty frame. */
+  .loop[hidden] { display: none; }
   .loop {
     display: block;
     width: 100%;


### PR DESCRIPTION
Reported: the storm-of-the-day card renders an empty frame with alt text in it.

![before](https://github.com/user-attachments/assets/placeholder)

Two causes, both introduced by #231.

1. **`[hidden]` was doing nothing.** `.loop { display: block }` is an author rule and outranks the browser's `[hidden] { display: none }` regardless of specificity, so whichever of the `<video>`/`<img>` pair was hidden got painted anyway — a black video box, or the image's alt text in an empty frame. `LiveMosaic` carried the identical rule and the identical bug.
2. **Nothing showed until the clip loaded.** The video only unhid on `loadeddata`, and a cold `/loop.mp4` is ~20 s of rendering six frames. It now takes the current still as its `poster` — already rendered, already cached by the origin — so the card shows the radar immediately and starts moving when the clip arrives.

## Verification
Headless Chrome against the built site, computed styles rather than eyeballing:

```
before: storyVideo {hidden:true, display:"block", h:550}   ← painted while hidden
after:  storyVideo {hidden:false, display:"block", h:550}  ← poster visible, then plays
        storyImg   {hidden:true,  display:"none",  h:0}
        mosImg     {hidden:true,  display:"none",  h:0}
```

`npm run build` + `npm run linkcheck` (737 links). Card screenshotted rendering KTLX rather than an empty frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)