### PR TITLE
feat(overlays): SPC watch-box layer

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -118,6 +118,8 @@ pub struct OverlayFilters {
     /// Day-1 outlook hazard: categorical risk, or a tornado/wind/hail probability grid.
     pub outlook_kind: wxdata::spc::OutlookKind,
     pub show_mds: bool,
+    /// SPC tornado and severe thunderstorm watches in effect.
+    pub show_watches: bool,
     /// WPC Winter Storm Severity Index day (0 = off, else 1-3).
     pub wssi_day: u8,
     /// WPC Excessive Rainfall Outlook day (0 = off, else 1-3).
@@ -153,6 +155,7 @@ impl Default for OverlayFilters {
             ero_day: 0,
 
             show_mds: true,
+            show_watches: true,
             show_cells: true,
             show_tracks: true,
             show_arrival_cones: false,
@@ -184,6 +187,7 @@ enum OverlayMsg {
     Fronts(wxdata::fronts::SurfaceAnalysis),
     Outlook(u8, Vec<GeoFeature>),
     Mds(Vec<GeoFeature>),
+    Watches(Vec<GeoFeature>),
     /// WPC Winter Storm Severity Index polygons for a day.
     Wssi(u8, Vec<GeoFeature>),
     /// WPC Excessive Rainfall Outlook polygons for a day.
@@ -280,6 +284,8 @@ enum OverlaySource {
     /// whether European warnings are worth fetching alongside them.
     Alerts(Vec<(f64, f64)>, (f64, f64, f64, f64)),
     Mds,
+    /// Tornado and severe thunderstorm watch polygons in effect.
+    Watches,
     /// Winter Storm Severity Index for a day (1-3).
     Wssi(u8),
     /// Excessive Rainfall Outlook for a day (1-3).
@@ -414,6 +420,7 @@ impl OverlaySource {
             OverlaySource::Mds => {
                 OverlayMsg::Mds(wxdata::spc::fetch_mesoscale_discussions(http).await?)
             }
+            OverlaySource::Watches => OverlayMsg::Watches(wxdata::spc::fetch_watches(http).await?),
             OverlaySource::Wssi(day) => {
                 OverlayMsg::Wssi(day, wxdata::wssi::fetch(http, day).await?)
             }
@@ -1124,6 +1131,8 @@ pub(crate) enum OverlayToggle {
     Pireps,
     Recon,
     Fronts,
+    /// SPC tornado and severe thunderstorm watches in effect.
+    Watches,
     GlmLightning,
     /// Ground strikes republished onto the user's own MQTT broker (see `strikes_topic`).
     Strikes,
@@ -1149,7 +1158,7 @@ pub(crate) struct BlockageKey {
 impl OverlayToggle {
     /// Every toggle, for the persistence sweep. A new variant belongs here too, or it silently
     /// stops being remembered across restarts.
-    pub(crate) const ALL: [OverlayToggle; 38] = [
+    pub(crate) const ALL: [OverlayToggle; 39] = [
         Self::AlertPanel,
         Self::StormReports,
         Self::Spotters,
@@ -1182,6 +1191,7 @@ impl OverlayToggle {
         Self::Pireps,
         Self::Recon,
         Self::Fronts,
+        Self::Watches,
         Self::GlmLightning,
         Self::Strikes,
         Self::Wind,
@@ -2023,6 +2033,8 @@ pub struct HookEchoApp {
     /// One slot per SPC outlook day, 1..=8 (Days 4–8 are the experimental probability layer).
     outlook_features: [Vec<GeoFeature>; 8],
     md_features: Vec<GeoFeature>,
+    /// Watch boxes in effect, one feature per county row the service returns.
+    watch_features: Vec<GeoFeature>,
     /// Winter Storm Severity Index polygons for the selected day.
     wssi_features: Vec<GeoFeature>,
     /// Excessive Rainfall Outlook polygons for the selected day.
@@ -2975,6 +2987,7 @@ impl HookEchoApp {
             arch_lsr_shown: None,
             outlook_features: std::array::from_fn(|_| Vec::new()),
             md_features: Vec::new(),
+            watch_features: Vec::new(),
             wssi_features: Vec::new(),
             ero_features: Vec::new(),
             show_mping: false,
@@ -3796,6 +3809,7 @@ impl HookEchoApp {
         points.extend(self.settings.markers.iter().map(|m| (m.lat, m.lon)));
         self.spawn_overlay(ctx, OverlaySource::Alerts(points, self.view_bounds()));
         self.spawn_overlay(ctx, OverlaySource::Mds);
+        self.spawn_overlay(ctx, OverlaySource::Watches);
         if (1..=3).contains(&self.filters.wssi_day) {
             self.spawn_overlay(ctx, OverlaySource::Wssi(self.filters.wssi_day));
         }
@@ -7227,6 +7241,7 @@ impl HookEchoApp {
             T::Couplets => &mut self.filters.show_couplets,
             T::Alerts => &mut self.filters.show_alerts,
             T::Mds => &mut self.filters.show_mds,
+            T::Watches => &mut self.filters.show_watches,
             T::Mping => &mut self.show_mping,
             T::Pireps => &mut self.show_pireps,
             T::Recon => &mut self.show_recon,
@@ -7467,6 +7482,7 @@ impl HookEchoApp {
                     self.alert_features = f;
                 }
                 OverlayMsg::Mds(f) => self.md_features = f,
+                OverlayMsg::Watches(f) => self.watch_features = f,
                 OverlayMsg::Mping(r) => self.mping_reports = r,
                 OverlayMsg::Pireps(p) => self.pireps = p,
                 OverlayMsg::Recon(o) => self.recon = o,
@@ -8563,6 +8579,9 @@ impl HookEchoApp {
         }
         if self.filters.show_mds {
             v.extend(self.md_features.iter().cloned());
+        }
+        if self.filters.show_watches {
+            v.extend(self.watch_features.iter().cloned());
         }
         if (1..=3).contains(&self.filters.wssi_day) {
             v.extend(self.wssi_features.iter().cloned());

--- a/crates/hookecho/src/app/chrome/registry.rs
+++ b/crates/hookecho/src/app/chrome/registry.rs
@@ -471,6 +471,13 @@ impl HookEchoApp {
                 false,
             ),
             (
+                T::Watches,
+                "Severe",
+                "Watch boxes",
+                "SPC tornado and severe thunderstorm watches in effect",
+                false,
+            ),
+            (
                 T::Mds,
                 "Severe",
                 "Mesoscale discussions",

--- a/crates/wxdata/src/spc.rs
+++ b/crates/wxdata/src/spc.rs
@@ -15,6 +15,11 @@ const OUTLOOK_BASE: &str = "https://www.spc.noaa.gov/products/outlook";
 const OUTLOOK_EXPER_BASE: &str = "https://www.spc.noaa.gov/products/exper/day4-8";
 const MD_URL: &str = "https://mapservices.weather.noaa.gov/vector/rest/services/outlooks/spc_mesoscale_discussion/MapServer/0/query?where=1%3D1&outFields=*&f=geojson";
 
+/// Watch polygons (tornado and severe thunderstorm) from the same map service the MDs come from,
+/// so this needs no proxy-allowlist change. Layer 1 is the county-resolution watch/warning layer;
+/// filtering to the two watch products server-side keeps the payload to the boxes in effect.
+const WATCH_URL: &str = "https://mapservices.weather.noaa.gov/eventdriven/rest/services/WWA/watch_warn_adv/MapServer/1/query?where=prod_type+IN+%28%27Tornado+Watch%27%2C%27Severe+Thunderstorm+Watch%27%29&outFields=*&f=geojson";
+
 /// Fill color for a categorical risk label, when the GeoJSON doesn't supply one.
 pub(crate) fn risk_color(label: &str) -> [u8; 3] {
     match label.to_ascii_uppercase().as_str() {
@@ -239,6 +244,70 @@ pub fn parse_md(json: &str) -> anyhow::Result<Vec<(GeoFeature, Option<String>)>>
         }
     })?;
     Ok(out)
+}
+
+/// Parse the watch layer's GeoJSON into features.
+///
+/// Tornado watches are red and severe thunderstorm watches yellow, the colors SPC itself uses,
+/// and both are drawn faint: a watch covers whole states for hours and must not compete with the
+/// warning polygons inside it.
+pub fn parse_watches(json: &str) -> anyhow::Result<Vec<GeoFeature>> {
+    let mut out = Vec::new();
+    for_each_feature(json, |geom, props| {
+        let str_of = |k: &str| props.get(k).and_then(|v| v.as_str()).unwrap_or("");
+        let prod = str_of("prod_type");
+        let tornado = prod.starts_with("Tornado");
+        // The service returns one row per county in a watch, so a single watch arrives as dozens
+        // of features. They keep their own polygons — merging them would need a union — but they
+        // share a title, and the number is what identifies the watch to a chaser.
+        let number = str_of("event");
+        let title = if number.is_empty() {
+            prod.to_string()
+        } else {
+            format!("{prod} {number}")
+        };
+        let mut detail = String::new();
+        for (label, key) in [("Until", "ends"), ("Issued", "issuance"), ("Office", "wfo")] {
+            let v = str_of(key);
+            if !v.is_empty() {
+                detail.push_str(&format!("{label}: {v}\n"));
+            }
+        }
+        detail.push_str(str_of("url"));
+        for poly in polygons_of(geom) {
+            out.push(GeoFeature {
+                rings: poly,
+                fill: if tornado {
+                    [230, 40, 40, 20]
+                } else {
+                    [230, 200, 30, 18]
+                },
+                stroke: if tornado {
+                    [230, 40, 40, 235]
+                } else {
+                    [230, 200, 30, 235]
+                },
+                kind: FeatureKind::WatchBox,
+                title: title.clone(),
+                detail: detail.clone(),
+                alert: None,
+            });
+        }
+    })?;
+    Ok(out)
+}
+
+/// Fetch the watches in effect.
+pub async fn fetch_watches(client: &reqwest::Client) -> anyhow::Result<Vec<GeoFeature>> {
+    let body = client
+        .get(crate::net::fetch_url(WATCH_URL))
+        .header("User-Agent", USER_AGENT)
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+    parse_watches(&body)
 }
 
 /// Fetch the categorical outlook for `day` (1–3), or the severe probability for a Day 4–8.
@@ -467,5 +536,28 @@ mod tests {
     fn hex_parse() {
         assert_eq!(hex_rgb("#ff8800"), Some([255, 136, 0]));
         assert_eq!(hex_rgb("bad"), None);
+    }
+
+    #[test]
+    fn watches_parse_with_spc_colors_and_a_watch_number() {
+        // Trimmed from a live response: one row per county, product name and number in props.
+        let json = r#"{"type":"FeatureCollection","features":[
+          {"type":"Feature",
+           "geometry":{"type":"Polygon","coordinates":[[[-100.0,48.0],[-101.0,48.0],[-101.0,49.0],[-100.0,48.0]]]},
+           "properties":{"prod_type":"Tornado Watch","event":"0638","wfo":"KOUN",
+                         "ends":"2026-08-30T23:00:00-05:00","url":"https://api.weather.gov/alerts/x"}},
+          {"type":"Feature",
+           "geometry":{"type":"Polygon","coordinates":[[[-90.0,38.0],[-91.0,38.0],[-91.0,39.0],[-90.0,38.0]]]},
+           "properties":{"prod_type":"Severe Thunderstorm Watch","event":"0637","wfo":"KBIS"}}]}"#;
+        let f = parse_watches(json).unwrap();
+        assert_eq!(f.len(), 2);
+        assert_eq!(f[0].title, "Tornado Watch 0638");
+        assert_eq!(f[0].kind, FeatureKind::WatchBox);
+        assert_eq!(f[0].stroke, [230, 40, 40, 235]);
+        assert!(f[0].detail.contains("Until: 2026-08-30T23:00:00-05:00"));
+        assert_eq!(f[1].title, "Severe Thunderstorm Watch 0637");
+        assert_eq!(f[1].stroke, [230, 200, 30, 235]);
+        // A watch is a backdrop for the warnings inside it, so both fills stay nearly clear.
+        assert!(f.iter().all(|x| x.fill[3] < 30));
     }
 }


### PR DESCRIPTION
Tornado and severe thunderstorm watches in effect, drawn under the warnings.

- `spc::WATCH_URL` queries layer 1 of `mapservices.weather.noaa.gov/eventdriven/.../watch_warn_adv`, filtering `prod_type IN ('Tornado Watch','Severe Thunderstorm Watch')` server-side. **Same host as the existing MD query, so the proxy allowlists are byte-identical — zero allowlist edits.**
- `spc::parse_watches` mirrors `parse_md`: `for_each_feature` + `polygons_of`, no second fetch. Title is the product plus the watch number (`Tornado Watch 0638`); detail carries the end time, issuance, office and the api.weather.gov URL.
- SPC's colors — red for tornado, yellow for severe thunderstorm — with fill alpha under 20. A watch covers whole states for hours; it is a backdrop for the warnings inside it.
- `OverlaySource::Watches` / `OverlayMsg::Watches` / `filters.show_watches` clone the Mds twin at each site, refreshed on the same clock. `OverlayToggle::Watches` sits beside mesoscale discussions in the Severe category.

The service returns one row per county in a watch, so one watch arrives as dozens of features sharing a title. They keep their own polygons — merging them would need a union — which is also how the alert layer already behaves.

Verified against the live service while writing the parser (19 features in effect, `prod_type`/`event`/`ends`/`wfo`/`url` fields confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
