### PR TITLE
perf(wasm): ship the 25 timezones this app names, not all 597

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,16 @@
+# Only the timezones this app names are compiled in.
+#
+# `chrono-tz` embeds the whole IANA database by default — every zone on earth, with every
+# historical transition. `wxdata::tz` answers one question ("what time is it at this radar site")
+# from a hand-written table, and `wxdata::meteoalarm` and friends name a handful of European
+# zones. That is 25 zones out of nearly 600, and carrying the rest cost 119403 bytes gzipped in
+# the browser bundle — measured, not estimated.
+#
+# This lives here rather than in a build script so that every cargo invocation gets it: a plain
+# `cargo test`, CI, `scripts/web/build.sh`, and anyone's editor.
+#
+# Keeping it in sync needs no discipline. Name a zone the filter does not match and the build
+# fails with "cannot find value `Europe__Somewhere` in this scope" — a compile error, not a
+# wrong answer at runtime. Add it to the list and rebuild.
+[env]
+CHRONO_TZ_TIMEZONE_FILTER = "(America/(Anchorage|Boise|Chicago|Denver|Detroit|Indiana/Indianapolis|Los_Angeles|New_York|Phoenix|Puerto_Rico|Sitka)|Atlantic/Reykjavik|Europe/(Amsterdam|Berlin|Brussels|Bucharest|Copenhagen|Dublin|Ljubljana|Prague|Warsaw|Zagreb)|Pacific/(Guam|Honolulu)|UTC)"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,7 +930,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
+ "chrono-tz-build",
  "phf 0.12.1",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d8d1efd5109b9c1cd3b7966bd071cdfb53bb6eb0b22a473a68c2f70a11a1eb"
+dependencies = [
+ "parse-zoneinfo",
+ "phf_codegen",
+ "regex",
 ]
 
 [[package]]
@@ -4117,6 +4129,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c406c9e2aa74554e662d2c2ee11cd3e73756988800be7e6f5eddb16fed4699"
+
+[[package]]
 name = "pastey"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4178,6 +4196,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_codegen"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbdcb6f01d193b17f0b9c3360fa7e0e620991b193ff08702f78b3ce365d7e61"
+dependencies = [
+ "phf_generator 0.12.1",
+ "phf_shared 0.12.1",
+]
+
+[[package]]
 name = "phf_generator"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4185,6 +4213,16 @@ checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
  "rand 0.8.7",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cbb1126afed61dd6368748dae63b1ee7dc480191c6262a3b4ff1e29d86a6c5b"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.12.1",
 ]
 
 [[package]]

--- a/crates/wxdata/Cargo.toml
+++ b/crates/wxdata/Cargo.toml
@@ -29,7 +29,7 @@ geojson = "1.0.0"
 # Already in the tree under reqwest; used here to run the per-forecast-hour HRRR fetches with
 # bounded concurrency instead of one at a time.
 futures-util = { version = "0.3", default-features = false, features = ["std", "async-await-macro"] }
