### PR TITLE
feat(web): offline chase packs

### DIFF
--- a/crates/hookecho/Cargo.toml
+++ b/crates/hookecho/Cargo.toml
@@ -122,7 +122,7 @@ console_error_panic_hook = "0.1"
 console_log = "1"
 # The file-dialog set (HtmlInputElement/FileList/File through Blob/Url/HtmlAnchorElement) is what
 # lets `dialog.rs` import and export in a browser — see its `web_open` and `web_save`.
-web-sys = { version = "0.3", features = ["Document", "Window", "HtmlCanvasElement", "Location", "Storage", "HtmlAudioElement", "SpeechSynthesis", "SpeechSynthesisUtterance", "HtmlInputElement", "HtmlAnchorElement", "HtmlElement", "CssStyleDeclaration", "Element", "FileList", "File", "Blob", "Url", "Navigator", "Geolocation", "Position", "Coordinates", "PositionError", "PositionOptions", "Notification", "NotificationOptions", "NotificationPermission", "History", "Performance"] }
+web-sys = { version = "0.3", features = ["Document", "Window", "HtmlCanvasElement", "Location", "Storage", "HtmlAudioElement", "SpeechSynthesis", "SpeechSynthesisUtterance", "HtmlInputElement", "HtmlAnchorElement", "HtmlElement", "CssStyleDeclaration", "Element", "FileList", "File", "Blob", "Url", "Navigator", "Geolocation", "Position", "Coordinates", "PositionError", "PositionOptions", "Notification", "NotificationOptions", "NotificationPermission", "History", "Performance", "IdbFactory", "IdbOpenDbRequest", "IdbDatabase", "IdbObjectStore", "IdbTransaction", "IdbTransactionMode", "IdbRequest", "DomException"] }
 
 # Native file dialogs — desktop only. rfd has no Android backend, and Android replaces it with a
 # fixed exports dir + Storage-Access-Framework (deferred); see `dialog.rs`.

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -6213,6 +6213,57 @@ impl HookEchoApp {
         out
     }
 
+    /// Packs saved in this browser, refreshed in the background whenever one is written.
+    #[cfg(target_arch = "wasm32")]
+    fn packs(&self) -> Vec<crate::webcache::Pack> {
+        crate::webcache::known_packs()
+    }
+
+    /// The last thing the pack machinery has to say — a progress line or an error.
+    #[cfg(target_arch = "wasm32")]
+    fn pack_status(&self) -> Option<String> {
+        crate::webcache::status()
+    }
+
+    /// Save the active timeline's archived frames into an offline pack.
+    ///
+    /// The live head is skipped on purpose: the newest object can still be uploading, and half a
+    /// volume kept forever is worse than one frame missing from a saved loop.
+    #[cfg(target_arch = "wasm32")]
+    fn save_offline_pack(&mut self, ctx: &egui::Context) {
+        let tl = &self.views[self.active].timeline;
+        let ids: Vec<_> = tl.frames.iter().take(tl.playhead + 1).cloned().collect();
+        let site = self.views[self.active].site.clone().unwrap_or_default();
+        let date = tl.date.format("%Y-%m-%d").to_string();
+        let ctx = ctx.clone();
+        self.spawner.spawn(async move {
+            crate::webcache::save_timeline(site, date, ids).await;
+            ctx.request_repaint();
+        });
+    }
+
+    /// Point the active pane at a saved pack: its site and day, and its frames, without listing
+    /// anything over the network. Playback then reads each volume back out of IndexedDB.
+    #[cfg(target_arch = "wasm32")]
+    fn load_offline_pack(&mut self, pack: &crate::webcache::Pack) {
+        let Ok(date) = chrono::NaiveDate::parse_from_str(&pack.date, "%Y-%m-%d") else {
+            return;
+        };
+        self.views[self.active].site = Some(pack.site.clone());
+        let tl = &mut self.views[self.active].timeline;
+        tl.date = date;
+        tl.following = false;
+        tl.listing = false;
+        tl.frames = pack
+            .volumes
+            .iter()
+            .map(|n| Identifier::new(n.clone()))
+            .collect();
+        tl.playhead = 0;
+        tl.playing = true;
+        tl.loop_enabled = true;
+    }
+
     /// Cell tracks for the active pane, computed here from reflectivity rather than read from a
     /// Level 3 storm-cell table — the point of the layer is the sites that have no such table.
     ///
