### PR TITLE
feat(wxdata): vertical fill-down in derived products

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -3656,6 +3656,7 @@ impl HookEchoApp {
         let opts = wxdata::derived::DerivedOpts {
             etop_dbz: self.settings.etop_dbz,
             time: vol.time,
+            ..Default::default()
         };
         self.derived_key = Some(key);
         let tx = self.overlay_tx.clone();

--- a/crates/wxdata/benches/hot_paths.rs
+++ b/crates/wxdata/benches/hot_paths.rs
@@ -39,6 +39,7 @@ fn bench_derived(c: &mut Criterion) {
     let opts = DerivedOpts {
         etop_dbz: 18.0,
         time: chrono::Utc::now(),
+        ..Default::default()
     };
     let mut g = c.benchmark_group("derived");
     g.sample_size(10);

--- a/crates/wxdata/src/derived.rs
+++ b/crates/wxdata/src/derived.rs
@@ -28,6 +28,10 @@ pub struct DerivedOpts {
     /// Stamped onto the output fields — the volume's time, so a scrubbed archive frame doesn't
     /// claim to be current.
     pub time: DateTime<Utc>,
+    /// Fill the column down from the lowest beam to the surface before integrating, when that
+    /// beam is low enough for the extension to be an extrapolation rather than a guess. See
+    /// [`FILL_DOWN_CAP_KM`].
+    pub extrapolate: bool,
 }
 
 impl Default for DerivedOpts {
@@ -35,6 +39,7 @@ impl Default for DerivedOpts {
         Self {
             etop_dbz: 18.5,
             time: Utc::now(),
+            extrapolate: true,
         }
     }
 }
@@ -112,6 +117,12 @@ impl Grid {
     }
 }
 
+/// How high the lowest beam may sit and still have its value carried down to the surface.
+/// Under this height the beam is close enough that the air beneath it is the same air; above it,
+/// at a 0.5° tilt roughly 200 km out, the layer being invented is most of the column and the
+/// value carried into it is a guess dressed as a measurement.
+const FILL_DOWN_CAP_KM: f64 = 2.0;
+
 /// dBZ → linear reflectivity factor Z (mm⁶/m³), capped at [`Z_CAP_DBZ`].
 fn z_linear(dbz: f32) -> f64 {
     10f64.powf(dbz.min(Z_CAP_DBZ) as f64 / 10.0)
@@ -120,8 +131,11 @@ fn z_linear(dbz: f32) -> f64 {
 /// VIL (kg/m²) of one vertical profile: Σ 3.44×10⁻⁶ · Z̄^(4/7) · Δh, over the layers between
 /// consecutive beams.
 ///
-/// ponytail: no extrapolation below the lowest beam or above the highest — the classic
-/// definition, and inventing a layer under a 0.5° beam 100 km out invents most of the answer.
+/// The profile is taken as given: this integrates between the samples it is handed and does not
+/// invent layers at either end. The layer below the lowest beam is handled by the caller, which
+/// knows how high that beam actually is (see [`FILL_DOWN_CAP_KM`]); nothing is added above the
+/// highest beam, because a storm's top is the one place the classic definition is right — there
+/// is no water up there to integrate.
 fn vil_of(samples: &[(f64, f32)]) -> f32 {
     let mut vil = 0.0;
     for w in samples.windows(2) {
@@ -180,6 +194,18 @@ pub fn derive(sweeps: &[BinnedSweep], opts: &DerivedOpts) -> Option<Derived> {
             }
             if samples.len() < 2 {
                 continue;
+            }
+            // The beam leaves the radar at an angle, so every column more than a few kilometres
+            // out has its lowest sample somewhere above the ground, and the classic VIL simply
+            // discards that layer. Near the radar that is throwing away the wettest part of the
+            // column. Carry the lowest observed value down to the surface — but only while the
+            // beam is low enough that the air below it is the same air.
+            if opts.extrapolate {
+                if let Some(&(h_lowest, v_lowest)) = samples.first() {
+                    if h_lowest > 0.0 && h_lowest <= FILL_DOWN_CAP_KM {
+                        samples.insert(0, (0.0, v_lowest));
+                    }
+                }
             }
             let v = vil_of(&samples);
             if v > 0.0 {
@@ -309,6 +335,39 @@ mod tests {
         let mut s = Vec::new();
         column_samples(sweeps, ground_km, 0.0, &mut s);
         s
+    }
+
+    /// Filling down adds the layer between the lowest beam and the ground, so VIL near the radar
+    /// has to come out larger — and only near the radar, where the cap allows it.
+    #[test]
+    fn filling_down_adds_liquid_only_under_a_low_beam() {
+        let sweeps = uniform_sweeps(45.0, &[0.5, 1.5, 2.4, 3.4, 4.3, 6.0, 9.9]);
+        let on = derive(&sweeps, &DerivedOpts::default()).expect("grid");
+        let off = derive(
+            &sweeps,
+            &DerivedOpts {
+                extrapolate: false,
+                ..Default::default()
+            },
+        )
+        .expect("grid");
+        let pairs: Vec<(f32, f32)> = on
+            .vil
+            .values
+            .iter()
+            .zip(&off.vil.values)
+            .filter(|(a, b)| a.is_finite() && b.is_finite())
+            .map(|(a, b)| (*a, *b))
+            .collect();
+        assert!(!pairs.is_empty(), "some column integrated");
+        assert!(
+            pairs.iter().all(|(a, b)| a >= b),
+            "filling down never removes liquid"
+        );
+        assert!(
+            pairs.iter().any(|(a, b)| *a > b + 0.01),
+            "some column near the radar gained its surface layer"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #252.

Adds `DerivedOpts::extrapolate` (default **true**): before integrating a column, carry the lowest observed reflectivity down to the surface as a virtual `(0.0, v_lowest)` sample — but only when the lowest beam is at or below `FILL_DOWN_CAP_KM` (2.0 km).

**Why:** classic VIL discards the layer between the ground and the lowest beam. Near the radar that layer is the wettest part of the column, so VIL under-reads for storms directly overhead. Past the 2 km cap the invented layer would be most of the column, so the classic behaviour stands.

**Unaffected by design:** composite (a maximum — the added sample is never larger), echo tops (read from the highest sample), and `hail()`/SHI (Witt integrates above the freezing level; changing it changes published science, not a display convention).

Call sites switched to `..Default::default()` (app.rs, benches).

**Test:** `filling_down_adds_liquid_only_under_a_low_beam` — on ≥ off everywhere, strictly greater somewhere near the radar.

**Gate:** clippy -D warnings clean · workspace tests green · wasm check green · `shoot.sh check` passed (no golden drift — worth a second look at review time if you expect VIL shots to move) · web build 3 984 285 gz, budget unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)