### PR TITLE
feat(web): alert-rule backtests in the browser

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -4561,7 +4561,6 @@ impl HookEchoApp {
     /// The site is whichever radar the active pane is on: a rule about a place is only replayable
     /// against a radar that can see it, and the pane the user is looking at is the best guess
     /// anyone can make without asking.
-    #[cfg(not(target_arch = "wasm32"))]
     fn start_backtest(&mut self, rule_idx: usize, day: chrono::NaiveDate) {
         let Some(rule) = self.settings.alert_rules.get(rule_idx).cloned() else {
             return;
@@ -16001,7 +16000,6 @@ impl eframe::App for HookEchoApp {
             }
         }
 
-        #[cfg(not(target_arch = "wasm32"))]
         if let Some((i, day)) = self.rules_window.backtest_request.take() {
             self.start_backtest(i, day);
         }

--- a/crates/hookecho/src/backtest.rs
+++ b/crates/hookecho/src/backtest.rs
@@ -8,8 +8,12 @@
 //! already a couple of hundred megabytes and a minute of CPU. Parallelising it would finish
 //! sooner and make the progress readout a lie about what is downloading.
 //!
-//! ponytail: capped at 24 volumes and one rule at a time. Both are one constant and one loop away
-//! if anyone actually wants a whole outbreak day scored at once.
+//! Runs in the browser too — it is plain async, and the archive list and download both have wasm
+//! paths. The only difference there is the cap (see [`MAX_VOLUMES`]) and that decoding happens on
+//! the main thread, so a run is a series of brief hitches rather than a background hum.
+//!
+//! ponytail: one rule at a time, and decoding on the main thread on the web. Both are one loop
+//! away if anyone actually wants a whole outbreak day scored at once.
 
 use crate::rules::Detection;
 use crate::settings::{AlertRule, RuleTrigger as T, Settings};
@@ -17,7 +21,15 @@ use std::sync::{Arc, Mutex};
 use wxdata::level2::{self, Moment};
 
 /// Most volumes one backtest will pull. About two hours at a severe-weather VCP.
+#[cfg(not(target_arch = "wasm32"))]
 pub const MAX_VOLUMES: usize = 24;
+
+/// Half that in the browser. Each volume is tens of megabytes and every one of them crosses a
+/// shared proxy on its way in — and decoding happens on the main thread there, so a long run is
+/// also a long series of visible hitches. An hour of weather is enough to answer "would this rule
+/// have fired", which is the question a backtest is for.
+#[cfg(target_arch = "wasm32")]
+pub const MAX_VOLUMES: usize = 12;
 
 /// Shared with the UI thread: what the run is doing and what it found.
 #[derive(Default)]

--- a/crates/hookecho/src/lib.rs
+++ b/crates/hookecho/src/lib.rs
@@ -10,7 +10,6 @@ pub mod alert_snapshot;
 pub mod app;
 pub mod astro;
 pub mod audio;
-#[cfg(not(target_arch = "wasm32"))]
 pub mod backtest;
 pub mod basemap_style;
 /// Live camera video (desktop only — Android cannot spawn an ffmpeg child).

--- a/crates/hookecho/src/ui/rules_window.rs
+++ b/crates/hookecho/src/ui/rules_window.rs
@@ -14,13 +14,10 @@ pub struct RulesWindow {
     pub open: bool,
     /// A backtest the user asked for, picked up by the app (which owns the runtime) on its next
     /// frame: rule index, and the UTC day to replay.
-    #[cfg(not(target_arch = "wasm32"))]
     pub backtest_request: Option<(usize, chrono::NaiveDate)>,
     /// The run in flight or the last one's result.
-    #[cfg(not(target_arch = "wasm32"))]
     pub backtest: Option<crate::backtest::Shared>,
     /// The day the buttons replay, edited as text because a date picker is a dependency.
-    #[cfg(not(target_arch = "wasm32"))]
     pub backtest_day: String,
 }
 
@@ -154,7 +151,6 @@ pub fn show(
             changed = true;
         }
 
-        #[cfg(not(target_arch = "wasm32"))]
         backtest_bar(ui, state, settings);
 
         ui.add_space(6.0);
@@ -290,7 +286,6 @@ fn place_combo(
 ///
 /// The window has no tokio runtime and no HTTP client, so the button records a request the app
 /// picks up on its next frame — the same handover the voice download and the file picker use.
-#[cfg(not(target_arch = "wasm32"))]
 fn backtest_bar(ui: &mut egui::Ui, state: &mut RulesWindow, settings: &Settings) {
     ui.add_space(6.0);
     ui.separator();


### PR DESCRIPTION
Stacked on #257.

Deletes eight `#[cfg(not(target_arch = "wasm32"))]` gates (lib.rs, rules_window.rs ×5, app.rs ×2) so the backtest button exists on the web.

**The gate's stated reason was stale.** It cited a native runtime and threads. `backtest::run` is plain async, `level2::list_volumes`/`download_scan` both have wasm branches, `download_scan` takes an `Option` cache dir, `rt::Spawner` has a wasm impl, and the archive bucket is already in the proxy allowlist. Running the wasm check with the gates removed was the hypothesis test and it passed unchanged — no fallback gating was needed.

`MAX_VOLUMES` is 12 on wasm (24 native): each volume is tens of megabytes through a shared proxy, and decoding is on the main thread there. An hour of weather answers the question a backtest asks.

**Known and documented, not fixed:** `bin_scan` runs on the main thread on wasm, so a run is a series of brief hitches. Noted in the module doc.

**Gate:** clippy -D warnings clean · workspace tests green · wasm check green · shots pass · web 3 993 123 gz (budget 4 125 000).

🤖 Generated with [Claude Code](https://claude.com/claude-code)