### PR TITLE
fix(web): budget the outage layer at its CI size, not its local one

### DIFF
--- a/scripts/web/build.sh
+++ b/scripts/web/build.sh
@@ -116,7 +116,7 @@ gz_bytes="$(gzip -9 -c "web/dist/hookecho_bg-$wasm_hash.wasm" | wc -c)"
 #
 # Raised deliberately for the offline chase packs (IndexedDB via web-sys) — the one budget raise
 # the R18 batch reserved for itself.
-budget="${HOOKECHO_WASM_BUDGET:-4151000}"
+budget="${HOOKECHO_WASM_BUDGET:-4157000}"
 printf 'wasm: %s raw, %s gzipped (budget %s)\n' \
   "$(stat -c%s "web/dist/hookecho_bg-$wasm_hash.wasm")" "$gz_bytes" "$budget"
 if [ "$gz_bytes" -gt "$budget" ]; then


### PR DESCRIPTION
The Demo deploy for #273 failed: `wasm: 11854758 raw, 4156828 gzipped (budget 4151000)`.

#273 set the budget from a local release build (4,150,994 gz). CI's build of the same commit is 5,834 bytes larger — a different toolchain produces a slightly different binary, and the budget has to cover the build that actually gates the deploy.

Measured on CI: 4,149,382 (run for #271, unchanged main) → 4,156,828 (#273) = **+7,446** for the outage layer. Budget set to **4,157,000**, the measured amount plus the same rounding the previous value used.

No code change; `app.hookecho.io` is still serving the pre-#273 bundle until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)