### PR TITLE
feat(serve): ?palette= for snapshot renders

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,7 +560,7 @@ and you get the full app there.
 | `/obs.json` | conditions only |
 | `/cells.json?site=KTLX` | every storm cell the radar's algorithms track — hail size, tops, VIL, TVS, forecast track |
 | `/health.json` | version, uptime and how stale the answers are, for a container health check |
-| `/snapshot.png?site=KTLX` | a radar render — `&product=VEL`, `&basemap=none`, `&size=512` (256–2048), `&zoom=6.5`, `&tilt=1` |
+| `/snapshot.png?site=KTLX` | a radar render — `&product=VEL`, `&basemap=none`, `&size=512` (256–2048), `&zoom=6.5`, `&tilt=1`, `&palette=` (a built-in alternate's exact name, e.g. `Colorblind-safe (viridis)`) |
 | `/loop.gif?site=KTLX` | the last half hour animating — same render knobs, plus `&frames=6` (2–12) and `&fps=2` |
 | `/loop.mp4?site=KTLX` | the same loop as H.264, if ffmpeg is installed |
 | `/national.png` | the MRMS national mosaic, rendered here rather than hotlinked |

--- a/crates/hookecho/src/cloud.rs
+++ b/crates/hookecho/src/cloud.rs
@@ -244,7 +244,7 @@ fn pkce_challenge(verifier: &str) -> String {
 }
 
 /// Percent-encode a query parameter value. Only the characters Google's URLs actually need.
-fn urlencode(s: &str) -> String {
+pub(crate) fn urlencode(s: &str) -> String {
     s.chars()
         .map(|c| match c {
             'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '.' | '_' | '~' => c.to_string(),

--- a/crates/hookecho/src/colormap.rs
+++ b/crates/hookecho/src/colormap.rs
@@ -318,6 +318,11 @@ pub fn alt_names(moment: Moment) -> impl Iterator<Item = &'static str> {
 }
 
 /// Parse the built-in alternate `name`, or `None` if there is no such alternate.
+pub fn builtin_alt(name: &str) -> Option<ColorTable> {
+    resolve_builtin(name)
+}
+
+/// Parse the built-in alternate `name`, or `None` if there is no such alternate.
 fn resolve_builtin(name: &str) -> Option<ColorTable> {
     let (_, _, src) = ALT_SRC.iter().find(|(n, _, _)| *n == name)?;
     parse_pal(src).ok()

--- a/crates/hookecho/src/headless.rs
+++ b/crates/hookecho/src/headless.rs
@@ -57,6 +57,21 @@ pub fn set_output(px: Option<u32>, zoom: Option<f64>) {
     );
 }
 
+/// Built-in alternate palette for the renders that follow, or `None` for each moment's default.
+///
+/// Same process-global shape as [`set_output`], and set under the same render lock — and for the
+/// same reason it clears rather than persists: the next render is somebody else's request, and a
+/// sticky palette would hand one caller's colorblind-safe table to every snapshot after it.
+static PALETTE_NAME: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
+
+/// Ask for a built-in alternate palette (by its [`crate::colormap::alt_names`] name) on the
+/// renders that follow. `None` restores the moment's default table.
+pub fn set_palette(name: Option<String>) {
+    if let Ok(mut p) = PALETTE_NAME.lock() {
+        *p = name;
+    }
+}
+
 /// `HOOKECHO_CAM=lon,lat,zoom` overrides any headless camera — framing knob for screenshots.
 /// An explicit `--zoom`/`?zoom=` beats both, since it was typed for this render.
 fn cam_or_env(lon: f64, lat: f64, zoom: f64) -> Camera {
@@ -255,9 +270,16 @@ pub fn run(
         .enable_all()
         .build()?;
 
+    // A `.pal` file on the command line beats everything: it is the caller holding the table in
+    // their hand. Otherwise an alternate may have been requested by name — never by path, so a
+    // request can never name a file.
     let table = match pal {
         Some(path) => crate::colormap::parse_pal(&std::fs::read_to_string(path)?)?,
-        None => crate::colormap::default_table(moment).clone(),
+        None => PALETTE_NAME
+            .lock()
+            .ok()
+            .and_then(|p| p.as_deref().and_then(crate::colormap::builtin_alt))
+            .unwrap_or_else(|| crate::colormap::default_table(moment).clone()),
     };
 
     // The volume's own time, formatted, for the caption — carried as a string because each

--- a/crates/hookecho/src/serve.rs
+++ b/crates/hookecho/src/serve.rs
@@ -580,6 +580,8 @@ struct Frame {
     zoom: Option<f64>,
     zoom_tag: String,
     tilt: usize,
+    /// Built-in alternate palette by name, or `None` for the product's default table.
+    palette: Option<String>,
 }
 
 impl Frame {
@@ -607,6 +609,19 @@ impl Frame {
             .and_then(|v| v.parse().ok())
             .unwrap_or(0)
             .min(30);
+        // Palettes are chosen by exact name from the built-in alternates for this product, and
+        // an unknown one is a 400 rather than a silent fallback — the caller asked for a specific
+        // picture. A name is never a path: this must not become a way to read a file off the
+        // server, so nothing here touches the filesystem.
+        let palette = match crate::cloud::param(query, "palette") {
+            Some(name) => {
+                if !crate::colormap::alt_names(moment).any(|n| n == name) {
+                    anyhow::bail!("unknown palette '{name}' for {}", moment.short_name());
+                }
+                Some(name)
+            }
+            None => None,
+        };
         Ok(Frame {
             site,
             moment,
@@ -615,6 +630,7 @@ impl Frame {
             zoom,
             zoom_tag: zoom.map_or_else(|| "auto".to_string(), |z| format!("{z:.2}")),
             tilt,
+            palette,
         })
     }
 
@@ -622,14 +638,22 @@ impl Frame {
     /// have to carry all of it. The basemap used to be missing from the filename, so two styles
     /// of the same site raced over one file on disk.
     fn tag(&self) -> String {
+        // The palette belongs here for the same reason the basemap does: two callers asking for
+        // the same site with different tables would otherwise race over one file on disk.
+        let palette = self.palette.as_deref().map_or("std".to_string(), |p| {
+            p.chars()
+                .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+                .collect()
+        });
         format!(
-            "{}-{}-{}-{}-{}-{}",
+            "{}-{}-{}-{}-{}-{}-{}",
             self.site,
             self.moment.short_name(),
             self.basemap.slug(),
             self.px,
             self.zoom_tag,
-            self.tilt
+            self.tilt,
+            palette
         )
     }
 }
@@ -657,6 +681,9 @@ fn render_png(
         // Anything this server hands out is a picture someone will look at away from the app, so
         // it carries its warnings, its caption and its scale. The CLI verifiers do not.
         crate::headless::set_extras(true);
+        // Set on every render, `Some` or `None`: an unset palette has to clear whatever the
+        // previous caller left behind, exactly like the zoom override.
+        crate::headless::set_palette(f.palette.clone());
         crate::headless::run(
             out.to_string_lossy().as_ref(),
             &f.site,
@@ -723,7 +750,8 @@ fn fresh_on_disk(path: &std::path::Path) -> Option<Vec<u8>> {
 
 /// A radar PNG through the same off-screen renderer the `--headless` verifier uses.
 ///
-// ponytail: one render at a time; the palette is still fixed. Add it when someone asks.
+// ponytail: one render at a time. `palette=` selects a built-in alternate by name; a caller's
+// own `.pal` file is not accepted, because a name can never become a path.
 fn snapshot(server: &Server, query: &str) -> anyhow::Result<Vec<u8>> {
     let f = Frame::parse(query)?;
     let key = format!("/snapshot.png?{}", f.tag());
@@ -777,6 +805,7 @@ fn national(server: &Server) -> anyhow::Result<Vec<u8>> {
             Some(_one_at_a_time) => {
                 crate::headless::set_output(Some(NATIONAL_PX), Some(NATIONAL_ZOOM));
                 crate::headless::set_extras(true);
+                crate::headless::set_palette(None);
                 crate::headless::run_mrms(out.to_string_lossy().as_ref())?;
                 archive_national_frame(&out);
                 std::fs::read(&out)?
@@ -1589,6 +1618,25 @@ mod tests {
         // A dashboard's `?token=` form.
         assert_eq!(query_token("site=KTLX&token=abc"), Some("abc".to_string()));
         assert_eq!(query_token("site=KTLX"), None);
+    }
+
+    #[test]
+    fn a_palette_is_an_exact_alternate_name_or_a_refusal() {
+        let name = crate::colormap::alt_names(wxdata::level2::Moment::Reflectivity)
+            .next()
+            .expect("reflectivity has an alternate");
+        let q = format!("site=KTLX&palette={}", crate::cloud::urlencode(name));
+        let f = Frame::parse(&q).unwrap();
+        assert_eq!(f.palette.as_deref(), Some(name));
+        // The palette changes the pixels, so it has to change the filename too.
+        assert_ne!(f.tag(), Frame::parse("site=KTLX").unwrap().tag());
+        assert!(!f.tag().contains(['/', '\\', ' ']), "tag becomes a filename");
+
+        // Not a name of a table this product has, not a path, not a near miss.
+        assert!(Frame::parse("site=KTLX&palette=viridis").is_err());
+        assert!(Frame::parse("site=KTLX&palette=../../etc/passwd").is_err());
+        // The alternate belongs to reflectivity; spectrum width has none at all.
+        assert!(Frame::parse(&format!("site=KTLX&product=SW&palette={name}")).is_err());
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #255.

`/snapshot.png?...&palette=Colorblind-safe%20(viridis)` renders with a built-in alternate table instead of the product's default.

**Security stance:** the value is matched *exactly* against `colormap::alt_names(moment)` and rejected otherwise. A palette is a name, never a path — nothing in the request path touches the filesystem, so this cannot become a file-read primitive. Rejections take the server's existing error route (503 with a JSON body, same as a bad `site` or `product`); no new status mapping was introduced.

**Cache correctness:** `Frame::tag()` includes a slugified palette token. Without it two callers asking for the same site with different tables would race over one file on disk — the bug the basemap token already exists to prevent.

**Statefulness:** `headless::set_palette` is set on *every* render, `Some` or `None`, under the render lock, so one caller's palette never leaks into the next request (the `set_output`/zoom-override lesson). The national render clears it explicitly.

Alternates currently exist for REF and VEL only; anything else refuses cleanly.

**Tests:** exact-name accept, unknown-name reject, path-shaped reject, right-name-wrong-product reject, tag inclusion, no filename-hostile characters in the tag.

**Live verify:** `curl 'http://127.0.0.1:8099/snapshot.png?site=KTLX&palette=Colorblind-safe%20(viridis)'` → 200, 557 690 bytes, written as `snapshot-KTLX-REF-dark-1000-auto-0-Colorblind-safe--viridis-.png`; `&palette=nope` → refused with `unknown palette 'nope' for REF`. Bound to loopback as always.

**Gate:** clippy -D warnings clean · workspace tests green · wasm check green · shots pass · web 3 987 532 gz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)