-chrono-tz = "0.10"
+chrono-tz = { version = "0.10", default-features = false, features = ["filter-by-regex"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio.workspace = true

--- a/packaging/flatpak/cargo-sources.json
+++ b/packaging/flatpak/cargo-sources.json
@@ -9399,6 +9399,58 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/chrono-tz-build/chrono-tz-build-0.5.0.crate",
+        "sha256": "c7d8d1efd5109b9c1cd3b7966bd071cdfb53bb6eb0b22a473a68c2f70a11a1eb",
+        "dest": "cargo/vendor/chrono-tz-build-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c7d8d1efd5109b9c1cd3b7966bd071cdfb53bb6eb0b22a473a68c2f70a11a1eb\", \"files\": {}}",
+        "dest": "cargo/vendor/chrono-tz-build-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/parse-zoneinfo/parse-zoneinfo-0.4.1.crate",
+        "sha256": "e3c406c9e2aa74554e662d2c2ee11cd3e73756988800be7e6f5eddb16fed4699",
+        "dest": "cargo/vendor/parse-zoneinfo-0.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e3c406c9e2aa74554e662d2c2ee11cd3e73756988800be7e6f5eddb16fed4699\", \"files\": {}}",
+        "dest": "cargo/vendor/parse-zoneinfo-0.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/phf_codegen/phf_codegen-0.12.1.crate",
+        "sha256": "efbdcb6f01d193b17f0b9c3360fa7e0e620991b193ff08702f78b3ce365d7e61",
+        "dest": "cargo/vendor/phf_codegen-0.12.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"efbdcb6f01d193b17f0b9c3360fa7e0e620991b193ff08702f78b3ce365d7e61\", \"files\": {}}",
+        "dest": "cargo/vendor/phf_codegen-0.12.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/phf_generator/phf_generator-0.12.1.crate",
+        "sha256": "2cbb1126afed61dd6368748dae63b1ee7dc480191c6262a3b4ff1e29d86a6c5b",
+        "dest": "cargo/vendor/phf_generator-0.12.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2cbb1126afed61dd6368748dae63b1ee7dc480191c6262a3b4ff1e29d86a6c5b\", \"files\": {}}",
+        "dest": "cargo/vendor/phf_generator-0.12.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
         "type": "inline",
         "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n",
         "dest": "cargo",

--- a/scripts/web/bloat.sh
+++ b/scripts/web/bloat.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# What is actually in the browser bundle, by item and by generic instantiation.
+#
+# `build.sh`'s size budget says when the bundle got bigger. It cannot say what got bigger, and
+# guessing has been wrong: `env_logger` looked like the obvious win and costs nothing (it is only
+# named from `main.rs`, which is not in the cdylib), while `chrono-tz`, which nobody suspected,
+# was 119403 bytes gzipped of IANA database for the 25 zones this app names.
+#
+# This builds its own wasm rather than reading `web/dist`, because the shipped profile has
+# `strip = true` and twiggy on a stripped module can only report `code[2199]`. The absolute
+# numbers here are therefore larger than what ships; the ranking is the point.
+#
+# Usage:  scripts/web/bloat.sh [top-n]
+# Needs:  cargo install twiggy
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+n="${1:-40}"
+
+if ! command -v twiggy >/dev/null; then
+  echo "twiggy not found — cargo install twiggy" >&2
+  exit 1
+fi
+
+out=target/bloat
+rm -rf "$out"
+RUSTFLAGS='--cfg getrandom_backend="wasm_js"' \
+  CARGO_PROFILE_WEB_STRIP=false \
+  CARGO_PROFILE_WEB_DEBUG=1 \
+  cargo build --profile web --target wasm32-unknown-unknown -p hookecho --lib
+wasm-bindgen --target web --no-typescript \
+  --out-dir "$out" target/wasm32-unknown-unknown/web/hookecho.wasm
+wasm="$out/hookecho_bg.wasm"
+
+echo
+echo "== $wasm ($(stat -c%s "$wasm") bytes unstripped)"
+echo
+echo "== biggest items"
+twiggy top -n "$n" "$wasm"
+echo
+# `monos` groups the generic instantiations, which is where one over-generic helper becomes forty
+# copies of itself and no single copy looks big enough to notice.
+echo "== generic bloat (one function, many instantiations)"
+twiggy monos -n 20 "$wasm"

--- a/scripts/web/build.sh
+++ b/scripts/web/build.sh
@@ -116,7 +116,7 @@ gz_bytes="$(gzip -9 -c "web/dist/hookecho_bg-$wasm_hash.wasm" | wc -c)"
 #
 # Raised deliberately for the offline chase packs (IndexedDB via web-sys) — the one budget raise
 # the R18 batch reserved for itself.
-budget="${HOOKECHO_WASM_BUDGET:-4174000}"
+budget="${HOOKECHO_WASM_BUDGET:-4060000}"
 printf 'wasm: %s raw, %s gzipped (budget %s)\n' \
   "$(stat -c%s "web/dist/hookecho_bg-$wasm_hash.wasm")" "$gz_bytes" "$budget"
 if [ "$gz_bytes" -gt "$budget" ]; then


### PR DESCRIPTION
## Measured

**119,403 bytes gzipped**, or 2.9% of the whole bundle. Local web build `4164045` → `4044642`; raw `11856` KB → `11152` KB. Budget lowered `4174000` → `4060000` to match.

The largest single saving so far, and it was not on anyone's suspect list.

## What

`chrono-tz` embeds the entire IANA database — every zone on earth, every historical transition. This app names 25 zones: `wxdata::tz` maps each NEXRAD site to one from a hand-written table, and a handful of European zones appear elsewhere. So the crate gets `filter-by-regex`, and `.cargo/config.toml` pins the filter.

```toml
[env]
CHRONO_TZ_TIMEZONE_FILTER = "(America/(Anchorage|Boise|Chicago|…)|Europe/(…)|Pacific/(Guam|Honolulu)|UTC)"
```

In `.cargo/config.toml` rather than a build script so that every invocation gets it without anyone remembering: plain `cargo test`, CI, `scripts/web/build.sh`, an editor's `rust-analyzer`.

**Staying in sync needs no discipline.** Name a zone the filter does not match and the build fails with ``cannot find value `Europe__Somewhere` in this scope``. A compile error, not a wrong time on screen. Confirmed by writing the first filter too narrowly — it failed exactly this way, on the eleven European zones it had missed.

No new dependency: this is a feature flag on a crate already in the tree. It does pull four build-time crates (`chrono-tz-build`, `parse-zoneinfo`, `phf_codegen`, `phf_generator`), none of which reach the binary, and `packaging/flatpak/cargo-sources.json` is updated for them — each sha256 fetched from crates.io and cross-checked against `Cargo.lock`'s own checksum, since `flatpak-cargo-generator.py` is not installed here.

## The tool that found it

`scripts/web/bloat.sh` — twiggy's `top` and `monos` over the wasm.

It builds its own module rather than reading `web/dist`, because the shipped profile has `strip = true` and twiggy on a stripped module can only tell you that `code[2199]` is large. The absolute numbers are therefore bigger than what ships; the ranking is the point.

## What the ranking said

| suspect | verdict |
|---|---|
| `chrono-tz` full database | **real, 119403 bytes.** Fixed here. |
| `env_logger` + regex on wasm | **costs nothing.** Only named from `main.rs`, which is not in the cdylib. |
| duplicate `png` 0.17/0.18 | not in the top items. |
| `vello_cpu` + `fearless_simd` | **real, roughly 300 KB** — a CPU software rasterizer, with `Overlay`, `HardLight` and `Difference` blend modes at ~50 KB each, in an app that renders through wgpu. Not fixable here: it is a non-optional dependency of `epaint` 0.35, with no feature to turn it off. Worth an upstream issue. |

Two of the four guesses were wrong, which is the argument for the script.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — pass, including `tz::tests::every_site_has_a_timezone` (the table is self-policing) and `cargo_sources_covers_the_lockfile`, which is what caught the four new build crates
- `RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check --target wasm32-unknown-unknown -p hookecho --lib`
- `./scripts/shots/shoot.sh check` — pass
- `./scripts/web/build.sh` — pass at the new, lower budget
- `cargo build -p hookecho` — the native build uses the same filter and is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)