### PR TITLE
feat(mqtt): lightning strikes layer from the user's broker

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1125,6 +1125,8 @@ pub(crate) enum OverlayToggle {
     Recon,
     Fronts,
     GlmLightning,
+    /// Ground strikes republished onto the user's own MQTT broker (see `strikes_topic`).
+    Strikes,
     Wind,
     LinkCameras,
     /// The always-on-top mini-loop window (desktop only).
@@ -1147,7 +1149,7 @@ pub(crate) struct BlockageKey {
 impl OverlayToggle {
     /// Every toggle, for the persistence sweep. A new variant belongs here too, or it silently
     /// stops being remembered across restarts.
-    pub(crate) const ALL: [OverlayToggle; 37] = [
+    pub(crate) const ALL: [OverlayToggle; 38] = [
         Self::AlertPanel,
         Self::StormReports,
         Self::Spotters,
@@ -1181,6 +1183,7 @@ impl OverlayToggle {
         Self::Recon,
         Self::Fronts,
         Self::GlmLightning,
+        Self::Strikes,
         Self::Wind,
         Self::LinkCameras,
         Self::MiniLoop,
@@ -1842,6 +1845,31 @@ fn data_attribution(site_id: &str) -> Option<&'static str> {
 /// How a lightning flash looks at `age_secs`: bright white-hot when it just happened, fading to a
 /// dim orange ember by the end of the window. The brightness IS the recency cue — a map of
 /// same-colored dots says where lightning has been, not where it is now.
+/// Most strikes kept at once. A continent-wide topic on an active night runs tens of thousands
+/// an hour, and the painter walks the whole deque every frame.
+const STRIKE_CAP: usize = 20_000;
+
+/// How long a strike stays on the map. Same window as the GLM feed, so the two layers age alike.
+const STRIKE_WINDOW_SECS: i64 = 900;
+
+/// Cyan-white for a fresh strike fading to deep blue, deliberately nothing like [`glm_style`]'s
+/// white-to-orange: with both layers on, colour is the only thing telling optical flashes from
+/// ground strikes.
+fn strike_style(age_secs: f32) -> (egui::Color32, f32) {
+    let t = (age_secs / STRIKE_WINDOW_SECS as f32).clamp(0.0, 1.0);
+    let r = 3.4 - 1.4 * t;
+    let lerp = |a: f32, b: f32| (a + (b - a) * t) as u8;
+    (
+        egui::Color32::from_rgba_unmultiplied(
+            lerp(225.0, 40.0),
+            lerp(250.0, 90.0),
+            lerp(255.0, 220.0),
+            lerp(255.0, 70.0),
+        ),
+        r,
+    )
+}
+
 fn glm_style(age_secs: f32) -> (egui::Color32, f32) {
     const WINDOW: f32 = 900.0; // 15 minutes, matching the feed
     let t = (age_secs / WINDOW).clamp(0.0, 1.0);
@@ -2503,6 +2531,11 @@ pub struct HookEchoApp {
     glm: std::sync::Arc<std::sync::Mutex<wxdata::glm::GlmFeed>>,
     glm_last_poll: Option<Instant>,
     glm_polling: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    /// Ground strikes as they arrive over MQTT, oldest first. Nothing fills this unless the user
+    /// points `strikes_topic` at a broker that carries them — the app never talks to a strike
+    /// network itself.
+    show_strikes: bool,
+    strikes: std::collections::VecDeque<(f64, f64, chrono::DateTime<chrono::Utc>)>,
     /// Animated wind particles. The grids are shared; the particle sets are per pane, because each
     /// pane has its own camera. Nothing here persists to settings — neither do fronts or GLM.
     show_wind: bool,
@@ -3223,6 +3256,8 @@ impl HookEchoApp {
             fronts: None,
             fronts_last_fetch: None,
             show_glm: false,
+            show_strikes: false,
+            strikes: std::collections::VecDeque::new(),
             glm: std::sync::Arc::new(std::sync::Mutex::new(wxdata::glm::GlmFeed::new(15))),
             glm_last_poll: None,
             glm_polling: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
@@ -7178,6 +7213,7 @@ impl HookEchoApp {
             T::RangeRings => &mut self.show_range_rings,
             T::Fronts => &mut self.show_fronts,
             T::GlmLightning => &mut self.show_glm,
+            T::Strikes => &mut self.show_strikes,
             T::Wind => &mut self.show_wind,
             T::Sensors => &mut self.show_sensors,
             T::Hodo => &mut self.show_hodo,
@@ -11049,6 +11085,33 @@ impl HookEchoApp {
             }
         }
 
+        // Ground strikes off the broker. Same shape as the GLM block above, including the
+        // lon/lat prefilter, because the deque is just as long and the pane just as small.
+        if self.show_strikes && !self.strikes.is_empty() {
+            let now = chrono::Utc::now();
+            let corner = |px: (f32, f32)| {
+                let w = cam.screen_to_world(px, vp);
+                crate::render::mercator::world_to_lonlat(w.0, w.1)
+            };
+            let (c0, c1) = (corner((0.0, 0.0)), corner((vp.0, vp.1)));
+            let (lon_lo, lon_hi) = (c0.0.min(c1.0), c0.0.max(c1.0));
+            let (lat_lo, lat_hi) = (c0.1.min(c1.1), c0.1.max(c1.1));
+            for &(lon, lat, time) in &self.strikes {
+                if lon < lon_lo || lon > lon_hi || lat < lat_lo || lat > lat_hi {
+                    continue;
+                }
+                let w = crate::render::mercator::lonlat_to_world(lon, lat);
+                let (sx, sy) = cam.world_to_screen(w, vp);
+                let p = egui::pos2(prect.left() + sx, prect.top() + sy);
+                if !prect.contains(p) {
+                    continue;
+                }
+                let age = (now - time).num_seconds().max(0) as f32;
+                let (col, r) = strike_style(age);
+                painter.circle_filled(p, r, col);
+            }
+        }
+
         // Animated wind particles, when they are being drawn on the CPU. The GPU path draws
         // inside the map callback instead (see `wind_gpu_frame`), which is also what puts it
         // under the warning polygons rather than over them.
@@ -14790,6 +14853,15 @@ impl eframe::App for HookEchoApp {
             }
         }
 
+        // Strikes age out on their own clock: the deque only shrinks here, so a quiet topic
+        // still empties the map rather than freezing the last minute of a storm on it.
+        if !self.strikes.is_empty() {
+            let cutoff = chrono::Utc::now() - chrono::Duration::seconds(STRIKE_WINDOW_SECS);
+            while self.strikes.front().is_some_and(|&(_, _, t)| t < cutoff) {
+                self.strikes.pop_front();
+            }
+        }
+
         // Commands off the broker, drained the same way and applied through the same paths the
         // tray uses. They land on the next repaint rather than instantly, which for "point at the
         // storm" is close enough and keeps every state change on one thread.
@@ -14812,6 +14884,14 @@ impl eframe::App for HookEchoApp {
                     if let Some(m) = Moment::from_code(&code) {
                         let srv = self.views[self.active].srv;
                         self.apply_palette(PaletteAction::SetMoment(m, srv), ctx);
+                    }
+                }
+                crate::mqtt::Cmd::Strike { lon, lat, time } => {
+                    self.strikes.push_back((lon, lat, time));
+                    // A busy night over a whole continent is a lot of strikes, and the painter
+                    // walks the whole deque. Cap it and let the oldest fall off early.
+                    while self.strikes.len() > STRIKE_CAP {
+                        self.strikes.pop_front();
                     }
                 }
             }

--- a/crates/hookecho/src/app/chrome/registry.rs
+++ b/crates/hookecho/src/app/chrome/registry.rs
@@ -627,6 +627,15 @@ impl HookEchoApp {
                 true,
             ),
             (
+                T::Strikes,
+                "Severe",
+                "Lightning strikes (MQTT)",
+                "Ground strikes republished onto your own MQTT broker \u{2014} needs a relay or a \
+                 Home Assistant rebroadcast and the strikes topic set in Settings. Nothing is \
+                 fetched from a strike network by the app itself.",
+                true,
+            ),
+            (
                 T::Fronts,
                 "Reference",
                 "Surface fronts (H/L)",

--- a/crates/hookecho/src/mqtt.rs
+++ b/crates/hookecho/src/mqtt.rs
@@ -25,7 +25,7 @@ use std::time::Duration;
 
 /// A command that arrived from the broker. The app drains these once a frame and applies them,
 /// so a house automation can point the window at the storm it just noticed.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Cmd {
     /// Show this radar site in the active pane.
     Site(String),
@@ -33,6 +33,45 @@ pub enum Cmd {
     Product(String),
     /// Mute or unmute alert sound.
     Mute(bool),
+    /// One lightning strike, republished by the user's own relay.
+    Strike {
+        lon: f64,
+        lat: f64,
+        time: chrono::DateTime<chrono::Utc>,
+    },
+}
+
+/// Parse a strike off the strikes topic.
+///
+/// The payload shape is the one the Home Assistant Blitzortung component republishes — JSON with
+/// `lat`, `lon` and a nanosecond-epoch `time` — but leniently: a relay that sends seconds,
+/// milliseconds, or no time at all still produces a usable strike, because a strike with a
+/// plausible position and a slightly wrong age is worth more than a dropped one.
+pub fn parse_strike(payload: &str) -> Option<Cmd> {
+    let v: serde_json::Value = serde_json::from_str(payload).ok()?;
+    let lon = v["lon"].as_f64()?;
+    let lat = v["lat"].as_f64()?;
+    if !(-180.0..=180.0).contains(&lon) || !(-90.0..=90.0).contains(&lat) {
+        return None;
+    }
+    let now = chrono::Utc::now();
+    let time = match v["time"].as_i64() {
+        // Nanoseconds is what the component publishes; the other two are what a hand-rolled
+        // relay usually sends. They are orders of magnitude apart, so the magnitude tells them
+        // apart without the relay having to say.
+        Some(t) if t > 1_000_000_000_000_000 => chrono::DateTime::from_timestamp_nanos(t),
+        Some(t) if t > 1_000_000_000_000 => chrono::DateTime::from_timestamp_millis(t)?,
+        Some(t) if t > 1_000_000_000 => chrono::DateTime::from_timestamp(t, 0)?,
+        _ => now,
+    };
+    // A strike from the future, or from last week, is a clock problem somewhere upstream. Treat
+    // it as "now" rather than dropping it: the position is still real.
+    let time = if (time - now).num_seconds().abs() > 3600 {
+        now
+    } else {
+        time
+    };
+    Some(Cmd::Strike { lon, lat, time })
 }
 
 /// Parse one command from its topic suffix and payload.
@@ -221,6 +260,13 @@ pub fn spawn(settings: &Settings, subscribe: bool) {
         }
     }
     let cmd_prefix = format!("{prefix}/cmd/");
+    // Empty means off, and it stays off in a `--serve` process for the same reason commands do:
+    // nothing there drains the channel.
+    let strikes_topic = if subscribe {
+        settings.strikes_topic.trim().to_string()
+    } else {
+        String::new()
+    };
     let sub_client = client.clone();
     let sub_prefix = prefix.clone();
     std::thread::spawn(move || {
@@ -237,6 +283,13 @@ pub fn spawn(settings: &Settings, subscribe: bool) {
                             log::warn!("mqtt: subscribing to {topic} failed: {e}");
                         }
                     }
+                    if !strikes_topic.is_empty() {
+                        // At most once: a strike that arrives late is worth less than the
+                        // bandwidth of redelivering it, and there are thousands an hour.
+                        if let Err(e) = sub_client.subscribe(&strikes_topic, QoS::AtMostOnce) {
+                            log::warn!("mqtt: subscribing to {strikes_topic} failed: {e}");
+                        }
+                    }
                     if discovery_on {
                         for (topic, payload) in discovery(&sub_prefix) {
                             publish(&sub_client, &topic, payload, true);
@@ -244,10 +297,19 @@ pub fn spawn(settings: &Settings, subscribe: bool) {
                     }
                 }
                 Ok(rumqttc::Event::Incoming(rumqttc::Packet::Publish(p))) => {
+                    let payload = String::from_utf8_lossy(&p.payload);
                     let Some(suffix) = p.topic.strip_prefix(&cmd_prefix) else {
+                        // Anything else on this connection is a strike, since the strikes topic
+                        // is the only other thing subscribed. Unparseable ones are silent: a
+                        // wildcard topic carries the network's own housekeeping messages too,
+                        // and warning per message would be thousands of lines an hour.
+                        if !strikes_topic.is_empty() {
+                            if let Some(cmd) = parse_strike(&payload) {
+                                let _ = tx.send(cmd);
+                            }
+                        }
                         continue;
                     };
-                    let payload = String::from_utf8_lossy(&p.payload);
                     match parse_cmd(suffix, &payload) {
                         Some(cmd) => {
                             let _ = tx.send(cmd);
@@ -403,5 +465,38 @@ mod tests {
         assert_eq!(v["body"], "Norman until 21:15");
         assert_eq!(v["urgent"], true);
         assert!(v["time"].as_str().unwrap().contains('T'));
+    }
+
+    #[test]
+    fn strikes_parse_the_shape_the_blitzortung_relay_publishes() {
+        // Captured payload shape: nanosecond epoch, degrees.
+        let cmd = parse_strike(r#"{"time":1756500000000000000,"lat":35.2,"lon":-97.4}"#);
+        let Some(Cmd::Strike { lon, lat, time }) = cmd else {
+            panic!("expected a strike, got {cmd:?}");
+        };
+        assert!((lon + 97.4).abs() < 1e-9 && (lat - 35.2).abs() < 1e-9);
+        // Well outside the hour window, so it is clamped to now rather than dropped.
+        assert!((chrono::Utc::now() - time).num_seconds().abs() < 5);
+    }
+
+    #[test]
+    fn a_recent_second_epoch_keeps_its_own_time() {
+        let then = chrono::Utc::now() - chrono::Duration::seconds(120);
+        let json = format!(
+            r#"{{"time":{},"lat":51.5,"lon":-0.1}}"#,
+            then.timestamp_millis()
+        );
+        let Some(Cmd::Strike { time, .. }) = parse_strike(&json) else {
+            panic!("expected a strike");
+        };
+        assert!((time - then).num_seconds().abs() <= 1);
+    }
+
+    #[test]
+    fn junk_on_the_strikes_topic_is_dropped() {
+        // Housekeeping messages and out-of-range positions both share the wildcard topic.
+        assert_eq!(parse_strike("hello"), None);
+        assert_eq!(parse_strike(r#"{"lat":35.2}"#), None);
+        assert_eq!(parse_strike(r#"{"lat":935.2,"lon":-97.4}"#), None);
     }
 }

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -282,6 +282,13 @@ pub struct Settings {
     /// Topic prefix everything is published under, e.g. `home/weather`.
     #[serde(default = "default_mqtt_prefix")]
     pub mqtt_prefix: String,
+    /// Topic the broker republishes lightning strikes on, e.g. `blitzortung/1.1/#`. Empty is off.
+    ///
+    /// The app never talks to a strike network itself — Blitzortung's terms ask third-party apps
+    /// to run their own relay rather than point clients at theirs, and this is the subscriber end
+    /// of that arrangement (see `scripts/strikes-relay/`).
+    #[serde(default)]
+    pub strikes_topic: String,
     /// Publish retained Home Assistant discovery configs so it creates the device by itself.
     ///
     /// Off by default, and deliberately: retained config topics on a broker that is not running
@@ -1091,6 +1098,7 @@ impl Default for Settings {
             mqtt_user: String::new(),
             mqtt_pass: String::new(),
             mqtt_prefix: default_mqtt_prefix(),
+            strikes_topic: String::new(),
             mqtt_discovery: false,
             background_alerts: false,
             pack_hires_dem: false,
@@ -1569,6 +1577,7 @@ mod tests {
             mqtt_user: String::new(),
             mqtt_pass: String::new(),
             mqtt_prefix: default_mqtt_prefix(),
+            strikes_topic: String::new(),
             mqtt_discovery: false,
             background_alerts: false,
             pack_hires_dem: false,

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -1134,6 +1134,19 @@ fn alerts_tab(ui: &mut egui::Ui, settings: &mut Settings) {
                      this broker has no Home Assistant on it.",
                 );
         });
+        ui.horizontal(|ui| {
+            ui.label("Strikes topic:");
+            ui.add(
+                egui::TextEdit::singleline(&mut settings.strikes_topic)
+                    .hint_text("blitzortung/1.1/#"),
+            )
+            .on_hover_text(
+                "Subscribe to lightning strikes someone else is already publishing to this \
+                 broker \u{2014} a Home Assistant Blitzortung integration, or the relay in \
+                 scripts/strikes-relay. Empty is off. HookEcho never connects to a strike \
+                 network itself.",
+            );
+        });
         ui.weak(
             "Publishes <prefix>/status and <prefix>/nearest every five minutes, and \
              <prefix>/alerts as warnings arrive. Takes effect on restart.",


### PR DESCRIPTION
Subscribes to a user-named topic alongside the command topic and paints whatever strikes arrive on it. The app never connects to a strike network itself — Blitzortung asks third-party apps not to point clients at their servers, so the supported arrangement is a relay (or a Home Assistant Blitzortung integration) republishing onto the user's own broker, and this is the subscriber end of it.

- `Settings::strikes_topic`, empty by default = off, with a settings row next to the MQTT block.
- `mqtt::parse_strike` reads the shape that integration publishes (`lat`, `lon`, nanosecond `time`) leniently: second and millisecond epochs are told apart by magnitude, a missing or implausible time falls back to now, out-of-range positions are dropped. Unparseable payloads are silent, because a wildcard topic carries the network's housekeeping too.
- App keeps a 15-minute, 20 000-strike deque that ages out on its own clock, and paints it with the GLM block's bbox prefilter and a cyan-white to deep-blue fade — deliberately unlike GLM's white-to-orange, since with both layers on colour is the only thing separating optical flashes from ground strikes.
- `OverlayToggle::Strikes` in the Severe category; QoS 0 for strikes, since a late one is worth less than the bandwidth of redelivering it.

Not verified against a live broker: mosquitto is not installed here and installing it needs sudo. The parser is unit-tested against the captured payload shape; the subscribe path is the same one the command topic already uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
