### PR TITLE
feat(render): cities you can navigate by

### DIFF
--- a/crates/hookecho/src/chrome.rs
+++ b/crates/hookecho/src/chrome.rs
@@ -73,6 +73,11 @@ pub fn draw(rgba: &mut [u8], w: u32, h: u32, stamp: &Stamp) {
         let box_ = [x0, y0, x0 + size.0, y0 + size.1];
         // Greedy: first label in wins its space, later ones that would collide are dropped. A
         // proper label solver is a different project; ten names on a radar picture is the job.
+        // A name the canvas cuts in half ("Lafayett") reads as a rendering fault rather than a
+        // place, so a label that does not fit whole is not drawn at all.
+        if x0 < 0.0 || y0 < 0.0 || box_[2] > w as f32 || box_[3] > h as f32 {
+            continue;
+        }
         if taken.iter().any(|t| overlaps(t, &box_)) {
             continue;
         }

--- a/crates/hookecho/src/headless.rs
+++ b/crates/hookecho/src/headless.rs
@@ -210,6 +210,13 @@ fn screen_labels(
 ) -> Vec<(f32, f32, String)> {
     let mut cities: Vec<_> = labels.iter().filter(|l| l.city).collect();
     cities.sort_by_key(|l| l.rank);
+    // One name, one label. A place sits in every tile that overlaps it, and a frame covers
+    // dozens of tiles, so the same city arrives many times over — and since they are all at the
+    // same pixel, the copies collided with each other and ate the budget. Dallas, Houston and
+    // Oklahoma City were the only names surviving on a frame that had five thousand labels to
+    // choose from.
+    let mut seen = std::collections::HashSet::new();
+    cities.retain(|l| seen.insert(l.name.clone()));
     cities
         .iter()
         .map(|l| {
@@ -218,7 +225,7 @@ fn screen_labels(
             (x, y, l.name.clone())
         })
         .filter(|(x, y, _)| *x > 0.0 && *y > 0.0 && *x < vp.0 && *y < vp.1)
-        .take(10)
+        .take(25)
         .collect()
 }
 


### PR DESCRIPTION
Requested: major cities on the radar frames, so there is a point of reference.

The frames already tried. `KFWS` had **5,498 labels** available and drew **three** of them.

A place sits in every tile that overlaps it, and a frame covers dozens of tiles, so the same city arrives dozens of times. Sorted by rank, the top slots filled with duplicate "Dallas" entries — all at one pixel, so they collided with each other and the greedy collision pass threw them away. Three names survived a budget of ten.

One name, one label now, and the cap goes 10 → 25 since the slots hold distinct places. Also: a label the canvas would cut in half is skipped, because `Lafayett` at the frame edge reads as a rendering fault rather than a place.

## Before / after — KFWS
| before | after |
|---|---|
| Dallas, Houston, Oklahoma City | Fort Worth, Dallas, Waco, Tyler, Austin, Houston, Galveston, San Antonio, Victoria, Shreveport, Alexandria, Tulsa, Fort Smith, Fayetteville, Little Rock, Oklahoma City, Norman, Lawton, Wichita Falls, Abilene, Odessa, Lubbock, Amarillo |

Render time unchanged (4.3 s cold, the radar volume dominates).

## Things I tried that were not the cause
Fetching label tiles one zoom deeper (`zoom_bias 1.0`, 4× the tile requests) and admitting `town`-class places from z6.5 — each added exactly one name. Both reverted; the diff is the dedup and the clip.

Gate green: clippy `-D warnings`, `cargo test --workspace`, wasm check, shots check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)