### PR TITLE
feat(mqtt): command subscribe loop and Home Assistant discovery

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -3307,7 +3307,7 @@ impl HookEchoApp {
         // The broker is publish-only and reconnects on its own, so it starts here and is never
         // stopped; changing the setting takes a restart, same as the tray.
         #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
-        crate::mqtt::spawn(&app.settings);
+        crate::mqtt::spawn(&app.settings, true);
         // Point the speech path at Piper before anything can speak.
         #[cfg(not(target_arch = "wasm32"))]
         crate::speech::set_piper(&app.settings.piper_path, &app.settings.piper_voice);
@@ -14785,6 +14785,33 @@ impl eframe::App for HookEchoApp {
                         self.views[self.active].site = Some(id);
                         ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
                         ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
+                    }
+                }
+            }
+        }
+
+        // Commands off the broker, drained the same way and applied through the same paths the
+        // tray uses. They land on the next repaint rather than instantly, which for "point at the
+        // storm" is close enough and keeps every state change on one thread.
+        #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
+        for cmd in crate::mqtt::drain() {
+            match cmd {
+                crate::mqtt::Cmd::Mute(want) => {
+                    if self.settings.mute_alerts != want {
+                        self.apply_action(BindableAction::ToggleMute, ctx);
+                    }
+                }
+                crate::mqtt::Cmd::Site(id) => {
+                    if wxdata::sites::site_by_id(&id).is_some() {
+                        self.views[self.active].site = Some(id);
+                    } else {
+                        log::warn!("mqtt: no such site {id}");
+                    }
+                }
+                crate::mqtt::Cmd::Product(code) => {
+                    if let Some(m) = Moment::from_code(&code) {
+                        let srv = self.views[self.active].srv;
+                        self.apply_palette(PaletteAction::SetMoment(m, srv), ctx);
                     }
                 }
             }

--- a/crates/hookecho/src/main.rs
+++ b/crates/hookecho/src/main.rs
@@ -98,7 +98,9 @@ fn main() -> eframe::Result<()> {
         let spots = hookecho::status::spots(&saved, None);
         // A headless box on a shelf is exactly where MQTT earns its keep — this is the process
         // that is always up.
-        hookecho::mqtt::spawn(&saved);
+        // No `subscribe` here: a `--serve` process has no frame loop to drain commands, and a
+        // channel nobody reads is a slow leak.
+        hookecho::mqtt::spawn(&saved, false);
         // `--public` serves the site's preset frames to callers with no token, and 403s
         // everything else. Without it a token still means "all or nothing".
         let public = args.iter().any(|a| a == "--public");

--- a/crates/hookecho/src/mqtt.rs
+++ b/crates/hookecho/src/mqtt.rs
@@ -13,15 +13,135 @@
 //!
 //! Credentials are a user secret — settings.json only, never the shots template, never logged.
 //
-// ponytail: one broker, one publisher thread, publish-only — no subscribe side and no Home
-// Assistant discovery config. The ceiling is "a house automates on this"; if someone wants
-// commands back (change site, start a loop) that is a subscribe loop on the same client.
+// ponytail: one broker, one thread each way. Commands are three verbs (site, product, mute), not
+// a remote-control protocol — anything richer belongs behind the HTTP server, which already
+// answers questions.
 
 use crate::settings::Settings;
 use crate::status::Spot;
 use rumqttc::{Client, MqttOptions, QoS, Transport};
 use std::sync::OnceLock;
 use std::time::Duration;
+
+/// A command that arrived from the broker. The app drains these once a frame and applies them,
+/// so a house automation can point the window at the storm it just noticed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Cmd {
+    /// Show this radar site in the active pane.
+    Site(String),
+    /// Switch the active pane to this product code (`REF`, `VEL`, …).
+    Product(String),
+    /// Mute or unmute alert sound.
+    Mute(bool),
+}
+
+/// Parse one command from its topic suffix and payload.
+///
+/// Everything arriving here came off a broker, which is a trust boundary even when the broker is
+/// on the same machine: a payload is whatever anyone with publish rights felt like sending. Site
+/// ids are validated to the shape a site id has, products go through `Moment::from_code`, and
+/// anything else is `None` rather than a guess.
+pub fn parse_cmd(suffix: &str, payload: &str) -> Option<Cmd> {
+    let payload = payload.trim();
+    match suffix {
+        "site" => {
+            let id = payload.to_ascii_uppercase();
+            let ok = (3..=5).contains(&id.len()) && id.chars().all(|c| c.is_ascii_alphanumeric());
+            ok.then_some(Cmd::Site(id))
+        }
+        "product" => {
+            let code = payload.to_ascii_uppercase();
+            wxdata::level2::Moment::from_code(&code).map(|_| Cmd::Product(code))
+        }
+        "mute" => match payload.to_ascii_lowercase().as_str() {
+            "on" | "1" | "true" | "mute" => Some(Cmd::Mute(true)),
+            "off" | "0" | "false" | "unmute" => Some(Cmd::Mute(false)),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Commands parked by the event loop for the app to drain. A bounded channel would drop the
+/// command a user is waiting on; an unbounded one grows only if nobody drains it, which is
+/// exactly why [`spawn`] takes `subscribe`.
+static CMD_RX: std::sync::Mutex<Option<std::sync::mpsc::Receiver<Cmd>>> =
+    std::sync::Mutex::new(None);
+
+/// Take everything the broker has sent since the last frame.
+pub fn drain() -> Vec<Cmd> {
+    CMD_RX
+        .lock()
+        .ok()
+        .and_then(|g| g.as_ref().map(|rx| rx.try_iter().collect()))
+        .unwrap_or_default()
+}
+
+/// The Home Assistant discovery configs, as `(topic, payload)` pairs.
+///
+/// Published retained so Home Assistant finds the device whenever it restarts, and republished on
+/// every reconnect — which is idempotent, since a retained config is overwritten rather than
+/// appended.
+fn discovery(prefix: &str) -> Vec<(String, String)> {
+    let device = serde_json::json!({
+        "identifiers": ["hookecho"],
+        "name": "HookEcho",
+        "manufacturer": "HookEcho",
+        "model": "radar",
+    });
+    vec![
+        (
+            "homeassistant/sensor/hookecho_status/config".to_string(),
+            serde_json::json!({
+                "name": "HookEcho status",
+                "unique_id": "hookecho_status",
+                "state_topic": format!("{prefix}/status"),
+                "value_template": "{{ value_json | length }}",
+                "json_attributes_topic": format!("{prefix}/nearest"),
+                "device": device,
+            })
+            .to_string(),
+        ),
+        (
+            "homeassistant/sensor/hookecho_nearest/config".to_string(),
+            serde_json::json!({
+                "name": "HookEcho nearest cell",
+                "unique_id": "hookecho_nearest",
+                "state_topic": format!("{prefix}/nearest"),
+                // A cell that is not there is `null`, which has no distance — the sensor goes
+                // unavailable rather than reporting a made-up zero.
+                "value_template": "{{ value_json.distance_km | default('unavailable') }}",
+                "unit_of_measurement": "km",
+                "device": device,
+            })
+            .to_string(),
+        ),
+        (
+            "homeassistant/sensor/hookecho_alerts/config".to_string(),
+            serde_json::json!({
+                "name": "HookEcho last alert",
+                "unique_id": "hookecho_alerts",
+                "state_topic": format!("{prefix}/alerts"),
+                "value_template": "{{ value_json.title }}",
+                "device": device,
+            })
+            .to_string(),
+        ),
+        (
+            "homeassistant/switch/hookecho_mute/config".to_string(),
+            serde_json::json!({
+                "name": "HookEcho mute",
+                "unique_id": "hookecho_mute",
+                "command_topic": format!("{prefix}/cmd/mute"),
+                "payload_on": "on",
+                "payload_off": "off",
+                "optimistic": true,
+                "device": device,
+            })
+            .to_string(),
+        ),
+    ]
+}
 
 /// How often the retained status/nearest topics are refreshed. A volume is ~5 minutes wide and
 /// the observation feeds update slower than that, so anything quicker only spends network.
@@ -65,7 +185,7 @@ fn alert_payload(title: &str, body: &str, urgent: bool) -> String {
 ///
 /// Two threads: rumqttc's event loop must be driven by someone, and the status poll blocks on
 /// feeds for seconds at a time, so it cannot be the same one.
-pub fn spawn(settings: &Settings) {
+pub fn spawn(settings: &Settings, subscribe: bool) {
     let host = settings.mqtt_host.trim().to_string();
     if host.is_empty() || CLIENT.get().is_some() {
         return;
@@ -93,13 +213,53 @@ pub fn spawn(settings: &Settings) {
     }
     log::info!("mqtt: publishing under {prefix}/");
 
+    let discovery_on = settings.mqtt_discovery;
+    let (tx, rx) = std::sync::mpsc::channel();
+    if subscribe {
+        if let Ok(mut g) = CMD_RX.lock() {
+            *g = Some(rx);
+        }
+    }
+    let cmd_prefix = format!("{prefix}/cmd/");
+    let sub_client = client.clone();
+    let sub_prefix = prefix.clone();
     std::thread::spawn(move || {
         // Iterating the connection *is* the reconnect loop — rumqttc yields the error and then
         // tries again, so this only ends when the process does.
         for event in conn.iter() {
-            if let Err(e) = event {
-                log::debug!("mqtt: {e}");
-                std::thread::sleep(Duration::from_secs(5));
+            match event {
+                // A fresh connection is where subscriptions and retained configs go: this fires
+                // again after every reconnect, and both are idempotent.
+                Ok(rumqttc::Event::Incoming(rumqttc::Packet::ConnAck(_))) => {
+                    if subscribe {
+                        let topic = format!("{sub_prefix}/cmd/#");
+                        if let Err(e) = sub_client.subscribe(&topic, QoS::AtLeastOnce) {
+                            log::warn!("mqtt: subscribing to {topic} failed: {e}");
+                        }
+                    }
+                    if discovery_on {
+                        for (topic, payload) in discovery(&sub_prefix) {
+                            publish(&sub_client, &topic, payload, true);
+                        }
+                    }
+                }
+                Ok(rumqttc::Event::Incoming(rumqttc::Packet::Publish(p))) => {
+                    let Some(suffix) = p.topic.strip_prefix(&cmd_prefix) else {
+                        continue;
+                    };
+                    let payload = String::from_utf8_lossy(&p.payload);
+                    match parse_cmd(suffix, &payload) {
+                        Some(cmd) => {
+                            let _ = tx.send(cmd);
+                        }
+                        None => log::warn!("mqtt: ignoring {} = {payload:?}", p.topic),
+                    }
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    log::debug!("mqtt: {e}");
+                    std::thread::sleep(Duration::from_secs(5));
+                }
             }
         }
     });
@@ -164,6 +324,58 @@ pub fn publish_alert(settings: &Settings, title: &str, body: &str, urgent: bool)
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A payload off a broker is whatever anyone with publish rights sent, so the parser is a
+    /// trust boundary and not a convenience.
+    #[test]
+    fn commands_are_validated_before_they_are_believed() {
+        assert_eq!(parse_cmd("site", "ktlx"), Some(Cmd::Site("KTLX".into())));
+        assert_eq!(
+            parse_cmd("site", " kfws \n"),
+            Some(Cmd::Site("KFWS".into()))
+        );
+        assert_eq!(parse_cmd("site", "../../etc"), None);
+        assert_eq!(parse_cmd("site", "K"), None);
+        assert_eq!(parse_cmd("site", "KTLX; DROP"), None);
+
+        assert_eq!(
+            parse_cmd("product", "vel"),
+            Some(Cmd::Product("VEL".into()))
+        );
+        assert_eq!(parse_cmd("product", "nope"), None);
+
+        assert_eq!(parse_cmd("mute", "ON"), Some(Cmd::Mute(true)));
+        assert_eq!(parse_cmd("mute", "0"), Some(Cmd::Mute(false)));
+        assert_eq!(parse_cmd("mute", "maybe"), None);
+
+        // An unknown verb is silence, not a guess.
+        assert_eq!(parse_cmd("reboot", "on"), None);
+    }
+
+    /// Home Assistant keys entities by `unique_id` and the configs are retained, so a collision
+    /// or a stray topic is a mess in somebody's house that outlives the app.
+    #[test]
+    fn discovery_configs_are_distinct_and_point_at_our_prefix() {
+        let configs = discovery("home/weather");
+        assert_eq!(configs.len(), 4);
+        let mut ids: Vec<String> = Vec::new();
+        for (topic, payload) in &configs {
+            assert!(topic.starts_with("homeassistant/"), "{topic}");
+            let v: serde_json::Value = serde_json::from_str(payload).expect("config is JSON");
+            let id = v["unique_id"].as_str().expect("unique_id").to_string();
+            assert!(!ids.contains(&id), "duplicate unique_id {id}");
+            ids.push(id);
+            let points_at_us = v["state_topic"]
+                .as_str()
+                .or_else(|| v["command_topic"].as_str())
+                .expect("a topic");
+            assert!(points_at_us.starts_with("home/weather/"), "{points_at_us}");
+            assert_eq!(v["device"]["identifiers"][0], "hookecho");
+        }
+        // The switch commands the topic the subscribe loop actually listens on.
+        let (_, mute) = configs.last().unwrap();
+        assert!(mute.contains("home/weather/cmd/mute"));
+    }
 
     #[test]
     fn a_prefix_cannot_carry_a_wildcard_into_a_publish() {

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -282,6 +282,12 @@ pub struct Settings {
     /// Topic prefix everything is published under, e.g. `home/weather`.
     #[serde(default = "default_mqtt_prefix")]
     pub mqtt_prefix: String,
+    /// Publish retained Home Assistant discovery configs so it creates the device by itself.
+    ///
+    /// Off by default, and deliberately: retained config topics on a broker that is not running
+    /// Home Assistant are litter somebody else has to clear up.
+    #[serde(default)]
+    pub mqtt_discovery: bool,
     /// Fetch terrain at z12 (~40 m/px) instead of z10. Sixteen times the tiles, so it is off by
     /// default and meant for chase packs you download deliberately.
     #[serde(default)]
@@ -1085,6 +1091,7 @@ impl Default for Settings {
             mqtt_user: String::new(),
             mqtt_pass: String::new(),
             mqtt_prefix: default_mqtt_prefix(),
+            mqtt_discovery: false,
             background_alerts: false,
             pack_hires_dem: false,
             pack_include_vector: true,
@@ -1562,6 +1569,7 @@ mod tests {
             mqtt_user: String::new(),
             mqtt_pass: String::new(),
             mqtt_prefix: default_mqtt_prefix(),
+            mqtt_discovery: false,
             background_alerts: false,
             pack_hires_dem: false,
             pack_include_vector: true,

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -1126,6 +1126,14 @@ fn alerts_tab(ui: &mut egui::Ui, settings: &mut Settings) {
             ui.label("Topic prefix:");
             ui.add(egui::TextEdit::singleline(&mut settings.mqtt_prefix).hint_text("home/weather"));
         });
+        ui.horizontal(|ui| {
+            ui.checkbox(&mut settings.mqtt_discovery, "Home Assistant discovery")
+                .on_hover_text(
+                    "Publish retained config topics so Home Assistant creates the device itself, \
+                     with a mute switch that publishes back to <prefix>/cmd/mute. Leave off if \
+                     this broker has no Home Assistant on it.",
+                );
+        });
         ui.weak(
             "Publishes <prefix>/status and <prefix>/nearest every five minutes, and \
              <prefix>/alerts as warnings arrive. Takes effect on restart.",


### PR DESCRIPTION
Stacked on #258.

MQTT was publish-only. Now the same client subscribes to `{prefix}/cmd/#` and the app applies three verbs: `site`, `product`, `mute`.

**Trust boundary.** `parse_cmd` is pure and validated: site ids are uppercased and checked for 3–5 alphanumerics, products go through `Moment::from_code`, mute takes on/off/1/0/true/false. Anything else is ignored and logged. A broker payload is whatever anyone with publish rights sent, even on a LAN.

**`spawn(settings, subscribe)`.** `main.rs` (the `--serve` path) passes `false`: that process has no frame loop to drain the channel, and an undrained channel is a slow leak. The GUI passes `true`.

**Home Assistant discovery** (`settings.mqtt_discovery`, **default false**): four retained configs — status/nearest/last-alert sensors and a mute switch whose `command_topic` is the topic the subscribe loop listens on. Published on `ConnAck`, so they survive reconnects, and idempotent because retained configs overwrite. Default-off is deliberate and the one debatable call here: retained config topics on a broker with no Home Assistant on it are litter someone else has to clear up.

Commands apply on the next repaint (they route through the same `apply_action`/`apply_palette` paths the tray uses, so all state changes stay on one thread). Documented, not fixed.

**Tests:** the `parse_cmd` table including rejections; discovery configs distinct by `unique_id`, all pointing at our prefix, mute switch commanding `{prefix}/cmd/mute`.

**Not yet verified live:** no broker on this machine (`mosquitto` isn't installed and installing needs sudo). The `mosquitto_pub -t hookecho/cmd/mute -m on` check is still outstanding.

**Gate:** clippy -D warnings clean · workspace tests green · wasm check green · shots pass · web 3 989 791 gz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)