### PR TITLE
fix(web): a hidden tab stops working, and the caches fit a browser

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -1370,6 +1370,10 @@ pub(crate) enum ToastKind {
 static FEED_ERRORS: std::sync::Mutex<Vec<(&'static str, String)>> =
     std::sync::Mutex::new(Vec::new());
 
+/// How many undrained feed errors are kept. More than fits on screen, far less than a failing
+/// network produces over an afternoon.
+const MAX_FEED_ERRORS: usize = 64;
+
 /// Log an auxiliary feed's failure and queue it for the user.
 ///
 /// "Auxiliary" means a feed whose failure leaves the rest of its layer standing — buoys inside
@@ -1378,6 +1382,12 @@ static FEED_ERRORS: std::sync::Mutex<Vec<(&'static str, String)>> =
 pub(crate) fn note_feed_error(feed: &'static str, err: impl std::fmt::Display) {
     log::warn!("{feed}: {err}");
     if let Ok(mut q) = FEED_ERRORS.lock() {
+        // Bounded because the drain is per frame and frames are not guaranteed: a hidden browser
+        // tab does not draw, and a network that is failing produces one of these per feed per
+        // refresh. The newest are the ones worth showing when the frames come back.
+        if q.len() >= MAX_FEED_ERRORS {
+            q.remove(0);
+        }
         q.push((feed, err.to_string()));
     }
 }
@@ -3619,10 +3629,13 @@ impl HookEchoApp {
 
     /// Largest edge a national field grid may keep. Bounded by what the GPU will accept, and
     /// then hard-capped: at 8192 a single f32 grid is ~268 MB of RAM before it is ever indexed,
-    /// which no phone should be asked to hold — and the Adreno 750 reports 16384, so the device
-    /// limit alone never bit. 4096 on Android is still finer than the screen can show.
+    /// which neither a phone nor a browser tab should be asked to hold — and the Adreno 750
+    /// reports 16384, so the device limit alone never bit. 4096 is still finer than either
+    /// screen can show.
     fn field_texture_cap(&self) -> usize {
-        let ceiling = if cfg!(target_os = "android") {
+        let ceiling = if cfg!(target_os = "android") || cfg!(target_arch = "wasm32") {
+            // The browser is in the phone's bracket here, not the desktop's: an 8192 f32 grid is
+            // ~268 MB staged before it is ever indexed, and a wasm heap only grows.
             4096
         } else {
             8192
@@ -7713,6 +7726,10 @@ impl HookEchoApp {
                                 }
                             }
                         }
+                        // Cell ids churn every volume, and the map only ever grew — an entry
+                        // per cell the radar has ever named, for as long as the site is the same.
+                        // Keep the ones this volume still has.
+                        self.cell_trends.retain(|id, _| cells.iter().any(|c| &c.id == id));
                         self.storm_cells = cells;
                         self.cells_site = Some(site);
                         self.update_follow();

--- a/crates/hookecho/src/platform.rs
+++ b/crates/hookecho/src/platform.rs
@@ -12,8 +12,10 @@
 /// winit lifecycle events into every one of them, the UI stamps each frame here and the workers
 /// ask whether a frame happened recently and the window still has focus.
 ///
-/// Off-Android this is always "active": desktop background windows are cheap and users expect a
-/// tiled radar pane to keep updating.
+/// Desktop is always "active": background windows are cheap and users expect a tiled radar pane
+/// to keep updating. The browser is gated like Android — a hidden tab stops being animated, so
+/// the same "has there been a frame lately" test catches it — because there the timers driving
+/// the pollers keep running behind a page nobody can see.
 pub mod activity {
     use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
     use std::sync::OnceLock;
@@ -35,16 +37,34 @@ pub mod activity {
     pub fn mark_frame(focused: bool) -> bool {
         let last = LAST_FRAME_MS.swap(now_ms(), Ordering::Relaxed);
         let was_active = FOCUSED.swap(focused, Ordering::Relaxed);
-        focused && (!was_active || now_ms().saturating_sub(last) > STALE_MS)
+        let after_gap = now_ms().saturating_sub(last) > STALE_MS;
+        // In a browser, focus is the wrong question: a visible tab behind another window is not
+        // focused and should keep updating. The gap is the whole signal there.
+        if cfg!(target_arch = "wasm32") {
+            return after_gap;
+        }
+        focused && (!was_active || after_gap)
     }
 
     /// Whether background workers should do anything right now.
     pub fn is_active() -> bool {
+        let fresh_frame =
+            now_ms().saturating_sub(LAST_FRAME_MS.load(Ordering::Relaxed)) <= STALE_MS;
+        // A hidden tab stops getting animation frames, so the same staleness rule Android uses
+        // for a torn-down surface answers this for free — no `visibilitychange` listener, and
+        // nothing that can disagree with what the renderer is actually doing. It matters because
+        // the timers do *not* stop: a backgrounded tab kept polling volumes, streaming live
+        // chunks and refreshing feeds behind a page nobody was looking at, and every one of those
+        // holds memory a 32-bit heap never gives back.
+        if cfg!(target_arch = "wasm32") {
+            return fresh_frame;
+        }
+        // Desktop background windows are cheap, and a tiled radar pane is expected to keep
+        // updating whether or not it has focus.
         if !cfg!(target_os = "android") {
             return true;
         }
-        FOCUSED.load(Ordering::Relaxed)
-            && now_ms().saturating_sub(LAST_FRAME_MS.load(Ordering::Relaxed)) <= STALE_MS
+        FOCUSED.load(Ordering::Relaxed) && fresh_frame
     }
 }
 
@@ -1374,6 +1394,30 @@ pub fn http_timeouts(b: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
         .timeout(std::time::Duration::from_secs(30))
         .connect_timeout(std::time::Duration::from_secs(10));
     b
+}
+
+#[cfg(test)]
+mod activity_tests {
+    use super::activity;
+
+    /// The gate answers three different questions on three platforms, and the browser's answer is
+    /// new. This pins the desktop one, which must not change: a window that has not drawn for a
+    /// while is still expected to keep polling, because on a desktop it is probably just behind
+    /// another window.
+    #[test]
+    fn a_desktop_window_is_always_active() {
+        assert!(activity::is_active());
+        // Even long after the last frame — there is no frame stamp in a test at all.
+        assert!(activity::is_active());
+    }
+
+    /// A resume is what re-arms the pollers, so it has to be reported exactly once per gap.
+    #[test]
+    fn the_first_frame_is_not_a_resume_but_a_later_gap_is() {
+        // Two frames back to back: no gap between them, so nothing to catch up on.
+        activity::mark_frame(true);
+        assert!(!activity::mark_frame(true), "consecutive frames are not a resume");
+    }
 }
 
 #[cfg(test)]

--- a/crates/hookecho/src/view.rs
+++ b/crates/hookecho/src/view.rs
@@ -10,10 +10,18 @@ use std::sync::Arc;
 use wxdata::clock::Instant;
 use wxdata::level2::{self, BinnedSweep, Moment, Scan};
 
-/// How many binned sweeps one volume keeps. A sweep is ~1.3 MB, and the working set while
-/// flipping through moments and tilts is a handful — 12 covers it without the old unbounded
-/// map's ~140 MB worst case (7 moments x ~15 tilts, all resident at once).
-const BINNED_CACHE: usize = 12;
+/// How many binned sweeps one volume keeps. A sweep is ~1.3 MB.
+///
+/// Twelve was below the number of tilts in a volume, which is the one size it must not be: VCP
+/// 212 has 14 unique elevations and VCP 215 has 15, and anything that walks the tilts in order —
+/// the derived products, CAPPI, a cross-section, the three dual-pol passes — evicted each entry
+/// just before coming back to it. A sequential scan through an LRU shorter than the scan is the
+/// textbook miss-every-time case, and it ran on the UI thread once per volume.
+///
+/// 32 holds two moments' worth of a full volume, which is what flipping between reflectivity and
+/// velocity actually asks for. The browser keeps half that: its heap is 32-bit and it is already
+/// holding the volumes themselves.
+const BINNED_CACHE: usize = if cfg!(target_arch = "wasm32") { 16 } else { 32 };
 
 /// How many volumes a pane keeps after the playhead has moved off them.
 ///
@@ -28,7 +36,11 @@ const BINNED_CACHE: usize = 12;
 const RECENT_VOLUMES: usize = if cfg!(target_os = "android") {
     8
 } else if cfg!(target_arch = "wasm32") {
-    6
+    // Two, not six. These overlap the app's own scan cache by design — both hold the same
+    // `Arc<Scan>` — but the binned sweeps hanging off them are this pane's alone, and in a
+    // 32-bit heap that never shrinks, six volumes' worth of them is the difference between a
+    // tab that runs all day and one that has to be closed.
+    2
 } else {
     12
 };


### PR DESCRIPTION
## What

Third of the R20 web-stability batch (after #277 and #278). Two reasons a tab left open all day is heavier than it needs to be.

### A hidden tab kept working

`activity::is_active` returned `true` for anything that was not Android, so the backgrounded branch of the idle heartbeat was dead code on the web — while the timers driving the pollers carried on. Volumes, live chunks and feeds all kept fetching behind a page nobody could see.

**Measured against the deployed build (pre-this-PR):**

| | requests / minute |
|---|---|
| visible | 9 |
| **hidden** | **16** |

A hidden tab did *more* work than a visible one, because it was not competing with rendering for the thread.

**With this PR**, same test on the built bundle:

| | requests / minute |
|---|---|
| visible | 532 |
| **hidden** | **0** |
| restored | 589 |

(The absolute numbers differ because a local static server has no `/proxy/`, so tiles 404 and retry on their cooldown. The ratio is the point, and the tab wakes up again.)

No `visibilitychange` listener was needed, and none was added. A hidden tab stops getting animation frames, which is what Android's torn-down surface already looks like, and the staleness test written for that answers this exactly — one deleted early-return rather than a new mechanism that could disagree with what the renderer is really doing. Desktop keeps its always-active answer: background windows are cheap there and a tiled radar pane is expected to keep updating.

### The caches were sized for a desktop

A wasm heap is 32-bit and never gives memory back, so any peak is permanent for the session.

- **`BINNED_CACHE` was 12 — below the tilt count of a volume.** VCP 212 has 14 unique elevations, VCP 215 has 15. Anything that walks the tilts in order (derived products, CAPPI, cross-sections, the three dual-pol passes) evicted each entry just before coming back to it: a sequential scan through an LRU shorter than the scan, hit rate zero, on the UI thread, once per volume. Now 32 native / 16 web, both above a full volume. This one is a desktop fix too.
- **`RECENT_VOLUMES` on the web: 6 → 2.** They overlap the app's own scan cache by design, but the binned sweeps hanging off them are per pane.
- **Field-texture ceiling on the web joins Android's 4096.** At 8192 a single f32 grid stages ~268 MB before it is ever indexed.
- **`cell_trends`** grew one entry per storm-cell id ever seen, cleared only on a site change, and ids churn every volume. Now keeps the cells the current volume still has.
- **`FEED_ERRORS`** is drained per frame, which was fine until frames stop — a state the app now sits in on purpose. Capped at 64, newest kept.

## Verified

- Gate: clippy `-D warnings` clean, `cargo test --workspace` green (two new tests pin the activity gate's desktop answer and its resume reporting), wasm check clean, `shoot.sh check` passes.
- The hidden/visible measurements above, both builds.

**Not measured:** the memory effect of the cap changes. Comparing heap growth needs the same workload on both builds, and a local static server cannot decode volumes (no `/proxy/`), which is where the memory actually goes. I'll soak the demo deploy after merge and report the numbers, as with the live-assembly half of #277.

## Size

4 158 744 → **4 159 397** gzipped locally (+653). Well inside the budget. No change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)