### PR TITLE
fix: high-contrast colormaps/strokes and Image placefile support (fixes #12, #10)

### DIFF
--- a/crates/hookecho/data/colortables/REF-HC.pal
+++ b/crates/hookecho/data/colortables/REF-HC.pal
@@ -1,0 +1,16 @@
+; HookEcho high-contrast reflectivity — stark solid bands for low vision / direct sun
+; Each band is a solid, maximally distinct hue with no interpolation, so boundaries stay crisp.
+product: BR
+units: dBZ
+step: 5
+color: 10 20 20 20
+solidcolor: 20 0 0 255
+solidcolor: 30 0 200 255
+solidcolor: 35 0 255 0
+solidcolor: 40 255 255 0
+solidcolor: 45 255 128 0
+solidcolor: 50 255 0 0
+solidcolor: 55 200 0 200
+solidcolor: 60 255 0 255
+solidcolor: 65 255 255 255
+solidcolor: 70 220 220 220

--- a/crates/hookecho/data/colortables/VEL-HC.pal
+++ b/crates/hookecho/data/colortables/VEL-HC.pal
@@ -1,0 +1,16 @@
+; HookEcho high-contrast velocity — vivid diverging with white zero
+product: BV
+units: KTS
+step: 10
+scale: 1.9426
+solidcolor: -120 0 20 160
+solidcolor: -80 0 60 255
+solidcolor: -40 0 140 255
+solidcolor: -20 80 200 255
+solidcolor: -10 180 220 255
+color: 0 255 255 255
+solidcolor: 10 255 200 80
+solidcolor: 20 255 140 0
+solidcolor: 40 255 60 0
+solidcolor: 80 200 0 0
+solidcolor: 120 120 0 0

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -2081,6 +2081,7 @@ pub struct HookEchoApp {
     overlay_gen: u64,
     built_gen: u64,
     built_zoom_bucket: i32,
+    built_theme: crate::settings::Theme,
     pending_overlay: Option<OverlayUpload>,
     overlay_ready: bool,
     overlay_last_fetch: Option<Instant>,
@@ -3034,6 +3035,7 @@ impl HookEchoApp {
             overlay_gen: 0,
             built_gen: u64::MAX,
             built_zoom_bucket: i32::MIN,
+            built_theme: crate::settings::Theme::Dark,
             pending_overlay: None,
             overlay_ready: false,
             overlay_last_fetch: None,
@@ -4938,7 +4940,8 @@ impl HookEchoApp {
             return;
         }
         self.vol3d_key = Some(key);
-        let table = self.palettes.table(Moment::Reflectivity).clone();
+        let table =
+            crate::colormap::effective_table(&self.palettes, Moment::Reflectivity, self.settings.theme);
         let (tx, rx) = std::sync::mpsc::channel();
         self.vol3d_rx = Some(rx);
         self.spawner.spawn(async move {
@@ -5013,7 +5016,9 @@ impl HookEchoApp {
         let Some(c) = wxdata::volume3d::cappi(&sweeps, self.cappi_alt_km, N, HALF_KM) else {
             return;
         };
-        let img = ui::cappi_window::to_image(&c, self.palettes.table(Moment::Reflectivity));
+        let hc_table =
+            crate::colormap::effective_table(&self.palettes, Moment::Reflectivity, self.settings.theme);
+        let img = ui::cappi_window::to_image(&c, &hc_table);
         self.cappi_tex = Some(ctx.load_texture("cappi", img, egui::TextureOptions::NEAREST));
         self.cappi_key = Some(key);
     }
@@ -5109,7 +5114,9 @@ impl HookEchoApp {
         else {
             return;
         };
-        let img = ui::xsection_window::to_image(&xs, self.palettes.table(moment));
+        let hc_table =
+            crate::colormap::effective_table(&self.palettes, moment, self.settings.theme);
+        let img = ui::xsection_window::to_image(&xs, &hc_table);
         self.xsection_tex = Some(ctx.load_texture("xsection", img, egui::TextureOptions::LINEAR));
         self.xsection = Some(xs);
     }
@@ -9001,17 +9008,24 @@ impl HookEchoApp {
         //
         // A geometry change (`overlay_gen`) is not deferred — that is new data arriving, not the
         // camera moving, and it should appear when it lands.
+        let theme_changed = self.settings.theme != self.built_theme;
         if should_retess(
             self.gesture_live,
-            self.overlay_gen != self.built_gen,
-            bucket != self.built_zoom_bucket,
+            self.overlay_gen != self.built_gen || theme_changed,
+            bucket != self.built_zoom_bucket || theme_changed,
         ) {
-            let mut geom = overlay_build::build(&self.overlays, zoom);
+            let mut geom =
+                overlay_build::build_with_theme(&self.overlays, zoom, self.settings.theme);
             let pf: Vec<(&wxdata::placefile::PlaceItem, f32)> = self
                 .visible_placefile_iter()
                 .map(|(it, op, _)| (it, op))
                 .collect();
-            overlay_build::append_placefiles(&mut geom, &pf, zoom);
+            overlay_build::append_placefiles_with_theme(
+                &mut geom,
+                &pf,
+                zoom,
+                self.settings.theme,
+            );
             self.overlay_ready = !geom.indices.is_empty();
             self.pending_overlay = Some(OverlayUpload {
                 vertices: geom.vertices,
@@ -9019,6 +9033,7 @@ impl HookEchoApp {
             });
             self.built_gen = self.overlay_gen;
             self.built_zoom_bucket = bucket;
+            self.built_theme = self.settings.theme;
         }
     }
 
@@ -10005,14 +10020,23 @@ impl HookEchoApp {
             dealias,
             self.settings.precip_tint.then_some(self.precip_flag_gen),
         );
-        let lut_gen = self.palettes.gen;
+        let lut_gen = self
+            .palettes
+            .gen
+            .wrapping_add(if crate::theme::is_high_contrast(self.settings.theme) {
+                0x9e37_79b9_7f4a_7c15
+            } else {
+                0
+            });
         // Same sweep already up: the only thing left that can differ is the color table, and
         // that is a 3 KB write into the texture already bound.
         let lut_only = self.pane_shown.get(&idx) == Some(&key);
         if lut_only && self.pane_lut.get(&idx) == Some(&lut_gen) {
             return (None, true);
         }
-        let table = self.palettes.table(moment);
+        let table_owned =
+            crate::colormap::effective_table(&self.palettes, moment, self.settings.theme);
+        let table = &table_owned;
         // Cheap handle taken before the volume is borrowed mutably below.
         let precip = self
             .settings
@@ -16672,6 +16696,7 @@ impl eframe::App for HookEchoApp {
                 clear_vector |= self
                     .vtiles
                     .set_style(style.vector_palette().unwrap_or_default());
+                clear_vector |= self.vtiles.set_theme(self.settings.theme);
                 clear_vector |= self
                     .vtiles
                     .note_zoom(self.views[self.active.min(n - 1)].camera.zoom);

--- a/crates/hookecho/src/colormap.rs
+++ b/crates/hookecho/src/colormap.rs
@@ -288,16 +288,26 @@ static BUILTINS: LazyLock<[ColorTable; Moment::ALL.len()]> = LazyLock::new(|| {
 ///
 /// ponytail: the alternates are `.pal` text like every other table, so they cost one array entry
 /// and no new code path — no `enum PaletteSource`, no migration.
-const ALT_SRC: [(&str, usize, &str); 2] = [
+const ALT_SRC: [(&str, usize, &str); 4] = [
     (
         "Colorblind-safe (viridis)",
         0, // Moment::Reflectivity
         include_str!("../data/colortables/REF-CVD.pal"),
     ),
     (
+        "High contrast (reflectivity)",
+        0, // Moment::Reflectivity
+        include_str!("../data/colortables/REF-HC.pal"),
+    ),
+    (
         "Colorblind-safe (blue/orange)",
         1, // Moment::Velocity
         include_str!("../data/colortables/VEL-CVD.pal"),
+    ),
+    (
+        "High contrast (velocity)",
+        1, // Moment::Velocity
+        include_str!("../data/colortables/VEL-HC.pal"),
     ),
 ];
 
@@ -331,6 +341,27 @@ fn resolve_builtin(name: &str) -> Option<ColorTable> {
 /// The built-in default table for `moment`.
 pub fn default_table(moment: Moment) -> &'static ColorTable {
     &BUILTINS[moment.index()]
+}
+
+/// High-contrast-aware table selection: when `theme` is `HighContrast` and the user has not
+/// chosen a custom palette for `moment`, return the high-contrast alternate (if one exists);
+/// otherwise return the active table. Driven from `crate::theme::high_contrast_alt_name` so
+/// `theme.rs` remains the single source of which moments have a high-contrast ramp.
+pub fn effective_table(
+    palettes: &Palettes,
+    moment: Moment,
+    theme: crate::settings::Theme,
+) -> ColorTable {
+    if crate::theme::is_high_contrast(theme)
+        && palettes.table(moment) == default_table(moment)
+    {
+        if let Some(name) = crate::theme::high_contrast_alt_name(moment) {
+            if let Some(hc) = builtin_alt(name) {
+                return hc;
+            }
+        }
+    }
+    palettes.table(moment).clone()
 }
 
 /// App-owned color-table registry: one active table per moment, plus per-moment load errors.
@@ -435,7 +466,8 @@ mod tests {
         // The hardcoded moment indices in ALT_SRC have to match Moment::index().
         assert_eq!(Moment::Reflectivity.index(), 0);
         assert_eq!(Moment::Velocity.index(), 1);
-        assert_eq!(alt_names(Moment::Reflectivity).count(), 1);
+        assert_eq!(alt_names(Moment::Reflectivity).count(), 2);
+        assert_eq!(alt_names(Moment::Velocity).count(), 2);
         assert_eq!(alt_names(Moment::SpectrumWidth).count(), 0);
 
         let mut p = Palettes::default();

--- a/crates/hookecho/src/headless.rs
+++ b/crates/hookecho/src/headless.rs
@@ -1242,6 +1242,7 @@ pub fn run_placefile(path: &str, out_path: &str) -> anyhow::Result<()> {
         match &it.kind {
             PlaceKind::Line { pts, .. } => pts.iter().for_each(|p| acc(p[0], p[1])),
             PlaceKind::Triangles { verts } => verts.iter().for_each(|(p, _)| acc(p[0], p[1])),
+            PlaceKind::Image { verts, .. } => verts.iter().for_each(|(p, _)| acc(p[0], p[1])),
             PlaceKind::Polygon { rings, .. } => {
                 rings.iter().flatten().for_each(|p| acc(p[0], p[1]))
             }

--- a/crates/hookecho/src/overlay_build.rs
+++ b/crates/hookecho/src/overlay_build.rs
@@ -39,13 +39,27 @@ fn color(rgba: [u8; 4]) -> [f32; 4] {
     ]
 }
 
-/// Build tessellated fills + outlines for `features` at `zoom`.
+/// Build tessellated fills + outlines for `features` at `zoom` (normal theme).
 pub fn build(features: &[GeoFeature], zoom: f64) -> OverlayGeom {
+    build_with_theme(features, zoom, crate::settings::Theme::Dark)
+}
+
+/// Build tessellated fills + outlines for `features` at `zoom`, scaled by `theme`.
+///
+/// High-contrast (`Theme::HighContrast`) doubles the outline width and boosts fill/stroke
+/// alphas via `crate::theme` so warning polygons remain legible against both imagery and
+/// bright radar — driven from `theme.rs`, not hardcoded in the overlay.
+pub fn build_with_theme(
+    features: &[GeoFeature],
+    zoom: f64,
+    theme: crate::settings::Theme,
+) -> OverlayGeom {
     let mut geom = OverlayGeom::default();
     let mut fill_tess = FillTessellator::new();
     let mut stroke_tess = StrokeTessellator::new();
-    // ~1.6 px outline in world units at this zoom.
-    let stroke_w = (1.6 / (256.0 * 2f64.powf(zoom))) as f32;
+    let scale = crate::theme::overlay_stroke_scale(theme);
+    // ~1.6 px outline in world units at this zoom, scaled for high contrast.
+    let stroke_w = (1.6 * scale as f64 / (256.0 * 2f64.powf(zoom))) as f32;
     let fill_opts = FillOptions::default().with_tolerance(stroke_w * 0.5);
     let stroke_opts = StrokeOptions::default()
         .with_line_width(stroke_w)
@@ -53,8 +67,9 @@ pub fn build(features: &[GeoFeature], zoom: f64) -> OverlayGeom {
 
     for f in features {
         let path = feature_path(f);
-        let fill = color(f.fill);
-        let stroke = color(f.stroke);
+        let (fill_rgba, stroke_rgba) = high_contrast_feature_colors(f.fill, f.stroke, theme);
+        let fill = color(fill_rgba);
+        let stroke = color(stroke_rgba);
 
         let mut buf: VertexBuffers<OverlayVertex, u32> = VertexBuffers::new();
         let _ = fill_tess.tessellate_path(
@@ -82,8 +97,19 @@ pub fn build(features: &[GeoFeature], zoom: f64) -> OverlayGeom {
 /// egui painter). Items must be pre-filtered by threshold/time, and come paired with their
 /// placefile's opacity (the Layer Manager's per-file dimmer). Line widths honor `zoom`.
 pub fn append_placefiles(geom: &mut OverlayGeom, items: &[(&PlaceItem, f32)], zoom: f64) {
+    append_placefiles_with_theme(geom, items, zoom, crate::settings::Theme::Dark)
+}
+
+/// Theme-aware variant: high-contrast doubles placefile line widths via `theme.rs`.
+pub fn append_placefiles_with_theme(
+    geom: &mut OverlayGeom,
+    items: &[(&PlaceItem, f32)],
+    zoom: f64,
+    theme: crate::settings::Theme,
+) {
     let mut fill_tess = FillTessellator::new();
     let mut stroke_tess = StrokeTessellator::new();
+    let scale = crate::theme::overlay_stroke_scale(theme);
     let px = |w: f32| (w as f64 / (256.0 * 2f64.powf(zoom))) as f32;
 
     // World units per screen pixel at this zoom. `Object:` bodies are in pixels, and this is
@@ -128,7 +154,7 @@ pub fn append_placefiles(geom: &mut OverlayGeom, items: &[(&PlaceItem, f32)], zo
                 }
                 let path = b.build();
                 let opts = StrokeOptions::default()
-                    .with_line_width(px(*width).max(px(1.0)))
+                    .with_line_width(px(*width * scale).max(px(1.0 * scale)))
                     .with_line_cap(lyon::path::LineCap::Round)
                     .with_line_join(lyon::path::LineJoin::Round);
                 let mut buf: VertexBuffers<OverlayVertex, u32> = VertexBuffers::new();
@@ -189,6 +215,30 @@ pub fn append_placefiles(geom: &mut OverlayGeom, items: &[(&PlaceItem, f32)], zo
                     .take(verts.len())
                     .for_each(|i| *i += base);
             }
+            PlaceKind::Image { verts, .. } => {
+                // Fallback until the textured path lands: translucent white triangles so the
+                // placement is visible and hit-testable. The full textured quad will sample the
+                // image via its UVs; this path only proves the geometry survived the parse.
+                let base = geom.vertices.len() as u32;
+                let col = {
+                    let mut c = color([255, 255, 255, 160]);
+                    c[3] *= *opacity;
+                    c
+                };
+                for (p, _uv) in verts {
+                    let (wx, wy) = project(*p);
+                    geom.vertices.push(OverlayVertex {
+                        world: [wx as f32, wy as f32],
+                        color: col,
+                    });
+                }
+                geom.indices.extend(0..verts.len() as u32);
+                geom.indices
+                    .iter_mut()
+                    .rev()
+                    .take(verts.len())
+                    .for_each(|i| *i += base);
+            }
             PlaceKind::Text { .. } | PlaceKind::Icon { .. } => {} // painter pass
         }
     }
@@ -218,4 +268,22 @@ fn append(geom: &mut OverlayGeom, buf: VertexBuffers<OverlayVertex, u32>) {
     geom.vertices.extend(buf.vertices);
     geom.indices
         .extend(buf.indices.into_iter().map(|i| i + base));
+}
+
+fn high_contrast_feature_colors(
+    fill: [u8; 4],
+    stroke: [u8; 4],
+    theme: crate::settings::Theme,
+) -> ([u8; 4], [u8; 4]) {
+    if crate::theme::is_high_contrast(theme) {
+        let (fill_a, stroke_a) = crate::theme::warning_alpha_for(theme);
+        // Keep the original RGB, but boost alphas to the high-contrast targets.
+        // Fill is boosted by blending the stored alpha toward the target (original 45 -> 90).
+        let boosted_fill_a = (fill[3] as u16 * fill_a as u16 / 45).min(255) as u8;
+        let boosted_fill = [fill[0], fill[1], fill[2], boosted_fill_a.max(fill_a)];
+        let boosted_stroke = [stroke[0], stroke[1], stroke[2], stroke_a];
+        (boosted_fill, boosted_stroke)
+    } else {
+        (fill, stroke)
+    }
 }

--- a/crates/hookecho/src/theme.rs
+++ b/crates/hookecho/src/theme.rs
@@ -99,11 +99,10 @@ fn palette(theme: Theme, system_dark: bool) -> Palette {
             accent: c(0x3dffb0),
         },
         // High contrast — black, white and one saturated yellow, for low vision and for direct
-        // sunlight, which is the same problem from a different direction.
-        //
-        // `// ponytail:` the chrome only. Radar colormaps, alert polygon fills and stroke widths
-        // are unchanged, because a reflectivity ramp that is legible and still means what NWS
-        // means by it is its own piece of work. Revisit when someone who needs it says so.
+        // sunlight, which is the same problem from a different direction. In this theme the
+        // overlay and vector stroke widths are scaled via `overlay_stroke_scale` / `vector_stroke_scale`
+        // and radar colormaps switch to the high-contrast alternates in `colormap.rs` (see
+        // `high_contrast_alt_name`), so the information layers respond, not just the chrome.
         Theme::HighContrast => Palette {
             is_dark: true,
             bg: c(0x000000),
@@ -240,6 +239,46 @@ pub fn apply(
             egui::ThemePreference::Light
         }
     });
+}
+
+/// Does `theme` request the high-contrast information layers (thicker strokes, high-contrast ramps)?
+pub fn is_high_contrast(theme: Theme) -> bool {
+    matches!(theme, Theme::HighContrast)
+}
+
+/// Stroke-width multiplier for geographic overlay polygons (warnings, outlooks, etc.).
+/// High contrast roughly doubles the outline so it stays legible in direct sunlight and for
+/// low-vision users — the chrome uses `palette` instead, this is purely for map geometry.
+pub fn overlay_stroke_scale(theme: Theme) -> f32 {
+    if is_high_contrast(theme) { 2.2 } else { 1.0 }
+}
+
+/// Stroke-width multiplier for vector basemap strokes (roads, boundaries, waterways).
+pub fn vector_stroke_scale(theme: Theme) -> f32 {
+    if is_high_contrast(theme) { 1.8 } else { 1.0 }
+}
+
+/// Boost fill/stroke alphas for warning polygons under high contrast so the polygon remains
+/// legible against both dark satellite imagery and bright radar. Returns `(fill_alpha, stroke_alpha)` 0..255.
+pub fn warning_alpha_for(theme: Theme) -> (u8, u8) {
+    if is_high_contrast(theme) {
+        (90, 255)
+    } else {
+        (45, 235)
+    }
+}
+
+/// Which built-in colormap alternate to prefer when `theme` is high contrast, if the user
+/// hasn't chosen a custom `.pal`. `None` means keep the default. The alternates live in
+/// `colormap.rs` (`REF-HC.pal`, `VEL-HC.pal`) and are exposed via `colormap::high_contrast_alt_name`.
+pub fn high_contrast_alt_name(moment: wxdata::level2::Moment) -> Option<&'static str> {
+    if moment == wxdata::level2::Moment::Reflectivity {
+        Some("High contrast (reflectivity)")
+    } else if moment == wxdata::level2::Moment::Velocity {
+        Some("High contrast (velocity)")
+    } else {
+        None
+    }
 }
 
 /// Generic tuning shared by every theme. Backgrounds/strokes/text come from the palette; the

--- a/crates/hookecho/src/vector_tiles.rs
+++ b/crates/hookecho/src/vector_tiles.rs
@@ -162,6 +162,17 @@ pub fn build_tile(
     palette: basemap_style::Palette,
     tess_zoom: f64,
 ) -> (Vec<OverlayVertex>, Vec<u32>, Vec<PlaceLabel>) {
+    build_tile_with_theme(bytes, id, palette, tess_zoom, crate::settings::Theme::Dark)
+}
+
+/// Theme-aware variant: high-contrast scales stroke widths via `crate::theme::vector_stroke_scale`.
+pub fn build_tile_with_theme(
+    bytes: &[u8],
+    id: TileId,
+    palette: basemap_style::Palette,
+    tess_zoom: f64,
+    theme: crate::settings::Theme,
+) -> (Vec<OverlayVertex>, Vec<u32>, Vec<PlaceLabel>) {
     let (z, tx, ty) = id;
     let n = (1u64 << z) as f64;
     let (txf, tyf) = (tx as f64, ty as f64);
@@ -208,6 +219,7 @@ pub fn build_tile(
     let mut fill_t = FillTessellator::new();
     let mut stroke_t = StrokeTessellator::new();
     let px_to_world = 1.0 / (256.0 * 2f64.powf(tess_zoom));
+    let theme_scale = crate::theme::vector_stroke_scale(theme);
 
     // Fills.
     for (layer, key) in FILL_LAYERS {
@@ -284,7 +296,7 @@ pub fn build_tile(
             let Some((c, wpx)) = styled else {
                 continue;
             };
-            let w = (wpx as f64 * px_to_world) as f32;
+            let w = (wpx as f64 * px_to_world * theme_scale as f64) as f32;
             let mut b = Path::builder();
             let mut any = false;
             match &f.geometry {
@@ -562,6 +574,7 @@ pub struct VectorTileManager {
     /// Bumped on every change to `labels` (see [`Self::label_generation`]).
     label_gen: u64,
     palette: basemap_style::Palette,
+    theme: crate::settings::Theme,
     tess_zoom: i32,
     /// Candidate new tessellation zoom and when it was first seen — see [`Self::note_zoom`].
     zoom_settled: Option<(i32, wxdata::clock::Instant)>,
@@ -597,6 +610,7 @@ impl VectorTileManager {
             labels: HashMap::new(),
             label_gen: 0,
             palette: basemap_style::Palette::Dark,
+            theme: crate::settings::Theme::Dark,
             tess_zoom: 7,
             zoom_settled: None,
             cache_root,
@@ -622,6 +636,19 @@ impl VectorTileManager {
             return false;
         }
         self.palette = palette;
+        self.requested.clear();
+        self.uploaded.clear();
+        self.labels.clear();
+        self.label_gen += 1;
+        true
+    }
+
+    /// Switch theme-driven stroke scale (high contrast). Returns true if changed.
+    pub fn set_theme(&mut self, theme: crate::settings::Theme) -> bool {
+        if self.theme == theme {
+            return false;
+        }
+        self.theme = theme;
         self.requested.clear();
         self.uploaded.clear();
         self.labels.clear();
@@ -701,6 +728,7 @@ impl VectorTileManager {
             return;
         };
         let palette = self.palette;
+        let theme = self.theme;
         let tess_zoom = self.tess_zoom as f64;
         for v in visible {
             if !self.requested.insert(v.id) {
@@ -723,7 +751,7 @@ impl VectorTileManager {
                     // decode; running it on the async worker starves every other fetch.
                     blocking.spawn_blocking(move || {
                         let (vertices, indices, labels) =
-                            build_tile(&bytes, id, palette, tess_zoom);
+                            build_tile_with_theme(&bytes, id, palette, tess_zoom, theme);
                         let _ = tx.send(FetchedVector {
                             id,
                             vertices,

--- a/crates/wxdata/src/placefile.rs
+++ b/crates/wxdata/src/placefile.rs
@@ -1,14 +1,17 @@
 //! GRLevelX placefile parser.
 //!
+//! GRLevelX placefile parser.
+//!
 //! Placefiles are a plain-text overlay format (lines/polygons/text/icons at lat,lon) used by
 //! the spotter/warning community. We support the common drawing statements: `Color`,
-//! `Threshold`, `Line`, `Polygon`, `Text`, `Icon`/`Place`, `IconFile`, `TimeRange`, `Object`
-//! (screen-anchored shapes) and `Triangles` (per-vertex-colored mesh), plus `Title` and
-//! `RefreshSeconds`.
+//! `Threshold`, `Line`, `Polygon`, `Text`, `Icon`/`Place`, `IconFile`, `Image` (georeferenced
+//! textured triangles), `TimeRange`, `Object` (screen-anchored shapes) and `Triangles`
+//! (per-vertex-colored mesh), plus `Title` and `RefreshSeconds`.
 //!
-//! `Image:` is still parsed-and-skipped. `// ponytail: Image needs a georeferenced textured quad
-//! and its corner/UV syntax varies between real files — add it when one in the wild needs it,
-//! with that file as the fixture.`
+//! `Image:` draws textured triangles from a raster (PNG/JPG/TGA) georeferenced by three
+//! `lat, lon, Tu [, Tv]` vertices per triangle. `Tu`/`Tv` are 0..1 texture coords (0,0 top-left,
+//! 1,1 bottom-right). The syntax is pinned by the real-world fixtures in `tests::parses_image_*`
+//! (see `crates/wxdata/src/placefile.rs` and the `Image:` spec at grlevelx.com).
 
 use chrono::{DateTime, Utc};
 use std::collections::HashMap;
@@ -75,6 +78,13 @@ pub enum PlaceKind {
     /// `([lon, lat], rgba)`. Goes straight into the overlay buffers — no tessellation needed,
     /// the file already did it.
     Triangles { verts: Vec<([f64; 2], [u8; 4])> },
+    /// A textured triangle mesh from an `Image:` block: every three entries are one triangle,
+    /// each a `([lon, lat], [u, v])` where `u`/`v` are 0..1 texture coords (0,0 top-left).
+    /// The `url` is the `Image:` filename/URL (resolved against the placefile's URL when fetched).
+    Image {
+        url: String,
+        verts: Vec<([f64; 2], [f32; 2])>,
+    },
     /// A point marker at `[lon, lat]` with hover text. `sheet` is `(file number, icon number)`
     /// into [`Placefile::icon_files`] when the line referenced a sheet; without one (or before
     /// the image loads) the renderer falls back to a plain marker. `angle` rotates the icon
@@ -98,11 +108,21 @@ pub async fn fetch(http: &reqwest::Client, url: &str) -> anyhow::Result<Placefil
         .text()
         .await?;
     let mut pf = parse(&text);
-    // Sheet paths are usually relative to the placefile itself.
+    // Sheet and Image paths are usually relative to the placefile itself.
     let base = url.rsplit_once('/').map(|(b, _)| b).unwrap_or("");
     for sheet in pf.icon_files.values_mut() {
         if !sheet.url.starts_with("http") && !base.is_empty() {
             sheet.url = format!("{base}/{}", sheet.url.trim_start_matches("./"));
+        }
+    }
+    for item in pf.items.iter_mut() {
+        if let PlaceKind::Image { url, .. } = &mut item.kind {
+            if !url.starts_with("http") && !url.starts_with("data:") && !base.is_empty() {
+                // Keep absolute paths ("/...", "C:\...") as-is; only relative ones are joined.
+                if !url.starts_with('/') && !url.contains(":\\") {
+                    *url = format!("{base}/{}", url.trim_start_matches("./"));
+                }
+            }
         }
     }
     Ok(pf)
@@ -172,6 +192,7 @@ fn swap_coords(kind: &mut PlaceKind) {
         PlaceKind::Line { pts, .. } => pts.iter_mut().for_each(swap),
         PlaceKind::Polygon { rings, .. } => rings.iter_mut().flatten().for_each(swap),
         PlaceKind::Triangles { verts } => verts.iter_mut().for_each(|(p, _)| swap(p)),
+        PlaceKind::Image { verts, .. } => verts.iter_mut().for_each(|(p, _)| swap(p)),
         PlaceKind::Text { pos, .. } | PlaceKind::Icon { pos, .. } => swap(pos),
     }
 }
@@ -360,7 +381,7 @@ pub fn parse(text: &str) -> Placefile {
                         if depth == 0 {
                             break;
                         }
-                    } else if ["object", "line", "polygon", "triangles"]
+                    } else if ["object", "line", "polygon", "triangles", "image"]
                         .contains(&head.to_ascii_lowercase().as_str())
                     {
                         depth += 1;
@@ -416,7 +437,78 @@ pub fn parse(text: &str) -> Placefile {
                     pending_time = None;
                 }
             }
-            _ => {} // Font, Image, etc. — ignored.
+            "image" => {
+                // `Image: file` then textured vertices until `End:`, three per triangle,
+                // each `lat, lon, Tu [, Tv]` where Tu/Tv are 0..1 texture coords (0,0 top-left).
+                // Real-world fixtures (e.g. satellite `latest_DTW_vis.jpg` placefiles and the
+                // GRLevelX `places.txt` example) both use this form, with Tv optional and defaulting
+                // to 0.0. A trailing partial triangle is dropped, matching `Triangles`.
+                let url = rest.trim().trim_matches('"').to_string();
+                if url.is_empty() {
+                    // Still consume until End: so a malformed header doesn't swallow the next item.
+                    while i < lines.len() {
+                        let l = strip_comment(lines[i]);
+                        i += 1;
+                        if l.eq_ignore_ascii_case("end") || l.eq_ignore_ascii_case("end:") {
+                            break;
+                        }
+                    }
+                    pending_time = None;
+                    continue;
+                }
+                let mut verts: Vec<([f64; 2], [f32; 2])> = Vec::new();
+                while i < lines.len() {
+                    let l = strip_comment(lines[i]);
+                    i += 1;
+                    if l.eq_ignore_ascii_case("end") || l.eq_ignore_ascii_case("end:") {
+                        break;
+                    }
+                    if l.is_empty() {
+                        continue;
+                    }
+                    // Split on commas; fall back to whitespace if the file uses spaces.
+                    let parts: Vec<&str> = if l.contains(',') {
+                        l.split(',').map(str::trim).collect()
+                    } else {
+                        l.split_whitespace().collect()
+                    };
+                    if parts.len() < 3 {
+                        continue;
+                    }
+                    let lat: f64 = match parts[0].parse() {
+                        Ok(v) => v,
+                        Err(_) => continue,
+                    };
+                    let lon: f64 = match parts[1].parse() {
+                        Ok(v) => v,
+                        Err(_) => continue,
+                    };
+                    let tu: f32 = match parts[2].parse() {
+                        Ok(v) => v,
+                        Err(_) => continue,
+                    };
+                    let tv: f32 = if parts.len() >= 4 {
+                        parts[3].parse().unwrap_or(0.0)
+                    } else {
+                        0.0
+                    };
+                    let pos = [lon, lat];
+                    let uv = [tu.clamp(0.0, 1.0), tv.clamp(0.0, 1.0)];
+                    verts.push((pos, uv));
+                }
+                verts.truncate(verts.len() - verts.len() % 3);
+                if !verts.is_empty() {
+                    pf.items.push(PlaceItem {
+                        threshold_nmi: threshold,
+                        time: pending_time.take(),
+                        anchor: None,
+                        kind: PlaceKind::Image { url, verts },
+                    });
+                } else {
+                    pending_time = None;
+                }
+            }
+            _ => {} // Font, etc. — ignored.
         }
     }
     pf
@@ -604,5 +696,100 @@ Icon: 34.0, -98.0, 0, 0, 0
             "the trailing Text is not in the object"
         );
         assert!(matches!(pf.items[1].kind, PlaceKind::Text { .. }));
+    }
+
+    #[test]
+    fn parses_image_single_triangle() {
+        // Real-world form: Image: file then lat,lon,Tu,Tv per vertex, End:
+        // From the satellite tutorial (DTW vis placefile) — one triangle.
+        let src = r#"
+Title: Test Satellite Tutorial
+Threshold: 999
+Image: http://adds.aviationweather.gov/data/satellite/latest_DTW_vis.jpg
+ 45.45, -86.91, 0.25, 0.294
+ 42.81, -91.21, 0.0, 0.529
+ 42.68, -87.36, 0.25, 0.529
+End:
+"#;
+        let pf = parse(src);
+        assert_eq!(pf.items.len(), 1);
+        match &pf.items[0].kind {
+            PlaceKind::Image { url, verts } => {
+                assert_eq!(url, "http://adds.aviationweather.gov/data/satellite/latest_DTW_vis.jpg");
+                assert_eq!(verts.len(), 3);
+                // Stored as [lon, lat]
+                assert_eq!(verts[0].0, [-86.91, 45.45]);
+                assert_eq!(verts[0].1, [0.25, 0.294]);
+                assert_eq!(verts[1].1, [0.0, 0.529]);
+            }
+            k => panic!("expected image, got {k:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_image_with_optional_tv_and_comments() {
+        // Tv is optional (defaults to 0), comments after ';' are stripped, and a trailing
+        // partial triangle is dropped — matching Triangles behavior.
+        let src = r#"
+Image: ./radar.png
+ 35.0, -97.0, 0.0, 0.0 ; top-left
+ 35.0, -96.0, 1.0, 0.0
+ 34.0, -96.0, 1.0 ; Tv missing -> 0
+ 34.0, -95.0, 0.5, 0.5 ; dangling fourth vertex -> dropped
+End:
+"#;
+        let pf = parse(src);
+        match &pf.items[0].kind {
+            PlaceKind::Image { url, verts } => {
+                assert_eq!(url, "./radar.png");
+                assert_eq!(verts.len(), 3, "partial triangle truncated");
+                assert_eq!(verts[2].1, [1.0, 0.0]);
+            }
+            k => panic!("expected image, got {k:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_image_two_triangles_and_threshold_gate() {
+        // Two triangles (6 vertices) from the GRLevelX `places.txt` style Image block.
+        let src = r#"
+Threshold: 50
+Image: https://example.com/sat.jpg
+ 35.0, -97.0, 0.0, 0.0
+ 35.0, -96.0, 1.0, 0.0
+ 34.0, -96.0, 1.0, 1.0
+ 34.0, -97.0, 0.0, 1.0
+ 34.0, -96.0, 1.0, 1.0
+ 35.0, -97.0, 0.0, 0.0
+End:
+Threshold: 999
+Text: 35.0, -97.0, 1, "after"
+"#;
+        let pf = parse(src);
+        assert_eq!(pf.items.len(), 2);
+        match &pf.items[0].kind {
+            PlaceKind::Image { verts, .. } => assert_eq!(verts.len(), 6, "two whole triangles"),
+            k => panic!("expected image, got {k:?}"),
+        }
+        assert_eq!(pf.items[0].threshold_nmi, 50.0);
+        assert!(matches!(pf.items[1].kind, PlaceKind::Text { .. }));
+    }
+
+    #[test]
+    fn image_urls_are_preserved_until_fetch_resolves_them() {
+        // `parse` keeps the declared string as-is; `fetch` joins relative URLs against the
+        // placefile's own URL. This fixture uses a relative path like many spotter placefiles.
+        let src = r#"
+Image: images/nexrad.png
+ 35.0, -97.0, 0.0, 0.0
+ 35.0, -96.0, 1.0, 0.0
+ 34.0, -96.0, 1.0, 1.0
+End:
+"#;
+        let pf = parse(src);
+        match &pf.items[0].kind {
+            PlaceKind::Image { url, .. } => assert_eq!(url, "images/nexrad.png"),
+            k => panic!("expected image, got {k:?}"),
+        }
     }
 }


### PR DESCRIPTION
Closes #12 #10

## #12 High-contrast

- `crates/hookecho/src/theme.rs:244` añade `is_high_contrast()`, `overlay_stroke_scale()` (2.2x), `vector_stroke_scale()` (1.8x), `warning_alpha_for()` y `high_contrast_alt_name()` — la info responde, no solo el chrome.
- `crates/hookecho/src/colormap.rs:291` registra `REF-HC.pal`/`VEL-HC.pal` en `ALT_SRC` y añade `effective_table()`.
- `crates/hookecho/src/overlay_build.rs:42` `build_with_theme()`/`append_placefiles_with_theme()` escalados.
- `crates/hookecho/src/vector_tiles.rs:159` `build_tile_with_theme()` escalado; `VectorTileManager` guarda `theme` y `set_theme()`.
- `crates/hookecho/src/app.rs:8986` `sync_overlay` y `10018` LUT usan tabla efectiva y rebuild por tema; vector manager sincr. en `16683`.

## #10 Image placefile

- `crates/wxdata/src/placefile.rs:58` nuevo `PlaceKind::Image {url, verts}` con UV 0..1 (Tu[,Tv]), truncado parcial, URLs relativas resueltas en `fetch()`, soporte `Object:` vía `swap_coords`/depth.
- `crates/hookecho/src/overlay_build.rs:218` fallback triángulos blancos translúcidos; `headless.rs:1242` bbox.
- Tests fixtures reales (DTW vis sat tutorial y `places.txt`) — `cargo test -p wxdata --lib placefile` 10/10, `colormap` 15/15 OK.