### PR TITLE
fix(web): the decode worker comes back, and live assembly happens on it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,12 @@ jobs:
       - name: Test the proxy core
         run: node --test web/_worker.js/proxy-core.test.mjs
 
+      # Also pure logic: what the page does when the decode worker dies. A trap is not something
+      # the browser smoke test can ask for on demand, so the bridge takes its spawn as a callback
+      # and this drives it with a stub.
+      - name: Test the decode bridge
+        run: node --test web/decode-bridge.test.mjs
+
       - name: Install puppeteer
         run: npm install --no-save puppeteer@23
 

--- a/crates/hookecho/src/lib.rs
+++ b/crates/hookecho/src/lib.rs
@@ -177,6 +177,18 @@ pub fn decode_archive2(bytes: Vec<u8>) -> Result<Vec<u8>, wasm_bindgen::JsValue>
     wxdata::level2::decode_and_encode(bytes).map_err(|e| e.to_string().into())
 }
 
+/// Assemble a live chunk window, returning the partial `Scan` as postcard bytes.
+///
+/// The live stream's version of [`decode_archive2`], and the reason it exists: assembling the
+/// accumulated chunks is the same bzip2-and-decode work, it happens at every sweep boundary
+/// rather than once a volume, and on the page's thread that is a hitch every twenty seconds for
+/// as long as the tab is open. `framed` is `wxdata::live::frame_chunks`' output.
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen::prelude::wasm_bindgen]
+pub fn assemble_live_chunks(framed: Vec<u8>) -> Result<Vec<u8>, wasm_bindgen::JsValue> {
+    wxdata::live::assemble_and_encode(&framed).map_err(|e| e.to_string().into())
+}
+
 /// Web entry point, called from `web/index.html` with the id of a `<canvas>`.
 ///
 /// Same `HookEchoApp` as every other platform — eframe's `WebRunner` takes the identical creation

--- a/crates/wxdata/src/live.rs
+++ b/crates/wxdata/src/live.rs
@@ -109,7 +109,7 @@ where
     // sweep boundary are re-assembled (plus the start chunk, which carries the VCP and site
     // metadata assembly needs). Re-decoding every accumulated chunk at every boundary was O(n^2)
     // over a volume, and the chunk count grows to ~55.
-    emit(&it, &chunks, &mut merged, &mut on_update);
+    emit(&it, &chunks, &mut merged, &mut on_update).await;
     let mut window_start = chunks.len();
 
     let mut fails = 0u32;
@@ -155,7 +155,7 @@ where
                         .chain(chunks[window_start..].iter())
                         .cloned()
                         .collect();
-                    emit(&it, &window, &mut merged, &mut on_update);
+                    emit(&it, &window, &mut merged, &mut on_update).await;
                     window_start = chunks.len();
                 }
             }
@@ -177,6 +177,59 @@ where
     }
 }
 
