### PR TITLE
fix(app): a layer you switch off stays off

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -3389,32 +3389,26 @@ impl HookEchoApp {
             vol3d_pending: None,
             max_texture_dim,
         };
-        // Restore the overlays that were on last time. Unknown names (an older build reading a
-        // newer file) are skipped rather than treated as an error.
-        let restore: Vec<OverlayToggle> = app
-            .settings
-            .overlays_on
-            .iter()
-            .filter_map(|s| OverlayToggle::from_slug(s))
-            .collect();
-        let needs_rebuild = restore.iter().any(|t| {
-            use OverlayToggle as T;
-            matches!(
-                t,
-                T::Tropical
-                    | T::Outages
-                    | T::ProbSevere
-                    | T::Aviation
-                    | T::Tfr
-                    | T::Alerts
-                    | T::Mds
-                    | T::Fires
-            )
-        });
-        for t in restore {
-            *app.overlay_flag(t) = true;
-        }
-        if needs_rebuild {
+        // Restore the overlays from last time, assigning rather than only ever switching on: the
+        // additive version could never turn a default-on layer off, so unchecking one lasted until
+        // the next restart and then came back. `None` is "no run has recorded this yet", where the
+        // built-in defaults still stand; a recorded list is the whole truth about every layer.
+        //
+        // Unknown names (an older build reading a newer file) are skipped rather than treated as
+        // an error.
+        if let Some(saved) = app.settings.overlays_on.clone() {
+            let restore: Vec<OverlayToggle> = saved
+                .iter()
+                .filter_map(|s| OverlayToggle::from_slug(s))
+                .collect();
+            for t in OverlayToggle::ALL {
+                if t.session_only() {
+                    continue;
+                }
+                *app.overlay_flag(t) = restore.contains(&t);
+            }
+            // Whatever the outcome, the overlay set now differs from the one the constructor built,
+            // so the derived features have to be rebuilt from it once.
             app.rebuild_overlays();
         }
         app.palettes.reload(&app.settings.palette_paths());
@@ -16813,7 +16807,7 @@ impl eframe::App for HookEchoApp {
                 .filter(|t| !t.session_only() && *self.overlay_flag(*t))
                 .map(|t| t.slug())
                 .collect();
-            self.settings.overlays_on = on;
+            self.settings.overlays_on = Some(on);
         }
         if due && self.settings != self.saved {
             // A palette-map change reloads the color tables (bumps gen -> LUT re-bake).

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -450,8 +450,12 @@ pub struct Settings {
     /// Overlay toggles that were on when the app last ran, by name (see `OverlayToggle::slug`).
     /// Names rather than the enum on purpose: a name this build doesn't know is skipped, where an
     /// unknown enum variant would fail the parse and reset every other setting with it.
+    ///
+    /// `None` means no run has recorded its layers yet — a fresh install, or a file written before
+    /// this key existed — and the app's built-in defaults stand. An empty list is a different
+    /// statement: someone turned everything off, and it has to survive a restart.
     #[serde(default)]
-    pub overlays_on: Vec<String>,
+    pub overlays_on: Option<Vec<String>>,
     /// Saved pane layouts (see `crate::workspace`), applied from the command palette. Distinct
     /// from `presets`, which is the starred-radar-site list.
     #[serde(default)]
@@ -1140,7 +1144,7 @@ impl Default for Settings {
             alert_volume: default_volume(),
             live_loop_frames: default_live_loop_frames(),
             basemap: String::new(),
-            overlays_on: Vec::new(),
+            overlays_on: None,
             workspaces: Vec::new(),
             seeded_workspaces: false,
             last_view: None,
@@ -1626,7 +1630,7 @@ mod tests {
             alert_volume: 0.7,
             live_loop_frames: 12,
             basemap: "carto-dark".to_string(),
-            overlays_on: vec!["Alerts".to_string(), "Wind".to_string()],
+            overlays_on: Some(vec!["Alerts".to_string(), "Wind".to_string()]),
             last_view: Some(StartView {
                 site: "KOUN".to_string(),
                 x: 0.2,
@@ -1698,7 +1702,20 @@ mod tests {
         let json = r#"{"default_site":"KDMX","overlays_on":["Alerts","Teleportation"]}"#;
         let s: Settings = serde_json::from_str(json).unwrap();
         assert_eq!(s.default_site, "KDMX");
-        assert_eq!(s.overlays_on, vec!["Alerts", "Teleportation"]);
+        assert_eq!(s.overlays_on.unwrap(), vec!["Alerts", "Teleportation"]);
+    }
+
+    #[test]
+    fn no_layers_and_no_record_of_layers_are_different_things() {
+        // The whole reason `overlays_on` is an Option. An empty list is a user who turned
+        // everything off and expects it to stay off; a missing key is a fresh install, where the
+        // app's own defaults have to win. Collapsing the two booted every new user with a blank
+        // map, or resurrected a layer they had just switched off.
+        let none: Settings = serde_json::from_str(r#"{"default_site":"KDMX"}"#).unwrap();
+        assert_eq!(none.overlays_on, None);
+        let empty: Settings =
+            serde_json::from_str(r#"{"default_site":"KDMX","overlays_on":[]}"#).unwrap();
+        assert_eq!(empty.overlays_on, Some(Vec::new()));
     }
 
     #[test]


### PR DESCRIPTION
## What

Startup no longer restores saved layers additively. It assigns across every non-session `OverlayToggle`, the way the workspace restore path already did.

`Settings::overlays_on` becomes `Option<Vec<String>>` so the two empty-list meanings stay apart:

| value | meaning |
|---|---|
| `None` | no run has recorded layers — fresh install, or a file predating the key. Built-in defaults stand. |
| `Some([])` | everything was switched off on purpose. Stays off. |
| `Some([…])` | exactly these are on, everything else is off. |

The `needs_rebuild` allowlist is deleted: an assignment can now change any layer in either direction, so a rebuild is always warranted when a list was recorded.

## Why

Restore was `for t in restore { *app.overlay_flag(t) = true; }`. A layer that defaults on could never be persistently turned off — uncheck alerts, restart, alerts are back. The bug is invisible for default-off layers, which is why it survived this long.

## wasm

Before `4166254`, after `4166254` — unchanged. No budget move.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 324 pass, plus the new `no_layers_and_no_record_of_layers_are_different_things`, which pins the `None` vs `Some([])` distinction at the serde layer (the only place it can be tested without a GPU)
- `RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check --target wasm32-unknown-unknown -p hookecho --lib`
- `./scripts/shots/shoot.sh check` — pass
- `./scripts/web/build.sh` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)