### PR TITLE
feat(desktop): reopen at the size you left it

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -16833,6 +16833,38 @@ impl eframe::App for HookEchoApp {
                 .map(|t| t.slug())
                 .collect();
             self.settings.overlays_on = Some(on);
+            // Same trick for the window: fold the live size in, and the ordinary diff-and-save
+            // below persists it.
+            //
+            // Measured from the root `Ui`, not `ViewportInfo::inner_rect`: on Wayland the
+            // compositor never tells a client where its window is, so `inner_rect` is `None`
+            // there and this silently saved nothing at all. The root ui covers the whole
+            // viewport, in egui points — logical points divided by the ui-scale zoom — so
+            // multiplying the zoom back gives the units `with_inner_size` wants.
+            //
+            // While maximized the size on screen is the screen's, not the one to restore to, so
+            // the previous size is kept and only the flag moves.
+            #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
+            {
+                let (maximized, minimized) = root.ctx().input(|i| {
+                    (
+                        i.viewport().maximized.unwrap_or(false),
+                        i.viewport().minimized.unwrap_or(false),
+                    )
+                });
+                let size = root.max_rect().size() * root.ctx().zoom_factor();
+                if !minimized && size.x > 1.0 && size.y > 1.0 {
+                    let (width, height) = match self.settings.window {
+                        Some(w) if maximized => (w.width, w.height),
+                        _ => (size.x, size.y),
+                    };
+                    self.settings.window = Some(crate::settings::WindowGeom {
+                        width,
+                        height,
+                        maximized,
+                    });
+                }
+            }
         }
         if due && self.settings != self.saved {
             // A palette-map change reloads the color tables (bumps gen -> LUT re-bake).

--- a/crates/hookecho/src/lib.rs
+++ b/crates/hookecho/src/lib.rs
@@ -143,9 +143,15 @@ pub fn os_decorated() -> bool {
 /// dispatched any `--headless-*` verifier.
 #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
 pub fn run_desktop() -> eframe::Result<()> {
+    // Reopen at the size you left it. Read from the settings file this app already writes rather
+    // than eframe's `persistence` feature, which would pull a whole key-value store in to remember
+    // two floats and a bool.
+    let saved = crate::settings::Settings::load().window;
+    let size = saved.map_or([1280.0, 800.0], |w| [w.width, w.height]);
     let mut native_options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
-            .with_inner_size([1280.0, 800.0])
+            .with_inner_size(size)
+            .with_maximized(saved.is_some_and(|w| w.maximized))
             // The floating chrome has fixed-width cards; below this they stack on top of the map
             // and each other.
             .with_min_inner_size([800.0, 500.0])

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -104,6 +104,17 @@ fn default_live_loop_frames() -> usize {
     10
 }
 
+/// Where the desktop window was last time. Size only, not position: a saved position is wrong the
+/// moment a monitor is unplugged or a laptop is docked, and a window that opens off-screen is a
+/// worse bug than one that opens in the wrong place.
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct WindowGeom {
+    pub width: f32,
+    pub height: f32,
+    #[serde(default)]
+    pub maximized: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Settings {
@@ -456,6 +467,14 @@ pub struct Settings {
     /// statement: someone turned everything off, and it has to survive a restart.
     #[serde(default)]
     pub overlays_on: Option<Vec<String>>,
+    /// Desktop window size in logical points, and whether it was maximized, as of the last run.
+    /// `None` on a first run, where the built-in 1280x800 stands.
+    ///
+    /// Kept here rather than turning on eframe's `persistence` feature: that pulls in a whole
+    /// key-value store and its serialization to remember two floats and a bool that this file is
+    /// already being written for.
+    #[serde(default)]
+    pub window: Option<WindowGeom>,
     /// Saved pane layouts (see `crate::workspace`), applied from the command palette. Distinct
     /// from `presets`, which is the starred-radar-site list.
     #[serde(default)]
@@ -1145,6 +1164,7 @@ impl Default for Settings {
             live_loop_frames: default_live_loop_frames(),
             basemap: String::new(),
             overlays_on: None,
+            window: None,
             workspaces: Vec::new(),
             seeded_workspaces: false,
             last_view: None,
@@ -1631,6 +1651,7 @@ mod tests {
             live_loop_frames: 12,
             basemap: "carto-dark".to_string(),
             overlays_on: Some(vec!["Alerts".to_string(), "Wind".to_string()]),
+            window: None,
             last_view: Some(StartView {
                 site: "KOUN".to_string(),
                 x: 0.2,
@@ -1716,6 +1737,21 @@ mod tests {
         let empty: Settings =
             serde_json::from_str(r#"{"default_site":"KDMX","overlays_on":[]}"#).unwrap();
         assert_eq!(empty.overlays_on, Some(Vec::new()));
+    }
+
+    #[test]
+    fn a_window_size_is_remembered_and_an_old_file_still_loads() {
+        // Written by a build that predates the key: no window, so the built-in 1280x800 stands.
+        let old: Settings = serde_json::from_str(r#"{"default_site":"KDMX"}"#).unwrap();
+        assert_eq!(old.window, None);
+        // `maximized` has its own default, so a file written before that field existed is fine too.
+        let s: Settings =
+            serde_json::from_str(r#"{"window":{"width":1600.0,"height":900.0}}"#).unwrap();
+        let w = s.window.unwrap();
+        assert_eq!((w.width, w.height, w.maximized), (1600.0, 900.0, false));
+        // And it round-trips, which is what the save path relies on.
+        let back: Settings = serde_json::from_str(&serde_json::to_string(&s).unwrap()).unwrap();
+        assert_eq!(back.window, s.window);
     }
 
     #[test]


### PR DESCRIPTION
## What

The desktop window opened at 1280x800 every time, whatever you had resized it to. It now reopens at the last size, and maximized if it was maximized.

`Settings` gains a `window: Option<WindowGeom>` — width, height, maximized. `run_desktop` reads it before building the viewport; the app folds the live size into `self.settings` in the same once-a-second block that already does this for `overlays_on`, and the existing dirty-diff save writes it.

## Why not eframe's `persistence` feature

That was the obvious answer and it is the wrong one here. It pulls in a whole key-value store and its serialization to remember two floats and a bool, into a build with a wasm size budget — and this app already writes a settings file every time anything changes. No new dependency.

## Size only, not position

A saved position is wrong the moment a monitor is unplugged or a laptop is docked, and a window that opens off-screen is a worse bug than one that opens in the wrong place.

## The Wayland part

The first version read `ViewportInfo::inner_rect` and saved nothing at all, silently. A Wayland compositor never tells a client where its window is, so `inner_rect` is `None` there — and `None` took the early-out. It measures the root `Ui` instead, which is the whole viewport by definition and exists on every backend. That is in egui points, so it is multiplied by the ui-scale zoom to get back to the logical points `with_inner_size` wants.

While maximized the on-screen size is the screen's, not the size to restore to, so the flag moves and the stored size is kept.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — pass, plus `a_window_size_is_remembered_and_an_old_file_still_loads`: a file predating the key gives `None`, a file predating the `maximized` field still parses, and the value round-trips
- `RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check --target wasm32-unknown-unknown -p hookecho --lib`
- `./scripts/shots/shoot.sh check` — pass
- `./scripts/web/build.sh` — pass
- Ran the real app against an isolated `XDG_CONFIG_HOME` and read the file back: `{'width': 1710.0, 'height': 1375.0, 'maximized': True}`. This is what caught the `inner_rect` bug — the first version wrote nothing here and looked fine in every other check.

The restore half could not be observed on this box: Hyprland tiles the window and overrides the requested size, so the requested value is unobservable from outside. The read is a direct `Settings::load().window` into `with_inner_size`, and the round-trip it depends on is under test.

## wasm

Before `4164045`, after `4165293` — +1248 bytes, from the serde code for the new field. Budget unchanged at 4174000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)