### PR TITLE
feat(tts): a voice picker for Piper

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -5204,14 +5204,18 @@ impl HookEchoApp {
     // files are validated (the JSON parses, the model is the size of a model); pinning a digest
     // means pinning a version, and I could not verify one offline to pin.
     #[cfg(not(target_arch = "wasm32"))]
-    fn download_voice(&self) {
-        let Some(path) = crate::speech::default_voice_path() else {
+    fn download_voice(&self, id: String) {
+        let Some(path) = crate::speech::voice_path(&id) else {
             crate::speech::set_voice_status(false, "no data directory to download into");
+            return;
+        };
+        let Some(url) = crate::speech::voice_url(&id) else {
+            crate::speech::set_voice_status(false, "that is not a Piper voice id");
             return;
         };
         let http = self.http.clone();
         self.spawner.spawn(async move {
-            let cfg_url = format!("{}.json", crate::speech::VOICE_URL);
+            let cfg_url = format!("{url}.json");
             let cfg_path = path.with_extension("onnx.json");
             if let Some(dir) = path.parent() {
                 if let Err(e) = std::fs::create_dir_all(dir) {
@@ -5245,7 +5249,7 @@ impl HookEchoApp {
                 crate::speech::set_voice_status(false, "voice config was not JSON; refusing it");
                 return;
             }
-            let model = match get(crate::speech::VOICE_URL.to_string()).await {
+            let model = match get(url).await {
                 Ok(b) => b,
                 Err(e) => {
                     crate::speech::set_voice_status(false, format!("voice download failed: {e}"));
@@ -14730,8 +14734,8 @@ impl eframe::App for HookEchoApp {
         // The settings window has no HTTP client or runtime, so the voice-download button raises
         // a flag and the work happens here, on the same spawner everything else fetches on.
         #[cfg(not(target_arch = "wasm32"))]
-        if crate::speech::take_voice_request() {
-            self.download_voice();
+        if let Some(id) = crate::speech::take_voice_request() {
+            self.download_voice(id);
         }
         // A file the user picked, from any of the import buttons. Routed here rather than at the
         // button, because on Android the picker is an activity result that lands long after the

--- a/crates/hookecho/src/serve.rs
+++ b/crates/hookecho/src/serve.rs
@@ -1630,7 +1630,10 @@ mod tests {
         assert_eq!(f.palette.as_deref(), Some(name));
         // The palette changes the pixels, so it has to change the filename too.
         assert_ne!(f.tag(), Frame::parse("site=KTLX").unwrap().tag());
-        assert!(!f.tag().contains(['/', '\\', ' ']), "tag becomes a filename");
+        assert!(
+            !f.tag().contains(['/', '\\', ' ']),
+            "tag becomes a filename"
+        );
 
         // Not a name of a table this product has, not a path, not a near miss.
         assert!(Frame::parse("site=KTLX&palette=viridis").is_err());

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -338,6 +338,10 @@ pub struct Settings {
     /// nothing to say. Never committed: it is a ~60 MB download or a file the user already has.
     #[serde(default)]
     pub piper_voice: String,
+    /// Which curated voice the picker has selected for download. Only the picker reads it;
+    /// `piper_voice` above is still what actually speaks.
+    #[serde(default)]
+    pub piper_download_voice: String,
     /// While chase mode is on, speak the nearest storm's bearing and distance as it changes.
     #[serde(default)]
     pub speak_position: bool,
@@ -1094,6 +1098,7 @@ impl Default for Settings {
             speak_warnings: false,
             piper_path: String::new(),
             piper_voice: String::new(),
+            piper_download_voice: String::new(),
             speak_position: false,
             rain_alerts: false,
             rain_sound: AlertSound::default(),
@@ -1578,6 +1583,7 @@ mod tests {
             speak_warnings: true,
             piper_path: String::new(),
             piper_voice: String::new(),
+            piper_download_voice: String::new(),
             speak_position: false,
             rain_alerts: true,
             rain_sound: AlertSound::Ding,

--- a/crates/hookecho/src/speech.rs
+++ b/crates/hookecho/src/speech.rs
@@ -27,22 +27,73 @@ pub fn set_piper(bin: &str, voice: &str) {
     }
 }
 
-/// Where a downloaded voice lands. One slot: a second voice is a preference, not a capability.
-// ponytail: one voice slot; a picker if anyone actually wants two.
+/// Where a downloaded voice lands. One file per voice id, so downloading a second voice does not
+/// destroy the first — but only one is ever active, which is what `settings.piper_voice` says.
 #[cfg(not(target_arch = "wasm32"))]
-pub fn default_voice_path() -> Option<std::path::PathBuf> {
-    crate::paths::data_dir().map(|d| d.join("voices").join(VOICE_FILE))
+pub fn voice_path(id: &str) -> Option<std::path::PathBuf> {
+    crate::paths::data_dir().map(|d| d.join("voices").join(format!("{id}.onnx")))
 }
 
-/// The voice the download button fetches — a mid-quality US English model, the smallest one that
+/// Where the default voice lands — the one the old single-slot download wrote, so an install that
+/// already has it keeps working without downloading anything.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn default_voice_path() -> Option<std::path::PathBuf> {
+    voice_path(DEFAULT_VOICE)
+}
+
+/// The voice preselected in the picker: a mid-quality US English model, the smallest one that
 /// does not sound worse than espeak.
 #[cfg(not(target_arch = "wasm32"))]
-pub const VOICE_FILE: &str = "en_US-lessac-medium.onnx";
+pub const DEFAULT_VOICE: &str = "en_US-lessac-medium";
 
-/// Upstream for that model. Piper's own voice repository; the `.onnx.json` beside it is required,
-/// since Piper reads its sample rate and phoneme table from there.
+/// The voices the picker offers, by Piper id (`{lang}_{REGION}-{name}-{quality}`).
+///
+/// ponytail: a curated handful, not the whole repository. Piper publishes hundreds across dozens
+/// of languages, and listing them means shipping (and refreshing) an index of a repository that
+/// is not ours. Anything not here is still reachable — the voice field takes a path to any
+/// `.onnx` the user downloaded themselves.
 #[cfg(not(target_arch = "wasm32"))]
-pub const VOICE_URL: &str = "https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/lessac/medium/en_US-lessac-medium.onnx";
+pub const VOICES: &[&str] = &[
+    "en_US-lessac-medium",
+    "en_US-amy-medium",
+    "en_US-ryan-high",
+    "en_US-joe-medium",
+    "en_US-kusal-medium",
+    "en_US-hfc_female-medium",
+    "en_US-hfc_male-medium",
+    "en_GB-alba-medium",
+    "en_GB-jenny_dioco-medium",
+    "en_GB-northern_english_male-medium",
+    "es_ES-davefx-medium",
+    "de_DE-thorsten-medium",
+    "fr_FR-siwis-medium",
+    "it_IT-riccardo-x_low",
+    "pt_BR-faber-medium",
+];
+
+/// Upstream `.onnx` for a voice id, in Piper's own voice repository. The layout is derived from
+/// the id itself — `en_US-lessac-medium` lives at `en/en_US/lessac/medium/` — and the
+/// `.onnx.json` beside it is required, since Piper reads its sample rate and phoneme table
+/// from there.
+///
+/// `None` for an id that is not shaped like a Piper id, which is how a hand-typed value is
+/// refused before it becomes a URL.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn voice_url(id: &str) -> Option<String> {
+    let mut parts = id.split('-');
+    let (lang, name, quality) = (parts.next()?, parts.next()?, parts.next()?);
+    if parts.next().is_some()
+        || !id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        return None;
+    }
+    let base = lang.split('_').next()?;
+    Some(format!(
+        "https://huggingface.co/rhasspy/piper-voices/resolve/main/{base}/{lang}/{name}/{quality}/{id}.onnx"
+    ))
+}
 
 /// What the settings row shows about the voice download.
 #[cfg(not(target_arch = "wasm32"))]
@@ -57,7 +108,7 @@ pub struct VoiceStatus {
 #[cfg(not(target_arch = "wasm32"))]
 static VOICE: std::sync::RwLock<Option<VoiceStatus>> = std::sync::RwLock::new(None);
 #[cfg(not(target_arch = "wasm32"))]
-static WANT_VOICE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+static WANT_VOICE: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
 
 #[cfg(not(target_arch = "wasm32"))]
 pub fn voice_status() -> VoiceStatus {
@@ -78,18 +129,20 @@ pub fn set_voice_status(busy: bool, text: impl Into<String>) {
     }
 }
 
-/// Ask for the voice download. The settings window has no HTTP client or runtime of its own, so
-/// it raises this flag and the app's frame loop does the work on the shared spawner.
+/// Ask for a voice download by id. The settings window has no HTTP client or runtime of its own,
+/// so it parks the request here and the app's frame loop does the work on the shared spawner.
 #[cfg(not(target_arch = "wasm32"))]
-pub fn request_voice_download() {
-    WANT_VOICE.store(true, std::sync::atomic::Ordering::Relaxed);
+pub fn request_voice_download(id: &str) {
+    if let Ok(mut g) = WANT_VOICE.lock() {
+        *g = Some(id.to_string());
+    }
     set_voice_status(true, "starting…");
 }
 
 /// Drained once per frame by the app.
 #[cfg(not(target_arch = "wasm32"))]
-pub fn take_voice_request() -> bool {
-    WANT_VOICE.swap(false, std::sync::atomic::Ordering::Relaxed)
+pub fn take_voice_request() -> Option<String> {
+    WANT_VOICE.lock().ok().and_then(|mut g| g.take())
 }
 
 /// Speak `text` aloud, if the platform can. Returns immediately.
@@ -242,5 +295,38 @@ mod imp {
     /// Android's TextToSpeech is JNI, and all JNI lives in `platform`.
     pub fn speak_blocking(text: &str) -> Result<(), String> {
         crate::platform::speak(text)
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+
+    /// The repository layout is derived from the id rather than listed, so the derivation is the
+    /// thing that can be wrong. Every id in [`VOICES`] was checked live when it was added.
+    #[test]
+    fn a_voice_id_derives_its_own_download_url() {
+        assert_eq!(
+            voice_url("en_US-lessac-medium").as_deref(),
+            Some("https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/lessac/medium/en_US-lessac-medium.onnx")
+        );
+        assert_eq!(
+            voice_url("pt_BR-faber-medium").as_deref(),
+            Some("https://huggingface.co/rhasspy/piper-voices/resolve/main/pt/pt_BR/faber/medium/pt_BR-faber-medium.onnx")
+        );
+        // Underscores are part of names and qualities both, and must survive.
+        assert!(voice_url("en_US-hfc_female-medium")
+            .unwrap()
+            .ends_with("/en/en_US/hfc_female/medium/en_US-hfc_female-medium.onnx"));
+        assert!(voice_url("it_IT-riccardo-x_low")
+            .unwrap()
+            .ends_with("/it/it_IT/riccardo/x_low/it_IT-riccardo-x_low.onnx"));
+
+        // Anything not shaped like a Piper id is refused before it becomes a URL.
+        assert_eq!(voice_url("lessac"), None);
+        assert_eq!(voice_url("en_US-lessac-medium-extra"), None);
+        assert_eq!(voice_url("en_US-../../etc-medium"), None);
+        assert!(VOICES.iter().all(|id| voice_url(id).is_some()));
+        assert!(VOICES.contains(&DEFAULT_VOICE));
     }
 }

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -1265,22 +1265,53 @@ fn piper_row(ui: &mut egui::Ui, settings: &mut Settings) {
     if edited {
         crate::speech::set_piper(&settings.piper_path, &settings.piper_voice);
     }
+    // The picker downloads; the field above is what actually gets spoken with. Picking a voice
+    // that is already on disk switches to it without touching the network.
     ui.horizontal(|ui| {
         let status = crate::speech::voice_status();
-        if settings.piper_voice.is_empty()
-            && !status.busy
-            && ui.button("Download a voice").clicked()
-        {
-            crate::speech::request_voice_download();
+        let mut want = settings.piper_download_voice.clone();
+        if want.is_empty() {
+            want = crate::speech::DEFAULT_VOICE.to_string();
+        }
+        egui::ComboBox::from_id_salt("piper-voice-pick")
+            .selected_text(&want)
+            .show_ui(ui, |ui| {
+                for id in crate::speech::VOICES {
+                    if ui.selectable_label(want == *id, *id).clicked() {
+                        settings.piper_download_voice = (*id).to_string();
+                    }
+                }
+            });
+        let on_disk = crate::speech::voice_path(&want).filter(|p| p.exists());
+        match on_disk {
+            Some(p) if settings.piper_voice != p.to_string_lossy() => {
+                if ui.button("Use this voice").clicked() {
+                    settings.piper_voice = p.to_string_lossy().into_owned();
+                    crate::speech::set_piper(&settings.piper_path, &settings.piper_voice);
+                }
+            }
+            Some(_) => {
+                ui.weak("in use");
+            }
+            None => {
+                if !status.busy && ui.button("Download").clicked() {
+                    crate::speech::request_voice_download(&want);
+                }
+            }
         }
         if !status.text.is_empty() {
             ui.weak(&status.text);
         }
     });
-    // The download writes the model to a known path, so filling the field in for the user is the
-    // whole handoff — there is nothing else to configure.
+    // A finished download is only useful once something points at it, and the user asking for a
+    // voice is the whole configuration step — so adopt it as soon as it lands.
     if settings.piper_voice.is_empty() {
-        if let Some(p) = crate::speech::default_voice_path().filter(|p| p.exists()) {
+        let want = if settings.piper_download_voice.is_empty() {
+            crate::speech::DEFAULT_VOICE.to_string()
+        } else {
+            settings.piper_download_voice.clone()
+        };
+        if let Some(p) = crate::speech::voice_path(&want).filter(|p| p.exists()) {
             settings.piper_voice = p.to_string_lossy().into_owned();
             crate::speech::set_piper(&settings.piper_path, &settings.piper_voice);
         }

--- a/crates/wxdata/src/dealias.rs
+++ b/crates/wxdata/src/dealias.rs
@@ -177,8 +177,10 @@ pub fn dealias_with_reference(
     // order. The old greedy BFS took whatever edge it happened to reach first, which is why a
     // multi-fold field could come apart at a seam: one thin boundary early in the walk fixed a
     // region, and every region behind it inherited the mistake.
-    let mut pair_votes: std::collections::HashMap<(usize, usize), std::collections::HashMap<i32, u32>> =
-        std::collections::HashMap::new();
+    let mut pair_votes: std::collections::HashMap<
+        (usize, usize),
+        std::collections::HashMap<i32, u32>,
+    > = std::collections::HashMap::new();
     for (ra, list) in edges.iter().enumerate() {
         for &(rb, v_self, v_nb) in list {
             if ra >= rb {


### PR DESCRIPTION
Stacked on #256.

The Piper download button fetched one hardcoded voice into one slot (`en_US-lessac-medium`), with a note saying to add a picker if anyone wanted two.

Adds `speech::VOICES` — 15 curated ids across en_US, en_GB, es, de, fr, it, pt_BR — and `voice_url(id)`, which *derives* the repository path from the id (`en_US-lessac-medium` → `en/en_US/lessac/medium/…`) rather than listing URLs. **Every one of the 15 was HEAD-verified against huggingface.co/rhasspy/piper-voices while writing the list (all 200).**

- Voices land at `voices/{id}.onnx`, so downloading a second does not destroy the first; only one is active, which is what `settings.piper_voice` still says.
- `WANT_VOICE` becomes `Mutex<Option<String>>` (which voice), drained by the same frame-loop hook as before.
- Settings row gains a ComboBox plus a Download / "Use this voice" / "in use" button, depending on whether the picked voice is already on disk. The free-text path field stays — a voice outside the curated list is still reachable.
- `voice_url` refuses anything not shaped like a Piper id, so a hand-typed value cannot become an arbitrary URL.
- Existing installs keep working: `default_voice_path()` still points at the old file.

Native-only cfg blocks throughout.

**Test:** URL derivation for four ids (including underscore-bearing names and `x_low` quality), refusal of malformed and path-shaped ids, and that every listed id derives.

**Gate:** clippy -D warnings clean · workspace tests green · wasm check green · shots pass · web 3 988 747 gz. Also ran `cargo fmt --all`, which swept up one pre-existing wrap in `dealias.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)