@@ -9022,7 +9073,7 @@ impl HookEchoApp {
                         let time = id.date_time().unwrap_or_else(Utc::now);
                         // No cache at the live head: the newest object can still be uploading, and a
                         // half-written volume is not something to keep.
-                        let fetched = match level2::download_scan(id, None).await {
+                        let fetched = match crate::volume::fetch(id, None).await {
                             Ok(scan) => Ok((name.clone(), time, scan)),
                             Err(e) => match prev {
                                 // Only worth retrying when there IS an older volume and we're not
@@ -9033,7 +9084,7 @@ impl HookEchoApp {
                                     log::debug!(
                                         "newest volume unusable ({e}); falling back to {pname}"
                                     );
-                                    level2::download_scan(p, None)
+                                    crate::volume::fetch(p, None)
                                         .await
                                         .map(|scan| (pname, ptime, scan))
                                         .map_err(|_| e)
@@ -9769,7 +9820,7 @@ impl HookEchoApp {
         let view = idx;
         self.spawner.spawn(async move {
             let name = id.name().to_string();
-            if let Ok(scan) = level2::download_scan(id, crate::paths::cache_dir()).await {
+            if let Ok(scan) = crate::volume::fetch(id, crate::paths::cache_dir()).await {
                 let _ = tx.send(DataMsg::Prefetched {
                     view,
                     site,
@@ -9814,7 +9865,7 @@ impl HookEchoApp {
         self.spawner.spawn(async move {
             let name = id.name().to_string();
             let time = id.date_time().unwrap_or_else(Utc::now);
-            let msg = match level2::download_scan(id, crate::paths::cache_dir()).await {
+            let msg = match crate::volume::fetch(id, crate::paths::cache_dir()).await {
                 Ok(scan) => DataMsg::Volume {
                     view: view_idx,
                     site,

--- a/crates/hookecho/src/app/chrome/scrubber.rs
+++ b/crates/hookecho/src/app/chrome/scrubber.rs
@@ -44,6 +44,13 @@ impl HookEchoApp {
             .as_deref()
             .is_some_and(wxdata::sites::is_nexrad);
         let mut go_head = false;
+        // Offline chase packs are a browser-only idea: on desktop the volumes are already on disk.
+        #[cfg(target_arch = "wasm32")]
+        let mut save_pack = false;
+        #[cfg(target_arch = "wasm32")]
+        let mut load_pack: Option<crate::webcache::Pack> = None;
+        #[cfg(target_arch = "wasm32")]
+        let (packs, pack_status) = (self.packs(), self.pack_status());
         // Soonest rain arrival and the DVR buffer depth ride the pill: both are about time, and
         // both used to sit in an always-on chip in the opposite corner.
         let rain = self
@@ -222,6 +229,36 @@ impl HookEchoApp {
                             .on_hover_text(
                                 "How many of the newest volumes ▶ cycles through when live",
                             );
+                            #[cfg(target_arch = "wasm32")]
+                            {
+                                ui.separator();
+                                if ui
+                                    .button("Save this loop offline")
+                                    .on_hover_text(
+                                        "Keep this loop's volumes in the browser so it plays \
+                                         with no signal. Archived volumes only \u{2014} the live \
+                                         head is still being written.",
+                                    )
+                                    .clicked()
+                                {
+                                    save_pack = true;
+                                }
+                                for p in &packs {
+                                    ui.horizontal(|ui| {
+                                        if ui.button(p.label()).clicked() {
+                                            load_pack = Some(p.clone());
+                                        }
+                                        if ui.small_button("\u{d7}").on_hover_text("Delete").clicked()
+                                        {
+                                            load_pack = None;
+                                            crate::webcache::spawn_remove(p.key());
+                                        }
+                                    });
+                                }
+                                if let Some(msg) = &pack_status {
+                                    ui.weak(msg);
+                                }
+                            }
                         });
                     // The clock and the two status readouts ride the top row with the
                     // transport; the track gets a row to itself underneath.
@@ -308,6 +345,15 @@ impl HookEchoApp {
                 });
             });
         self.settings.live_loop_frames = loop_frames;
+        #[cfg(target_arch = "wasm32")]
+        {
+            if save_pack {
+                self.save_offline_pack(ctx);
+            }
+            if let Some(p) = load_pack {
+                self.load_offline_pack(&p);
+            }
+        }
         if let Some(r) = scrub_rect {
             // The scrubber swallows two-finger gestures on the phone like any other surface.
             self.mobile_occlusion.push(r);

--- a/crates/hookecho/src/lib.rs
+++ b/crates/hookecho/src/lib.rs
@@ -89,6 +89,8 @@ pub mod tray;
 pub mod ui;
 pub mod vector_tiles;
 pub mod view;
+pub mod volume;
+pub mod webcache;
 pub mod wind_draw;
 pub mod wind_gpu;
 pub mod workspace;

--- a/crates/hookecho/src/volume.rs
+++ b/crates/hookecho/src/volume.rs
@@ -1,0 +1,25 @@
+//! Where a radar volume comes from, per target.
+//!
+//! Native reads through the on-disk cache; the browser reads through an offline chase pack in
+//! IndexedDB (`webcache.rs`) before touching the network, which is what makes a saved loop play
+//! with no signal at all. Every timeline fetch goes through here so both caches are one seam, not
+//! four call sites each.
+
+use wxdata::level2::{self, Identifier, Scan};
+
+/// Fetch and decode one volume, using whatever cache this target has.
+///
+/// `cache` is the native disk cache directory, or `None` at the live head where the newest object
+/// may still be uploading.
+pub async fn fetch(id: Identifier, cache: Option<std::path::PathBuf>) -> anyhow::Result<Scan> {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let _ = &cache;
+        let name = id.name().to_string();
+        if let Some(bytes) = crate::webcache::volume(&name).await {
+            log::debug!("volume {name} came from an offline pack");
+            return level2::scan_from_volume_bytes(&name, bytes).await;
+        }
+    }
+    level2::download_scan(id, cache).await
+}

--- a/crates/hookecho/src/webcache.rs
+++ b/crates/hookecho/src/webcache.rs
@@ -1,0 +1,358 @@
+//! Offline chase packs: raw radar volumes kept in IndexedDB so a saved loop plays with no network.
+//!
+//! The service worker already caches basemap tiles (`web/sw.src.js`, `tiles-v1`) and deliberately
+//! excludes radar — a volume is tens of megabytes and the newest one changes every few minutes,
+//! which is exactly what a cache-first HTTP cache handles worst. But a chaser about to lose
+//! signal wants the opposite trade: pin *these specific* archived volumes, which never change,
+//! and read them back with no request at all. That is a pack.
+//!
+//! Raw Archive II bytes are stored rather than decoded scans, for the same reason the native disk
+//! cache stores them: they are smaller, they need no serialization of their own, and they go back
+//! through the same decode path either way.
+//!
+//! ponytail: no eviction inside a pack and no sharing accounting between packs — a volume in two
+//! packs is stored once and freed when the last pack referencing it goes. Packs are deleted whole,
+//! oldest first, once the store passes [`BYTE_CAP`].
+
+#[cfg(target_arch = "wasm32")]
+use anyhow::anyhow;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_futures::JsFuture;
+#[cfg(target_arch = "wasm32")]
+use web_sys::{IdbDatabase, IdbObjectStore, IdbRequest, IdbTransactionMode};
+
+#[cfg(target_arch = "wasm32")]
+const DB_NAME: &str = "hookecho-packs";
+#[cfg(target_arch = "wasm32")]
+const VOLUMES: &str = "volumes";
+#[cfg(target_arch = "wasm32")]
+const PACKS: &str = "packs";
+
+/// How much radar may sit in IndexedDB before saving a pack evicts the oldest one.
+///
+/// A browser's quota is a fraction of free disk and is not knowable up front, so this is a
+/// self-imposed ceiling well under any plausible quota: about ten loops of a dozen volumes.
+#[cfg(target_arch = "wasm32")]
+const BYTE_CAP: f64 = 250.0 * 1024.0 * 1024.0;
+
+/// One saved loop.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+pub struct Pack {
+    /// Radar site the loop was saved from.
+    pub site: String,
+    /// UTC day of the loop, `YYYY-MM-DD`.
+    pub date: String,
+    /// Volume object names, oldest first — the timeline as it stood when saved.
+    pub volumes: Vec<String>,
+    /// Unix seconds when it was saved.
+    pub saved_at: i64,
+    /// Total size of the volumes, for the eviction accounting and the picker's readout.
+    pub bytes: f64,
+}
+
+impl Pack {
+    /// Stable key: one pack per site and day, so re-saving a loop replaces it.
+    pub fn key(&self) -> String {
+        format!("{}-{}", self.site, self.date)
+    }
+
+    /// One line for the picker.
+    pub fn label(&self) -> String {
+        format!(
+            "{} {} \u{2014} {} volume{}, {:.0} MB",
+            self.site,
+            self.date,
+            self.volumes.len(),
+            if self.volumes.len() == 1 { "" } else { "s" },
+            self.bytes / 1024.0 / 1024.0
+        )
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+/// Await an `IDBRequest`, resolving to its result.
+#[cfg(target_arch = "wasm32")]
+async fn await_request(req: IdbRequest) -> anyhow::Result<JsValue> {
+    let promise = js_sys::Promise::new(&mut |resolve, reject| {
+        let r = req.clone();
+        let ok = Closure::once_into_js(move |_: JsValue| {
+            let _ = resolve.call1(&JsValue::NULL, &r.result().unwrap_or(JsValue::NULL));
+        });
+        req.set_onsuccess(Some(ok.unchecked_ref()));
+        let err = Closure::once_into_js(move |_: JsValue| {
+            let _ = reject.call1(&JsValue::NULL, &"indexeddb request failed".into());
+        });
+        req.set_onerror(Some(err.unchecked_ref()));
+    });
+    JsFuture::from(promise).await.map_err(|e| anyhow!("{e:?}"))
+}
+
+/// Open the database, creating the two stores on first use or version bump.
+#[cfg(target_arch = "wasm32")]
+async fn open() -> anyhow::Result<IdbDatabase> {
+    let factory = web_sys::window()
+        .and_then(|w| w.indexed_db().ok().flatten())
+        .ok_or_else(|| anyhow!("no IndexedDB in this browser"))?;
+    let req = factory
+        .open_with_u32(DB_NAME, 1)
+        .map_err(|e| anyhow!("{e:?}"))?;
+    let upgrade = Closure::<dyn FnMut(web_sys::Event)>::new(move |ev: web_sys::Event| {
+        let Some(req) = ev.target().and_then(|t| t.dyn_into::<IdbRequest>().ok()) else {
+            return;
+        };
+        let Ok(db) = req.result().and_then(|v| v.dyn_into::<IdbDatabase>()) else {
+            return;
+        };
+        let _ = db.create_object_store(VOLUMES);
+        let _ = db.create_object_store(PACKS);
+    });
+    req.set_onupgradeneeded(Some(upgrade.as_ref().unchecked_ref()));
+    let db = await_request(req.clone().unchecked_into()).await?;
+    // The closure has to outlive the open, and the database outlives everything: leaking one
+    // closure per open beats a lifetime dance for an object that lives as long as the page.
+    upgrade.forget();
+    db.dyn_into::<IdbDatabase>().map_err(|e| anyhow!("{e:?}"))
+}
+
+/// The object store for `name`, in a transaction of `mode`.
+#[cfg(target_arch = "wasm32")]
+fn store(db: &IdbDatabase, name: &str, mode: IdbTransactionMode) -> anyhow::Result<IdbObjectStore> {
+    db.transaction_with_str_and_mode(name, mode)
+        .and_then(|tx| tx.object_store(name))
+        .map_err(|e| anyhow!("{e:?}"))
+}
+
+/// Raw bytes of one volume, if a pack holds it.
+#[cfg(target_arch = "wasm32")]
+pub async fn volume(name: &str) -> Option<Vec<u8>> {
+    let db = open().await.ok()?;
+    let s = store(&db, VOLUMES, IdbTransactionMode::Readonly).ok()?;
+    let v = await_request(s.get(&name.into()).ok()?).await.ok()?;
+    let arr = v.dyn_into::<js_sys::Uint8Array>().ok()?;
+    Some(arr.to_vec())
+}
+
+/// Store one volume's bytes.
+#[cfg(target_arch = "wasm32")]
+async fn put_volume(db: &IdbDatabase, name: &str, bytes: &[u8]) -> anyhow::Result<()> {
+    let s = store(db, VOLUMES, IdbTransactionMode::Readwrite)?;
+    let arr = js_sys::Uint8Array::from(bytes);
+    let req = s
+        .put_with_key(&arr, &name.into())
+        .map_err(|e| anyhow!("{e:?}"))?;
+    await_request(req).await.map(|_| ())
+}
+
+/// Every saved pack, newest first.
+#[cfg(target_arch = "wasm32")]
+pub async fn packs() -> Vec<Pack> {
+    let Ok(db) = open().await else {
+        return Vec::new();
+    };
+    let Ok(s) = store(&db, PACKS, IdbTransactionMode::Readonly) else {
+        return Vec::new();
+    };
+    let Ok(req) = s.get_all() else {
+        return Vec::new();
+    };
+    let Ok(v) = await_request(req).await else {
+        return Vec::new();
+    };
+    let mut out: Vec<Pack> = js_sys::Array::from(&v)
+        .iter()
+        .filter_map(|e| e.as_string())
+        .filter_map(|s| serde_json::from_str(&s).ok())
+        .collect();
+    out.sort_by_key(|p: &Pack| std::cmp::Reverse(p.saved_at));
+    out
+}
+
+/// Save a pack: store every volume's bytes, then the manifest, then evict oldest packs until the
+/// store is back under [`BYTE_CAP`].
+///
+/// `volumes` is `(object name, raw bytes)` in timeline order. Returns the pack as stored.
+#[cfg(target_arch = "wasm32")]
+pub async fn save_pack(
+    site: &str,
+    date: &str,
+    volumes: Vec<(String, Vec<u8>)>,
+) -> anyhow::Result<Pack> {
+    if volumes.is_empty() {
+        anyhow::bail!("nothing in the loop to save");
+    }
+    let db = open().await?;
+    let mut bytes = 0.0;
+    let mut names = Vec::new();
+    for (name, data) in &volumes {
+        put_volume(&db, name, data).await?;
+        bytes += data.len() as f64;
+        names.push(name.clone());
+    }
+    let pack = Pack {
+        site: site.to_string(),
+        date: date.to_string(),
+        volumes: names,
+        saved_at: chrono::Utc::now().timestamp(),
+        bytes,
+    };
+    let s = store(&db, PACKS, IdbTransactionMode::Readwrite)?;
+    let json = serde_json::to_string(&pack)?;
+    let req = s
+        .put_with_key(&json.as_str().into(), &pack.key().into())
+        .map_err(|e| anyhow!("{e:?}"))?;
+    await_request(req).await?;
+    evict(&db).await;
+    Ok(pack)
+}
+
+/// Delete oldest packs until the store fits under the cap.
+#[cfg(target_arch = "wasm32")]
+async fn evict(db: &IdbDatabase) {
+    let mut all = packs().await;
+    let mut total: f64 = all.iter().map(|p| p.bytes).sum();
+    all.sort_by_key(|p| p.saved_at);
+    for p in all {
+        if total <= BYTE_CAP {
+            break;
+        }
+        total -= p.bytes;
+        let _ = delete_pack(db, &p).await;
+    }
+}
+
+/// Remove a pack and any volume of its that no surviving pack still lists.
+#[cfg(target_arch = "wasm32")]
+async fn delete_pack(db: &IdbDatabase, pack: &Pack) -> anyhow::Result<()> {
+    let others: Vec<Pack> = packs()
+        .await
+        .into_iter()
+        .filter(|p| p.key() != pack.key())
+        .collect();
+    let s = store(db, VOLUMES, IdbTransactionMode::Readwrite)?;
+    for name in &pack.volumes {
+        if others.iter().any(|p| p.volumes.contains(name)) {
+            continue;
+        }
+        if let Ok(req) = s.delete(&name.as_str().into()) {
+            let _ = await_request(req).await;
+        }
+    }
+    let s = store(db, PACKS, IdbTransactionMode::Readwrite)?;
+    let req = s
+        .delete(&pack.key().as_str().into())
+        .map_err(|e| anyhow!("{e:?}"))?;
+    await_request(req).await.map(|_| ())
+}
+
+/// Delete one pack by key, for the picker's remove button.
+#[cfg(target_arch = "wasm32")]
+pub async fn remove(key: String) {
+    let Ok(db) = open().await else { return };
+    if let Some(p) = packs().await.into_iter().find(|p| p.key() == key) {
+        let _ = delete_pack(&db, &p).await;
+    }
+}
+
+/// What the UI reads: the packs on hand and the last progress line. Filled by the async saves and
+/// loads, which have nowhere else to put a result — the picker is drawn from a `&mut self` the
+/// spawned task cannot hold.
+#[cfg(target_arch = "wasm32")]
+static STATE: std::sync::Mutex<(Vec<Pack>, Option<String>, bool)> =
+    std::sync::Mutex::new((Vec::new(), None, false));
+
+/// Packs known to the UI. The first call kicks off the read that fills them.
+#[cfg(target_arch = "wasm32")]
+pub fn known_packs() -> Vec<Pack> {
+    let asked = {
+        let Ok(mut s) = STATE.lock() else {
+            return Vec::new();
+        };
+        std::mem::replace(&mut s.2, true)
+    };
+    if !asked {
+        wasm_bindgen_futures::spawn_local(async {
+            refresh().await;
+        });
+    }
+    STATE.lock().map(|s| s.0.clone()).unwrap_or_default()
+}
+
+/// The last progress or error line, for the picker.
+#[cfg(target_arch = "wasm32")]
+pub fn status() -> Option<String> {
+    STATE.lock().ok().and_then(|s| s.1.clone())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn set_status(msg: Option<String>) {
+    if let Ok(mut s) = STATE.lock() {
+        s.1 = msg;
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn refresh() {
+    let list = packs().await;
+    if let Ok(mut s) = STATE.lock() {
+        s.0 = list;
+    }
+}
+
+/// Fetch every volume in `ids` — from the pack store when it is already there, from the bucket
+/// otherwise — and save them as one pack.
+#[cfg(target_arch = "wasm32")]
+pub async fn save_timeline(site: String, date: String, ids: Vec<wxdata::level2::Identifier>) {
+    let total = ids.len();
+    let mut out = Vec::new();
+    for (i, id) in ids.into_iter().enumerate() {
+        let name = id.name().to_string();
+        set_status(Some(format!("saving {} of {total}\u{2026}", i + 1)));
+        let bytes = match volume(&name).await {
+            Some(b) => b,
+            None => match wxdata::level2::volume_bytes(id).await {
+                Ok(b) => b,
+                Err(e) => {
+                    log::warn!("pack: skipping {name}: {e}");
+                    continue;
+                }
+            },
+        };
+        out.push((name, bytes));
+    }
+    match save_pack(&site, &date, out).await {
+        Ok(p) => set_status(Some(format!("saved {}", p.label()))),
+        Err(e) => set_status(Some(format!("could not save the pack: {e}"))),
+    }
+    refresh().await;
+}
+
+/// Delete a pack from the picker.
+#[cfg(target_arch = "wasm32")]
+pub fn spawn_remove(key: String) {
+    wasm_bindgen_futures::spawn_local(async move {
+        remove(key).await;
+        refresh().await;
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_pack_round_trips_through_its_manifest() {
+        let p = Pack {
+            site: "KTLX".into(),
+            date: "2026-05-20".into(),
+            volumes: vec!["KTLX20260520_231502_V06".into()],
+            saved_at: 1_780_000_000,
+            bytes: 32.0 * 1024.0 * 1024.0,
+        };
+        let back: Pack = serde_json::from_str(&serde_json::to_string(&p).unwrap()).unwrap();
+        assert_eq!(back, p);
+        assert_eq!(back.key(), "KTLX-2026-05-20");
+        assert_eq!(back.label(), "KTLX 2026-05-20 — 1 volume, 32 MB");
+    }
+}

--- a/crates/wxdata/src/level2.rs
+++ b/crates/wxdata/src/level2.rs
@@ -376,6 +376,33 @@ pub fn scan_from_wire(bytes: &[u8]) -> anyhow::Result<Scan> {
     postcard::from_bytes(bytes).map_err(|e| anyhow::anyhow!("decode scan wire: {e}"))
 }
 
+/// Raw Archive II bytes for one volume, straight from the bucket.
+pub async fn volume_bytes(id: Identifier) -> anyhow::Result<Vec<u8>> {
+    let f = nexrad_data::aws::archive::download_file(id)
+        .await
+        .map_err(|e| anyhow::anyhow!("download_file: {e}"))?;
+    crate::stats::net(f.data().len());
+    Ok(f.data().to_vec())
+}
+
+/// Decode raw Archive II bytes that came from somewhere other than the bucket — a browser's
+/// offline pack, say. Same decode path (and the same Web Worker hop) `download_scan` uses.
+pub async fn scan_from_volume_bytes(name: &str, bytes: Vec<u8>) -> anyhow::Result<Scan> {
+    let file = nexrad_data::volume::File::new(bytes);
+    #[cfg(not(target_arch = "wasm32"))]
+    let scan = crate::task::blocking(move || decode_file(file)).await??;
+    #[cfg(target_arch = "wasm32")]
+    let scan = match crate::wasm_worker::decode_volume(file.data().to_vec()).await {
+        Ok(wire) => scan_from_wire(&wire)?,
+        Err(crate::wasm_worker::Error::Unavailable) => decode_file(file)?,
+        Err(e) => anyhow::bail!("{e}"),
+    };
+    Ok(match scan.site() {
+        Some(_) => scan,
+        None => with_registry_site(scan, &name[..4.min(name.len())]),
+    })
+}
+
 /// Download and decode a specific volume to a [`Scan`].
 ///
 /// With `cache_dir` set the raw Archive II bytes are kept on disk, exactly as the bucket served


### PR DESCRIPTION
The thing `web/sw.src.js` deliberately excludes: radar volumes, kept for offline use.

- **`crates/hookecho/src/webcache.rs`** (wasm-only): IndexedDB with two stores — raw Archive II bytes keyed by object name, and pack manifests (site, date, volume list, saved-at, bytes). 250 MB self-imposed cap; over it, oldest packs are deleted whole, and a volume is only dropped when no surviving pack lists it. `Pack` and its manifest test compile on every target, so the round-trip is covered by `cargo test --workspace`.
- **`crates/hookecho/src/volume.rs`**: one seam for every timeline fetch. Native reads through the disk cache; wasm checks the pack store first and only then the network. Replaces four direct `download_scan` call sites in `app.rs`.
- **`wxdata::level2::volume_bytes` / `scan_from_volume_bytes`**: the two halves of `download_scan` a pack needs — raw bytes out, and decode-from-bytes back in through the same Web Worker hop.
- **UI**: "Save this loop offline" plus a pack picker in the scrubber's context menu, under `cfg(target_arch = "wasm32")`. Saving walks the frames up to the playhead and skips the live head, whose object may still be uploading. Loading sets the pane's site and the timeline's frames straight from the manifest — no network listing at all.
- `Cargo.toml`: web-sys `IdbFactory, IdbOpenDbRequest, IdbDatabase, IdbObjectStore, IdbTransaction, IdbTransactionMode, IdbRequest, DomException`.

**Budget: not raised.** Measured gzipped wasm 4 000 185 → 4 012 261, +12 076 bytes, against the existing `HOOKECHO_WASM_BUDGET` of 4 125 000. The plan reserved a deliberate raise for this PR and it turned out not to be needed.

Not verified in a browser yet: saving a pack, going offline in DevTools, reloading and playing it back is the end-to-end check and it needs a live session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
