### PR TITLE
docs(roadmap): drop the three things that already shipped

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,10 +16,14 @@ upgrade path out of it (`grep -rn "ponytail:" crates/`).
 
 ## Next
 
-- **GOES satellite imagery** — ABI Level 2 CMIP from the `noaa-goes19`/`-18`
-  buckets, CONUS to start, three bands (visible, clean IR, mid-level water
-  vapor), animated on the timeline the radar already uses. The GIBS basemap
-  layer shows the latest image; this is the archive and the loop.
+- **GOES from the source.** The outcome this entry described — satellite
+  imagery animated on the timeline the radar already uses — is shipped, but
+  through GIBS' time dimension rather than the `noaa-goes19`/`-18` buckets:
+  fifteen timed layers (GeoColor, clean IR, air mass, dust, fire temperature,
+  plus Himawari and IMERG), a frame bar, and a "follow the radar clock" mode
+  that scrubs the imagery with the volume. Reading ABI Level 2 CMIP directly
+  would still buy native resolution, bands GIBS does not publish, and imagery
+  inside an offline chase pack — which is what is actually left.
 - Blending surface observations into the effective-layer analysis, which is the
   remaining difference from SPC's mesoanalysis now that the vertical resolution
   is there.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,8 +13,6 @@ upgrade path out of it (`grep -rn "ponytail:" crates/`).
   are in the repo and build; none of them is published, which is an account and
   a review queue away rather than a code change. The order and the per-store
   steps are in [packaging/SUBMITTING.md](packaging/SUBMITTING.md).
-- **Placefile `Image:` support**: parsed and skipped today, waiting on a real
-  file in the wild to use as a fixture.
 
 ## Next
 
@@ -25,27 +23,23 @@ upgrade path out of it (`grep -rn "ponytail:" crates/`).
 - Blending surface observations into the effective-layer analysis, which is the
   remaining difference from SPC's mesoanalysis now that the vertical resolution
   is there.
-- Per-pane thresholds and field layers, saved with the workspace. The difference
-  layer would rather be two panes than one subtraction, but field layers are
-  app-global, so that waits on this.
+- The difference layer as two panes rather than one subtraction. Per-pane field
+  layers landed, so the thing this was waiting on is done; what is left is the
+  comparison UI itself.
 
 ## Later
 
-Restocked from `grep -rn "ponytail:" crates/` — 88 of them at the moment, each
+Restocked from `grep -rn "ponytail:" crates/` — 161 of them at the moment, each
 naming its own upgrade path.
 
 - A valid-time alignment for the difference layer: it labels the two cycles
   today rather than interpolating either onto the other's instant.
-- Colormaps and stroke widths that respond to the high-contrast theme, not just
-  the chrome (`theme.rs`).
 - Web persistence: caches live in memory in the browser, so a reload refetches
   everything. IndexedDB or OPFS is the upgrade (`paths.rs`).
 - A tablet layout for Android — the phone chrome is what a tablet gets today
   (`ui/m3.rs`).
 - Background alerts that test real polygon intersection instead of sampling
   points around a marker's radius (`Nws.kt`).
-- Placefile `Image:`, which needs a georeferenced textured quad — and a real
-  file in the wild to pin the corner syntax.
 - Snap positions for the mobile sheets; they dismiss on a drag today but have no
   half-open state.
 - Temperature units for the gridded contour labels, which still do their own


### PR DESCRIPTION
## What

Three roadmap entries describe work that is on `main`.

| entry | where it was | reality |
|---|---|---|
| Placefile `Image:` support — "parsed and skipped today" | **Now**, and again in **Later** | Shipped in #276: georeferenced textured triangles, with fixtures from two real files |
| Colormaps and stroke widths responding to the high-contrast theme | **Later** | Shipped in #276: `REF-HC.pal`, `VEL-HC.pal`, scaled overlay and vector strokes |
| Per-pane thresholds and field layers saved with the workspace | **Next** | Shipped, and fixed again tonight in #291 |

The last one was load-bearing for the entry above it — the difference layer "waits on this" — so that entry is rewritten to say what it is actually waiting on now, which is the comparison UI.

The `ponytail:` count in the **Later** preamble said 88. It is 161.

## Why it matters

The preamble promises "'Later' is a real list, not a graveyard". A list with three finished items at the top of it is a graveyard, and the count being off by nearly half undercuts the one instruction the section gives the reader (`grep -rn "ponytail:" crates/`).

## Verification

- `grep -rn "ponytail:" crates/ --include=*.rs | wc -l` → 161
- Each removed entry checked against the tree: `PlaceKind::Image` with `parses_image_*` fixtures, `theme::overlay_stroke_scale`/`vector_stroke_scale`/`high_contrast_alt_name` with the two `.pal` files, `PaneSnap::fields_on` and `PaneSnap::thresholds` captured and applied.

Docs only — no code, no tests, no wasm change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)