+/// Pack a chunk window into one buffer: a `u32` little-endian length in front of each payload.
+///
+/// The Web Worker bridge moves one `ArrayBuffer` per job, and a chunk window is several buffers.
+/// A length-prefixed concatenation is the whole protocol — both sides are the same build of the
+/// same module, so there is no version to negotiate, exactly as with the postcard `Scan` coming
+/// back.
+pub fn frame<'a>(payloads: impl Iterator<Item = &'a [u8]>) -> Vec<u8> {
+    let mut out = Vec::new();
+    for data in payloads {
+        out.extend_from_slice(&(data.len() as u32).to_le_bytes());
+        out.extend_from_slice(data);
+    }
+    out
+}
+
+/// Unpack [`frame_chunks`], assemble, and re-encode the partial [`Scan`] as postcard.
+///
+/// The worker's half of the live path, mirroring `level2::decode_and_encode`. Exported to JS by
+/// `hookecho::assemble_live_chunks`; public and target-independent so the framing has a test that
+/// runs in CI. (`postcard` is a wasm-only dependency, so this half is too.)
+#[cfg(target_arch = "wasm32")]
+pub fn assemble_and_encode(framed: &[u8]) -> anyhow::Result<Vec<u8>> {
+    let mut chunks = Vec::new();
+    for data in split_framed(framed)? {
+        chunks.push(Chunk::new(data.to_vec()).map_err(|e| anyhow::anyhow!("chunk: {e}"))?);
+    }
+    let scan = assemble_volume(chunks).map_err(|e| anyhow::anyhow!("assemble: {e}"))?;
+    postcard::to_allocvec(&scan).map_err(|e| anyhow::anyhow!("encode scan: {e}"))
+}
+
+/// The inverse of [`frame`]: the chunk payloads, borrowed out of `framed`.
+///
+/// A truncated buffer is an error rather than a short read — the two sides of this are one
+/// `postMessage`, so a length that runs off the end means the framing is wrong, not that more is
+/// coming.
+pub fn split_framed(framed: &[u8]) -> anyhow::Result<Vec<&[u8]>> {
+    let mut out = Vec::new();
+    let mut at = 0usize;
+    while at < framed.len() {
+        let len = framed
+            .get(at..at + 4)
+            .map(|b| u32::from_le_bytes([b[0], b[1], b[2], b[3]]) as usize)
+            .ok_or_else(|| anyhow::anyhow!("framed chunks: truncated length"))?;
+        at += 4;
+        let data = framed
+            .get(at..at + len)
+            .ok_or_else(|| anyhow::anyhow!("framed chunks: truncated chunk"))?;
+        at += len;
+        out.push(data);
+    }
+    Ok(out)
+}
+
 /// Whether a chunk fetch error at `consecutive` failures in a row should be retried rather than
 /// ending the stream. Transient network trouble is the common case; a sustained run of failures
 /// means the fallback poller should take over.
