### PR TITLE
fix(wxdata): an upstream error is reported as one, not as bad GeoJSON

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -50,7 +50,17 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: npx --yes wrangler@3 pages deploy web --project-name=hookecho --branch=main
+        # Keep the deployment's own URL. Every check below runs against *this* deploy rather
+        # than the production alias, because the alias can still be serving the previous one:
+        # on 2026-09-03 a deploy went green while app.hookecho.io answered with the bundle from
+        # two merges earlier, and nothing here noticed.
+        run: |
+          npx --yes wrangler@3 pages deploy web --project-name=hookecho --branch=main \
+            | tee /tmp/deploy.log
+          url=$(grep -oE 'https://[0-9a-f]+\.hookecho\.pages\.dev' /tmp/deploy.log | tail -1)
+          test -n "$url" || { echo "::error::wrangler printed no deployment URL"; exit 1; }
+          echo "DEPLOY_URL=$url" >> "$GITHUB_ENV"
+          echo "deployment: $url"
 
       - uses: actions/setup-node@v4
         with:
@@ -68,7 +78,7 @@ jobs:
           asset=$(grep -o 'dist/hookecho_bg-[0-9a-f]*\.wasm' web/index.html | head -1)
           echo "waiting for /$asset"
           for _ in $(seq 1 20); do
-            code=$(curl -s -o /dev/null -w '%{http_code}' "https://hookecho.pages.dev/$asset")
+            code=$(curl -s -o /dev/null -w '%{http_code}' "$DEPLOY_URL/$asset")
             [ "$code" = 200 ] && exit 0
             sleep 10
           done
@@ -77,27 +87,42 @@ jobs:
 
       # The same boot check CI runs against a local server, now against the deployed origin.
       - name: Smoke-test the deployed demo
-        run: node scripts/web/smoke.mjs https://hookecho.pages.dev/ --expect-loop
+        run: node scripts/web/smoke.mjs "$DEPLOY_URL/" --expect-loop
 
       # The lite viewer is a separate page with its own wasm; it boots without WebGL, so a failure
       # here is its own decode or projection, not the GPU.
       - name: Smoke-test the lite viewer
         run: |
           asset=$(grep -o 'dist/lite-[0-9a-f]*\.js' web/lite/index.html | head -1)
-          test "$(curl -s -o /dev/null -w '%{http_code}' "https://hookecho.pages.dev/$asset")" = 200
-          node scripts/web/smoke-lite.mjs https://hookecho.pages.dev/lite/
+          test "$(curl -s -o /dev/null -w '%{http_code}' "$DEPLOY_URL/$asset")" = 200
+          node scripts/web/smoke-lite.mjs "$DEPLOY_URL/lite/"
 
       - name: Check the proxy answers and refuses
         run: |
-          curl -sf "https://hookecho.pages.dev/proxy/api.weather.gov/alerts/active/count" >/dev/null
-          test "$(curl -s -o /dev/null -w '%{http_code}' https://hookecho.pages.dev/proxy/evil.example/x)" = 403
+          curl -sf "$DEPLOY_URL/proxy/api.weather.gov/alerts/active/count" >/dev/null
+          test "$(curl -s -o /dev/null -w '%{http_code}' "$DEPLOY_URL/proxy/evil.example/x")" = 403
 
       # A proxied response has to be cacheable and revalidatable, or every repeat poll pays for
       # the whole body again. The two calls land inside the 15 s edge TTL, so the second sees the
       # same cached upstream response — which is the point: the 304 is answered at the edge.
