### PR TITLE
perf(gpu): field textures get evicted, tile cache weighs bytes

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1427,7 +1427,15 @@ type ZdrCache = (
 pub(crate) struct FieldState {
     pub pending: Option<crate::render::MrmsUpload>,
     pub last_fetch: Option<Instant>,
+    /// Since when no pane has drawn this layer. Its GPU texture (up to 8192 px of R8) is freed
+    /// after [`FIELD_EVICT`]; before this, thirty-five layers could stay resident until exit.
+    pub off_since: Option<Instant>,
 }
+
+/// How long a field layer stays uploaded after the last pane turns it off. Long enough that
+/// toggling a layer to compare it against another doesn't re-fetch, short enough that an
+/// afternoon of browsing doesn't end with every layer's texture still on the GPU.
+const FIELD_EVICT: std::time::Duration = std::time::Duration::from_secs(300);
 
 /// What a settings-sync worker reports back. Everything network lives on the runtime; the app
 /// thread only ever applies the outcome.
@@ -4116,7 +4124,8 @@ impl HookEchoApp {
             Err(_) => return,
         };
         for (feed, err) in queued {
-            let due = self.feed_errors_told
+            let due = self
+                .feed_errors_told
                 .get(feed)
                 .is_none_or(|t| t.elapsed().as_secs() >= 1800);
             if due {
@@ -10583,6 +10592,35 @@ impl HookEchoApp {
 
         // Field layers: upload freshly-fetched grids on the first pane; every pane draws the
         // currently-enabled layers.
+        // Field textures are evicted the way tiles are: decided here, where the state that knows
+        // whether a re-upload will follow lives, and handed to the renderer to free.
+        let drop_fields: Vec<crate::render::FieldLayer> = if first {
+            let now = Instant::now();
+            let on: std::collections::HashSet<crate::render::FieldLayer> = self
+                .views
+                .iter()
+                .flat_map(|v| v.fields_on.iter().copied())
+                .collect();
+            let mut drop = Vec::new();
+            for (layer, st) in self.fields.iter_mut() {
+                if on.contains(layer) {
+                    st.off_since = None;
+                } else if let Some(since) = st.off_since {
+                    if now.duration_since(since) >= FIELD_EVICT {
+                        st.off_since = None;
+                        // The grid is gone from the GPU, so the next enable must re-fetch it
+                        // rather than trust its refresh cadence.
+                        st.last_fetch = None;
+                        drop.push(*layer);
+                    }
+                } else {
+                    st.off_since = Some(now);
+                }
+            }
+            drop
+        } else {
+            Vec::new()
+        };
         let field_uploads: Vec<(crate::render::FieldLayer, crate::render::MrmsUpload)> = if first {
             self.fields
                 .iter_mut()
@@ -10623,6 +10661,7 @@ impl HookEchoApp {
             draw_overlay: self.overlay_ready,
             field_uploads,
             field_draws,
+            drop_fields,
             clear_tiles,
             drop_tiles,
             new_vector_tiles,

--- a/crates/hookecho/src/chrome.rs
+++ b/crates/hookecho/src/chrome.rs
@@ -204,12 +204,7 @@ fn text(c: &mut Canvas<'_>, fonts: &mut Fonts, s: &str, px: f32, x: f32, y: f32,
                         if px_x < 0.0 || px_y < 0.0 {
                             continue;
                         }
-                        c.blend(
-                            px_x as u32,
-                            px_y as u32,
-                            [ink.r(), ink.g(), ink.b()],
-                            alpha,
-                        );
+                        c.blend(px_x as u32, px_y as u32, [ink.r(), ink.g(), ink.b()], alpha);
                     }
                 }
             }

--- a/crates/hookecho/src/headless.rs
+++ b/crates/hookecho/src/headless.rs
@@ -165,9 +165,8 @@ fn cached_warnings(
     rt: &tokio::runtime::Runtime,
     client: &reqwest::Client,
 ) -> Option<Vec<wxdata::overlay::GeoFeature>> {
-    static CACHE: std::sync::Mutex<
-        Option<(std::time::Instant, Vec<wxdata::overlay::GeoFeature>)>,
-    > = std::sync::Mutex::new(None);
+    static CACHE: std::sync::Mutex<Option<(std::time::Instant, Vec<wxdata::overlay::GeoFeature>)>> =
+        std::sync::Mutex::new(None);
     let mut slot = CACHE.lock().unwrap_or_else(|e| e.into_inner());
     if let Some((at, warned)) = slot.as_ref() {
         if at.elapsed() < WARNING_TTL {
@@ -221,8 +220,7 @@ fn screen_labels(
     cities
         .iter()
         .map(|l| {
-            let (x, y) =
-                camera.world_to_screen((l.world[0] as f64, l.world[1] as f64), vp);
+            let (x, y) = camera.world_to_screen((l.world[0] as f64, l.world[1] as f64), vp);
             (x, y, l.name.clone())
         })
         .filter(|(x, y, _)| *x > 0.0 && *y > 0.0 && *x < vp.0 && *y < vp.1)
@@ -458,6 +456,7 @@ pub fn run(
         field_draws: Vec::new(),
         clear_tiles: false,
         drop_tiles: Vec::new(),
+        drop_fields: Vec::new(),
         new_vector_tiles,
         visible_vector,
         clear_vector: false,
@@ -512,6 +511,7 @@ pub fn run_multipane(site: &str, out_a: &str, out_b: &str) -> anyhow::Result<()>
             field_draws: Vec::new(),
             clear_tiles: false,
             drop_tiles: Vec::new(),
+            drop_fields: Vec::new(),
             new_vector_tiles: Vec::new(),
             visible_vector: Vec::new(),
             clear_vector: false,
@@ -1176,6 +1176,7 @@ pub fn run_live(out_path: &str, site: &str, moment: Moment) -> anyhow::Result<()
         field_draws: Vec::new(),
         clear_tiles: false,
         drop_tiles: Vec::new(),
+        drop_fields: Vec::new(),
         new_vector_tiles: Vec::new(),
         visible_vector: Vec::new(),
         clear_vector: false,
@@ -1260,6 +1261,7 @@ pub fn run_placefile(path: &str, out_path: &str) -> anyhow::Result<()> {
         field_draws: Vec::new(),
         clear_tiles: false,
         drop_tiles: Vec::new(),
+        drop_fields: Vec::new(),
         new_vector_tiles: Vec::new(),
         visible_vector: Vec::new(),
         clear_vector: false,
@@ -1292,7 +1294,8 @@ pub fn run_overlay(out_path: &str) -> anyhow::Result<()> {
 
     let zoom = 4.0;
     let camera = cam_or_env(-97.0, 38.0, zoom); // CONUS center
-    let (new_tiles, visible, new_vector_tiles, visible_vector, _place_labels) = national_basemap(&rt, &camera);
+    let (new_tiles, visible, new_vector_tiles, visible_vector, _place_labels) =
+        national_basemap(&rt, &camera);
     let geom = overlay_build::build(&features, zoom);
     println!(
         "tessellated {} verts / {} indices",
@@ -1320,6 +1323,7 @@ pub fn run_overlay(out_path: &str) -> anyhow::Result<()> {
         field_draws: Vec::new(),
         clear_tiles: false,
         drop_tiles: Vec::new(),
+        drop_fields: Vec::new(),
         new_vector_tiles,
         visible_vector,
         clear_vector: false,
@@ -1438,6 +1442,7 @@ pub fn run_mrms(out_path: &str) -> anyhow::Result<()> {
         field_draws: vec![(crate::render::FieldLayer::Mrms, 1.0)],
         clear_tiles: false,
         drop_tiles: Vec::new(),
+        drop_fields: Vec::new(),
         new_vector_tiles,
         visible_vector,
         clear_vector: false,
@@ -1475,7 +1480,8 @@ pub fn run_lightning(out_path: &str) -> anyhow::Result<()> {
 
     let upload = crate::app::lightning_upload(&field);
     let camera = cam_or_env(-97.0, 38.0, 4.0);
-    let (new_tiles, visible, new_vector_tiles, visible_vector, _place_labels) = national_basemap(&rt, &camera);
+    let (new_tiles, visible, new_vector_tiles, visible_vector, _place_labels) =
+        national_basemap(&rt, &camera);
     let (center, scale) = camera.world_to_clip_uniform((size() as f32, size() as f32));
     let cb = MapCallback {
         pane: 0,
@@ -1493,6 +1499,7 @@ pub fn run_lightning(out_path: &str) -> anyhow::Result<()> {
         field_draws: vec![(crate::render::FieldLayer::Lightning, 1.0)],
         clear_tiles: false,
         drop_tiles: Vec::new(),
+        drop_fields: Vec::new(),
         new_vector_tiles,
         visible_vector,
         clear_vector: false,
@@ -1546,7 +1553,8 @@ pub fn run_field(slug: &str, out_path: &str) -> anyhow::Result<()> {
     let field = field.decimated(8192); // fit oversized (14000×7000) rotation/AzShear grids
     let upload = crate::app::field_upload_indexed(layer, &field);
     let camera = cam_or_env(-97.0, 38.0, 4.0);
-    let (new_tiles, visible, new_vector_tiles, visible_vector, _place_labels) = national_basemap(&rt, &camera);
+    let (new_tiles, visible, new_vector_tiles, visible_vector, _place_labels) =
+        national_basemap(&rt, &camera);
     let (center, scale) = camera.world_to_clip_uniform((size() as f32, size() as f32));
     let cb = MapCallback {
         pane: 0,
@@ -1564,6 +1572,7 @@ pub fn run_field(slug: &str, out_path: &str) -> anyhow::Result<()> {
         field_draws: vec![(layer, 1.0)],
         clear_tiles: false,
         drop_tiles: Vec::new(),
+        drop_fields: Vec::new(),
         new_vector_tiles,
         visible_vector,
         clear_vector: false,
@@ -1645,7 +1654,8 @@ pub fn run_global(model: &str, slug: &str, out_path: &str) -> anyhow::Result<()>
 
     let upload = crate::app::field_upload_indexed(layer, &field);
     let camera = cam_or_env(0.0, 20.0, 2.0);
-    let (new_tiles, visible, new_vector_tiles, visible_vector, _place_labels) = national_basemap(&rt, &camera);
+    let (new_tiles, visible, new_vector_tiles, visible_vector, _place_labels) =
+        national_basemap(&rt, &camera);
     let (center, scale) = camera.world_to_clip_uniform((size() as f32, size() as f32));
     let cb = MapCallback {
         pane: 0,
@@ -1663,6 +1673,7 @@ pub fn run_global(model: &str, slug: &str, out_path: &str) -> anyhow::Result<()>
         field_draws: vec![(layer, 1.0)],
         clear_tiles: false,
         drop_tiles: Vec::new(),
+        drop_fields: Vec::new(),
         new_vector_tiles,
         visible_vector,
         clear_vector: false,
@@ -1759,7 +1770,8 @@ pub fn run_diff(slug: &str, out_path: &str) -> anyhow::Result<()> {
         crate::fielddiff::diverging_lut(range, deadband),
     );
     let camera = cam_or_env(-97.0, 38.0, 4.0);
-    let (new_tiles, visible, new_vector_tiles, visible_vector, _place_labels) = national_basemap(&rt, &camera);
+    let (new_tiles, visible, new_vector_tiles, visible_vector, _place_labels) =
+        national_basemap(&rt, &camera);
     let (center, scale) = camera.world_to_clip_uniform((size() as f32, size() as f32));
     let cb = MapCallback {
         pane: 0,
@@ -1777,6 +1789,7 @@ pub fn run_diff(slug: &str, out_path: &str) -> anyhow::Result<()> {
         field_draws: vec![(FL::ModelDiff, 1.0)],
         clear_tiles: false,
         drop_tiles: Vec::new(),
+        drop_fields: Vec::new(),
         new_vector_tiles,
         visible_vector,
         clear_vector: false,
@@ -2078,7 +2091,8 @@ pub fn run_l3grid(kind: &str, site: &str, out_path: &str) -> anyhow::Result<()> 
     );
     let upload = crate::app::field_upload_indexed(layer, &field);
     let camera = cam_or_env(clon, clat, 7.0);
-    let (new_tiles, visible, new_vector_tiles, visible_vector, _place_labels) = national_basemap(&rt, &camera);
+    let (new_tiles, visible, new_vector_tiles, visible_vector, _place_labels) =
+        national_basemap(&rt, &camera);
     let (center, scale) = camera.world_to_clip_uniform((size() as f32, size() as f32));
     let cb = MapCallback {
         pane: 0,
@@ -2096,6 +2110,7 @@ pub fn run_l3grid(kind: &str, site: &str, out_path: &str) -> anyhow::Result<()> 
         field_draws: vec![(layer, 1.0)],
         clear_tiles: false,
         drop_tiles: Vec::new(),
+        drop_fields: Vec::new(),
         new_vector_tiles,
         visible_vector,
         clear_vector: false,
@@ -2151,7 +2166,8 @@ pub fn run_env(slug: &str, out_path: &str) -> anyhow::Result<()> {
 
     let upload = crate::app::field_upload_indexed(layer, f);
     let camera = cam_or_env(-97.0, 38.0, 4.0);
-    let (new_tiles, visible, new_vector_tiles, visible_vector, _place_labels) = national_basemap(&rt, &camera);
+    let (new_tiles, visible, new_vector_tiles, visible_vector, _place_labels) =
+        national_basemap(&rt, &camera);
     let (center, scale) = camera.world_to_clip_uniform((size() as f32, size() as f32));
     let cb = MapCallback {
         pane: 0,
@@ -2169,6 +2185,7 @@ pub fn run_env(slug: &str, out_path: &str) -> anyhow::Result<()> {
         field_draws: vec![(layer, 1.0)],
         clear_tiles: false,
         drop_tiles: Vec::new(),
+        drop_fields: Vec::new(),
         new_vector_tiles,
         visible_vector,
         clear_vector: false,
@@ -2333,7 +2350,8 @@ pub fn run_hrrr_layer(
         lut: crate::colormap::bake_lut(table, (vmin, vspan_max), None).to_vec(),
     };
     let camera = cam_or_env(-97.0, 38.0, 4.0);
-    let (new_tiles, visible, new_vector_tiles, visible_vector, _place_labels) = national_basemap(&rt, &camera);
+    let (new_tiles, visible, new_vector_tiles, visible_vector, _place_labels) =
+        national_basemap(&rt, &camera);
     let (center, scale) = camera.world_to_clip_uniform((size() as f32, size() as f32));
     let cb = MapCallback {
         pane: 0,
@@ -2351,6 +2369,7 @@ pub fn run_hrrr_layer(
         field_draws: vec![(FieldLayer::Hrrr, 1.0)],
         clear_tiles: false,
         drop_tiles: Vec::new(),
+        drop_fields: Vec::new(),
         new_vector_tiles,
         visible_vector,
         clear_vector: false,
@@ -2369,7 +2388,8 @@ fn render_field_png(
     out_path: &str,
 ) -> anyhow::Result<()> {
     let camera = cam_or_env(-97.0, 38.0, 4.0);
-    let (new_tiles, visible, new_vector_tiles, visible_vector, _place_labels) = national_basemap(rt, &camera);
+    let (new_tiles, visible, new_vector_tiles, visible_vector, _place_labels) =
+        national_basemap(rt, &camera);
     let (center, scale) = camera.world_to_clip_uniform((size() as f32, size() as f32));
     let cb = MapCallback {
         pane: 0,
@@ -2387,6 +2407,7 @@ fn render_field_png(
         field_draws: vec![(layer, 1.0)],
         clear_tiles: false,
         drop_tiles: Vec::new(),
+        drop_fields: Vec::new(),
         new_vector_tiles,
         visible_vector,
         clear_vector: false,
@@ -3162,6 +3183,7 @@ mod golden_tests {
                 field_draws: Vec::new(),
                 clear_tiles: false,
                 drop_tiles: Vec::new(),
+                drop_fields: Vec::new(),
                 new_vector_tiles: Vec::new(),
                 visible_vector: Vec::new(),
                 clear_vector: false,
@@ -3211,6 +3233,7 @@ mod golden_tests {
             field_draws: Vec::new(),
             clear_tiles: false,
             drop_tiles: Vec::new(),
+            drop_fields: Vec::new(),
             new_vector_tiles: Vec::new(),
             visible_vector: Vec::new(),
             clear_vector: false,

--- a/crates/hookecho/src/render/mod.rs
+++ b/crates/hookecho/src/render/mod.rs
@@ -337,6 +337,9 @@ pub struct MapCallback {
     pub field_uploads: Vec<(FieldLayer, MrmsUpload)>,
     /// Which field layers to paint this frame, with their opacity (0..1).
     pub field_draws: Vec<(FieldLayer, f32)>,
+    /// Field layers the app has stopped drawing for long enough to free; same contract as
+    /// `drop_tiles` — the app decides, we free, and it re-uploads on the next enable.
+    pub drop_fields: Vec<FieldLayer>,
     /// Newly tessellated vector basemap tiles to upload this frame.
     pub new_vector_tiles: Vec<PendingVectorTile>,
     /// Vector tile ids to draw this frame (drawn first, under the raster/radar layers).
@@ -1190,6 +1193,9 @@ impl RenderResources {
         // Touch everything this frame draws so the LRU evicts what is off screen, not what is in
         // front of the user. Visible entries can't be evicted mid-frame: the caches only shrink
         // here, before any drawing.
+        for layer in &cb.drop_fields {
+            self.fields.remove(layer);
+        }
         for (layer, up) in &cb.field_uploads {
             let gpu = self.build_field_layer(device, queue, up);
             self.fields.insert(*layer, gpu);

--- a/crates/hookecho/src/serve.rs
+++ b/crates/hookecho/src/serve.rs
@@ -851,12 +851,20 @@ fn national_clip(server: &Server) -> anyhow::Result<Vec<u8>> {
     }
     let out = snapshot_dir()?.join("national.mp4");
     // Re-encode only when the ring has moved on since the last one.
-    let newest = frames.last().and_then(|p| p.metadata().ok()?.modified().ok());
+    let newest = frames
+        .last()
+        .and_then(|p| p.metadata().ok()?.modified().ok());
     let encoded = out.metadata().ok().and_then(|m| m.modified().ok());
     if !matches!((encoded, newest), (Some(e), Some(n)) if e >= n) {
         let images: Vec<_> = frames
             .iter()
-            .filter_map(|p| Some(image::load_from_memory(&std::fs::read(p).ok()?).ok()?.to_rgba8()))
+            .filter_map(|p| {
+                Some(
+                    image::load_from_memory(&std::fs::read(p).ok()?)
+                        .ok()?
+                        .to_rgba8(),
+                )
+            })
             .collect();
         crate::loopexport::encode_mp4(&images, 6, &out)?;
     }

--- a/crates/hookecho/src/tiles.rs
+++ b/crates/hookecho/src/tiles.rs
@@ -1157,7 +1157,9 @@ pub struct TileManager {
     /// Tiles believed to be live on the GPU, newest-touched first. This mirrors the renderer's
     /// tile map exactly: the CPU side decides what gets evicted and tells the renderer, so the
     /// two can never disagree about whether a tile still exists.
-    uploaded: LruCache<crate::render::TileKey, ()>,
+    /// Value is the tile's GPU byte size — 512-px providers cost four times what the 256-px
+    /// entry count assumed, so eviction weighs bytes as well as entries.
+    uploaded: LruCache<crate::render::TileKey, u32>,
     /// Ids evicted by the last `touch_visible`, handed to the renderer to drop.
     evicted: Vec<crate::render::TileKey>,
     /// Tiles counted visible across all panes this frame; drives the eviction high-water mark.
@@ -1579,7 +1581,8 @@ impl TileManager {
             self.failed.remove(&key);
             // `push` (not `put`) hands back whatever it evicted, so the renderer can free the
             // texture instead of leaking it.
-            let evicted = self.uploaded.push(key, ());
+            let bytes = t.width * t.height * 4;
+            let evicted = self.uploaded.push(key, bytes);
             if let Some((id, _)) = evicted.filter(|(id, _)| *id != key) {
                 self.requested.remove(&id);
                 self.evicted.push(id);
@@ -1621,7 +1624,22 @@ impl TileManager {
         // limit. An evicted tile also drops out of `requested`, so revisiting that area re-fetches
         // it (from disk, usually) instead of leaving a black square.
         let want = RASTER_TILE_CACHE.max(self.frame_visible + 16);
+        // What this frame drew must survive the byte sweep, exactly as it survives the entry cap.
+        let floor = self.frame_visible;
         self.frame_visible = 0;
+        // Entry count alone let a 512-px provider (Mapbox/MapTiler, Carto @2x) hold four times
+        // the intended GPU memory. Cheap to total: at most `want` entries.
+        while self.uploaded.len() > floor.max(1)
+            && self.uploaded.iter().map(|(_, b)| *b as u64).sum::<u64>() > RASTER_TILE_BYTES
+        {
+            match self.uploaded.pop_lru() {
+                Some((id, _)) => {
+                    self.requested.remove(&id);
+                    self.evicted.push(id);
+                }
+                None => break,
+            }
+        }
         // Pop down to size FIRST: shrinking an `LruCache` evicts silently, and a silently evicted
         // tile is a texture the renderer never hears about again.
         while self.uploaded.len() > want {
@@ -1715,10 +1733,18 @@ pub(crate) async fn load_tile_bytes(
     Ok(bytes)
 }
 
-/// How many uploaded raster tiles to keep. A 256x256 RGBA tile is ~256 KB on the GPU, so 512 is
-/// ~134 MB on a desktop and 128 keeps a phone near 34 MB. In a browser — especially an iframe on
-/// Safari, where a Retina raster_bias quadruples the tile count — a desktop budget gets the whole
-/// device recycled out from under us, so wasm gets ~50 MB.
+/// How much GPU memory the uploaded raster tiles may rest at. This is the budget the entry cap
+/// below was always *meant* to express; entries alone under-counted a 512-px provider fourfold.
+const RASTER_TILE_BYTES: u64 = if cfg!(target_os = "android") {
+    34 * 1024 * 1024
+} else if cfg!(target_arch = "wasm32") {
+    50 * 1024 * 1024
+} else {
+    134 * 1024 * 1024
+};
+
+/// How many uploaded raster tiles to keep, whatever their size. Still a hard ceiling because
+/// `MAX_TILE_VERTS` sizes the vertex buffer to it; [`RASTER_TILE_BYTES`] is the memory budget.
 const RASTER_TILE_CACHE: usize = if cfg!(target_os = "android") {
     128
 } else if cfg!(target_arch = "wasm32") {
@@ -2003,6 +2029,30 @@ pub fn start_pack_download(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// 512-px providers made the 512-entry cache four times the memory the entry count assumed.
+    /// Eviction has to weigh bytes, and has to leave the frame's own tiles alone.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn eviction_weighs_bytes() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("runtime");
+        let mut m = TileManager::new(crate::rt::Spawner::new(rt.handle().clone()));
+        // 512-px tiles: 1 MB each, so well under 512 entries busts the byte budget.
+        let per = 512u32 * 512 * 4;
+        let n = (RASTER_TILE_BYTES / per as u64) as usize + 20;
+        for i in 0..n {
+            m.uploaded.push((0, (6, i as u32, 0)), per);
+        }
+        let dropped = m.evict_excess();
+        assert!(!dropped.is_empty(), "byte budget must evict");
+        let total: u64 = m.uploaded.iter().map(|(_, b)| *b as u64).sum();
+        assert!(
+            total <= RASTER_TILE_BYTES,
+            "{total} over {RASTER_TILE_BYTES}"
+        );
+    }
 
     /// The shipped default. A fresh install with no settings file and no API key anywhere lands
     /// here, so it has to be keyless, reachable on the web build, and offered on a phone.

--- a/crates/hookecho/src/wind_gpu.rs
+++ b/crates/hookecho/src/wind_gpu.rs
@@ -727,7 +727,10 @@ mod tests {
         let mut out = Vec::with_capacity((SIDE * SIDE) as usize);
         for row in 0..SIDE {
             let start = (row * padded) as usize;
-            for px in mapped[start..start + (SIDE * 4) as usize].as_chunks::<4>().0 {
+            for px in mapped[start..start + (SIDE * 4) as usize]
+                .as_chunks::<4>()
+                .0
+            {
                 out.push((
                     px[0] as f32 / 255.0 + px[1] as f32 / 255.0 / 255.0,
                     px[2] as f32 / 255.0 + px[3] as f32 / 255.0 / 255.0,

--- a/crates/wxdata/src/dwd.rs
+++ b/crates/wxdata/src/dwd.rs
@@ -614,9 +614,8 @@ mod tests {
         let before = crate::stats::snapshot();
         let again = fetch_volume(&client, "DEBO", Some(&name)).await.unwrap();
         let after = crate::stats::snapshot();
-        let requests = |v: &Vec<(&'static str, u64)>| {
-            v.iter().find(|(l, _)| *l == "net_requests").unwrap().1
-        };
+        let requests =
+            |v: &Vec<(&'static str, u64)>| v.iter().find(|(l, _)| *l == "net_requests").unwrap().1;
         let bytes =
             |v: &Vec<(&'static str, u64)>| v.iter().find(|(l, _)| *l == "net_bytes").unwrap().1;
         assert!(again.is_none(), "unchanged volume should be skipped");

--- a/crates/wxdata/src/hrrr.rs
+++ b/crates/wxdata/src/hrrr.rs
@@ -455,10 +455,8 @@ async fn fetch_run_field(
         .await?;
 
     // gribberish can panic on some packings; contain it (see mrms::fetch_latest).
-    crate::task::guarded(|| {
-        decode_regrid(&bytes, model, min_valid)
-    })
-    .unwrap_or_else(|_| anyhow::bail!("{} grib decode panicked", model.label()))
+    crate::task::guarded(|| decode_regrid(&bytes, model, min_valid))
+        .unwrap_or_else(|_| anyhow::bail!("{} grib decode panicked", model.label()))
 }
 
 /// Find the `[start, end)` byte range of the message matching `var` (field 3) and `level`

--- a/crates/wxdata/src/meteoalarm.rs
+++ b/crates/wxdata/src/meteoalarm.rs
@@ -77,25 +77,26 @@ pub async fn fetch_in_view(
 ) -> anyhow::Result<Vec<GeoFeature>> {
     // Up to eleven countries can be in view, and they were fetched one after another — eleven
     // round trips deep instead of one wide, on a 120 s refresh.
-    let bodies = futures_util::future::join_all(countries_in_view(bounds).into_iter().map(|slug| {
-        let url = crate::net::fetch_url(&format!("{FEED}{slug}"));
-        async move {
-            match client.get(&url).send().await {
-                Ok(resp) => match resp.text().await {
-                    Ok(body) => Some(body),
+    let bodies =
+        futures_util::future::join_all(countries_in_view(bounds).into_iter().map(|slug| {
+            let url = crate::net::fetch_url(&format!("{FEED}{slug}"));
+            async move {
+                match client.get(&url).send().await {
+                    Ok(resp) => match resp.text().await {
+                        Ok(body) => Some(body),
+                        Err(e) => {
+                            log::warn!("meteoalarm {slug}: body read failed ({e})");
+                            None
+                        }
+                    },
                     Err(e) => {
-                        log::warn!("meteoalarm {slug}: body read failed ({e})");
+                        log::warn!("meteoalarm {slug}: fetch failed ({e})");
                         None
                     }
-                },
-                Err(e) => {
-                    log::warn!("meteoalarm {slug}: fetch failed ({e})");
-                    None
                 }
             }
-        }
-    }))
-    .await;
+        }))
+        .await;
     let mut out = Vec::new();
     for body in bodies.into_iter().flatten() {
         out.extend(parse(&body));

--- a/crates/wxdata/src/net.rs
+++ b/crates/wxdata/src/net.rs
@@ -102,9 +102,7 @@ pub mod validators {
     fn store() -> &'static Mutex<lru::LruCache<String, Entry>> {
         static STORE: std::sync::OnceLock<Mutex<lru::LruCache<String, Entry>>> =
             std::sync::OnceLock::new();
-        STORE.get_or_init(|| {
-            Mutex::new(lru::LruCache::new(NonZeroUsize::new(256).unwrap()))
-        })
+        STORE.get_or_init(|| Mutex::new(lru::LruCache::new(NonZeroUsize::new(256).unwrap())))
     }
 
     /// What is remembered for `url`, if anything.
@@ -153,7 +151,6 @@ pub mod validators {
             }
         }
     }
-
 }
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
@@ -181,12 +178,18 @@ mod validator_tests {
         let url = "https://example.invalid/one";
         validators::remember_headers(
             url,
-            &headers(&[("etag", "\"abc\""), ("last-modified", "Sat, 29 Aug 2026 10:00:00 GMT")]),
+            &headers(&[
+                ("etag", "\"abc\""),
+                ("last-modified", "Sat, 29 Aug 2026 10:00:00 GMT"),
+            ]),
             Some("VOL-1".into()),
         );
         let e = validators::get(url).expect("remembered");
         assert_eq!(e.etag.as_deref(), Some("\"abc\""));
-        assert_eq!(e.last_modified.as_deref(), Some("Sat, 29 Aug 2026 10:00:00 GMT"));
+        assert_eq!(
+            e.last_modified.as_deref(),
+            Some("Sat, 29 Aug 2026 10:00:00 GMT")
+        );
         assert_eq!(e.tag.as_deref(), Some("VOL-1"));
     }
 
@@ -214,7 +217,10 @@ mod validator_tests {
             "https://example.invalid/three",
         );
         let built = req.build().unwrap();
-        assert!(built.headers().get(reqwest::header::IF_NONE_MATCH).is_none());
+        assert!(built
+            .headers()
+            .get(reqwest::header::IF_NONE_MATCH)
+            .is_none());
         assert!(built
             .headers()
             .get(reqwest::header::IF_MODIFIED_SINCE)

--- a/crates/wxdata/src/odim.rs
+++ b/crates/wxdata/src/odim.rs
@@ -115,9 +115,7 @@ pub fn start_time(bytes: Vec<u8>) -> anyhow::Result<DateTime<Utc>> {
 }
 
 /// [`decode`], plus the sweep end stamp the DWD feed names its dual-pol files by.
-pub fn decode_with_stamp(
-    bytes: Vec<u8>,
-) -> anyhow::Result<(DateTime<Utc>, Scan, Option<String>)> {
+pub fn decode_with_stamp(bytes: Vec<u8>) -> anyhow::Result<(DateTime<Utc>, Scan, Option<String>)> {
     let f = hdf5lite::File::open(bytes).map_err(|e| anyhow::anyhow!("odim: {e}"))?;
     let stamp = stamp_of(&f);
 

--- a/crates/wxdata/src/sounding.rs
+++ b/crates/wxdata/src/sounding.rs
@@ -498,10 +498,8 @@ async fn sample_message(
     // Off the async worker: each of these decodes a full HRRR level and scans ~1.9M grid points,
     // so leaving them here made forty concurrent fetches finish one decode at a time.
     crate::task::blocking(move || {
-        crate::task::guarded(|| {
-            sample_nearest(&bytes, lon, lat)
-        })
-        .unwrap_or_else(|_| anyhow::bail!("grib decode panicked"))
+        crate::task::guarded(|| sample_nearest(&bytes, lon, lat))
+            .unwrap_or_else(|_| anyhow::bail!("grib decode panicked"))
     })
     .await?
 }

--- a/crates/wxdata/src/spoken.rs
+++ b/crates/wxdata/src/spoken.rs
@@ -178,7 +178,10 @@ pub fn position_script(
     } else {
         ((km * 0.621_371).round() as i32, "miles")
     };
-    let mut s = format!("{name} is {n} {unit} to your {}", spoken_compass(bearing_deg));
+    let mut s = format!(
+        "{name} is {n} {unit} to your {}",
+        spoken_compass(bearing_deg)
+    );
     if let Some(d) = moving_toward_deg {
         s.push_str(&format!(", moving {}", spoken_compass(d)));
     }
@@ -260,6 +263,9 @@ mod tests {
         let s = position_script("The storm", 90.0, 32.2, Some(225.0), false);
         assert_eq!(s, "The storm is 20 miles to your east, moving southwest.");
         let s = position_script("The storm", 90.0, 32.2, Some(225.0), true);
-        assert_eq!(s, "The storm is 32 kilometers to your east, moving southwest.");
+        assert_eq!(
+            s,
+            "The storm is 32 kilometers to your east, moving southwest."
+        );
     }
 }


### PR DESCRIPTION
Stacked on #244.

- **Field layers were never freed.** `RenderResources.fields` only ever gained entries: 35 layers × up to 8192-px R8 textures stayed resident until exit. The app now tracks how long each layer has been off in every pane and, after 5 minutes, sends `drop_fields` — same manager-decides/renderer-frees contract as `drop_tiles` (the comment at render/mod.rs explains why the GPU side must not decide alone). Eviction clears `last_fetch` so the next enable re-fetches rather than trusting its refresh cadence.
- **512-entry tile cache was 512 MB, not 134 MB.** The entry count assumed 256-px tiles; Mapbox/MapTiler and Carto @2x are 512-px. `uploaded` now stores each tile's byte size and `evict_excess` sweeps to `RASTER_TILE_BYTES` (134/34/50 MB desktop/Android/wasm) as well as the entry cap, which stays because `MAX_TILE_VERTS` is sized to it. This frame's visible tiles are never swept.

Test: `eviction_weighs_bytes` in tiles.rs. Gate green; wasm size unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)