### PR TITLE
fix(live): the stream survives the network

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1547,6 +1547,8 @@ enum DataMsg {
     LiveEnded {
         view: usize,
         site: String,
+        /// Stream generation — a stale end must not clear a newer stream's handle.
+        gen: u64,
     },
     /// The archive volume listing for a site+date (timeline frames).
     Frames {
@@ -8851,11 +8853,11 @@ impl HookEchoApp {
             let idx = msg.view();
             // LiveEnded must be handled even after a site change (to drop the stream handle).
             if matches!(msg, DataMsg::LiveEnded { .. }) {
-                if let DataMsg::LiveEnded { view, .. } = msg {
+                if let DataMsg::LiveEnded { view, gen, .. } = msg {
                     if self
                         .live_stream
                         .as_ref()
-                        .is_some_and(|(v, _, _)| *v == view)
+                        .is_some_and(|(v, _, g)| *v == view && *g == gen)
                     {
                         self.live_stream = None; // interval polling resumes automatically
                     }
@@ -8931,6 +8933,9 @@ impl HookEchoApp {
                     ..
                 } => {
                     let v = &mut self.views[view];
+                    if v.timeline.playing {
+                        continue; // looping pane owns its displayed frame (cf. Volume above)
+                    }
                     match &mut v.volume {
                         Some(vol) => vol.apply_live(scan, name, time, &changed),
                         None => v.volume = Some(Volume::new(scan, name, time)),
@@ -8983,7 +8988,7 @@ impl HookEchoApp {
             // Only WSR-88Ds have a Level 2 chunk stream to merge — asking for one downloads a
             // WSR-88D-shaped file that isn't there and decodes garbage.
             let want = v.timeline.following
-                && !v.timeline.live_looping()
+                && !v.timeline.playing
                 && v.site.as_deref().is_some_and(wxdata::sites::is_nexrad)
                 && v.volume.is_some();
             (
@@ -9005,6 +9010,8 @@ impl HookEchoApp {
                 self.live_gen
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 self.live_stream = None;
+                // A new site shouldn't inherit the old one's 60 s retry gate.
+                self.last_stream_attempt = None;
             }
         }
 
@@ -9044,6 +9051,7 @@ impl HookEchoApp {
             let cb_tx = tx.clone();
             let cb_ctx = ctx.clone();
             let cb_site = site.clone();
+            log::info!("live stream started for {end_site}");
             let res = live::stream(site, base, active, move |u| {
                 let _ = cb_tx.send(DataMsg::Live {
                     view: view_idx,
@@ -9062,6 +9070,7 @@ impl HookEchoApp {
             let _ = tx.send(DataMsg::LiveEnded {
                 view: view_idx,
                 site: end_site,
+                gen,
             });
             ctx.request_repaint();
         });

--- a/crates/hookecho/src/app/chrome/scrubber.rs
+++ b/crates/hookecho/src/app/chrome/scrubber.rs
@@ -30,6 +30,12 @@ impl HookEchoApp {
             format!("\u{b7} {} ago", humanize(secs))
         });
         let loading = self.views[self.active].loading;
+        // Which mechanism is actually feeding the pane: the sweep-by-sweep chunk stream, or the
+        // interval poller it falls back to when the stream can't run.
+        let streaming = self
+            .live_stream
+            .as_ref()
+            .is_some_and(|(v, _, _)| *v == self.active);
         // TDWR and DWD radars publish no archive, so their timeline is empty by design and stays
         // live. Saying "(no volumes)" there reads as a failed fetch while a live volume is on
         // screen; only a site that HAS an archive can be genuinely missing one.
@@ -123,7 +129,12 @@ impl HookEchoApp {
                         (
                             mobile::OMEGA_GREEN,
                             "LIVE".to_string(),
-                            "Following the newest volume.",
+                            if streaming {
+                                "Following the newest volume, sweep by sweep (live stream)."
+                            } else {
+                                "Following the newest volume, polling for new ones (no live \
+                                 stream — this site has none, or it is retrying)."
+                            },
                         )
                     } else if t.following {
                         (

--- a/crates/wxdata/src/live.rs
+++ b/crates/wxdata/src/live.rs
@@ -104,6 +104,7 @@ where
     chunks.push(init.latest_chunk.chunk);
 
     let mut merged = base;
+    let mut volume = init.latest_chunk.identifier.volume().as_number();
     // First emit assembles the whole backfilled volume; after that only the chunks since the last
     // sweep boundary are re-assembled (plus the start chunk, which carries the VCP and site
     // metadata assembly needs). Re-decoding every accumulated chunk at every boundary was O(n^2)
@@ -111,6 +112,7 @@ where
     emit(&it, &chunks, &mut merged, &mut on_update);
     let mut window_start = chunks.len();
 
+    let mut fails = 0u32;
     loop {
         let wait = it
             .time_until_next()
@@ -129,12 +131,18 @@ where
 
         match it.try_next().await {
             Ok(Some(dc)) => {
+                fails = 0;
                 let seq = dc.identifier.sequence();
                 let ctype = dc.identifier.chunk_type();
-                if ctype == ChunkType::Start {
+                let vol = dc.identifier.volume().as_number();
+                // Start chunk is the normal rollover marker, but a stream that joins mid-volume
+                // (or misses the Start) would otherwise keep assembling the previous volume's
+                // chunks alongside the new one's.
+                if ctype == ChunkType::Start || vol != volume {
                     chunks.clear(); // volume rollover: start a fresh accumulator
                     window_start = 0;
                 }
+                volume = vol;
                 chunks.push(dc.chunk);
                 let sweep_done = it.chunk_metadata(seq).is_some_and(|m| m.is_last_in_sweep());
                 // The fetch itself can outlast the cancellation: a sweep assembled for a site the
@@ -152,9 +160,28 @@ where
                 }
             }
             Ok(None) => { /* not available yet; loop and wait again */ }
-            Err(e) => return Err(anyhow::anyhow!("chunk stream: {e}")),
+            Err(e) => {
+                fails += 1;
+                if !tolerate_failure(fails) {
+                    return Err(anyhow::anyhow!("chunk stream: {e}"));
+                }
+                // A blip (S3 hiccup, laptop lid, Wi-Fi handover) used to kill the stream for
+                // good: the caller fell back to polling and its restart re-downloaded the whole
+                // ~53-chunk backfill. Retrying in place keeps the iterator and the accumulator.
+                log::debug!("chunk stream error ({fails}), retrying: {e}");
+                if !crate::task::sleep_while(Duration::from_secs(2), &active).await {
+                    return Ok(());
+                }
+            }
         }
     }
+}
+
+/// Whether a chunk fetch error at `consecutive` failures in a row should be retried rather than
+/// ending the stream. Transient network trouble is the common case; a sustained run of failures
+/// means the fallback poller should take over.
+fn tolerate_failure(consecutive: u32) -> bool {
+    consecutive < 5
 }
 
 /// Assemble `chunks`, merge into `merged`, and emit if anything changed. Assembly failure
@@ -428,5 +455,18 @@ mod tests {
         let r = merged.sweeps()[0].radials();
         assert_eq!(r.len(), 180, "overlap must dedupe, not duplicate");
         assert_eq!(r[60].collection_timestamp(), 9_000);
+    }
+}
+
+#[cfg(test)]
+mod retry_tests {
+    use super::tolerate_failure;
+
+    #[test]
+    fn transient_failures_retry_then_give_up() {
+        assert!(tolerate_failure(1));
+        assert!(tolerate_failure(4));
+        assert!(!tolerate_failure(5));
+        assert!(!tolerate_failure(9));
     }
 }


### PR DESCRIPTION
One transient S3 error killed the live chunk stream permanently (`live.rs` returned on any `Err` while `Ok(None)` looped). The app fell back to polling and its 60 s restart re-downloaded the ~53-chunk backfill each time. Now: retry in place, up to 5 consecutive failures, 2 s apart.

Also in the stream lifecycle:
- accumulator clears on volume-number change, not just on a Start chunk (mid-volume join mixed two volumes)
- `LiveEnded` carries `gen`; a stale end no longer clears the new stream's handle (which spawned a second stream for one site)
- `want` uses `!playing` instead of `!live_looping()` — the latter is false on the wrap frame, so a live loop churned a stream + backfill once a minute
- a residual `Live` update no longer yanks a looping pane's frame
- site change resets `last_stream_attempt` (fresh site waited up to 60 s)
- stream start logged; LIVE badge tooltip distinguishes sweep stream from polling

Test: `tolerate_failure` unit test in wxdata.

Gate: clippy · tests · wasm check · shots check · web build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)