+      # Deploying is not shipping. Pages promotes a `--branch=main` deployment to the production
+      # alias itself, and when that lags (or silently does not happen) every check above still
+      # passes against the deployment URL while visitors keep getting the old bundle. Ask the
+      # alias which wasm it names and wait for it to be this one.
+      - name: Wait for the deployment to become the live site
+        run: |
+          asset=$(grep -o 'dist/hookecho_bg-[0-9a-f]*\.wasm' web/index.html | head -1)
+          for _ in $(seq 1 30); do
+            live=$(curl -s https://hookecho.pages.dev/ | grep -o 'dist/hookecho_bg-[0-9a-f]*\.wasm' | head -1)
+            [ "$live" = "$asset" ] && { echo "live: $live"; exit 0; }
+            sleep 20
+          done
+          echo "::error::the alias still serves $live, not $asset — this deploy did not go live"
+          exit 1
+
       - name: Check the proxy caches and revalidates
         run: |
-          url="https://hookecho.pages.dev/proxy/api.weather.gov/alerts/active/count"
+          url="$DEPLOY_URL/proxy/api.weather.gov/alerts/active/count"
           curl -sD - -o /dev/null "$url" | tr -d '\r' > /tmp/h.txt
           grep -qi '^cache-control: public, max-age=15$' /tmp/h.txt
           etag=$(grep -i '^etag:' /tmp/h.txt | cut -d' ' -f2-)

--- a/crates/wxdata/src/overlay.rs
+++ b/crates/wxdata/src/overlay.rs
@@ -323,11 +323,47 @@ pub fn polygons_of(value: &GeometryValue) -> Vec<Vec<Vec<[f64; 2]>>> {
     }
 }
 
+/// The message from a body that is an error report rather than GeoJSON, if it is one.
+///
+/// ArcGIS REST — which is behind the watch boxes, the mesoscale discussions, WSSI, the ERO, the
+/// fire perimeters and the damage surveys — reports failure as **HTTP 200 with an error object**:
+///
+/// ```json
+/// {"error":{"code":404,"message":"Layer or Table not found","details":[]}}
+/// ```
+///
+/// `error_for_status()` sees a 200 and passes it straight to the parser, so a renumbered layer or
+/// an expired token surfaced as `geojson parse: missing field 'type' at line 1 column 72` — the
+/// length of that exact body, and a message that sends you looking at the parser instead of at
+/// the service. Checked here rather than at twelve call sites, because every one of them arrives
+/// through this function.
+fn upstream_error(json: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(json).ok()?;
+    let err = v.get("error")?;
+    // Both shapes seen in the wild: an object with a message, or a bare string.
+    let msg = match err {
+        serde_json::Value::String(s) => s.clone(),
+        _ => {
+            let text = err.get("message").and_then(|m| m.as_str()).unwrap_or("");
+            match err.get("code").and_then(|c| c.as_i64()) {
+                Some(code) if !text.is_empty() => format!("{text} ({code})"),
+                Some(code) => format!("code {code}"),
+                None if !text.is_empty() => text.to_string(),
+                None => return None,
+            }
+        }
+    };
+    Some(msg)
+}
+
 /// Iterate the features of a GeoJSON document, yielding (geometry value, properties).
 pub fn for_each_feature<F>(json: &str, mut f: F) -> anyhow::Result<()>
 where
     F: FnMut(&GeometryValue, &serde_json::Map<String, serde_json::Value>),
 {
+    if let Some(msg) = upstream_error(json) {
+        anyhow::bail!("upstream error: {msg}");
+    }
     let gj: GeoJson = json
         .parse()
         .map_err(|e| anyhow::anyhow!("geojson parse: {e}"))?;
@@ -491,5 +527,38 @@ mod dedupe_tests {
         let mut a = alert("urn:z", "");
         a.vtec = None;
         assert_eq!(a.dedupe_key(), "urn:z");
+    }
+
+    /// The body that sent someone looking at the parser: ArcGIS reports failure with HTTP 200 and
+    /// an error object, so it must be named as an upstream failure, not as malformed GeoJSON.
+    #[test]
+    fn an_error_body_is_reported_as_the_service_failing() {
+        let body = r#"{"error":{"code":404,"message":"Layer or Table not found","details":[]}}"#;
+        let err = super::for_each_feature(body, |_, _| {})
+            .expect_err("an error body is not a feature collection");
+        let msg = err.to_string();
+        assert!(msg.contains("upstream error"), "{msg}");
+        assert!(msg.contains("Layer or Table not found"), "{msg}");
+        assert!(msg.contains("404"), "{msg}");
+        // A bare-string `error` is the other shape these services use.
+        let bare = super::for_each_feature(r#"{"error":"Token Required"}"#, |_, _| {})
+            .expect_err("a string error body is still an error");
+        assert!(bare.to_string().contains("Token Required"));
+    }
+
+    /// Real GeoJSON must be unaffected — including a feature whose *properties* happen to carry an
+    /// `error` key, which is a shape the DAT damage surveys actually publish.
+    #[test]
+    fn ordinary_geojson_still_parses() {
+        let body = r#"{"type":"FeatureCollection","features":[
+            {"type":"Feature","properties":{"error":"none"},
+             "geometry":{"type":"Point","coordinates":[-97.0,35.0]}}]}"#;
+        let mut seen = 0;
+        super::for_each_feature(body, |_, props| {
+            seen += 1;
+            assert_eq!(props.get("error").and_then(|v| v.as_str()), Some("none"));
+        })
+        .expect("a feature collection parses");
+        assert_eq!(seen, 1);
     }
 }

