### PR TITLE
feat(tropical): show the NHC layer by default

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -2326,7 +2326,8 @@ pub struct HookEchoApp {
     contour_valid: Option<DateTime<Utc>>,
     contour_last_fetch: Option<Instant>,
     contour_fetched_kind: Option<(ContourKind, wxdata::hrrr::Model)>,
-    /// NHC tropical suite (feature V): toggle, fetched data, refresh clock.
+    /// NHC tropical suite (feature V): toggle, fetched data, refresh clock. On by default like
+    /// the other severe layers — an active hurricane is not something to have to go and enable.
     show_tropical: bool,
     tropical: Option<wxdata::tropical::TropicalData>,
     tropical_last_fetch: Option<Instant>,
@@ -3158,7 +3159,7 @@ impl HookEchoApp {
             contour_last_fetch: None,
             contour_fetched_kind: None,
             env_model: wxdata::hrrr::Model::Hrrr,
-            show_tropical: false,
+            show_tropical: true,
             tropical: None,
             tropical_last_fetch: None,
             show_cappi: false,


### PR DESCRIPTION
Follow-up to #268/#269: the layer is worth looking at now, and it was opt-in.

## Change

One line — `show_tropical` defaults to `true`, joining alerts, cells, tracks, watches, and
mesoscale discussions, all of which already default on in `OverlayFilters::default`.

Nothing else needed wiring:
- The refresh loop fetches when the layer is on and `tropical_last_fetch` is `None`, so the
  first fetch self-starts.
- The overlay rebuild is triggered by `OverlayMsg` arriving, so the cones appear with the first
  response.
- Off-season `CurrentStorms.json` returns an empty `activeStorms` and the fetch stops there —
  no per-storm MapServer queries.

The costly options stay opt-in: forecast wind radii (34/50/64 kt) and P-Surge polygons are
still off until enabled in Layer options.

Note the pre-existing behaviour this inherits: `overlays_on` records only what is *on*, and
restore is additive, so a default-on layer cannot be persistently switched off. That is already
true of alerts and cells; this PR does not change the mechanism.

## Verification

- Desktop, fresh config with **no** `overlays_on` key: the cone, dashed track, cyclone glyph
  and callouts for TD Five drew on boot without touching a menu.
- wasm, real headless Chrome against the built bundle: the page requests
  `/proxy/www.nhc.noaa.gov/CurrentStorms.json` during boot with no interaction, confirming the
  default reaches the browser build. (Locally `/proxy/` is a static 404; on the deployed origin
  the host is already allowlisted and unchanged.)
- Gate: clippy · `cargo test --workspace` · wasm check · `shoot.sh check` ·
  `scripts/web/build.sh` (4 143 019 gz, budget 4 150 000).

🤖 Generated with [Claude Code](https://claude.com/claude-code)