### PR TITLE
feat(models): 2 m dewpoint in the global layers and the model diff

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1378,6 +1378,7 @@ fn field_refresh_secs(layer: crate::render::FieldLayer) -> u64 {
         FL::GlobalMslp
         | FL::GlobalHeight500
         | FL::GlobalTemp2m
+        | FL::GlobalDewpoint2m
         | FL::GlobalWind10m
         | FL::GlobalPrecip
         // Two global cycles behind it, so the same half hour.
@@ -9342,6 +9343,7 @@ impl HookEchoApp {
             | FL::GlobalMslp
             | FL::GlobalHeight500
             | FL::GlobalTemp2m
+            | FL::GlobalDewpoint2m
             | FL::GlobalWind10m
             | FL::GlobalPrecip
             | FL::ModelDiff
@@ -14960,6 +14962,10 @@ impl eframe::App for HookEchoApp {
             (FL::GlobalMslp, wxdata::global::GlobalField::Mslp),
             (FL::GlobalHeight500, wxdata::global::GlobalField::Height500),
             (FL::GlobalTemp2m, wxdata::global::GlobalField::Temp2m),
+            (
+                FL::GlobalDewpoint2m,
+                wxdata::global::GlobalField::Dewpoint2m,
+            ),
             (FL::GlobalWind10m, wxdata::global::GlobalField::Wind10m),
             (FL::GlobalPrecip, wxdata::global::GlobalField::Precip),
         ] {

--- a/crates/hookecho/src/app/chrome/registry.rs
+++ b/crates/hookecho/src/app/chrome/registry.rs
@@ -289,6 +289,13 @@ impl HookEchoApp {
                 false,
             ),
             (
+                FL::GlobalDewpoint2m,
+                "Models",
+                "Surface dewpoint (2 m)",
+                "How much moisture the air is carrying, worldwide",
+                false,
+            ),
+            (
                 FL::GlobalWind10m,
                 "Models",
                 "Surface wind (10 m)",

--- a/crates/hookecho/src/fielddiff.rs
+++ b/crates/hookecho/src/fielddiff.rs
@@ -36,6 +36,7 @@ pub enum GlobalFieldKind {
     Mslp,
     Height500,
     Temp2m,
+    Dewpoint2m,
     Wind10m,
     Precip,
 }
@@ -46,6 +47,7 @@ impl From<GlobalFieldKind> for GlobalField {
             GlobalFieldKind::Mslp => GlobalField::Mslp,
             GlobalFieldKind::Height500 => GlobalField::Height500,
             GlobalFieldKind::Temp2m => GlobalField::Temp2m,
+            GlobalFieldKind::Dewpoint2m => GlobalField::Dewpoint2m,
             GlobalFieldKind::Wind10m => GlobalField::Wind10m,
             GlobalFieldKind::Precip => GlobalField::Precip,
         }
@@ -59,14 +61,15 @@ impl Default for DiffField {
 }
 
 impl DiffField {
-    /// ponytail: no moisture row. GFS publishes precipitable water and ECMWF publishes total
-    /// precipitation — subtracting them is subtracting two different quantities, and a plausible
-    /// looking map of nonsense is worse than no map. Add it when both sides read the same
-    /// variable.
-    pub const ALL: [DiffField; 6] = [
+    /// Moisture is here as 2 m dewpoint: both models publish it as the same quantity in the same
+    /// units, so the subtraction means something. Column moisture still is not — GFS publishes
+    /// precipitable water and ECMWF total precipitation, and subtracting them subtracts two
+    /// different things. A plausible looking map of nonsense is worse than no map.
+    pub const ALL: [DiffField; 7] = [
         DiffField::Global(GlobalFieldKind::Mslp),
         DiffField::Global(GlobalFieldKind::Height500),
         DiffField::Global(GlobalFieldKind::Temp2m),
+        DiffField::Global(GlobalFieldKind::Dewpoint2m),
         DiffField::Global(GlobalFieldKind::Wind10m),
         DiffField::Cape,
         DiffField::Srh,
@@ -116,6 +119,7 @@ impl DiffField {
             DiffField::Global(GlobalFieldKind::Mslp) => (8.0, 0.5),
             DiffField::Global(GlobalFieldKind::Height500) => (12.0, 1.0),
             DiffField::Global(GlobalFieldKind::Temp2m) => (6.0, 0.5),
+            DiffField::Global(GlobalFieldKind::Dewpoint2m) => (6.0, 0.5),
             DiffField::Global(GlobalFieldKind::Wind10m) => (20.0, 2.0),
             DiffField::Global(GlobalFieldKind::Precip) => (20.0, 1.0),
             DiffField::Cape => (1500.0, 200.0),
@@ -129,6 +133,7 @@ impl DiffField {
             DiffField::Global(GlobalFieldKind::Mslp) => "hPa",
             DiffField::Global(GlobalFieldKind::Height500) => "dam",
             DiffField::Global(GlobalFieldKind::Temp2m) => "°C",
+            DiffField::Global(GlobalFieldKind::Dewpoint2m) => "°C",
             DiffField::Global(GlobalFieldKind::Wind10m) => "kt",
             DiffField::Global(GlobalFieldKind::Precip) => "mm",
 

--- a/crates/hookecho/src/headless.rs
+++ b/crates/hookecho/src/headless.rs
@@ -1615,6 +1615,7 @@ pub fn run_global(model: &str, slug: &str, out_path: &str) -> anyhow::Result<()>
         GlobalField::Mslp => FL::GlobalMslp,
         GlobalField::Height500 => FL::GlobalHeight500,
         GlobalField::Temp2m => FL::GlobalTemp2m,
+        GlobalField::Dewpoint2m => FL::GlobalDewpoint2m,
         GlobalField::Wind10m => FL::GlobalWind10m,
         GlobalField::Precip => FL::GlobalPrecip,
     };

--- a/crates/hookecho/src/render/field_ramps.rs
+++ b/crates/hookecho/src/render/field_ramps.rs
@@ -376,6 +376,28 @@ static GLOBAL_HEIGHT_500: FieldRamp = FieldRamp {
 };
 
 /// Global 2 m temperature, in the units most of the planet reads.
+static GLOBAL_DEWPOINT_2M: FieldRamp = FieldRamp {
+    // Kelvin like the temperature ramp, but a moisture scale rather than a thermal one: brown
+    // and dry at the bottom, green and soupy at the top, with the 15 °C / 288 K "muggy" mark
+    // near the middle where severe forecasters look.
+    input_scale: 1.0,
+    ..ramp!(
+        "2 m dewpoint",
+        "K",
+        243.0,
+        300.0,
+        RampScale::Linear,
+        170,
+        &[
+            (0.0, [120, 90, 60]),
+            (0.35, [210, 200, 170]),
+            (0.6, [110, 190, 130]),
+            (0.8, [30, 140, 90]),
+            (1.0, [20, 80, 110]),
+        ]
+    )
+};
+
 static GLOBAL_TEMP_2M: FieldRamp = FieldRamp {
     // Kelvin → °C is an offset, not a scale, so the ramp is expressed in Kelvin and labelled °C
     // by the legend's own offset handling would be a lie — keep it in Kelvin-derived °C here.
@@ -648,6 +670,7 @@ pub fn ramp_for(layer: FieldLayer) -> Option<&'static FieldRamp> {
         FL::GlobalMslp => &GLOBAL_MSLP,
         FL::GlobalHeight500 => &GLOBAL_HEIGHT_500,
         FL::GlobalTemp2m => &GLOBAL_TEMP_2M,
+        FL::GlobalDewpoint2m => &GLOBAL_DEWPOINT_2M,
         FL::GlobalWind10m => &GLOBAL_WIND_10M,
         FL::GlobalPrecip => &GLOBAL_PRECIP,
         FL::Hca => &HCA,

--- a/crates/hookecho/src/render/mod.rs
+++ b/crates/hookecho/src/render/mod.rs
@@ -124,6 +124,8 @@ pub enum FieldLayer {
     GlobalHeight500,
     /// Global model 2 m temperature.
     GlobalTemp2m,
+    /// Global model 2 m dewpoint.
+    GlobalDewpoint2m,
     /// Global model 10 m wind speed.
     GlobalWind10m,
     /// Global model precipitable water / total precipitation.
@@ -156,6 +158,7 @@ impl FieldLayer {
                 | FieldLayer::GlobalMslp
                 | FieldLayer::GlobalHeight500
                 | FieldLayer::GlobalTemp2m
+                | FieldLayer::GlobalDewpoint2m
                 | FieldLayer::GlobalWind10m
                 | FieldLayer::GlobalPrecip
                 | FieldLayer::ModelDiff
@@ -163,12 +166,13 @@ impl FieldLayer {
     }
 
     /// Fixed bottom-to-top paint order within each band.
-    pub const DRAW_ORDER: [FieldLayer; 37] = [
+    pub const DRAW_ORDER: [FieldLayer; 38] = [
         // Below-radar context band (bottom to top). The global models sit at the very bottom:
         // they are the synoptic backdrop everything else is drawn against.
         FieldLayer::GlobalMslp,
         FieldLayer::GlobalHeight500,
         FieldLayer::GlobalTemp2m,
+        FieldLayer::GlobalDewpoint2m,
         FieldLayer::GlobalWind10m,
         FieldLayer::GlobalPrecip,
         FieldLayer::ModelDiff,
@@ -243,6 +247,7 @@ impl FieldLayer {
             FieldLayer::GlobalMslp => "global-mslp",
             FieldLayer::GlobalHeight500 => "global-height500",
             FieldLayer::GlobalTemp2m => "global-temp2m",
+            FieldLayer::GlobalDewpoint2m => "global-dewpoint2m",
             FieldLayer::GlobalWind10m => "global-wind10m",
             FieldLayer::GlobalPrecip => "global-precip",
             FieldLayer::ModelDiff => "model-diff",

--- a/crates/hookecho/src/ui/layer_options.rs
+++ b/crates/hookecho/src/ui/layer_options.rs
@@ -103,6 +103,7 @@ pub(crate) fn show(
         FL::GlobalMslp,
         FL::GlobalHeight500,
         FL::GlobalTemp2m,
+        FL::GlobalDewpoint2m,
         FL::GlobalWind10m,
         FL::GlobalPrecip,
     ]

--- a/crates/wxdata/src/global.rs
+++ b/crates/wxdata/src/global.rs
@@ -54,15 +54,17 @@ pub enum GlobalField {
     Mslp,
     Height500,
     Temp2m,
+    Dewpoint2m,
     Wind10m,
     Precip,
 }
 
 impl GlobalField {
-    pub const ALL: [GlobalField; 5] = [
+    pub const ALL: [GlobalField; 6] = [
         GlobalField::Mslp,
         GlobalField::Height500,
         GlobalField::Temp2m,
+        GlobalField::Dewpoint2m,
         GlobalField::Wind10m,
         GlobalField::Precip,
     ];
@@ -72,6 +74,7 @@ impl GlobalField {
             GlobalField::Mslp => "MSLP",
             GlobalField::Height500 => "500 hPa height",
             GlobalField::Temp2m => "2 m temp",
+            GlobalField::Dewpoint2m => "2 m dewpoint",
             GlobalField::Wind10m => "10 m wind",
             GlobalField::Precip => "Total precip",
         }
@@ -83,6 +86,7 @@ impl GlobalField {
             GlobalField::Mslp => "mslp",
             GlobalField::Height500 => "gh500",
             GlobalField::Temp2m => "t2m",
+            GlobalField::Dewpoint2m => "td2m",
             GlobalField::Wind10m => "wind10m",
             GlobalField::Precip => "precip",
         }
@@ -98,6 +102,7 @@ impl GlobalField {
             GlobalField::Mslp => ("PRMSL", "mean sea level"),
             GlobalField::Height500 => ("HGT", "500 mb"),
             GlobalField::Temp2m => ("TMP", "2 m above ground"),
+            GlobalField::Dewpoint2m => ("DPT", "2 m above ground"),
             GlobalField::Wind10m => ("UGRD", "10 m above ground"),
             GlobalField::Precip => ("PWAT", "entire atmosphere (considered as a single layer)"),
         }
@@ -109,6 +114,7 @@ impl GlobalField {
             GlobalField::Mslp => ("msl", "sfc", None),
             GlobalField::Height500 => ("gh", "pl", Some("500")),
             GlobalField::Temp2m => ("2t", "sfc", None),
+            GlobalField::Dewpoint2m => ("2d", "sfc", None),
             GlobalField::Wind10m => ("10u", "sfc", None),
             GlobalField::Precip => ("tp", "sfc", None),
         }
@@ -309,7 +315,8 @@ mod tests {
     fn ecmwf_index_lines_resolve_to_ranges() {
         let idx = "{\"domain\": \"g\", \"param\": \"msl\", \"levtype\": \"sfc\", \"_offset\": 100, \"_length\": 250}\n\
                    {\"domain\": \"g\", \"param\": \"gh\", \"levtype\": \"pl\", \"levelist\": \"850\", \"_offset\": 400, \"_length\": 60}\n\
-                   {\"domain\": \"g\", \"param\": \"gh\", \"levtype\": \"pl\", \"levelist\": \"500\", \"_offset\": 500, \"_length\": 75}\n";
+                   {\"domain\": \"g\", \"param\": \"gh\", \"levtype\": \"pl\", \"levelist\": \"500\", \"_offset\": 500, \"_length\": 75}\n\
+                   {\"domain\": \"g\", \"param\": \"2d\", \"levtype\": \"sfc\", \"_offset\": 700, \"_length\": 90}\n";
         assert_eq!(
             ecmwf_byte_range(idx, GlobalField::Mslp),
             Some((100, Some(350)))
@@ -318,6 +325,10 @@ mod tests {
         assert_eq!(
             ecmwf_byte_range(idx, GlobalField::Height500),
             Some((500, Some(575)))
+        );
+        assert_eq!(
+            ecmwf_byte_range(idx, GlobalField::Dewpoint2m),
+            Some((700, Some(790)))
         );
         assert_eq!(ecmwf_byte_range(idx, GlobalField::Temp2m), None);
     }


### PR DESCRIPTION
Stacked on #253.

Adds `GlobalField::Dewpoint2m` — GFS `("DPT", "2 m above ground")`, ECMWF `("2d", "sfc")`, slug `td2m` — and the matching `GlobalFieldKind`, so it appears both as its own global layer and as a row in the model-diff picker.

**Why the moisture row is finally allowed:** the old `ponytail:` note refused one because GFS publishes precipitable water while ECMWF publishes total precipitation — different quantities. Dewpoint is the same quantity in the same units on both sides, so the subtraction means something. Column moisture is still refused, and the comment now says which is which.

Diff range `(6.0, 0.5)` in °C, same as temperature (K − K is already °C, so `input_scale` falls through to 1.0). New standalone ramp `GLOBAL_DEWPOINT_2M`: dry brown to soupy green-blue, 243–300 K.

The rest is the mechanical spread a new `FieldLayer` requires — `DRAW_ORDER` 37→38, `below_radar`, slug, refresh interval, fetch table, registry row, layer-options group.

**Test:** ECMWF index fixture extended with a `2d` line, asserting it resolves to its byte range.

**Live verify:** `--headless-diff td2m` → `GFS (2026-08-30 18Z) − ECMWF (12Z) td2m: 1200x600 of 720000 finite, spread -21.77..24.87, median -0.43 °C`.

**Gate:** clippy -D warnings clean · workspace tests green · wasm check green · shots pass · web 3 986 257 gz (budget 4 125 000).

🤖 Generated with [Claude Code](https://claude.com/claude-code)