### PR TITLE
fix(app): honest crash reports, kept notifications, unpanickable click

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -2544,7 +2544,7 @@ pub struct HookEchoApp {
     /// lane, distinct from the warning banners (weather) and the error chip (radar feed).
     toasts: Vec<Toast>,
     /// Auxiliary feeds already reported to the user; see [`HookEchoApp::drain_feed_errors`].
-    feed_errors_told: std::collections::HashSet<&'static str>,
+    feed_errors_told: std::collections::HashMap<&'static str, Instant>,
     /// Right-dock active-alerts panel toggle.
     show_alert_panel: bool,
     /// Cross-section tool: clicked endpoints `[lon,lat]` (max 2), the built section + its texture.
@@ -3214,7 +3214,7 @@ impl HookEchoApp {
             rot_active: false,
             warning_banners: Vec::new(),
             toasts: Vec::new(),
-            feed_errors_told: std::collections::HashSet::new(),
+            feed_errors_told: std::collections::HashMap::new(),
             show_alert_panel: false,
             xsection_pts: Vec::new(),
             xsection: None,
@@ -4104,17 +4104,23 @@ impl HookEchoApp {
         self.settings.in_quiet_hours(chrono::Local::now().hour())
     }
 
-    /// Surface auxiliary-feed failures queued by [`note_feed_error`], once per feed per session.
+    /// Surface auxiliary-feed failures queued by [`note_feed_error`], at most once per feed per
+    /// half hour.
     ///
-    /// Once, deliberately: a feed that is down stays down, and a toast every refresh would be the
-    /// nag this app does not do. The log keeps every occurrence.
+    /// Rate-limited rather than silenced: a feed that is down stays down, and a toast every
+    /// refresh would be the nag this app does not do — but told-once-forever also swallowed a
+    /// genuine second outage hours after the feed had recovered. The log keeps every occurrence.
     fn drain_feed_errors(&mut self) {
         let queued: Vec<(&'static str, String)> = match FEED_ERRORS.lock() {
             Ok(mut q) => std::mem::take(&mut *q),
             Err(_) => return,
         };
         for (feed, err) in queued {
-            if self.feed_errors_told.insert(feed) {
+            let due = self.feed_errors_told
+                .get(feed)
+                .is_none_or(|t| t.elapsed().as_secs() >= 1800);
+            if due {
+                self.feed_errors_told.insert(feed, Instant::now());
                 self.toast(ToastKind::Error, format!("{feed} unavailable — {err}"));
             }
         }
@@ -4919,8 +4925,7 @@ impl HookEchoApp {
             .filter(|s| to_screen_hit(s.longitude as f64, s.latitude as f64) <= tap_r2(12.0))
             .min_by(|a, b| {
                 to_screen_hit(a.longitude as f64, a.latitude as f64)
-                    .partial_cmp(&to_screen_hit(b.longitude as f64, b.latitude as f64))
-                    .unwrap()
+                    .total_cmp(&to_screen_hit(b.longitude as f64, b.latitude as f64))
             });
         match hit {
             Some(s) if self.views[idx].site.as_deref() != Some(s.id) => {
@@ -14531,9 +14536,11 @@ impl eframe::App for HookEchoApp {
         }
         // Anything quiet hours is still holding: it is owed to the user when the window ends, and
         // that can be after a restart.
+        // A poisoned lock still holds the data; dropping it here would silently lose
+        // notifications the user is owed.
         self.settings.quiet_pending = match self.quiet_queue.lock() {
             Ok(q) => q.clone(),
-            Err(_) => Vec::new(),
+            Err(p) => p.into_inner().clone(),
         };
         if self.settings != self.saved {
             self.settings.save();

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1547,6 +1547,8 @@ enum DataMsg {
     LiveEnded {
         view: usize,
         site: String,
+        /// Stream generation — a stale end must not clear a newer stream's handle.
+        gen: u64,
     },
     /// The archive volume listing for a site+date (timeline frames).
     Frames {
@@ -8851,11 +8853,11 @@ impl HookEchoApp {
             let idx = msg.view();
             // LiveEnded must be handled even after a site change (to drop the stream handle).
             if matches!(msg, DataMsg::LiveEnded { .. }) {
-                if let DataMsg::LiveEnded { view, .. } = msg {
+                if let DataMsg::LiveEnded { view, gen, .. } = msg {
                     if self
                         .live_stream
                         .as_ref()
-                        .is_some_and(|(v, _, _)| *v == view)
+                        .is_some_and(|(v, _, g)| *v == view && *g == gen)
                     {
                         self.live_stream = None; // interval polling resumes automatically
                     }
@@ -8931,6 +8933,9 @@ impl HookEchoApp {
                     ..
                 } => {
                     let v = &mut self.views[view];
+                    if v.timeline.playing {
+                        continue; // looping pane owns its displayed frame (cf. Volume above)
+                    }
                     match &mut v.volume {
                         Some(vol) => vol.apply_live(scan, name, time, &changed),
                         None => v.volume = Some(Volume::new(scan, name, time)),
@@ -8983,7 +8988,7 @@ impl HookEchoApp {
             // Only WSR-88Ds have a Level 2 chunk stream to merge — asking for one downloads a
             // WSR-88D-shaped file that isn't there and decodes garbage.
             let want = v.timeline.following
-                && !v.timeline.live_looping()
+                && !v.timeline.playing
                 && v.site.as_deref().is_some_and(wxdata::sites::is_nexrad)
                 && v.volume.is_some();
             (
@@ -9005,6 +9010,8 @@ impl HookEchoApp {
                 self.live_gen
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 self.live_stream = None;
+                // A new site shouldn't inherit the old one's 60 s retry gate.
+                self.last_stream_attempt = None;
             }
         }
 
@@ -9044,6 +9051,7 @@ impl HookEchoApp {
             let cb_tx = tx.clone();
             let cb_ctx = ctx.clone();
             let cb_site = site.clone();
+            log::info!("live stream started for {end_site}");
             let res = live::stream(site, base, active, move |u| {
                 let _ = cb_tx.send(DataMsg::Live {
                     view: view_idx,
@@ -9062,6 +9070,7 @@ impl HookEchoApp {
             let _ = tx.send(DataMsg::LiveEnded {
                 view: view_idx,
                 site: end_site,
+                gen,
             });
             ctx.request_repaint();
         });

--- a/crates/hookecho/src/app/chrome/scrubber.rs
+++ b/crates/hookecho/src/app/chrome/scrubber.rs
@@ -30,6 +30,12 @@ impl HookEchoApp {
             format!("\u{b7} {} ago", humanize(secs))
         });
         let loading = self.views[self.active].loading;
+        // Which mechanism is actually feeding the pane: the sweep-by-sweep chunk stream, or the
+        // interval poller it falls back to when the stream can't run.
+        let streaming = self
+            .live_stream
+            .as_ref()
+            .is_some_and(|(v, _, _)| *v == self.active);
         // TDWR and DWD radars publish no archive, so their timeline is empty by design and stays
         // live. Saying "(no volumes)" there reads as a failed fetch while a live volume is on
         // screen; only a site that HAS an archive can be genuinely missing one.
@@ -123,7 +129,12 @@ impl HookEchoApp {
                         (
                             mobile::OMEGA_GREEN,
                             "LIVE".to_string(),
-                            "Following the newest volume.",
+                            if streaming {
+                                "Following the newest volume, sweep by sweep (live stream)."
+                            } else {
+                                "Following the newest volume, polling for new ones (no live \
+                                 stream — this site has none, or it is retrying)."
+                            },
                         )
                     } else if t.following {
                         (

--- a/crates/hookecho/src/crash.rs
+++ b/crates/hookecho/src/crash.rs
@@ -27,6 +27,13 @@ pub fn install_hook() {
             .location()
             .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()));
         let report = format_report(&msg, location.as_deref(), &Backtrace::capture().to_string());
+        // wxdata decodes malformed GRIB defensively, catching the panics gribberish throws on
+        // odd packings. Those are handled, not crashes — leaving a "the app crashed" report for
+        // one is a lie the user then reports as a bug.
+        if wxdata::task::panic_guarded() {
+            previous(info);
+            return;
+        }
         if let Some(p) = crate::paths::crash_file() {
             if let Some(dir) = p.parent() {
                 let _ = std::fs::create_dir_all(dir);

--- a/crates/hookecho/src/gps.rs
+++ b/crates/hookecho/src/gps.rs
@@ -43,7 +43,11 @@ pub fn spawn() -> Option<Receiver<(f64, f64)>> {
         {
             return;
         }
-        let reader = BufReader::new(stream.try_clone().expect("clone gpsd stream"));
+        let Ok(cloned) = stream.try_clone() else {
+            log::warn!("gpsd: cannot clone stream");
+            return;
+        };
+        let reader = BufReader::new(cloned);
         for line in reader.lines() {
             let Ok(line) = line else { break };
             if let Some(pos) = parse_tpv(&line) {

--- a/crates/wxdata/src/hrrr.rs
+++ b/crates/wxdata/src/hrrr.rs
@@ -455,9 +455,9 @@ async fn fetch_run_field(
         .await?;
 
     // gribberish can panic on some packings; contain it (see mrms::fetch_latest).
-    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+    crate::task::guarded(|| {
         decode_regrid(&bytes, model, min_valid)
-    }))
+    })
     .unwrap_or_else(|_| anyhow::bail!("{} grib decode panicked", model.label()))
 }
 

--- a/crates/wxdata/src/live.rs
+++ b/crates/wxdata/src/live.rs
@@ -104,6 +104,7 @@ where
     chunks.push(init.latest_chunk.chunk);
 
     let mut merged = base;
+    let mut volume = init.latest_chunk.identifier.volume().as_number();
     // First emit assembles the whole backfilled volume; after that only the chunks since the last
     // sweep boundary are re-assembled (plus the start chunk, which carries the VCP and site
     // metadata assembly needs). Re-decoding every accumulated chunk at every boundary was O(n^2)
@@ -111,6 +112,7 @@ where
     emit(&it, &chunks, &mut merged, &mut on_update);
     let mut window_start = chunks.len();
 
+    let mut fails = 0u32;
     loop {
         let wait = it
             .time_until_next()
@@ -129,12 +131,18 @@ where
 
         match it.try_next().await {
             Ok(Some(dc)) => {
+                fails = 0;
                 let seq = dc.identifier.sequence();
                 let ctype = dc.identifier.chunk_type();
-                if ctype == ChunkType::Start {
+                let vol = dc.identifier.volume().as_number();
+                // Start chunk is the normal rollover marker, but a stream that joins mid-volume
+                // (or misses the Start) would otherwise keep assembling the previous volume's
+                // chunks alongside the new one's.
+                if ctype == ChunkType::Start || vol != volume {
                     chunks.clear(); // volume rollover: start a fresh accumulator
                     window_start = 0;
                 }
+                volume = vol;
                 chunks.push(dc.chunk);
                 let sweep_done = it.chunk_metadata(seq).is_some_and(|m| m.is_last_in_sweep());
                 // The fetch itself can outlast the cancellation: a sweep assembled for a site the
@@ -152,9 +160,28 @@ where
                 }
             }
             Ok(None) => { /* not available yet; loop and wait again */ }
-            Err(e) => return Err(anyhow::anyhow!("chunk stream: {e}")),
+            Err(e) => {
+                fails += 1;
+                if !tolerate_failure(fails) {
+                    return Err(anyhow::anyhow!("chunk stream: {e}"));
+                }
+                // A blip (S3 hiccup, laptop lid, Wi-Fi handover) used to kill the stream for
+                // good: the caller fell back to polling and its restart re-downloaded the whole
+                // ~53-chunk backfill. Retrying in place keeps the iterator and the accumulator.
+                log::debug!("chunk stream error ({fails}), retrying: {e}");
+                if !crate::task::sleep_while(Duration::from_secs(2), &active).await {
+                    return Ok(());
+                }
+            }
         }
     }
+}
+
+/// Whether a chunk fetch error at `consecutive` failures in a row should be retried rather than
+/// ending the stream. Transient network trouble is the common case; a sustained run of failures
+/// means the fallback poller should take over.
+fn tolerate_failure(consecutive: u32) -> bool {
+    consecutive < 5
 }
 
 /// Assemble `chunks`, merge into `merged`, and emit if anything changed. Assembly failure
@@ -428,5 +455,18 @@ mod tests {
         let r = merged.sweeps()[0].radials();
         assert_eq!(r.len(), 180, "overlap must dedupe, not duplicate");
         assert_eq!(r[60].collection_timestamp(), 9_000);
+    }
+}
+
+#[cfg(test)]
+mod retry_tests {
+    use super::tolerate_failure;
+
+    #[test]
+    fn transient_failures_retry_then_give_up() {
+        assert!(tolerate_failure(1));
+        assert!(tolerate_failure(4));
+        assert!(!tolerate_failure(5));
+        assert!(!tolerate_failure(9));
     }
 }

--- a/crates/wxdata/src/mrms.rs
+++ b/crates/wxdata/src/mrms.rs
@@ -287,7 +287,7 @@ pub async fn fetch_latest(http: &reqwest::Client, product: &str) -> anyhow::Resu
     let raw = gunzip(&gz)?;
     // gribberish can panic on some MRMS product packings (a slice off-by-one on rotation-track /
     // AzShear grids). Contain it so a bad product surfaces as an error, never a process abort.
-    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| decode_grib2(&raw)))
+    crate::task::guarded(|| decode_grib2(&raw))
         .unwrap_or_else(|_| anyhow::bail!("grib decode panicked for {product}"))
 }
 

--- a/crates/wxdata/src/nohrsc.rs
+++ b/crates/wxdata/src/nohrsc.rs
@@ -56,7 +56,7 @@ pub async fn fetch(http: &reqwest::Client, hours: u16) -> anyhow::Result<MrmsFie
             continue;
         };
         // Same containment as the MRMS decode: a bad packing must not abort the process.
-        let decoded = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| decode(&raw)));
+        let decoded = crate::task::guarded(|| decode(&raw));
         match decoded {
             Ok(Ok(f)) => return Ok(f),
             Ok(Err(e)) => log::warn!("nohrsc decode {url}: {e}"),

--- a/crates/wxdata/src/sounding.rs
+++ b/crates/wxdata/src/sounding.rs
@@ -498,9 +498,9 @@ async fn sample_message(
     // Off the async worker: each of these decodes a full HRRR level and scans ~1.9M grid points,
     // so leaving them here made forty concurrent fetches finish one decode at a time.
     crate::task::blocking(move || {
-        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        crate::task::guarded(|| {
             sample_nearest(&bytes, lon, lat)
-        }))
+        })
         .unwrap_or_else(|_| anyhow::bail!("grib decode panicked"))
     })
     .await?

--- a/crates/wxdata/src/task.rs
+++ b/crates/wxdata/src/task.rs
@@ -89,3 +89,36 @@ mod tests {
         assert!(sleep_while(Duration::from_secs(3), || true).await);
     }
 }
+
+thread_local! {
+    static PANIC_GUARDED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Run `f` under `catch_unwind`, marking the thread so a panic hook can tell a *handled* panic
+/// (a malformed GRIB this crate decodes defensively) from a real crash. Without the mark the app
+/// writes a "the app crashed" report for a decode it recovered from perfectly.
+pub fn guarded<T>(f: impl FnOnce() -> T) -> std::thread::Result<T> {
+    PANIC_GUARDED.with(|g| g.set(true));
+    let r = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+    PANIC_GUARDED.with(|g| g.set(false));
+    r
+}
+
+/// Whether the current thread is inside [`guarded`].
+pub fn panic_guarded() -> bool {
+    PANIC_GUARDED.with(|g| g.get())
+}
+
+#[cfg(test)]
+mod guard_tests {
+    #[test]
+    fn guard_is_set_only_inside() {
+        assert!(!super::panic_guarded());
+        let r = super::guarded(|| {
+            assert!(super::panic_guarded());
+            7
+        });
+        assert_eq!(r.unwrap(), 7);
+        assert!(!super::panic_guarded());
+    }
+}


### PR DESCRIPTION
Stacked on #242.

- **False crash reports.** wxdata catches the panics gribberish throws on odd GRIB packings (mrms, nohrsc, hrrr, sounding), but the panic hook wrote a crash report for each one — so a recovered decode greeted the user with "the app crashed" on next launch. New `wxdata::task::guarded` sets a thread-local the hook reads; the `log::error!` stays.
- **Lost notifications.** A poisoned `quiet_queue` at exit discarded everything quiet hours was holding. Recover via `into_inner()`.
- **Panic on click.** Site hit-test used `partial_cmp().unwrap()` — NaN from a degenerate projection panicked. `total_cmp`.
- **GPS thread panic.** `.expect("clone gpsd stream")` on EMFILE; log and return.
- **Swallowed outages.** `feed_errors_told` never cleared, so a real second outage hours later was silent. Re-toast after 30 min.

Gate green (clippy, tests incl. new guard test, wasm check — wasm byte size unchanged, shots check, web build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)