### PR TITLE
perf(view): a live volume stops throwing away its binned tilts every chunk

### DIFF
--- a/crates/hookecho/src/view.rs
+++ b/crates/hookecho/src/view.rs
@@ -23,6 +23,25 @@ use wxdata::level2::{self, BinnedSweep, Moment, Scan};
 /// holding the volumes themselves.
 const BINNED_CACHE: usize = if cfg!(target_arch = "wasm32") { 16 } else { 32 };
 
+/// Whether `new` is `old` with tilts only added on the end, so every existing tilt index still
+/// points at the same elevation.
+///
+/// This is the ordinary shape of a live volume: chunks arrive every ten or twenty seconds and each
+/// one appends the next sweep. Treating that as "the tilt set changed" threw away every binned
+/// sweep in the volume, and the UI thread re-binned all of them on the next frame — a visible hitch
+/// once per chunk, for the whole life of the volume. A VCP restart or a re-ordered merge really
+/// does shift the indices, and still clears.
+///
+/// Compared with the same 0.15 degree tolerance the caller uses to match a changed tilt: the angles
+/// are recomputed from the merged scan each time and need not be bit-identical.
+fn tilts_only_grew(old: &[f32], new: &[f32]) -> bool {
+    new.len() >= old.len()
+        && old
+            .iter()
+            .zip(new)
+            .all(|(a, b)| (a - b).abs() < 0.15)
+}
+
 /// How many volumes a pane keeps after the playhead has moved off them.
 ///
 /// `Volume::new` is called every time the playhead lands on a frame, and a fresh `Volume` starts
@@ -101,7 +120,7 @@ impl Volume {
             return;
         }
         self.scan = scan;
-        if new_elev != self.elevations {
+        if !tilts_only_grew(&self.elevations, &new_elev) {
             self.binned.clear(); // tilt indices may have shifted
         } else {
             for angle in changed {
@@ -328,6 +347,25 @@ impl MapView {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn a_growing_live_volume_keeps_its_binned_tilts() {
+        use super::tilts_only_grew;
+        // The ordinary case: a chunk lands and appends the next sweep. Every index that already
+        // has a binned sweep still means the same elevation, so the cache survives.
+        assert!(tilts_only_grew(&[0.5, 0.5, 0.9], &[0.5, 0.5, 0.9, 1.3]));
+        // Nothing new yet is still "only grew".
+        assert!(tilts_only_grew(&[0.5, 0.9], &[0.5, 0.9]));
+        // A fresh volume from an empty list.
+        assert!(tilts_only_grew(&[], &[0.5]));
+        // Recomputed angles wobble slightly; that is not a re-order.
+        assert!(tilts_only_grew(&[0.5, 0.9], &[0.52, 0.88, 1.3]));
+        // A VCP change re-orders the prefix — index 1 now means a different tilt, so every binned
+        // sweep at an index is suspect and the cache has to go.
+        assert!(!tilts_only_grew(&[0.5, 0.9, 1.3], &[0.5, 1.3, 0.9]));
+        // Tilts disappearing is not growth either.
+        assert!(!tilts_only_grew(&[0.5, 0.9, 1.3], &[0.5, 0.9]));
+    }
+
     use super::*;
     use crate::render::mercator::Camera;
 


### PR DESCRIPTION
## What

`Volume::apply_live` cleared the entire binned-sweep cache whenever the merged scan's elevation list differed from the one before it. That is the ordinary shape of a live volume, not an exception: chunks arrive every ten or twenty seconds and each one appends the next sweep, so the list differs every single time.

It now clears only when the tilts were re-ordered or removed. Appending leaves every existing index pointing at the same elevation, so the cache is still valid.

```rust
fn tilts_only_grew(old: &[f32], new: &[f32]) -> bool {
    new.len() >= old.len() && old.iter().zip(new).all(|(a, b)| (a - b).abs() < 0.15)
}
```

Same 0.15° tolerance the caller already uses to match a changed tilt — the angles are recomputed from the merged scan each time and need not be bit-identical.

## Why

This is the live-loop hitch. Every binned sweep in the volume was discarded once per chunk, and the UI thread re-binned all of them on the next frame that asked for one. The per-tilt eviction path immediately below it — the code that carefully evicts only the tilts in `changed` — was unreachable in the case it was written for.

A VCP restart or a re-ordered merge genuinely does shift indices, and still clears the whole cache.

## wasm

Before `4164045`, after `4164045` — unchanged. No budget move.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — pass, plus `a_growing_live_volume_keeps_its_binned_tilts` covering append, no-change, empty-to-first, tolerance wobble, re-order and shrink
- `RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check --target wasm32-unknown-unknown -p hookecho --lib`
- `./scripts/shots/shoot.sh check` — pass
- `./scripts/web/build.sh` — pass

## Also looked at, and left alone

`overlay_build::build_with_theme` on the UI thread was the other suspect for this symptom. It is already gated behind `should_retess`: it runs on a geometry change or a half-zoom-bucket crossing, and is deferred entirely while a gesture is live. It does not run per frame and it does not run per chunk, so it is not what was stuttering the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)