--- a/scripts/web/smoke.mjs
+++ b/scripts/web/smoke.mjs
@@ -39,6 +39,15 @@ page.on("console", (m) => {
   const text = m.text();
   // A Rust panic reaches the console as a warning or a log depending on the panic hook.
   if (/panicked at|RuntimeError: unreachable/.test(text)) errors.push(`panic: ${text}`);
+  // A feed whose body does not parse is either a shape change upstream or a bug here, and both
+  // want a red build. It is not the same thing as a feed being *unreachable*, which is expected
+  // against a local server with no `/proxy/` and is why this is narrower than "any warning".
+  //
+  // Deliberately not caught: `upstream error: …`, which is a service having a bad day and says so
+  // in its own words. That distinction is the whole point of the check that produces it — before
+  // it existed, an ArcGIS error body reached the parser and read as malformed GeoJSON, and this
+  // line would have been failing builds for something no one here could fix.
+  if (/geojson parse:|placefile parse:/.test(text)) errors.push(`feed parse: ${text}`);
   // The app logs this once, from `sync_timeline`, when the opening loop starts playing.
   if (/loop: playing \d+\/\d+ frames/.test(text)) {
     loopStarted = true;


### PR DESCRIPTION
Two commits: the bug, and the CI holes that let it through.

## The bug

ArcGIS REST reports failure with **HTTP 200 and an error object**:

```json
{"error":{"code":404,"message":"Layer or Table not found","details":[]}}
```

`error_for_status()` sees the 200 and hands the body to the GeoJSON parser, so a renumbered layer or an expired token surfaced in the browser console as:

```
Overlay: geojson parse: missing field 'type' at line 1 column 72
```

Column 72 is the length of that exact body. It reads as a decoder bug and is nothing of the kind — this is what I chased when it first appeared in the console during the outage-layer work.

Six feeds sit behind that service (watch boxes, mesoscale discussions, WSSI, the ERO, fire perimeters, damage surveys) and all of them arrive through `overlay::for_each_feature`, so the check lives there rather than at twelve call sites. Both shapes are handled: an object with `message`/`code`, and a bare string.

A *feature* whose properties carry an `error` key still parses — the DAT damage surveys publish exactly that — and there's a test for it, because the naive version of this check would have broken them.

## The CI holes

**The smoke test ignored it.** It failed only on page errors and Rust panics, so this warning passed CI every time and shipped. `geojson parse:` and `placefile parse:` now fail the build. `upstream error:` deliberately does *not* — a service having a bad day is not something a red build here can fix, and telling those two apart is the whole reason the message changed.

**The Demo workflow checked the wrong thing, twice.** Every step ran against `hookecho.pages.dev` — the production alias — rather than the deployment it had just made. Last night Cloudflare didn't promote the deployment, so the smoke test, the lite check and the proxy checks all passed against a bundle from two merges earlier and the job went green while `app.hookecho.io` served the old build for the better part of an hour. Now:

- the deploy step keeps the URL wrangler prints, and everything downstream uses it;
- a final step waits for the alias to name this build's content-hashed wasm, and fails if it never does. Deploying is not shipping.

## Verified

- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo test --workspace` green, with two new tests: an ArcGIS error body (both shapes) is reported as an upstream failure with its own message, and ordinary GeoJSON carrying an `error` property still parses.
- wasm check clean, `shoot.sh check` passes, bundle builds at 4 159 396 gz (well inside budget, no change).
- The workflow changes are shell-only and will prove themselves on this PR's own deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)