### PR TITLE
fix(notify): real retry backoff on the web; persist the quiet queue as it changes

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -15044,6 +15044,17 @@ impl eframe::App for HookEchoApp {
             }
         }
         self.was_quiet = now_quiet;
+        // Hold the queue on disk as it changes, not only on a clean exit. A crash or a kill
+        // during quiet hours used to lose the whole night's held alerts; the queue is a handful
+        // of short strings, so comparing it every tick and writing only on a real change costs
+        // nothing worth measuring.
+        if let Ok(q) = self.quiet_queue.lock() {
+            if *q != self.settings.quiet_pending {
+                self.settings.quiet_pending = q.clone();
+                drop(q);
+                self.settings.save();
+            }
+        }
 
         // GOES lightning: granules land every 20 s, so poll about that often. One in flight at a
         // time — a slow fetch must not queue up behind itself.

--- a/crates/hookecho/src/notify.rs
+++ b/crates/hookecho/src/notify.rs
@@ -171,8 +171,7 @@ pub async fn send_retrying(what: &str, make: impl Fn() -> reqwest::RequestBuilde
     if log_outcome(what, "delivery", &first) {
         return;
     }
-    // On the web there is no timer and no runtime to wait on, so one attempt is the whole story.
-    if cfg!(target_arch = "wasm32") || !worth_retrying(&first) {
+    if !worth_retrying(&first) {
         return;
     }
     // Taking a retry slot is what the cap counts; the first attempt is always free.
@@ -217,16 +216,11 @@ fn log_outcome(what: &str, stage: &str, res: &Result<reqwest::Response, reqwest:
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+/// Both targets have a timer: tokio natively, `setTimeout` in the browser. `wxdata::task::sleep`
+/// is already the thing that knows which.
 async fn sleep_secs(secs: u64) {
-    tokio::time::sleep(std::time::Duration::from_secs(secs)).await;
+    wxdata::task::sleep(std::time::Duration::from_secs(secs)).await;
 }
-
-/// No tokio in the browser, and no timer worth pulling a crate for: the web build gets the one
-/// attempt it had before.
-// ponytail: web sends once; wire a `gloo-timers` sleep here if web push ever matters.
-#[cfg(target_arch = "wasm32")]
-async fn sleep_secs(_secs: u64) {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/hookecho/src/paths.rs
+++ b/crates/hookecho/src/paths.rs
@@ -25,8 +25,9 @@ fn root(kind: &str) -> Option<PathBuf> {
     // the web build keeps everything in memory. Settings are the exception: they persist through
     // `localStorage` instead, entirely inside `settings.rs` (nothing here returns a path for it).
     //
-    // ponytail: caches stay in memory on the web; IndexedDB/OPFS is the upgrade path if
-    // offline-web ever becomes real.
+    // Tiles are the exception, and they are cached outside Rust entirely: the service worker
+    // keeps them in Cache Storage (`web/sw.src.js`, the `tiles-v1` bucket). Radar volumes are
+    // deliberately left out of that bucket — they are large, per-scan, and would evict the map.
     #[cfg(target_arch = "wasm32")]
     {
         let _ = kind;


### PR DESCRIPTION
Stacked on #254.

Two small correctness fixes and one stale comment.

**Web retries.** `sleep_secs` was a no-op on wasm and delivery early-returned after one attempt, on the grounds that the browser has no timer. It does — `wxdata::task::sleep` is `gloo-timers`-backed there and the dependency was already present. Both targets now share one `sleep_secs`, and the web build gets the same backoff ladder, retry cap and `Slot` accounting as the desktop.

**Quiet queue durability.** `Settings::quiet_pending` was written on exit and restored on boot, so a clean shutdown kept held alerts — but a crash or a kill mid-quiet-hours lost the night. The queue is now compared against settings each tick and written when it actually differs. It is a handful of short strings; the comparison is free and the write only happens on a real change.

**Stale comment.** `paths.rs` claimed web caches live only in memory with IndexedDB as the upgrade path. Tiles have been cached by the service worker (`web/sw.src.js`, `tiles-v1`) for a while; the comment now says so, and says why radar volumes are deliberately excluded from that bucket.

**Gate:** clippy -D warnings clean · workspace tests green · wasm check green · shots pass · web 3 987 427 gz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)