### PR TITLE
fix(site): features eyebrows are a colour again

### DIFF
--- a/site/src/pages/features/index.astro
+++ b/site/src/pages/features/index.astro
@@ -192,14 +192,11 @@ const sections = [
     transition: border-color var(--dur-2) ease, color var(--dur-2) ease;
   }
   .jump a:hover { border-color: var(--accent); color: var(--text); }
-  .copy .eyebrow {
-    background: var(--ramp-cool);
-    -webkit-background-clip: text;
-    background-clip: text;
-    color: var(--ramp-1);
-    -webkit-text-fill-color: transparent;
-  }
-  .alt .copy .eyebrow { background: var(--ramp-hot); color: var(--ramp-3); }
+  /* Solid rather than gradient-clipped text: these rows fade in on reveal, and Chromium
+     leaves a clipped gradient unpainted in the composited layer that fade creates — the
+     eyebrow comes out as transparent glyphs. Same fix as the landing page's big number. */
+  .copy .eyebrow { color: var(--ramp-1); }
+  .alt .copy .eyebrow { color: var(--ramp-3); }
 
   /* Anchored sections land under the sticky header without this. */
   section[id] { scroll-margin-top: 4.5rem; }


### PR DESCRIPTION
Follow-up to #239, same root cause in the other place it appears.

`.copy .eyebrow` on `/features/` is gradient text (`background-clip: text` + transparent fill), and its row fades in via `[data-reveal]`. Chromium promotes the row to a composited layer for that opacity transition and doesn't paint the clipped gradient into it — the eyebrow ends up transparent.

Solid colours: `--ramp-1`, and `--ramp-3` for `.alt` rows, which is what each already declared as its `color` fallback. No visual change beyond the glyphs being a flat colour instead of a two-stop ramp.

npm run build ✓ · npm run linkcheck ✓ (737 links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)