### PR TITLE
build(web): raise the wasm budget for the chase-pack IndexedDB path

### DIFF
--- a/scripts/web/build.sh
+++ b/scripts/web/build.sh
@@ -109,9 +109,13 @@ gz_bytes="$(gzip -9 -c "web/dist/hookecho_bg-$wasm_hash.wasm" | wc -c)"
 # cutting a wgpu backend, which is not free. The fonts already went (they are fetched at runtime
 # now — see crates/hookecho/src/fonts.rs), which is what this number dropped by. Raise it
 # deliberately.
-# The number tracks CI's build, which runs ~15 KB above a local one, so a local build has that
-# much slack; CI is the gate that matters.
-budget="${HOOKECHO_WASM_BUDGET:-4125000}"
+# The number tracks CI's build, which runs ABOVE a local one — ~134 KB as of the R18 batch, not
+# the ~15 KB this comment claimed for a year. A local build therefore has that much slack and
+# passing locally proves little; CI is the gate that matters.
+#
+# Raised deliberately for the offline chase packs (IndexedDB via web-sys) — the one budget raise
+# the R18 batch reserved for itself.
+budget="${HOOKECHO_WASM_BUDGET:-4150000}"
 printf 'wasm: %s raw, %s gzipped (budget %s)\n' \
   "$(stat -c%s "web/dist/hookecho_bg-$wasm_hash.wasm")" "$gz_bytes" "$budget"
 if [ "$gz_bytes" -gt "$budget" ]; then

--- a/scripts/web/build.sh
+++ b/scripts/web/build.sh
@@ -109,9 +109,10 @@ gz_bytes="$(gzip -9 -c "web/dist/hookecho_bg-$wasm_hash.wasm" | wc -c)"
 # cutting a wgpu backend, which is not free. The fonts already went (they are fetched at runtime
 # now — see crates/hookecho/src/fonts.rs), which is what this number dropped by. Raise it
 # deliberately.
-# The number tracks CI's build, which runs ABOVE a local one — ~134 KB as of the R18 batch, not
-# the ~15 KB this comment claimed for a year. A local build therefore has that much slack and
-# passing locally proves little; CI is the gate that matters.
+# The number tracks CI's build, and a local build without binaryen does not reproduce it: wasm-opt
+# leaves a SMALLER raw module that GZIPS LARGER (11.8 MB raw / 4.15 MB gz in CI against 12.9 MB
+# raw / 4.01 MB gz here), so skipping it makes a local build look ~130 KB under the gate while CI
+# is over it. Install binaryen and the two agree; the warning above is not cosmetic.
 #
 # Raised deliberately for the offline chase packs (IndexedDB via web-sys) — the one budget raise
 # the R18 batch reserved for itself.


### PR DESCRIPTION
The Demo workflow (Cloudflare Pages) has failed on every run since #265 merged:

```
wasm: 11826453 raw, 4145098 gzipped (budget 4125000)
build.sh: wasm is over the size budget
```

This is the deliberate raise the R18 plan reserved for offline chase packs (#263), which add web-sys's IndexedDB bindings. New budget 4 150 000, about 3 KB of headroom over CI's current 4 146 278.

**Why a local build passed and CI did not:** the comment in `build.sh` said CI runs ~15 KB above a local build. It is now ~134 KB (local 4 014 892 vs CI 4 146 278), so a local pass proves very little. Comment corrected to say so; the divergence itself is worth a separate look — different toolchain or codegen between the two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)