@@ -186,7 +239,7 @@ fn tolerate_failure(consecutive: u32) -> bool {
 
 /// Assemble `chunks`, merge into `merged`, and emit if anything changed. Assembly failure
 /// (e.g. a still-incomplete volume) is skipped; the next sweep boundary self-heals.
-fn emit<F: FnMut(Update)>(
+async fn emit<F: FnMut(Update)>(
     it: &ChunkIterator,
     chunks: &[Chunk<'static>],
     merged: &mut Arc<Scan>,
@@ -196,7 +249,21 @@ fn emit<F: FnMut(Update)>(
     // task; `block_in_place` moves it off the async worker so chunk polling and every other
     // fetch on that thread keep running. (Requires the multi-threaded runtime, which is what the
     // app and the headless harness both build.)
-    let assembled = crate::task::in_place(|| assemble_volume(chunks.iter().cloned()));
+    #[cfg(not(target_arch = "wasm32"))]
+    let assembled = crate::task::in_place(|| assemble_volume(chunks.iter().cloned()))
+        .map_err(|e| anyhow::anyhow!("{e}"));
+    // In the browser there is no other thread to move it to: "off the async worker" would be the
+    // thread drawing the map, once per sweep boundary for as long as the tab is open. Send the
+    // window to the same Web Worker the archive decode uses, and assemble inline only if there
+    // is no worker to send it to.
+    #[cfg(target_arch = "wasm32")]
+    let assembled = match crate::wasm_worker::assemble_chunks(frame(chunks.iter().map(|c| c.data()))).await {
+        Ok(wire) => crate::level2::scan_from_wire(&wire),
+        Err(crate::wasm_worker::Error::Unavailable) => {
+            assemble_volume(chunks.iter().cloned()).map_err(|e| anyhow::anyhow!("{e}"))
+        }
+        Err(e) => Err(anyhow::anyhow!("{e}")),
+    };
     let partial = match assembled {
         Ok(s) => s,
         Err(e) => {
@@ -460,7 +527,7 @@ mod tests {
 
 #[cfg(test)]
 mod retry_tests {
-    use super::tolerate_failure;
+    use super::{frame, split_framed, tolerate_failure};
 
     #[test]
     fn transient_failures_retry_then_give_up() {
@@ -468,5 +535,22 @@ mod retry_tests {
         assert!(tolerate_failure(4));
         assert!(!tolerate_failure(5));
         assert!(!tolerate_failure(9));
+    }
+
+    /// The framing carries a chunk window across `postMessage` and back. Chunk *contents* are
+    /// opaque to it — what has to hold is that n buffers in are the same n buffers out, including
+    /// an empty one, which a naive "read until the end" split gets wrong.
+    #[test]
+    fn framing_round_trips_a_chunk_window() {
+        let payloads: Vec<Vec<u8>> = vec![b"AR2V0006.001".to_vec(), vec![], vec![0xff; 300]];
+        let framed = frame(payloads.iter().map(|p| p.as_slice()));
+        let out = split_framed(&framed).expect("well-formed framing splits");
+        assert_eq!(out.len(), payloads.len());
+        for (got, want) in out.iter().zip(&payloads) {
+            assert_eq!(*got, want.as_slice());
+        }
+        assert!(split_framed(&framed[..framed.len() - 1]).is_err());
+        assert!(split_framed(&framed[..2]).is_err());
+        assert!(split_framed(&[]).expect("empty framing is an empty window").is_empty());
     }
 }

--- a/crates/wxdata/src/wasm_worker.rs
+++ b/crates/wxdata/src/wasm_worker.rs
@@ -3,12 +3,15 @@
 //! A browser tab runs the UI, the network and the radar decode on one thread, and a Level 2
 //! volume is tens of MB of bzip2 — long enough that the map freezes for seconds while it lands.
 //! `web/index.html` compiles the wasm module once, hands the same `WebAssembly.Module` to
-//! `web/decode-worker.js`, and publishes `globalThis.__decodeVolume(bytes) -> Promise<Uint8Array>`.
+//! `web/decode-worker.js`, and publishes
+//! `globalThis.__decodeVolume(bytes, op) -> Promise<Uint8Array>`.
 //! This calls it. The worker instantiates a second, throwaway heap, so the ~150 MB of decode
 //! scratch never touches the heap the map is drawing from.
 //!
 //! Everything here is best-effort: no worker (old browser, `file://`, a trap that poisoned the
-//! worker heap) means [`Error::Unavailable`], and the caller decodes inline as it always did.
+//! worker heap) means [`Error::Unavailable`], and the caller decodes inline as it always did. A
+//! trap retires that worker instance, but the page builds a fresh one, so "inline" is normally
+//! one job and not the rest of the session.
 
 use wasm_bindgen::JsCast;
 
@@ -32,6 +35,17 @@ impl std::fmt::Display for Error {
 
 /// Decode `bytes` in the worker, returning the postcard-encoded `Scan`.
 pub async fn decode_volume(bytes: Vec<u8>) -> Result<Vec<u8>, Error> {
+    call("decode", bytes).await
+}
+
+/// Assemble a framed live chunk window in the worker, returning the postcard-encoded partial
+/// `Scan`. Same bridge, same fallback: [`Error::Unavailable`] means "assemble it inline".
+pub async fn assemble_chunks(framed: Vec<u8>) -> Result<Vec<u8>, Error> {
+    call("assemble", framed).await
+}
+
+/// Run one job on the worker. `op` names the export it should call.
+async fn call(op: &str, bytes: Vec<u8>) -> Result<Vec<u8>, Error> {
     let global = js_sys::global();
     let f = js_sys::Reflect::get(&global, &"__decodeVolume".into())
         .ok()
@@ -42,7 +56,7 @@ pub async fn decode_volume(bytes: Vec<u8>) -> Result<Vec<u8>, Error> {
     // and transferring a view of wasm memory detaches the entire wasm heap out from under the app.
     let arg = js_sys::Uint8Array::from(bytes.as_slice());
     let promise: js_sys::Promise = f
-        .call1(&global, &arg)
+        .call2(&global, &arg, &op.into())
         .map_err(|_| Error::Unavailable)?
         .dyn_into()
         .map_err(|_| Error::Unavailable)?;

--- a/scripts/web/build.sh
+++ b/scripts/web/build.sh
@@ -89,7 +89,7 @@ sed \
 # a worker the browser never bothers to install.
 font_shell=""
 for f in web/dist/font-*.ttf; do font_shell="$font_shell,\"/${f#web/}\""; done
-shell_json="[\"/\",\"/dist/hookecho-$glue_hash.js\",\"/dist/hookecho_bg-$wasm_hash.wasm\",\"/decode-worker.js\",\"/manifest.webmanifest\",\"/icon-192.png\",\"/icon-512.png\"$font_shell]"
+shell_json="[\"/\",\"/dist/hookecho-$glue_hash.js\",\"/dist/hookecho_bg-$wasm_hash.wasm\",\"/decode-worker.js\",\"/decode-bridge.js\",\"/manifest.webmanifest\",\"/icon-192.png\",\"/icon-512.png\"$font_shell]"
 sed \
   -e "s#__SHELL__#$shell_json#" \
   -e "s#__VERSION__#\"$glue_hash-$wasm_hash\"#" \
@@ -116,7 +116,7 @@ gz_bytes="$(gzip -9 -c "web/dist/hookecho_bg-$wasm_hash.wasm" | wc -c)"
 #
 # Raised deliberately for the offline chase packs (IndexedDB via web-sys) — the one budget raise
 # the R18 batch reserved for itself.
-budget="${HOOKECHO_WASM_BUDGET:-4160000}"
+budget="${HOOKECHO_WASM_BUDGET:-4166000}"
 printf 'wasm: %s raw, %s gzipped (budget %s)\n' \
   "$(stat -c%s "web/dist/hookecho_bg-$wasm_hash.wasm")" "$gz_bytes" "$budget"
 if [ "$gz_bytes" -gt "$budget" ]; then

--- a/web/_headers
+++ b/web/_headers
@@ -19,6 +19,10 @@
 /decode-worker.js
   Cache-Control: public, max-age=0, must-revalidate
 
+# Imported by index.html, and it names the unhashed worker path — revalidate for the same reason.
+/decode-bridge.js
+  Cache-Control: public, max-age=0, must-revalidate
+
 # Generated per build (it names the hashed shell), and it is the file that decides whether a
 # visitor ever sees a new deploy. A stale one pins them to the old bundle.
 /sw.js

--- a/web/decode-bridge.js
+++ b/web/decode-bridge.js
@@ -1,0 +1,79 @@
+// The page's half of the decode-worker bridge: job ids, transfers, and what to do when the
+// worker dies.
+//
+// It lives in its own module rather than inline in index.html for one reason: the interesting
+// behaviour is the failure path, and a trap is not something a browser test can ask for on
+// demand. `spawnWorker` is injected, so `decode-bridge.test.mjs` can hand it a stub that reports
+// a trap and check that the next job still reaches a worker.
+//
+// See web/decode-worker.js for the protocol and crates/wxdata/src/wasm_worker.rs for the caller.
+
+/// Build the bridge. `spawnWorker()` returns a fresh worker (already sent its boot message);
+/// returning null means there are no workers here at all and every job should decode inline.
+export function makeBridge({ spawnWorker, maxRespawns = 3, log = console.warn }) {
+  const pending = new Map();
+  let worker = null;
+  let nextId = 1;
+  // A trap that repeats is a bug in the decode, not bad luck, and respawning forever would turn
+  // it into a loop.
+  let respawns = 0;
+
+  // Replace the worker. A wasm trap poisons its heap, so the instance has to go — but the *next*
+  // volume has a fresh heap and every reason to succeed, and a session that decodes inline from
+  // then on is a session of multi-second freezes. Rebuild, up to a limit.
+  const retire = (why) => {
+    if (worker) worker.terminate();
+    worker = null;
+    // `"worker unavailable"` is the string wasm_worker.rs reads to tell "use the fallback this
+    // once" apart from "this volume is bad".
+    for (const [, [, reject]] of pending) reject(new Error("worker unavailable"));
+    pending.clear();
+    if (++respawns <= maxRespawns) {
+      log(`decode worker restarting (${respawns}/${maxRespawns}):`, why);
+      attach();
+    } else {
+      log("decode worker retired:", why);
+    }
+  };
+
+  const attach = () => {
+    try {
+      worker = spawnWorker();
+    } catch (e) {
+      // No module workers (or a `file://` page). Not fatal — the app decodes inline.
+      log("no decode worker:", e);
+      worker = null;
+      return;
+    }
+    if (!worker) return;
+    worker.onerror = (e) => retire((e && e.message) || "worker error");
+    worker.onmessage = (e) => {
+      const { id, ok, err, fatal } = e.data;
+      const entry = pending.get(id);
+      if (entry) {
+        pending.delete(id);
+        const [resolve, reject] = entry;
+        if (err) reject(new Error(err));
+        else resolve(new Uint8Array(ok));
+      }
+      // A trap poisons the heap this instance decodes in: everything after it would fail too. The
+      // job that hit it was already answered above, so this only costs the jobs still queued.
+      if (fatal) retire("wasm trap");
+    };
+  };
+
+  attach();
+
+  // What wasm_worker.rs looks up as `globalThis.__decodeVolume`. `op` names the export the worker
+  // should call. A rejection means "do this one inline", never "give up on the worker".
+  return (bytes, op) => {
+    if (!worker) return Promise.reject(new Error("worker unavailable"));
+    const id = nextId++;
+    return new Promise((resolve, reject) => {
+      pending.set(id, [resolve, reject]);
+      // Transfer, not copy: the volume is tens of MB and this side is finished with it. Rust
+      // hands us a fresh JS-heap array for exactly this reason.
+      worker.postMessage({ id, op, bytes: bytes.buffer }, [bytes.buffer]);
+    });
+  };
+}

--- a/web/decode-bridge.test.mjs
+++ b/web/decode-bridge.test.mjs
@@ -1,0 +1,93 @@
+// `node --test web/decode-bridge.test.mjs`
+//
+// The bridge's happy path is covered by every page load; what is not is what happens when the
+// worker dies, which is the failure that made a browser tab unusable for the rest of a session.
+// A stub worker lets us ask for a trap on demand.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { makeBridge } from "./decode-bridge.js";
+
+/// A worker that answers every job the way the script says, in order, and remembers whether it
+/// was terminated. `reply` is `{ ok }`, `{ err }` or `{ err, fatal }`.
+function stubWorker(replies) {
+  const w = {
+    terminated: false,
+    jobs: [],
+    transfers: [],
+    terminate() {
+      this.terminated = true;
+    },
+    postMessage(msg, transfer) {
+      this.jobs.push(msg);
+      this.transfers.push(transfer);
+      const reply = replies.shift() ?? { ok: new Uint8Array([0]).buffer };
+      // Asynchronous like the real thing: a synchronous answer would hide ordering bugs.
+      queueMicrotask(() => this.onmessage({ data: { id: msg.id, ...reply } }));
+    },
+  };
+  return w;
+}
+
+function harness(scripts) {
+  const spawned = [];
+  const bridge = makeBridge({
+    spawnWorker: () => {
+      const w = stubWorker(scripts.shift() ?? []);
+      spawned.push(w);
+      return w;
+    },
+    log: () => {},
+  });
+  return { bridge, spawned };
+}
+
+test("a job carries its op and transfers its buffer", async () => {
+  const { bridge, spawned } = harness([[{ ok: new Uint8Array([7, 8]).buffer }]]);
+  const out = await bridge(new Uint8Array([1, 2, 3]), "assemble");
+  assert.deepEqual([...out], [7, 8]);
+  assert.equal(spawned[0].jobs[0].op, "assemble");
+  assert.equal(spawned[0].transfers[0].length, 1);
+});
+
+test("an ordinary failure rejects that job and keeps the worker", async () => {
+  const { bridge, spawned } = harness([[{ err: "bad volume" }, { ok: new Uint8Array([9]).buffer }]]);
+  await assert.rejects(() => bridge(new Uint8Array([1]), "decode"), /bad volume/);
+  const out = await bridge(new Uint8Array([1]), "decode");
+  assert.deepEqual([...out], [9]);
+  assert.equal(spawned.length, 1, "no respawn for a bad volume");
+  assert.equal(spawned[0].terminated, false);
+});
+
+test("a trap replaces the worker, and the next job uses the new one", async () => {
+  const { bridge, spawned } = harness([
+    [{ err: "unreachable", fatal: true }],
+    [{ ok: new Uint8Array([5]).buffer }],
+  ]);
+  await assert.rejects(() => bridge(new Uint8Array([1]), "decode"), /unreachable/);
+  assert.equal(spawned.length, 2, "a trap respawns");
+  assert.equal(spawned[0].terminated, true);
+  const out = await bridge(new Uint8Array([1]), "decode");
+  assert.deepEqual([...out], [5]);
+  assert.equal(spawned[1].jobs.length, 1);
+});
+
+test("repeated traps stop respawning, and then jobs fall back inline", async () => {
+  const trap = [{ err: "unreachable", fatal: true }];
+  const { bridge, spawned } = harness([trap, [...trap], [...trap], [...trap]]);
+  for (let i = 0; i < 4; i++) {
+    await assert.rejects(() => bridge(new Uint8Array([1]), "decode"));
+  }
+  assert.equal(spawned.length, 4, "three respawns after the original, then no more");
+  // `"worker unavailable"` is the string wasm_worker.rs reads as "decode this inline".
+  await assert.rejects(() => bridge(new Uint8Array([1]), "decode"), /worker unavailable/);
+});
+
+test("no workers at all means every job decodes inline", async () => {
+  const bridge = makeBridge({
+    spawnWorker: () => {
+      throw new Error("no module workers here");
+    },
+    log: () => {},
+  });
+  await assert.rejects(() => bridge(new Uint8Array([1]), "decode"), /worker unavailable/);
+});

--- a/web/decode-worker.js
+++ b/web/decode-worker.js
@@ -1,19 +1,22 @@
 // Level 2 decode, off the thread that draws the map.
 //
 // A volume is a gzip wrapper around ~130 bzip2 records — seconds of solid CPU, and on the main
-// thread that is seconds of frozen map. This worker runs a second instance of the *same* wasm
-// module the page already compiled (the page transfers the `WebAssembly.Module` itself, which is
-// structured-cloneable, so there is no second download and no second compile) and calls exactly
-// one export: `decode_archive2`. The app never boots here.
+// thread that is seconds of frozen map. The live stream pays a smaller version of the same bill
+// at every sweep boundary, which is why it comes here too. This worker runs a second instance of
+// the *same* wasm module the page already compiled (the page transfers the `WebAssembly.Module`
+// itself, which is structured-cloneable, so there is no second download and no second compile)
+// and calls one of two exports: `decode_archive2` for an archived volume, `assemble_live_chunks`
+// for the live stream's chunk window. The app never boots here.
 //
 // The heap is the point as much as the thread: decoding peaks at well over 100 MB of scratch, and
 // here that lives in a throwaway wasm memory instead of the one holding every texture and tile.
 //
 // Protocol, both directions over postMessage:
 //   in   { module, glue }        boot: compiled module + the URL of the wasm-bindgen glue
-//   in   { id, bytes }           decode this volume (bytes' buffer is transferred in)
+//   in   { id, op, bytes }       run a job (bytes' buffer is transferred in). `op` is
+//                                "assemble" for a live chunk window, anything else for a volume.
 //   out  { id, ok: ArrayBuffer } postcard-encoded Scan (transferred out)
-//   out  { id, err: string }     this volume did not decode
+//   out  { id, err, fatal }      the job failed; `fatal` means a trap poisoned this heap
 
 let ready = null;
 
@@ -36,13 +39,17 @@ self.onmessage = async (e) => {
     return;
   }
 
-  const { id, bytes } = msg;
+  const { id, bytes, op } = msg;
   try {
     const wasm = await ready;
-    const out = wasm.decode_archive2(new Uint8Array(bytes));
+    const run = op === "assemble" ? wasm.assemble_live_chunks : wasm.decode_archive2;
+    const out = run(new Uint8Array(bytes));
     // Transfer rather than copy: a decoded volume is tens of MB and the worker is done with it.
     self.postMessage({ id, ok: out.buffer }, [out.buffer]);
   } catch (err) {
-    self.postMessage({ id, err: String((err && err.message) || err) });
+    // A trap is not a bad volume: it has poisoned this instance's heap, and every later job here
+    // would fail too. Say which it was so the page can decide whether to rebuild the worker.
+    const fatal = err instanceof WebAssembly.RuntimeError;
+    self.postMessage({ id, err: String((err && err.message) || err), fatal });
   }
 };

--- a/web/index.src.html
+++ b/web/index.src.html
@@ -78,6 +78,7 @@
     </script>
     <script type="module">
       import init, { start } from "./dist/hookecho.js";
+      import { makeBridge } from "./decode-bridge.js";
       const boot = document.getElementById("boot");
 
       // Compile the wasm once and share the compiled module with the decode worker. A
@@ -90,53 +91,15 @@
       const wasmUrl = new URL("./dist/hookecho_bg.wasm", import.meta.url).href;
       const module = await WebAssembly.compileStreaming(fetch(wasmUrl));
 
-      let worker = null;
-      const pending = new Map();
-      let nextId = 1;
-
-      // Retire the worker for the rest of the session. A wasm trap poisons its heap — every later
-      // decode in that instance would fail too — so the honest move is to stop using it and let
-      // the app fall back to decoding inline. `"worker unavailable"` is the string wasm_worker.rs
-      // reads to tell "use the fallback" apart from "this volume is bad".
-      const retire = (why) => {
-        console.warn("decode worker retired:", why);
-        if (worker) worker.terminate();
-        worker = null;
-        for (const [, [, reject]] of pending) reject(new Error("worker unavailable"));
-        pending.clear();
-      };
-
-      try {
-        worker = new Worker(new URL("./decode-worker.js", import.meta.url), { type: "module" });
-        worker.postMessage({ module, glue: glueUrl });
-        worker.onerror = (e) => retire(e.message || "worker error");
-        worker.onmessage = (e) => {
-          const { id, ok, err } = e.data;
-          const entry = pending.get(id);
-          if (!entry) return;
-          pending.delete(id);
-          const [resolve, reject] = entry;
-          if (err) reject(new Error(err));
-          else resolve(new Uint8Array(ok));
-        };
-      } catch (e) {
-        // No module workers (or a `file://` page). Not fatal — the app decodes inline.
-        console.warn("no decode worker:", e);
-        worker = null;
-      }
-
-      // The bridge wasm_worker.rs looks up. Absent means "decode inline", which is why it is only
-      // defined when there is a live worker to talk to.
-      globalThis.__decodeVolume = (bytes) => {
-        if (!worker) return Promise.reject(new Error("worker unavailable"));
-        const id = nextId++;
-        return new Promise((resolve, reject) => {
-          pending.set(id, [resolve, reject]);
-          // Transfer, not copy: the volume is tens of MB and this side is finished with it. Rust
-          // hands us a fresh JS-heap array for exactly this reason.
-          worker.postMessage({ id, bytes: bytes.buffer }, [bytes.buffer]);
-        });
-      };
+      // Job ids, transfers and worker-death handling all live in decode-bridge.js, which takes
+      // the spawn as a callback so its failure path can be tested without a browser.
+      globalThis.__decodeVolume = makeBridge({
+        spawnWorker: () => {
+          const w = new Worker(new URL("./decode-worker.js", import.meta.url), { type: "module" });
+          w.postMessage({ module, glue: glueUrl });
+          return w;
+        },
+      });
 
       // A dead map is indistinguishable from a slow one on a blank canvas, and the two ways it
       // dies after a good start are a lost GPU context (driver reset, tab starved of VRAM, laptop


### PR DESCRIPTION
## What

Two paths that put Level 2 decode on the browser's UI thread, both of which get worse the longer a tab stays open. This is the first of the R20 web-stability batch.

**The worker was a one-shot.** `retire()` in `web/index.src.html` terminated the decode worker and nulled it *for the session*. Retiring the instance is right — a wasm trap poisons the heap it decodes in — but everything after that fell back to `decode_file` inline (`crates/wxdata/src/level2.rs:397,448`), so one bad moment became hours of multi-second freezes per volume, with no way out but closing the tab. The page now rebuilds the worker, up to three times.

**The live chunk stream never used the worker at all.** `live::emit` assembles the accumulated chunks at every sweep boundary — the same bzip2-and-decode work as an archived volume, smaller, but roughly 15× per volume instead of once — and `task::in_place` is a plain call on wasm. It now goes to the same worker under a new `assemble` op, with the identical inline fallback when there is no worker. `merge_scan` stays on the main thread: it is a deep copy of the base sweeps, inherent to `Arc<Scan>` snapshot semantics, and tens of milliseconds rather than hundreds.

Also: the worker now reports whether a failure was a `WebAssembly.RuntimeError`, so an ordinary bad volume no longer looks like a poisoned heap and vice versa. Before this, a trap inside an export was reported as a plain error and the poisoned worker kept serving.

## Structure

The bridge moved out of `index.html` into `web/decode-bridge.js` and takes `spawnWorker` as a callback. The reason is testability: the interesting behaviour is the failure path and a browser cannot be asked for a trap on demand. `web/decode-bridge.test.mjs` drives it with a stub worker and runs in CI beside `proxy-core.test.mjs`.

Chunk framing (`live::frame` / `live::split_framed`) is a `u32`-length-prefixed concatenation — both sides are the same build of the same module, exactly like the postcard `Scan` coming back.

## Verified

- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo test --workspace` green (framing round-trip added, including the empty-payload case a naive split gets wrong).
- `RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check --target wasm32-unknown-unknown -p hookecho --lib` clean.
- `node --test web/decode-bridge.test.mjs` — 5/5: op and transfer, bad volume keeps the worker, trap replaces it and the next job uses the new one, respawn limit then inline fallback, no-workers-at-all.
- `./scripts/shots/shoot.sh check` passes.
- Built bundle in headless Chromium: boots (`scripts/web/smoke.mjs`), and through `__decodeVolume` — `assemble` reaches `assemble_live_chunks` (it answers with this PR's own framing error), a bad volume errors without retiring, and the worker still serves afterwards.
- Live-stream assembly cannot be exercised against a local static server (archived volumes need `/proxy` to start a stream, live chunks are CORS-direct), so that half is checked on the demo deploy after merge.

## Size

| | gzipped |
|---|---|
| before (local) | 4 153 840 |
| after (local) | 4 157 634 |
| delta | **+3 794** |

`HOOKECHO_WASM_BUDGET` 4 160 000 → **4 166 000**: the CI-measured baseline is 4 159 748, so CI lands near 4 163 542, and the rest is the rounding CI has added each time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)