### PR TITLE
chore(release): v0.12.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,104 @@ so **write the section before pushing the tag**, or the release job fails.
 
 The rolling `latest` release tracks `main` and is not listed here.
 
+## 0.12.0-beta.2 - 2026-08-30
+
+Third R18 checkpoint, and the biggest one: the app stops being a US radar
+viewer. Germany, Europe and Canada get their own radars, composites and
+warnings; the whole render and data path got measured and made faster; and the
+site, the Lite viewer and the headless server all grew up. Still a prerelease —
+0.12.0 waits on RRFS and the remaining store submissions.
+
+### The world, not just the States
+
+- German DWD radars decode natively, velocity and dual-pol moments included,
+  and the DWD national composites are a basemap layer.
+- The OPERA network via EUMETNET OpenRadarData puts European radars on the
+  map, with a generic WMS bridge behind them for composite layers.
+- Canada: ECCC GeoMet radar composites and ECCC public alerts.
+- MeteoAlarm European warnings, ranked by their own severity scale rather than
+  forced through the US one — Red now outranks Yellow, which it did not.
+- GIBS Himawari and IMERG basemaps for the rest of the planet.
+- Distances read in the units of the region on screen. A radar in Germany
+  measures in kilometres without being asked.
+- Site pages for the German and European networks, and a radar-data
+  attribution surface that names whose data you are looking at.
+
+### Faster
+
+A measured pass end to end, not a guess:
+
+- The decode path stops allocating per sweep, binned sweeps survive the
+  playhead, and the wasm build lost weight (fonts fetched, rayon and gif
+  degated).
+- The renderer reuses radar GPU state, wind particle bind groups and a
+  palette-only LUT; field textures get evicted; the tile cache weighs bytes
+  instead of counting entries (it was 512 MB while claiming 134 MB).
+- Overlay re-tessellation comes off the gesture, one janitor thread replaces
+  several, and an idle window slows its own heartbeat.
+- Every data feed asks before downloading (conditional requests), the proxy
+  caches, and neither cache can grow forever.
+- The Lite viewer fetches frames in parallel, decodes them as they arrive, and
+  a refresh only fetches what it does not already have.
+
+### Serve and headless
+
+- Every network renders headlessly, with warnings and chrome in the output.
+- `/national.png`, mp4 loops and velocity presets; the national mosaic moves.
+- A busy renderer serves a stale image rather than queueing, and the image
+  cache prunes itself.
+- One command stands the image origin back up (`scripts/img-origin`).
+
+### Analysis and data (R18 batch)
+
+- Dealiasing solves the whole sweep at once — a maximum spanning tree over
+  region-boundary votes — so a couplet folded twice comes back right.
+- Derived products extrapolate down to the surface under a low beam, so VIL
+  near the radar stops reading low.
+- 2 m dewpoint joins the global layers and the model-diff readout.
+- SPC watch boxes, tornado and severe thunderstorm, drawn under the warnings.
+- Local cell tracking computed from reflectivity, with 15- and 30-minute
+  extrapolation and a closest-approach ETA — for sites and networks with no
+  Level 3 storm-cell table.
+- Level 3 Digital Base Velocity (N0G) decodes.
+
+### Integrations and quality of life
+
+- MQTT gained a command topic (point the app at a site, a product, or mute it
+  from an automation) and optional Home Assistant discovery, so HA creates the
+  device itself.
+- A lightning-strikes layer fed from your own broker, plus a standalone relay
+  in `scripts/strikes-relay` that fills it. The app never connects to a strike
+  network itself.
+- A curated Piper voice picker instead of one hardcoded voice.
+- `?palette=` on snapshot renders.
+- Web retries actually back off now, and the quiet-hours queue is written as it
+  changes rather than only on exit.
+
+### The web build
+
+- Alert-rule backtests run in the browser.
+- Offline chase packs: save a loop into the browser and play it with no signal.
+- Zoom controls, full screen, a warnings overlay and neighbouring-radar
+  switching in the Lite viewer, whose app bundle is now content-hashed.
+
+### The site
+
+hookecho.io grew from a landing page into the product's front door: docs with
+search, a blog with RSS, per-site and per-state radar pages, TDWR and
+international pages, historic storm pages, a glossary, an honest comparison
+section, a live roadmap, an embed generator, comments, and OG cards built at
+build time. Live radar renders on the pages themselves.
+
+### Fixes
+
+- Archive-less sites (TDWR, DWD) no longer claim "(no volumes)" while showing a
+  live volume.
+- 1-degree sweeps filled every other azimuth bin.
+- Crash reports are honest: a caught decode panic is not a crash.
+- The live stream survives a network drop instead of restarting its backfill
+  every minute.
+
 ## 0.12.0-beta.1 - 2026-08-26
 
 Second R18 checkpoint. The phone gets the same chrome the desktop got in

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2484,7 +2484,7 @@ dependencies = [
 
 [[package]]
 name = "hdf5lite"
-version = "0.12.0-beta.1"
+version = "0.12.0-beta.2"
 dependencies = [
  "flate2",
  "log",
@@ -2547,7 +2547,7 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "hookecho"
-version = "0.12.0-beta.1"
+version = "0.12.0-beta.2"
 dependencies = [
  "android_logger",
  "anyhow",
@@ -2603,7 +2603,7 @@ dependencies = [
 
 [[package]]
 name = "hookecho-ffi"
-version = "0.12.0-beta.1"
+version = "0.12.0-beta.2"
 dependencies = [
  "nexrad-level3",
  "serde_json",
@@ -2611,7 +2611,7 @@ dependencies = [
 
 [[package]]
 name = "hookecho-lite"
-version = "0.12.0-beta.1"
+version = "0.12.0-beta.2"
 dependencies = [
  "nexrad-level3",
  "wasm-bindgen",
@@ -3513,7 +3513,7 @@ dependencies = [
 
 [[package]]
 name = "nexrad-level3"
-version = "0.12.0-beta.1"
+version = "0.12.0-beta.2"
 dependencies = [
  "bzip2",
  "flate2",
@@ -7256,7 +7256,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wxdata"
-version = "0.12.0-beta.1"
+version = "0.12.0-beta.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ opt-level = 3
 opt-level = 3
 
 [workspace.package]
-version = "0.12.0-beta.1"
+version = "0.12.0-beta.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/d4vid87/hookecho"

--- a/packaging/io.hookecho.HookEcho.metainfo.xml
+++ b/packaging/io.hookecho.HookEcho.metainfo.xml
@@ -37,19 +37,19 @@
   -->
   <screenshots>
     <screenshot type="default">
-      <image>https://raw.githubusercontent.com/d4vid87/hookecho/v0.12.0-beta.1/docs/shots/alltilts.jpg</image>
+      <image>https://raw.githubusercontent.com/d4vid87/hookecho/v0.12.0-beta.2/docs/shots/alltilts.jpg</image>
       <caption>Level 2 reflectivity at every tilt, over an interactive basemap</caption>
     </screenshot>
     <screenshot>
-      <image>https://raw.githubusercontent.com/d4vid87/hookecho/v0.12.0-beta.1/docs/shots/mosaic.jpg</image>
+      <image>https://raw.githubusercontent.com/d4vid87/hookecho/v0.12.0-beta.2/docs/shots/mosaic.jpg</image>
       <caption>The national MRMS mosaic</caption>
     </screenshot>
     <screenshot>
-      <image>https://raw.githubusercontent.com/d4vid87/hookecho/v0.12.0-beta.1/docs/shots/alerts.jpg</image>
+      <image>https://raw.githubusercontent.com/d4vid87/hookecho/v0.12.0-beta.2/docs/shots/alerts.jpg</image>
       <caption>Warnings, storm reports and spotters</caption>
     </screenshot>
     <screenshot>
-      <image>https://raw.githubusercontent.com/d4vid87/hookecho/v0.12.0-beta.1/docs/shots/hrrr.jpg</image>
+      <image>https://raw.githubusercontent.com/d4vid87/hookecho/v0.12.0-beta.2/docs/shots/hrrr.jpg</image>
       <caption>HRRR model fields and severe composite parameters</caption>
     </screenshot>
   </screenshots>
@@ -79,6 +79,7 @@
   <content_rating type="oars-1.1"/>
 
   <releases>
+    <release version="0.12.0-beta.2" date="2026-08-30" type="development"/>
     <release version="0.12.0-beta.1" date="2026-08-26" type="development"/>
     <release version="0.11.0" date="2026-08-25"/>
     <release version="0.10.0" date="2026-08-14"/>


### PR DESCRIPTION
Release prep for the third R18 checkpoint.

- Workspace version `0.12.0-beta.1` → `0.12.0-beta.2` (Android `versionName`/`versionCode` derive from it).
- `CHANGELOG.md` section — **the release workflow extracts this by heading, so it has to exist before the tag is pushed.** Covers 130 commits since beta.1: international networks (DWD, OPERA, ECCC GeoMet, MeteoAlarm, GIBS), the measured performance pass, headless/serve, the site and Lite viewer, and the R18 batch (#252–#264).
- `metainfo.xml`: new `<release>` row, screenshot URLs repinned to the new tag.

Nothing is tagged or published yet. After this merges: `git tag v0.12.0-beta.2 && git push origin v0.12.0-beta.2`, which is what triggers the release job and the store manifest stamping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)