### PR TITLE
feat(tray): a tray that knows the weather

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -2296,6 +2296,8 @@ pub struct HookEchoApp {
     hrrr_by_timeline: bool,
     /// Tray-menu command channel (Linux StatusNotifier); `None` if no tray host is available.
     tray_rx: std::sync::mpsc::Receiver<crate::tray::TrayCmd>,
+    /// Last state pushed to the tray, so an unchanged frame sends nothing.
+    tray_state: crate::tray::TrayState,
     /// True once a StatusNotifier host has taken the tray item; registration is async, so this
     /// can flip after the first frames.
     tray_present: std::sync::Arc<std::sync::atomic::AtomicBool>,
@@ -3111,6 +3113,7 @@ impl HookEchoApp {
             hrrr_last_fetch: None,
             hrrr_by_timeline: false,
             tray_rx: tray_rx_init,
+            tray_state: crate::tray::TrayState::default(),
             tray_present: tray_present_init,
             really_quit: false,
             show_storm_reports: false,
@@ -14741,9 +14744,23 @@ impl eframe::App for HookEchoApp {
         }
 
         // Tray menu commands (Linux StatusNotifier): restore the window or quit for real.
+        // Keep the tray menu telling the truth: alert count, mute state, starred sites. Sent only
+        // when it changes — every send is a D-Bus round trip on the tray thread.
         {
-            let rx = &self.tray_rx;
-            while let Ok(cmd) = rx.try_recv() {
+            let want = crate::tray::TrayState {
+                alerts: self.active_alert_features().len(),
+                muted: self.settings.mute_alerts,
+                starred: self.settings.presets.clone(),
+            };
+            if self.tray_state != want {
+                self.tray_state = want.clone();
+                crate::tray::set_state(want);
+            }
+        }
+        {
+            // Drained first: the handlers below need `&mut self`, and the receiver lives in it.
+            let cmds: Vec<crate::tray::TrayCmd> = self.tray_rx.try_iter().collect();
+            for cmd in cmds {
                 match cmd {
                     crate::tray::TrayCmd::Show => {
                         ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
@@ -14753,6 +14770,15 @@ impl eframe::App for HookEchoApp {
                     crate::tray::TrayCmd::Quit => {
                         self.really_quit = true;
                         ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+                    }
+                    crate::tray::TrayCmd::Mute => {
+                        self.apply_action(BindableAction::ToggleMute, ctx);
+                    }
+                    crate::tray::TrayCmd::Site(id) => {
+                        // Same path the site dialog uses: `sync_pane` does the rest next frame.
+                        self.views[self.active].site = Some(id);
+                        ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
+                        ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
                     }
                 }
             }

--- a/crates/hookecho/src/tray.rs
+++ b/crates/hookecho/src/tray.rs
@@ -8,11 +8,26 @@ pub enum TrayCmd {
     Show,
     /// Quit the application for real (bypasses close-to-tray).
     Quit,
+    /// Toggle audio alerts (mirrors the in-app mute action).
+    Mute,
+    /// Jump the active pane to this radar site.
+    Site(String),
+}
+
+/// What the tray shows about the app. Pushed only when it changes — the menu is a D-Bus object,
+/// not something to repaint per frame.
+#[derive(Clone, Default, PartialEq)]
+pub struct TrayState {
+    /// Active alerts in the current view, for the summary line.
+    pub alerts: usize,
+    pub muted: bool,
+    /// Starred sites, offered as jump items.
+    pub starred: Vec<String>,
 }
 
 #[cfg(target_os = "linux")]
 mod imp {
-    use super::TrayCmd;
+    use super::{TrayCmd, TrayState};
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::mpsc::{Receiver, Sender};
     use std::sync::Arc;
@@ -20,6 +35,7 @@ mod imp {
     struct HookEchoTray {
         tx: Sender<TrayCmd>,
         icon: ksni::Icon,
+        state: TrayState,
     }
 
     impl ksni::Tray for HookEchoTray {
@@ -37,8 +53,44 @@ mod imp {
             let _ = self.tx.send(TrayCmd::Show);
         }
         fn menu(&self) -> Vec<ksni::MenuItem<Self>> {
-            use ksni::menu::StandardItem;
-            vec![
+            use ksni::menu::{CheckmarkItem, StandardItem};
+            let mut items: Vec<ksni::MenuItem<Self>> = vec![
+                StandardItem {
+                    label: match self.state.alerts {
+                        0 => "No active alerts".into(),
+                        1 => "1 active alert".into(),
+                        n => format!("{n} active alerts"),
+                    },
+                    // A status line, not a button.
+                    enabled: false,
+                    ..Default::default()
+                }
+                .into(),
+                CheckmarkItem {
+                    label: "Mute audio alerts".into(),
+                    checked: self.state.muted,
+                    activate: Box::new(|t: &mut HookEchoTray| {
+                        let _ = t.tx.send(TrayCmd::Mute);
+                    }),
+                    ..Default::default()
+                }
+                .into(),
+            ];
+            // Starred sites: the same list the toolbox presets dropdown offers.
+            for site in &self.state.starred {
+                let id = site.clone();
+                items.push(
+                    StandardItem {
+                        label: id.clone(),
+                        activate: Box::new(move |t: &mut HookEchoTray| {
+                            let _ = t.tx.send(TrayCmd::Site(id.clone()));
+                        }),
+                        ..Default::default()
+                    }
+                    .into(),
+                );
+            }
+            items.extend([
                 StandardItem {
                     label: "Show HookEcho".into(),
                     activate: Box::new(|t: &mut HookEchoTray| {
@@ -55,7 +107,8 @@ mod imp {
                     ..Default::default()
                 }
                 .into(),
-            ]
+            ]);
+            items
         }
     }
 
@@ -83,28 +136,49 @@ mod imp {
     pub fn spawn() -> (Receiver<TrayCmd>, Arc<AtomicBool>) {
         use ksni::blocking::TrayMethods;
         let (tx, rx) = std::sync::mpsc::channel();
+        let (state_tx, state_rx) = std::sync::mpsc::channel::<TrayState>();
+        let _ = STATE_TX.set(state_tx);
         let present = Arc::new(AtomicBool::new(false));
         let flag = Arc::clone(&present);
         std::thread::spawn(move || {
             let tray = HookEchoTray {
                 tx,
                 icon: logo_icon(),
+                state: TrayState::default(),
             };
-            match tray.spawn() {
+            let handle = match tray.spawn() {
                 Ok(handle) => {
                     flag.store(true, Ordering::Relaxed);
-                    std::mem::forget(handle);
+                    handle
                 }
-                Err(e) => log::warn!("tray icon unavailable ({e}); using taskbar fallback"),
+                Err(e) => {
+                    log::warn!("tray icon unavailable ({e}); using taskbar fallback");
+                    return;
+                }
+            };
+            // The handle used to be leaked, which is why the menu could never change. Kept here
+            // instead: this thread outlives the process anyway, and it owns the updates.
+            while let Ok(state) = state_rx.recv() {
+                handle.update(|t: &mut HookEchoTray| t.state = state);
             }
         });
         (rx, present)
+    }
+
+    /// Where [`set_state`] posts; set once by [`spawn`].
+    static STATE_TX: std::sync::OnceLock<Sender<TrayState>> = std::sync::OnceLock::new();
+
+    /// Push new tray state. Cheap and non-blocking — the D-Bus update happens on the tray thread.
+    pub fn set_state(state: TrayState) {
+        if let Some(tx) = STATE_TX.get() {
+            let _ = tx.send(state);
+        }
     }
 }
 
 #[cfg(not(target_os = "linux"))]
 mod imp {
-    use super::TrayCmd;
+    use super::{TrayCmd, TrayState};
     use std::sync::atomic::AtomicBool;
     use std::sync::mpsc::Receiver;
     use std::sync::Arc;
@@ -116,6 +190,9 @@ mod imp {
         std::mem::forget(tx); // keep the channel open rather than hand back a disconnected one
         (rx, Arc::new(AtomicBool::new(false)))
     }
+
+    /// No tray to tell.
+    pub fn set_state(_state: TrayState) {}
 }
 
-pub use imp::spawn;
+pub use imp::{set_state, spawn};


### PR DESCRIPTION
Stacked on #249 (needs #247's threaded tray spawn).

The ksni `Handle` was `std::mem::forget`ed, so the menu was frozen as Show/Quit forever. The tray thread now keeps the handle and applies `TrayState { alerts, muted, starred }` pushed over a channel by `tray::set_state`. Menu: alert-count status line (disabled), Mute checkbox, one jump item per starred site, Show, Quit. New `TrayCmd::{Mute, Site}` route through the existing mute action and site-set path. State is pushed only when it changes — every send is a D-Bus round trip.

Non-Linux stub gains a no-op `set_state`; `--tray-test` unchanged.

Gate green; wasm unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)