### PR TITLE
fix(site): the network number is a colour again

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -363,11 +363,10 @@ const jsonld = {
     font-weight: 750;
     font-variant-numeric: tabular-nums;
     margin: 0;
-    background: var(--ramp-cool);
-    -webkit-background-clip: text;
-    background-clip: text;
+    /* Solid, not gradient-clipped text: this tile animates its opacity in on reveal, and
+       Chromium leaves the clipped gradient unpainted in that composited layer — the number
+       came out invisible-grey. One colour, no repaint to lose. */
     color: var(--ramp-1);
-    -webkit-text-fill-color: transparent;
   }
   .mosaic-tile { display: flex; }
   .join { display: block; color: var(--text); text-decoration: none; }


### PR DESCRIPTION
The landing page's `152` renders as dark grey rather than the ramp gradient.

**Cause:** `.numbers .big` is gradient text (`background-clip: text` + transparent fill). The tile fades in via `[data-reveal]`, which promotes it to a composited layer; Chromium doesn't paint the clipped gradient into that layer, leaving transparent glyphs over the dark card.

**Fix:** solid `var(--ramp-1)`. The `.grad-text` headline is untouched — it isn't inside a revealing tile and paints fine.

Verified via CDP against a local dev server: computed style was correct (`background-clip: text`, gradient present), and forcing the tile's opacity to 1 painted the number green — confirming it's the composited-layer paint, not the CSS.

npm run build ✓ · npm run linkcheck ✓ (737 links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)