### PR TITLE
fix(render): a zoom asked for once stopped applying forever

### DIFF
--- a/crates/hookecho/src/headless.rs
+++ b/crates/hookecho/src/headless.rs
@@ -41,17 +41,20 @@ fn extras() -> bool {
 }
 
 /// Ask for a different output size (256..=2048 px) and/or zoom for the renders that follow.
-/// `None` leaves that knob where it was.
+///
+/// `px: None` leaves the size where it was, but **`zoom: None` clears the override** rather than
+/// leaving it: the caller is saying "frame this the way the site deserves", and on a server the
+/// previous caller was somebody else's request. The national mosaic asks for a continental zoom
+/// every four minutes, and a sticky override handed that framing to every site snapshot after it
+/// — a radar page showing the whole continent with a `KFWS · REF 0.5°` caption on it.
 pub fn set_output(px: Option<u32>, zoom: Option<f64>) {
     if let Some(px) = px {
         SIZE_PX.store(px.clamp(256, 2048), std::sync::atomic::Ordering::Relaxed);
     }
-    if let Some(z) = zoom {
-        ZOOM_OVERRIDE.store(
-            z.clamp(1.0, 14.0).to_bits(),
-            std::sync::atomic::Ordering::Relaxed,
-        );
-    }
+    ZOOM_OVERRIDE.store(
+        zoom.map_or(u64::MAX, |z| z.clamp(1.0, 14.0).to_bits()),
+        std::sync::atomic::Ordering::Relaxed,
+    );
 }
 
 /// `HOOKECHO_CAM=lon,lat,zoom` overrides any headless camera — framing knob for screenshots.


### PR DESCRIPTION
Every radar snapshot the origin served was framed as a **continent** — a whole-USA view with a `KFWS · REF 0.5°` caption on it. Spotted on the live storm card.

`set_output` only ever *wrote* the zoom override and never cleared it, and `/national.png` asks for a continental zoom every four minutes on its warm timer. Every site render after that inherited the framing, forever.

`zoom: None` now clears the override instead of leaving it. A caller passing `None` is saying "frame this the way the site deserves" — and on a server the previous caller was somebody else's request. Process-global state that only accumulates is a server bug waiting for a second tenant; this one waited for the national timer.

## Verification
On the box, forcing the bad ordering (national render, then a cold site render):

- **Before:** `snapshot.png?site=KFWS` → the entire United States and Mexico
- **After:** Dallas-scale frame, Dallas and Houston legible, 4.4 s cold

Gate green: `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, wasm check, `scripts/shots/shoot.sh check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)