### PR TITLE
feat(wxdata): local cell tracking with extrapolation and ETA

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1133,6 +1133,8 @@ pub(crate) enum OverlayToggle {
     Fronts,
     /// SPC tornado and severe thunderstorm watches in effect.
     Watches,
+    /// Cell tracks computed here from reflectivity, for sites with no Level 3 SCIT product.
+    LocalTracks,
     GlmLightning,
     /// Ground strikes republished onto the user's own MQTT broker (see `strikes_topic`).
     Strikes,
@@ -1158,7 +1160,7 @@ pub(crate) struct BlockageKey {
 impl OverlayToggle {
     /// Every toggle, for the persistence sweep. A new variant belongs here too, or it silently
     /// stops being remembered across restarts.
-    pub(crate) const ALL: [OverlayToggle; 39] = [
+    pub(crate) const ALL: [OverlayToggle; 40] = [
         Self::AlertPanel,
         Self::StormReports,
         Self::Spotters,
@@ -1192,6 +1194,7 @@ impl OverlayToggle {
         Self::Recon,
         Self::Fronts,
         Self::Watches,
+        Self::LocalTracks,
         Self::GlmLightning,
         Self::Strikes,
         Self::Wind,
@@ -1984,6 +1987,12 @@ pub struct HookEchoApp {
     /// over every tilt, so they share one cache and are computed together.
     zdr_cache: Option<ZdrCache>,
     couplet_cache: Option<((usize, String, usize), Vec<wxdata::rotation::CoupletHit>)>,
+    /// Cells found per decoded volume, so a track built over a dozen frames flood-fills each
+    /// sweep once rather than once a frame.
+    celltrack_cache: LruCache<String, Vec<wxdata::celltrack::Blob>>,
+    /// The tracks themselves, with the frame list they were built from.
+    tracks_cache: Option<((usize, String, usize), Vec<wxdata::celltrack::Track>)>,
+    show_local_tracks: bool,
     site_dialog: Option<ui::site_dialog::SiteDialog>,
     firstrun: ui::firstrun::FirstRun,
     /// The optional spotlight tour, and where the chrome drew the things it points at this frame.
@@ -2943,6 +2952,9 @@ impl HookEchoApp {
             tbss_cache: None,
             zdr_cache: None,
             couplet_cache: None,
+            celltrack_cache: LruCache::new(NonZeroUsize::new(48).unwrap()),
+            tracks_cache: None,
+            show_local_tracks: false,
             site_dialog: None,
             firstrun: {
                 let mut w = ui::firstrun::FirstRun::default();
@@ -6201,6 +6213,64 @@ impl HookEchoApp {
         out
     }
 
+    /// Cell tracks for the active pane, computed here from reflectivity rather than read from a
+    /// Level 3 storm-cell table — the point of the layer is the sites that have no such table.
+    ///
+    /// Built by folding [`wxdata::celltrack::associate`] over the timeline frames still in the
+    /// decode cache, so it needs no extra downloads and silently produces nothing on a fresh boot
+    /// with one volume in hand.
+    fn compute_local_tracks(&mut self) -> Vec<wxdata::celltrack::Track> {
+        let key = self.volume_key(self.active);
+        if let Some((k, v)) = &self.tracks_cache {
+            if *k == key {
+                return v.clone();
+            }
+        }
+        let frames: Vec<_> = self.views[self.active]
+            .timeline
+            .frames
+            .iter()
+            .take(self.views[self.active].timeline.playhead + 1)
+            .filter_map(|id| id.date_time().map(|t| (id.name().to_string(), t)))
+            .filter(|(name, _)| self.scan_cache.contains(name))
+            .collect();
+        let mut tracks: Vec<wxdata::celltrack::Track> = Vec::new();
+        for (name, at) in frames {
+            let cells = match self.celltrack_cache.get(&name) {
+                Some(c) => c.clone(),
+                None => {
+                    let Some(scan) = self.scan_cache.get(&name).map(Arc::clone) else {
+                        continue;
+                    };
+                    // Lowest tilt: the cell a chaser is driving toward is the one at the ground.
+                    let cells = match level2::bin_scan(&scan, Moment::Reflectivity, 0) {
+                        Ok(sweep) => wxdata::celltrack::find_cells(&sweep, 45.0),
+                        Err(e) => {
+                            log::debug!("celltrack: skipping {name}: {e}");
+                            Vec::new()
+                        }
+                    };
+                    self.celltrack_cache.put(name.clone(), cells.clone());
+                    cells
+                }
+            };
+            tracks = wxdata::celltrack::associate(&tracks, &cells, at, 30.0);
+        }
+        // A track whose last point is older than the newest frame stopped being seen; drop it
+        // rather than leave a stale arrow pointing at empty sky.
+        if let Some(newest) = tracks
+            .iter()
+            .filter_map(|t| t.points.last())
+            .map(|p| p.2)
+            .max()
+        {
+            tracks
+                .retain(|t| t.points.last().is_some_and(|p| p.2 == newest) && t.points.len() >= 2);
+        }
+        self.tracks_cache = Some((key, tracks.clone()));
+        tracks
+    }
+
     fn compute_couplets_uncached(&mut self, idx: usize) -> Vec<wxdata::rotation::CoupletHit> {
         // Lowest tilt = closest to the ground; dealiased so folded gates don't fake huge shear.
         let vel = match self.views[idx]
@@ -7242,6 +7312,7 @@ impl HookEchoApp {
             T::Alerts => &mut self.filters.show_alerts,
             T::Mds => &mut self.filters.show_mds,
             T::Watches => &mut self.filters.show_watches,
+            T::LocalTracks => &mut self.show_local_tracks,
             T::Mping => &mut self.show_mping,
             T::Pireps => &mut self.show_pireps,
             T::Recon => &mut self.show_recon,
@@ -10877,6 +10948,11 @@ impl HookEchoApp {
         } else {
             Vec::new()
         };
+        let local_tracks = if self.show_local_tracks && idx == self.active {
+            self.compute_local_tracks()
+        } else {
+            Vec::new()
+        };
         if idx == self.active {
             self.check_rain_arrival();
             self.evaluate_scan_rules(idx, &tds_hits, &tbss_hits, &zdr_hits, &couplets);
@@ -11505,6 +11581,69 @@ impl HookEchoApp {
                     egui::FontId::proportional(11.0),
                     col,
                 );
+            }
+
+            // Locally-computed cell tracks, in cyan so they never read as the Level 3 storm-cell
+            // table drawn below in white and red. Same grammar: past polyline, dots, `T+NNm` labels.
+            if !local_tracks.is_empty() {
+                let cyan = egui::Color32::from_rgb(80, 220, 255);
+                for tr in &local_tracks {
+                    let pts: Vec<egui::Pos2> = tr
+                        .points
+                        .iter()
+                        .map(|&(lon, lat, _)| to_screen(lon, lat))
+                        .collect();
+                    painter.add(egui::Shape::line(
+                        pts.clone(),
+                        egui::Stroke::new(1.5, cyan.gamma_multiply(0.6)),
+                    ));
+                    let Some(&head) = pts.last() else { continue };
+                    if !prect.contains(head) {
+                        continue;
+                    }
+                    painter.circle_stroke(head, 6.0, egui::Stroke::new(2.0, cyan));
+                    for minutes in [15.0, 30.0] {
+                        let Some((lon, lat)) = tr.extrapolate(minutes) else {
+                            continue;
+                        };
+                        let p = to_screen(lon, lat);
+                        painter.line_segment(
+                            [head, p],
+                            egui::Stroke::new(1.0, cyan.gamma_multiply(0.5)),
+                        );
+                        painter.circle_filled(p, 3.0, cyan);
+                        if cam.zoom >= 7.0 {
+                            painter.text(
+                                p + egui::vec2(5.0, -2.0),
+                                egui::Align2::LEFT_CENTER,
+                                format!("T+{minutes:.0}m"),
+                                egui::FontId::proportional(10.0),
+                                cyan,
+                            );
+                        }
+                    }
+                    // With a GPS fix, the number a chaser actually wants: how close this cell comes
+                    // to where they are standing, and in how many minutes.
+                    if let Some((lon, lat)) = self.chase_pos {
+                        let last = tr.points[tr.points.len() - 1];
+                        let (km, min) = crate::geo::closest_approach(
+                            [last.0, last.1],
+                            tr.dir_deg,
+                            tr.speed_kt,
+                            [lon, lat],
+                            60.0,
+                        );
+                        if min >= 1.0 {
+                            painter.text(
+                                head + egui::vec2(0.0, 9.0),
+                                egui::Align2::CENTER_TOP,
+                                format!("\u{2248}{min:.0} min / {km:.0} km"),
+                                egui::FontId::proportional(10.0),
+                                cyan,
+                            );
+                        }
+                    }
+                }
             }
 
             let label_tracks = self.filters.show_tracks && cam.zoom >= 7.0;

--- a/crates/hookecho/src/app/chrome/registry.rs
+++ b/crates/hookecho/src/app/chrome/registry.rs
@@ -471,6 +471,15 @@ impl HookEchoApp {
                 false,
             ),
             (
+                T::LocalTracks,
+                "Severe",
+                "Local cell tracks (radar-derived)",
+                "Cell motion computed here from reflectivity, with 15- and 30-minute \
+                 extrapolation \u{2014} for sites and networks with no Level 3 storm-cell table. \
+                 Needs a few volumes in the loop before it has motion to show.",
+                false,
+            ),
+            (
                 T::Watches,
                 "Severe",
                 "Watch boxes",

--- a/crates/wxdata/src/celltrack.rs
+++ b/crates/wxdata/src/celltrack.rs
@@ -1,0 +1,360 @@
+//! Storm-cell identification and tracking from Level 2 reflectivity, for sites that have no
+//! Level 3 SCIT product.
+//!
+//! The NEXRAD network broadcasts storm-cell tables (the SCIT algorithm's output) as a Level 3
+//! product, and the app draws those where they exist. TDWRs, most international radars, and any
+//! site whose Level 3 feed is down have no such table — but they all have reflectivity, and the
+//! useful half of a cell track is arithmetic on centroids: where the cell is now, where it was,
+//! therefore where it will be.
+//!
+//! Deliberately simpler than SCIT: one threshold instead of seven nested ones, centroids instead
+//! of vertically-integrated cell components, nearest-neighbour association instead of a cost
+//! matrix. It finds the same big cells and misses the marginal ones, which is the right trade for
+//! a display layer that exists so a chaser can see motion at a glance.
+//!
+//! ponytail: single threshold, greedy association. Multi-threshold splitting matters when cells
+//! merge, and the honest fix there is decoding the real SCIT product where it exists.
+
+use crate::level2::BinnedSweep;
+
+/// One contiguous region of reflectivity at or above the threshold.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Blob {
+    pub lon: f64,
+    pub lat: f64,
+    /// Strongest gate in the region (dBZ).
+    pub dbz_max: f32,
+    /// Rough footprint, from gate areas summed over the region.
+    pub area_km2: f64,
+}
+
+/// Smallest region worth calling a cell. Below this, a handful of gates over threshold is as
+/// likely to be a bright patch of a squall line's leading edge as a storm.
+const MIN_AREA_KM2: f64 = 8.0;
+
+/// Decode a binned `u8` gate index back to dBZ, or `None` for below-threshold / range-folded
+/// gates. Same encoding as [`crate::rotation`] and [`crate::tds`].
+fn decode(sweep: &BinnedSweep, idx: u8) -> Option<f32> {
+    if idx < 2 {
+        return None;
+    }
+    let (lo, hi) = (sweep.value_min, sweep.value_max);
+    Some(lo + (idx as f32 - 2.0) / 253.0 * (hi - lo))
+}
+
+/// Great-circle destination point, placing a gate at its azimuth and range.
+fn dest(lon: f64, lat: f64, bearing_deg: f64, dist_km: f64) -> (f64, f64) {
+    let r = 6371.0;
+    let ad = dist_km / r;
+    let (br, la1, lo1) = (bearing_deg.to_radians(), lat.to_radians(), lon.to_radians());
+    let la2 = (la1.sin() * ad.cos() + la1.cos() * ad.sin() * br.cos()).asin();
+    let lo2 = lo1 + (br.sin() * ad.sin() * la1.cos()).atan2(ad.cos() - la1.sin() * la2.sin());
+    (lo2.to_degrees(), la2.to_degrees())
+}
+
+/// Distance between two points in km.
+fn haversine_km(a: (f64, f64), b: (f64, f64)) -> f64 {
+    let (dlon, dlat) = ((b.0 - a.0).to_radians(), (b.1 - a.1).to_radians());
+    let h = (dlat / 2.0).sin().powi(2)
+        + a.1.to_radians().cos() * b.1.to_radians().cos() * (dlon / 2.0).sin().powi(2);
+    2.0 * 6371.0 * h.sqrt().asin()
+}
+
+/// Bearing from `a` to `b`, degrees clockwise from north.
+fn bearing_deg(a: (f64, f64), b: (f64, f64)) -> f64 {
+    let (la1, la2) = (a.1.to_radians(), b.1.to_radians());
+    let dlon = (b.0 - a.0).to_radians();
+    let y = dlon.sin() * la2.cos();
+    let x = la1.cos() * la2.sin() - la1.sin() * la2.cos() * dlon.cos();
+    (y.atan2(x).to_degrees() + 360.0) % 360.0
+}
+
+/// Find cells in one sweep: flood-fill every region at or above `min_dbz` and return its
+/// reflectivity-weighted centroid.
+///
+/// The fill runs in polar space and wraps in azimuth, so a cell sitting due north of the radar is
+/// one region rather than two. Weighting by reflectivity puts the centroid on the core rather than
+/// the middle of the anvil-side gradient.
+pub fn find_cells(sweep: &BinnedSweep, min_dbz: f32) -> Vec<Blob> {
+    let (az_bins, gates) = (sweep.az_bins, sweep.gate_count);
+    if az_bins == 0 || gates == 0 {
+        return Vec::new();
+    }
+    let (rlon, rlat) = (sweep.radar_lon as f64, sweep.radar_lat as f64);
+    let az_step = 360.0 / az_bins as f64;
+    let mut seen = vec![false; az_bins * gates];
+    let mut out = Vec::new();
+    let mut stack: Vec<(usize, usize)> = Vec::new();
+
+    let over = |az: usize, g: usize| -> Option<f32> {
+        decode(sweep, sweep.data[az * gates + g]).filter(|&v| v >= min_dbz)
+    };
+
+    for az0 in 0..az_bins {
+        for g0 in 0..gates {
+            if seen[az0 * gates + g0] || over(az0, g0).is_none() {
+                continue;
+            }
+            let (mut wsum, mut wlon, mut wlat) = (0.0f64, 0.0f64, 0.0f64);
+            let (mut dbz_max, mut area) = (f32::MIN, 0.0f64);
+            seen[az0 * gates + g0] = true;
+            stack.push((az0, g0));
+            while let Some((az, g)) = stack.pop() {
+                let Some(v) = over(az, g) else { continue };
+                let range = sweep.first_gate_km as f64 + g as f64 * sweep.gate_interval_km as f64;
+                let (lon, lat) = dest(rlon, rlat, (az as f64 + 0.5) * az_step, range);
+                // Weight by dBZ above the threshold, not by raw dBZ: a logarithmic unit with an
+                // arbitrary zero makes a poor weight, and the offset is what varies here.
+                let w = (v - min_dbz + 1.0) as f64;
+                wsum += w;
+                wlon += lon * w;
+                wlat += lat * w;
+                dbz_max = dbz_max.max(v);
+                // Gate footprint: arc length across the beam times the gate depth.
+                area += range * az_step.to_radians() * sweep.gate_interval_km as f64;
+                let up = (az + 1) % az_bins;
+                let down = (az + az_bins - 1) % az_bins;
+                let mut push = |a: usize, gg: usize, stack: &mut Vec<(usize, usize)>| {
+                    if gg < gates && !seen[a * gates + gg] {
+                        seen[a * gates + gg] = true;
+                        stack.push((a, gg));
+                    }
+                };
+                push(up, g, &mut stack);
+                push(down, g, &mut stack);
+                push(az, g + 1, &mut stack);
+                if g > 0 {
+                    push(az, g - 1, &mut stack);
+                }
+            }
+            if area >= MIN_AREA_KM2 && wsum > 0.0 {
+                out.push(Blob {
+                    lon: wlon / wsum,
+                    lat: wlat / wsum,
+                    dbz_max,
+                    area_km2: area,
+                });
+            }
+        }
+    }
+    out
+}
+
+/// One cell followed across volumes, newest point last.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Track {
+    /// Position and observation time of each volume this cell appeared in.
+    pub points: Vec<(f64, f64, chrono::DateTime<chrono::Utc>)>,
+    /// Direction of travel, degrees clockwise from north (where it is heading, not where from).
+    pub dir_deg: f64,
+    pub speed_kt: f64,
+}
+
+impl Track {
+    /// Where this cell will be `minutes` from its last observation, on its current motion.
+    pub fn extrapolate(&self, minutes: f64) -> Option<(f64, f64)> {
+        let last = self.points.last()?;
+        let km = self.speed_kt * 1.852 / 60.0 * minutes;
+        Some(dest(last.0, last.1, self.dir_deg, km))
+    }
+}
+
+/// Points used to fit motion. Six volumes is 25–30 minutes, long enough to smooth centroid jitter
+/// and short enough that a turning storm's fit still points where it is actually going.
+const FIT_POINTS: usize = 6;
+
+/// Cell speed a gate allows for, in km per minute — 20 km per 5 minutes, comfortably above the
+/// fastest supercell but below the distance between distinct storms in a line.
+const GATE_KM_PER_MIN: f64 = 4.0;
+
+/// Extend `prev` with the cells seen at time `t`, and start tracks for the ones that match
+/// nothing.
+///
+/// Greedy nearest-neighbour within a gate that scales with the gap between volumes, so a track
+/// survives a skipped scan without letting a five-minute gap match across half a county. Tracks
+/// that match nothing this round are returned unchanged — the caller drops stale ones — which is
+/// what lets a cell disappear for one noisy volume and be picked up again on the next.
+pub fn associate(
+    prev: &[Track],
+    now: &[Blob],
+    t: chrono::DateTime<chrono::Utc>,
+    max_km: f64,
+) -> Vec<Track> {
+    let mut out = prev.to_vec();
+    let mut taken = vec![false; out.len()];
+    for cell in now {
+        let mut best: Option<(usize, f64)> = None;
+        for (i, tr) in out.iter().enumerate() {
+            if taken[i] {
+                continue;
+            }
+            let Some(&(lon, lat, last_t)) = tr.points.last() else {
+                continue;
+            };
+            let dt_min = (t - last_t).num_seconds() as f64 / 60.0;
+            if dt_min <= 0.0 {
+                continue; // same volume, or one arriving out of order
+            }
+            let gate = (dt_min * GATE_KM_PER_MIN).min(max_km);
+            let d = haversine_km((lon, lat), (cell.lon, cell.lat));
+            if d <= gate && best.is_none_or(|(_, bd)| d < bd) {
+                best = Some((i, d));
+            }
+        }
+        match best {
+            Some((i, _)) => {
+                taken[i] = true;
+                out[i].points.push((cell.lon, cell.lat, t));
+                let (dir, speed) = fit_motion(&out[i].points);
+                out[i].dir_deg = dir;
+                out[i].speed_kt = speed;
+            }
+            None => out.push(Track {
+                points: vec![(cell.lon, cell.lat, t)],
+                dir_deg: 0.0,
+                speed_kt: 0.0,
+            }),
+        }
+    }
+    out
+}
+
+/// Direction and speed over the last few points.
+///
+/// Endpoint-to-endpoint over the fit window rather than a per-step average: centroid jitter is
+/// the dominant error here, and a straight line between the ends of the window divides that error
+/// by the whole elapsed time instead of by one scan interval.
+fn fit_motion(points: &[(f64, f64, chrono::DateTime<chrono::Utc>)]) -> (f64, f64) {
+    let n = points.len();
+    if n < 2 {
+        return (0.0, 0.0);
+    }
+    let first = points[n.saturating_sub(FIT_POINTS)];
+    let last = points[n - 1];
+    let dt_min = (last.2 - first.2).num_seconds() as f64 / 60.0;
+    if dt_min <= 0.0 {
+        return (0.0, 0.0);
+    }
+    let km = haversine_km((first.0, first.1), (last.0, last.1));
+    (
+        bearing_deg((first.0, first.1), (last.0, last.1)),
+        km / dt_min * 60.0 / 1.852,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::level2::Moment;
+
+    /// A sweep with one square-ish patch of strong echo, everything else empty.
+    fn sweep_with_cell(az_center: usize, gate_center: usize) -> BinnedSweep {
+        let (az_bins, gate_count) = (360, 200);
+        let mut data = vec![0u8; az_bins * gate_count];
+        // 45 dBZ: encoded index for a -32..95 range.
+        let idx = ((45.0 + 32.0) / 127.0 * 253.0 + 2.0) as u8;
+        for az in 0..az_bins {
+            for g in 0..gate_count {
+                let daz = ((az + az_bins - az_center) % az_bins)
+                    .min((az_center + az_bins - az) % az_bins);
+                let dg = g.abs_diff(gate_center);
+                if daz <= 4 && dg <= 6 {
+                    data[az * gate_count + g] = idx;
+                }
+            }
+        }
+        BinnedSweep {
+            moment: Moment::Reflectivity,
+            az_bins,
+            gate_count,
+            data,
+            first_gate_km: 2.0,
+            gate_interval_km: 0.25,
+            radar_lat: 35.0,
+            radar_lon: -97.0,
+            elevation_deg: 0.5,
+            value_min: -32.0,
+            value_max: 95.0,
+        }
+    }
+
+    #[test]
+    fn one_patch_becomes_one_cell_at_its_centroid() {
+        let sweep = sweep_with_cell(90, 120);
+        let cells = find_cells(&sweep, 40.0);
+        assert_eq!(cells.len(), 1, "one patch, one cell: {cells:?}");
+        let c = cells[0];
+        // Due east of the radar at ~32 km: same latitude, east in longitude.
+        assert!((c.lat - 35.0).abs() < 0.05, "{c:?}");
+        assert!(c.lon > -97.0, "{c:?}");
+        assert!(c.dbz_max > 44.0 && c.dbz_max < 46.0, "{c:?}");
+        assert!(c.area_km2 > MIN_AREA_KM2, "{c:?}");
+    }
+
+    #[test]
+    fn a_cell_straddling_north_is_not_split_in_two() {
+        let cells = find_cells(&sweep_with_cell(0, 120), 40.0);
+        assert_eq!(cells.len(), 1, "azimuth wrap keeps it whole: {cells:?}");
+    }
+
+    #[test]
+    fn weak_echo_is_not_a_cell() {
+        assert!(find_cells(&sweep_with_cell(90, 120), 50.0).is_empty());
+    }
+
+    fn blob(lon: f64, lat: f64) -> Blob {
+        Blob {
+            lon,
+            lat,
+            dbz_max: 55.0,
+            area_km2: 50.0,
+        }
+    }
+
+    #[test]
+    fn two_volumes_give_an_eastward_track_at_the_right_speed() {
+        let t0 = chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+        let t1 = t0 + chrono::Duration::minutes(5);
+        // 4.6 km east in 5 minutes ≈ 30 kt.
+        let tracks = associate(&[], &[blob(-97.0, 35.0)], t0, 20.0);
+        let tracks = associate(&tracks, &[blob(-96.9494, 35.0)], t1, 20.0);
+        assert_eq!(tracks.len(), 1, "the second cell extended the first track");
+        let tr = &tracks[0];
+        assert!((tr.dir_deg - 90.0).abs() < 1.0, "{tr:?}");
+        assert!((tr.speed_kt - 30.0).abs() < 2.0, "{tr:?}");
+        let (lon, lat) = tr.extrapolate(5.0).unwrap();
+        assert!((lon - (-96.8988)).abs() < 0.01 && (lat - 35.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn a_far_cell_starts_its_own_track() {
+        let t0 = chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+        let tracks = associate(&[], &[blob(-97.0, 35.0)], t0, 20.0);
+        let tracks = associate(
+            &tracks,
+            &[blob(-97.0, 35.0), blob(-95.0, 35.0)],
+            t0 + chrono::Duration::minutes(5),
+            20.0,
+        );
+        assert_eq!(tracks.len(), 2, "180 km away is a different storm");
+    }
+
+    #[test]
+    fn jitter_does_not_swing_the_motion_estimate() {
+        let t0 = chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+        let mut tracks = Vec::new();
+        let jitter = [0.0, 0.004, -0.003, 0.002, -0.004];
+        for (i, dj) in jitter.iter().enumerate() {
+            tracks = associate(
+                &tracks,
+                &[blob(-97.0 + 0.0506 * i as f64, 35.0 + dj)],
+                t0 + chrono::Duration::minutes(5 * i as i64),
+                20.0,
+            );
+        }
+        assert_eq!(tracks.len(), 1);
+        let tr = &tracks[0];
+        assert!((tr.dir_deg - 90.0).abs() < 5.0, "{tr:?}");
+        assert!((tr.speed_kt - 30.0).abs() < 3.0, "{tr:?}");
+    }
+}

--- a/crates/wxdata/src/lib.rs
+++ b/crates/wxdata/src/lib.rs
@@ -7,6 +7,7 @@ pub mod archive_warnings;
 pub mod aviation;
 pub mod banding;
 pub mod cellscore;
+pub mod celltrack;
 pub mod clock;
 pub mod contour;
 pub mod dat;


### PR DESCRIPTION
Cell tracks computed from reflectivity, for sites and networks with no Level 3 SCIT product.

**`crates/wxdata/src/celltrack.rs`** (new, pure, six tests)
- `find_cells(sweep, min_dbz)` — polar flood fill with azimuth wrap, reflectivity-weighted centroid, 8 km² minimum footprint. Uses the same `u8` gate encoding `rotation`/`tds` already decode.
- `associate(prev, now, t, max_km)` — greedy nearest neighbour, gate = 4 km per minute of elapsed time capped at `max_km`, so a track survives a skipped volume without matching across half a county.
- `Track::extrapolate(minutes)`, motion fitted endpoint-to-endpoint over the last ≤6 points.

Deliberately simpler than SCIT: one threshold, centroids, greedy association. It finds the big cells and misses marginal ones, which is the right trade for a display layer — and where the real product exists, the app already draws it.

**App**
- `celltrack_cache` (48-entry LRU, keyed by volume name) so each sweep is filled once, not once a frame; `tracks_cache` keyed by the same volume key the couplet cache uses.
- Tracks are folded over timeline frames already in `scan_cache` — no extra downloads, silently empty on a fresh boot.
- Cyan render after the SCIT block: past polyline, T+15/T+30 dots and labels, and `≈NN min / NN km` closest approach when a GPS fix exists.
- `OverlayToggle::LocalTracks`, off by default, in the Severe category.

Wasm gzipped: 3 994 426 → 4 000 185 (budget 4 125 000, untouched).

Not yet verified against a live storm side by side with the Level 3 tracks — that needs convection in range. The synthetic tests cover centroid placement, azimuth wrap, association, and jitter stability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
