### PR TITLE
ci(release): stop the rolling release collecting a .deb per version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,11 @@ jobs:
         run: |
           bash packaging/build-deb.sh
           cp target/debian/*.deb dist/
+          # A second copy under a name that does not move, kept out of `dist/` so the tagged
+          # upload's `dist/*.deb` still means exactly one versioned file. The rolling release
+          # uploads this one, so each push replaces the previous build instead of adding to a pile.
+          mkdir -p dist/rolling
+          cp target/debian/*.deb dist/rolling/HookEcho-amd64.deb
           dpkg -c dist/*.deb
 
       - name: Upload artifact
@@ -135,7 +140,28 @@ jobs:
             is always the newest code. Older releases are kept as drafts.
           files: |
             dist/HookEcho-x86_64.AppImage
-            dist/*.deb
+            dist/rolling/HookEcho-amd64.deb
+
+      # The rolling release is supposed to hold one build, and it held eighteen assets: seven
+      # .debs going back to 0.8.0, because `cargo-deb` puts the version in the filename and
+      # `--clobber` cannot clobber a name that changes every release. A stable name for the
+      # rolling copy fixes that going forward; the step below clears what has already piled up.
+      #
+      # Tagged releases keep the versioned filename, which is correct — a tag *is* a version.
+      - name: Prune stale rolling assets
+        if: github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Two patterns, both provably dead, so this can never delete a live asset:
+          #   hookecho_<version>_amd64.deb   the versioned debs, superseded by HookEcho-amd64.deb
+          #   Hook_Echo-WX-*                 the old product name, last built 2026-08-26
+          gh release view latest --json assets -q '.assets[].name' \
+            | grep -E '^(hookecho_.*_amd64\.deb|Hook_Echo-WX-.*)$' \
+            | while read -r name; do
+                echo "removing stale asset $name"
+                gh release delete-asset latest "$name" --yes
+              done
 
   windows:
     name: Windows zip


### PR DESCRIPTION
## What the rolling release actually holds

Eighteen assets, six of which are the current build:

```
hookecho_0.8.0-1_amd64.deb            2026-08-12
hookecho_0.9.0-1_amd64.deb            2026-08-14
hookecho_0.10.0-1_amd64.deb           2026-08-25
hookecho_0.11.0-1_amd64.deb           2026-08-25
hookecho_0.12.0.alpha.1-1_amd64.deb   2026-08-26
hookecho_0.12.0.beta.1-1_amd64.deb    2026-08-31
hookecho_0.12.0.beta.2-1_amd64.deb    2026-09-03
Hook_Echo-WX-arm64-v8a.apk            2026-08-26   ← the old product name
Hook_Echo-WX-macos.zip                2026-08-26
Hook_Echo-WX-setup-x86_64.exe         2026-08-26
Hook_Echo-WX-x86_64.AppImage          2026-08-26
Hook_Echo-WX-x86_64.msi               2026-08-26
```

It is described as "rolling build of `main` — rebuilt and re-published on every push, so this is always the newest code". Someone landing there gets a .deb picker spanning four weeks and five files named after an app this is not called any more.

## Why

`--clobber` and `action-gh-release` both replace an asset *by name*, and `cargo-deb` puts the version in the filename. Every other platform emits a fixed name and has been overwriting itself correctly all along; the .deb is the only one that could not.

## Fix

**A stable name for the rolling copy.** The build makes a second copy at `dist/rolling/HookEcho-amd64.deb`, and the rolling release uploads that. It is deliberately outside `dist/`, so the tagged upload's `dist/*.deb` still means exactly one versioned file — a tag *is* a version, and its assets should say so.

**A prune step** for what has already accumulated, matching two patterns and nothing else:

- `hookecho_<version>_amd64.deb` — the versioned debs, now superseded
- `Hook_Echo-WX-*` — the old product name, last built 2026-08-26

Deliberately narrow rather than "delete anything not in the current set": the four platform jobs upload into `latest` in parallel, so a set-based prune would race them and delete a build that had landed seconds earlier. These two patterns cannot match a live asset.

## Verification

The patterns were run against the live release:

```
$ gh release view latest --json assets -q '.assets[].name' | grep -E '…' | wc -l
12
$ gh release view latest --json assets -q '.assets[].name' | grep -vE '…'
HookEcho-arm64-v8a.apk
HookEcho-macos.zip
HookEcho-setup-x86_64.exe
hookecho-windows-x86_64.zip
HookEcho-x86_64.AppImage
HookEcho-x86_64.msi
```

12 matched, and exactly the six current assets survive. `python3 -c "import yaml; yaml.safe_load(...)"` parses the workflow.

The prune runs after the upload in the same job, so the newly uploaded `HookEcho-amd64.deb` is in place before the versioned one it replaces is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)