### PR TITLE
feat(alerts): warnings say the county, the towns and what to do — after the tone, not over it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ so **write the section before pushing the tag**, or the release job fails.
 
 The rolling `latest` release tracks `main` and is not listed here.
 
+## Unreleased
+
+### Warnings say where, and what to do
+
+- Spoken warnings are on by default and now say something the tone cannot.
+  The script leads with the hazard, then where the warning sits against a
+  place you saved ("covering Home", "12 miles northeast of Home"), then the
+  counties with the state spoken in full, the towns from the bulletin's own
+  "Locations impacted include..." list, the motion, and the office's call to
+  action. Previously a warning that covered a saved marker was announced as
+  "Tornado warning for covers Home" and never named a county at all.
+- The tone plays first and the voice follows it, one announcement at a time.
+  Every cue used to open its own audio stream on its own thread, so the alert
+  tone played over the opening words and a squall line warning four counties
+  in one refresh produced four voices at once.
+- Spoken warnings honour quiet hours the way the tone always has. Escalated
+  warnings still go past it. The voice previously ignored quiet hours
+  entirely.
+- Speech follows the alert volume slider. Piper's output ignored it, so the
+  voice was louder than the tone introducing it.
+- Settings grows a "Speak a test warning" button that runs the whole chain on
+  a made-up warning, and tells you when a configured Piper cannot run — on
+  Arch the text-to-speech Piper is `piper-tts-bin` in the AUR, while
+  `extra/piper` is a mouse-configuration tool that installs the same binary
+  name.
+- An audio device unplugged mid-playback no longer strands the thread waiting
+  on it forever.
+
 ## 0.12.0-beta.2 - 2026-08-30
 
 Third R18 checkpoint, and the biggest one: the app stops being a US radar

--- a/README.md
+++ b/README.md
@@ -254,8 +254,13 @@ layer draws its own scale and units.
 - Escalation tiers (CONSIDERABLE → DESTRUCTIVE/observed tornado → **Tornado
   Emergency / PDS**) drive a pulsing polygon outline, priority sorting with red
   threat chips, a dedicated emergency siren, and `urgent`-priority phone push.
-- Warnings are read aloud through the system voice — the desktop speech engine,
-  or Android's own TTS on the phone.
+- Warnings are read aloud after the tone, on by default: which counties (with
+  the state said in full), the towns in the path from the bulletin's own
+  "Locations impacted" list, how far and which way it lies from your saved
+  place, and the office's call to action. Piper's neural voice on the desktop
+  when it is installed, otherwise the system speech engine, or Android's own TTS
+  on the phone. One warning at a time — the tone finishes before the words
+  start, and a pass that brings four warnings reads them in turn.
 - Watched-location monitoring, a lightning proximity alarm (a strike within
   ~15 km of a saved spot), rain-arrival alerts ("rain in about 20 minutes"), and
   live NWS Local Storm Reports, minutes fresh.

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -4319,6 +4319,9 @@ impl HookEchoApp {
         let metric = self.metric();
         let mut alerted = false;
         let mut max_esc = 0u8; // highest escalation among newly-seen warnings this pass
+        // Collected, not spoken here: the tone has to play first, and it plays once for the whole
+        // pass rather than once per warning.
+        let mut to_speak: Vec<String> = Vec::new();
                                // Only banner warnings within the selected radar's coverage — a warning covering a saved
                                // location still banners + pushes regardless (that's a watched place, not the viewed site).
         let site_box = self.active_site_bounds(250.0);
@@ -4334,6 +4337,16 @@ impl HookEchoApp {
             if self.known_warning_ids.insert(a.dedupe_key()) && self.warnings_seeded {
                 let esc = wxdata::alerts::escalation(a);
                 let urgent = esc >= 2;
+                // The polygon's middle, computed once: the rule pass below uses it as the
+                // warning's stand-in detection, and the spoken line uses it to say which way the
+                // warning lies from a watched place.
+                let centroid: Option<[f64; 2]> = f.rings.first().filter(|r| !r.is_empty()).map(|ring| {
+                    let n = ring.len() as f64;
+                    let (x, y) = ring
+                        .iter()
+                        .fold((0.0, 0.0), |(x, y), p| (x + p[0], y + p[1]));
+                    [x / n, y / n]
+                });
                 // Severity floor: below the tier the user set, the warning still banners and
                 // still joins the alert list — it just doesn't push, speak or make noise.
                 let notify_ok = esc >= self.settings.alert_min_escalation;
@@ -4342,20 +4355,26 @@ impl HookEchoApp {
                 // saved places should name the one you sleep in.
                 // Owned, not borrowed: the rule pass below needs `&mut self` while this is
                 // still in hand.
-                let hit: Option<(String, f64)> = self
+                let hit: Option<(String, f64, Option<f32>)> = self
                     .settings
                     .markers
                     .iter()
                     .filter_map(|m| {
                         let km = f.distance_km(m.lon, m.lat);
-                        (km <= m.alert_radius_mi * crate::geo::KM_PER_MILE)
-                            .then(|| (m.name.clone(), m.home, km))
+                        (km <= m.alert_radius_mi * crate::geo::KM_PER_MILE).then(|| {
+                            // Distance to the nearest edge, bearing to the middle: the edge is
+                            // what "how far" means for a polygon, and the middle is what "which
+                            // way" means. Mixing them is fine at the scale of one sentence.
+                            let bearing = centroid
+                                .map(|c| crate::geo::great_circle([m.lon, m.lat], c).1 as f32);
+                            (m.name.clone(), m.home, km, bearing)
+                        })
                     })
-                    .min_by(|(_, ha, ka), (_, hb, kb)| {
+                    .min_by(|(_, ha, ka, _), (_, hb, kb, _)| {
                         hb.cmp(ha)
                             .then(ka.partial_cmp(kb).unwrap_or(std::cmp::Ordering::Equal))
                     })
-                    .map(|(name, _, km)| (name, km));
+                    .map(|(name, _, km, bearing)| (name, km, bearing));
                 // A drawn watch zone the warning polygon touches. Independent of the markers: a
                 // zone is an area you care about, not a point with a radius around it.
                 let zone: Option<String> = self
@@ -4413,17 +4432,8 @@ impl HookEchoApp {
                         // The warning's own centroid stands in for a detection, so a warning rule
                         // can carry extra conditions like every other rule ("a tornado warning,
                         // and also rotation within 20 km").
-                        let hit = f
-                            .rings
-                            .first()
-                            .filter(|r| !r.is_empty())
-                            .map(|ring| {
-                                let n = ring.len() as f64;
-                                let (x, y) = ring
-                                    .iter()
-                                    .fold((0.0, 0.0), |(x, y), p| (x + p[0], y + p[1]));
-                                crate::rules::Detection::at(x / n, y / n)
-                            })
+                        let hit = centroid
+                            .map(|c| crate::rules::Detection::at(c[0], c[1]))
                             .unwrap_or(crate::rules::Detection::at(0.0, 0.0));
                         if crate::rules::compound_ok(&rule, &hit, &self.recent_for_rules()) {
                             self.fire_rule_named(&rule, &hit, Some(a.event.clone()));
@@ -4431,8 +4441,10 @@ impl HookEchoApp {
                     }
                 }
                 let zone_name = zone;
-                let (label, area) = match hit {
-                    Some((name, km)) => {
+                // `area` is banner text and `relation` is speech: "5 mi from Home" reads as
+                // "five em eye", and "covers Home" reads as a verb the sentence already had.
+                let (label, area, relation) = match hit {
+                    Some((name, km, bearing)) => {
                         // Watched location covered → push to the phone (opt-in ntfy topic).
                         if notify_ok {
                             self.notify_alert(
@@ -4450,51 +4462,51 @@ impl HookEchoApp {
                         } else {
                             format!("{} from {name}", crate::geo::fmt_distance(km, metric, 0))
                         };
-                        (format!("⚠ {}", a.event), where_)
+                        (
+                            format!("⚠ {}", a.event),
+                            where_,
+                            wxdata::spoken::relation(&name, km, bearing, metric),
+                        )
                     }
                     // A zone hit banners on its own terms, wherever the radar happens to be
                     // pointed — that is the whole point of drawing one.
-                    None if zone_name.is_some() => (
-                        format!("⚠ {}", a.event),
-                        format!("touches {}", zone_name.expect("checked Some")),
-                    ),
+                    None if zone_name.is_some() => {
+                        let zone = zone_name.expect("checked Some");
+                        (
+                            format!("⚠ {}", a.event),
+                            format!("touches {zone}"),
+                            format!("touching {zone}"),
+                        )
+                    }
                     None => {
                         // No watched location: banner only if it's near the selected radar.
                         if site_box.is_none_or(|bx| !feature_in_box(f, bx)) {
                             continue;
                         }
-                        (a.event.clone(), a.area.clone())
+                        // Nowhere of the user's own to relate it to; the counties carry it.
+                        (a.event.clone(), a.area.clone(), String::new())
                     }
                 };
                 if notify_ok {
                     max_esc = max_esc.max(esc);
                 }
-                // Read it out before the banner text is moved into the queue: chasing is an
+                // Queued, not spoken: the tone leads, and the whole pass is announced together
+                // below so two warnings in one fetch cannot talk over each other. Chasing is an
                 // eyes-on-the-road activity, and a warning you have to read is one you read late.
                 if self.settings.speak_warnings && notify_ok {
                     let until = a
                         .expires
                         .map(|t| {
-                            format!(
-                                " until {}",
-                                crate::timefmt::fmt_clock(
-                                    t,
-                                    self.settings
-                                        .tz_for(self.views[self.active].site.as_deref()),
-                                    false,
-                                )
+                            crate::timefmt::fmt_clock(
+                                t,
+                                self.settings.tz_for(self.views[self.active].site.as_deref()),
+                                false,
                             )
                         })
                         .unwrap_or_default();
-                    if !self.settings.mute_alerts {
-                        // Hazard, place and heading first — see `wxdata::spoken`. `until` here
-                        // still carries its leading " until ", which the script builder adds.
-                        crate::speech::speak(&wxdata::spoken::warning_script(
-                            a,
-                            &area,
-                            until.trim_start_matches(" until "),
-                        ));
-                    }
+                    // Hazard, then where it sits against a place you know, then the counties, the
+                    // towns in its path and what to do — see `wxdata::spoken`.
+                    to_speak.push(wxdata::spoken::warning_script(a, &relation, &until));
                 }
                 if notify_ok && self.settings.ntfy_snapshot {
                     // Newest wins: one picture per pass, of whatever last warned.
@@ -4509,14 +4521,30 @@ impl HookEchoApp {
             print!("\x07"); // free terminal bell alongside the chime
             use std::io::Write;
             let _ = std::io::stdout().flush();
-            if self.settings.alert_sound {
-                // Escalated (Tornado Emergency / PDS / destructive) warnings use the emergency sound.
-                if max_esc >= 2 {
-                    // Escalated (Tornado Emergency / PDS / destructive): past quiet hours too.
-                    self.play_alert_urgent(&self.settings.emergency_sound.clone());
-                } else {
-                    self.play_alert(&self.settings.warn_sound.clone());
+            // Escalated (Tornado Emergency / PDS / destructive) warnings use the emergency sound
+            // and go past quiet hours — which is now true of the words as well as the tone. The
+            // voice used to ignore quiet hours entirely, so a 3 a.m. warning too minor to chime
+            // for still read itself out in the dark.
+            let urgent = max_esc >= 2;
+            if !self.settings.mute_alerts && (urgent || !self.in_quiet_hours()) {
+                let tone = self.settings.alert_sound.then(|| {
+                    (
+                        if urgent {
+                            self.settings.emergency_sound.clone()
+                        } else {
+                            self.settings.warn_sound.clone()
+                        },
+                        self.settings.alert_volume,
+                    )
+                });
+                if tone.is_some() {
+                    crate::platform::haptic(crate::platform::Haptic::Alert);
                 }
+                // The voice tracks the same slider the tones do; Piper's output has no level of
+                // its own, so without this the words arrived louder than the tone.
+                crate::speech::set_volume(self.settings.alert_volume);
+                // One announcement for the whole pass: tone, then every new warning in turn.
+                crate::speech::announce(tone, to_speak);
             }
         }
     }

--- a/crates/hookecho/src/audio.rs
+++ b/crates/hookecho/src/audio.rs
@@ -22,56 +22,80 @@ use std::time::Duration;
 #[cfg(not(target_arch = "wasm32"))]
 pub fn play(sound: &AlertSound, volume: f32) {
     let sound = sound.clone();
-    std::thread::spawn(move || {
-        let (_stream, handle) = match rodio::OutputStream::try_default() {
-            Ok(s) => s,
-            Err(e) => {
-                log::warn!("no audio output for alert sound: {e}");
-                return;
-            }
-        };
-        let sink = match Sink::try_new(&handle) {
-            Ok(s) => s,
-            Err(e) => {
-                log::warn!("audio sink failed: {e}");
-                return;
-            }
-        };
-        sink.set_volume(volume.clamp(0.0, 1.0));
-        match &sound {
-            AlertSound::Custom(path) => {
-                if !append_file(&sink, path) {
-                    // Fall back to the default chime so the alert is never silent.
-                    append_builtin(&sink, &AlertSound::Chime);
-                }
-            }
-            builtin => append_builtin(&sink, builtin),
-        }
-        sink.sleep_until_end(); // keep the stream alive until playback finishes
-    });
+    std::thread::spawn(move || play_blocking(&sound, volume));
 }
 
-/// Play WAV bytes that some other part of the app just produced (today: Piper's stdout).
-/// Non-blocking, same detached-thread shape as [`play`].
+/// [`play`], but on the calling thread: returns when the sound has finished.
+///
+/// This is what lets the tone come *before* the voice instead of on top of it — see
+/// `speech::announce`, which owns the one thread both of them run on.
 #[cfg(not(target_arch = "wasm32"))]
-pub fn play_wav(bytes: Vec<u8>) {
-    std::thread::spawn(move || {
-        let Ok((_stream, handle)) = rodio::OutputStream::try_default() else {
-            log::warn!("no audio output for speech");
+pub fn play_blocking(sound: &AlertSound, volume: f32) {
+    let (_stream, handle) = match rodio::OutputStream::try_default() {
+        Ok(s) => s,
+        Err(e) => {
+            log::warn!("no audio output for alert sound: {e}");
             return;
-        };
-        let Ok(sink) = Sink::try_new(&handle) else {
+        }
+    };
+    let sink = match Sink::try_new(&handle) {
+        Ok(s) => s,
+        Err(e) => {
+            log::warn!("audio sink failed: {e}");
             return;
-        };
-        match rodio::Decoder::new(std::io::Cursor::new(bytes)) {
-            Ok(src) => sink.append(src),
-            Err(e) => {
-                log::warn!("speech audio decode failed: {e}");
-                return;
+        }
+    };
+    sink.set_volume(volume.clamp(0.0, 1.0));
+    match sound {
+        AlertSound::Custom(path) => {
+            if !append_file(&sink, path) {
+                // Fall back to the default chime so the alert is never silent.
+                append_builtin(&sink, &AlertSound::Chime);
             }
         }
-        sink.sleep_until_end();
-    });
+        builtin => append_builtin(&sink, builtin),
+    }
+    drain(&sink, Duration::from_secs(30));
+}
+
+/// Play WAV bytes that some other part of the app just produced (today: Piper's stdout), and
+/// return when they have finished.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn play_wav_blocking(bytes: Vec<u8>, volume: f32) {
+    let Ok((_stream, handle)) = rodio::OutputStream::try_default() else {
+        log::warn!("no audio output for speech");
+        return;
+    };
+    let Ok(sink) = Sink::try_new(&handle) else {
+        return;
+    };
+    sink.set_volume(volume.clamp(0.0, 1.0));
+    match rodio::Decoder::new(std::io::Cursor::new(bytes)) {
+        Ok(src) => sink.append(src),
+        Err(e) => {
+            log::warn!("speech audio decode failed: {e}");
+            return;
+        }
+    }
+    // A spoken warning runs longer than any tone, and a long instruction longer still.
+    drain(&sink, Duration::from_secs(120));
+}
+
+/// Wait for the sink to empty, but not forever.
+///
+/// `Sink::sleep_until_end` is a channel receive that never returns if the device disappears
+/// mid-stream — unplug a USB headset and the thread is gone for the life of the process. That was
+/// survivable when every playback owned a throwaway thread; now that one thread serializes the
+/// tone and the speech behind a lock, a wedged wait would silence every warning after it.
+#[cfg(not(target_arch = "wasm32"))]
+fn drain(sink: &Sink, cap: Duration) {
+    let start = std::time::Instant::now();
+    while !sink.empty() && start.elapsed() < cap {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    if !sink.empty() {
+        log::warn!("audio device stopped draining after {cap:?}; giving up on this cue");
+    }
 }
 
 /// Try to queue a user audio file (wav/mp3/ogg/flac). Returns false (logged) on any failure.
@@ -180,6 +204,15 @@ pub fn play(sound: &AlertSound, volume: f32) {
         }
         Err(e) => log::warn!("alert sound element failed: {e:?}"),
     }
+}
+
+/// How long [`play`] will be making noise for, in milliseconds.
+///
+/// The browser gives no completion callback worth having on a throwaway `<audio>` element, so the
+/// web build waits out the tone by the clock before it starts speaking.
+#[cfg(target_arch = "wasm32")]
+pub fn duration_ms(sound: &AlertSound) -> u32 {
+    segments(sound).iter().map(|(_, ms)| *ms as u32).sum()
 }
 
 /// The built-in cues as `(hz, ms)` runs, `0.0` meaning silence. Mirrors `append_builtin`'s

--- a/crates/hookecho/src/fonts.rs
+++ b/crates/hookecho/src/fonts.rs
@@ -151,7 +151,7 @@ pub fn spawn_load(ctx: egui::Context) {
 
 /// `setTimeout` as a future. The browser build has no runtime timer of its own — see `rt.rs`.
 #[cfg(target_arch = "wasm32")]
-async fn sleep_ms(ms: u32) {
+pub(crate) async fn sleep_ms(ms: u32) {
     let promise = js_sys::Promise::new(&mut |resolve, _| {
         if let Some(w) = web_sys::window() {
             let _ = w.set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, ms as i32);

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -351,8 +351,12 @@ pub struct Settings {
     /// Chime + push when cloud-to-ground lightning strikes within ~15 km of a saved location.
     #[serde(default)]
     pub lightning_alarm: bool,
-    /// Read new warnings aloud (system speech engine). Off by default — speech is intrusive.
-    #[serde(default)]
+    /// Read new warnings aloud after the alert tone.
+    ///
+    /// On by default. The tone says a warning exists and nothing else: not which counties, not
+    /// which towns are in the path, not whether it is coming at you, not what to do. Someone
+    /// driving cannot read the banner that carries all of that.
+    #[serde(default = "default_true")]
     pub speak_warnings: bool,
     /// Path to a Piper binary, or blank to look on `PATH`. Piper is a local neural voice; when it
     /// and a voice model are both present, spoken warnings go through it instead of espeak.
@@ -1133,7 +1137,7 @@ impl Default for Settings {
             bookmarks: Vec::new(),
             anthropic_key: String::new(),
             lightning_alarm: false,
-            speak_warnings: false,
+            speak_warnings: true,
             piper_path: String::new(),
             piper_voice: String::new(),
             piper_download_voice: String::new(),

--- a/crates/hookecho/src/speech.rs
+++ b/crates/hookecho/src/speech.rs
@@ -157,24 +157,76 @@ pub fn take_voice_request() -> Option<String> {
     WANT_VOICE.lock().ok().and_then(|mut g| g.take())
 }
 
-/// Speak `text` aloud, if the platform can. Returns immediately.
+/// Held for the length of one announcement, so the next one waits its turn.
+///
+/// Before this, every cue opened its own output stream on its own thread: the tone played over
+/// the first word, and a squall line that warned four counties in one fetch pass had four voices
+/// talking at once. None of it was audible and all of it was alarming.
 #[cfg(not(target_arch = "wasm32"))]
-pub fn speak(text: &str) {
-    let text = text.to_string();
+static SPEAKING: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// The tone, then the words — one announcement at a time.
+///
+/// Returns immediately; everything happens on one detached thread that holds [`SPEAKING`] for the
+/// whole sequence. `tone` is `None` when the user has alert sounds off, and `lines` is empty when
+/// they have speech off, so a run with both is a no-op rather than a silent thread.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn announce(tone: Option<(crate::settings::AlertSound, f32)>, lines: Vec<String>) {
+    if tone.is_none() && lines.is_empty() {
+        return;
+    }
     std::thread::spawn(move || {
-        if let Err(e) = imp::speak_blocking(&text) {
-            log::warn!("speech failed: {e}");
+        // A panic elsewhere in the audio path must not silence every later warning, so a poisoned
+        // lock is taken anyway — there is no shared state behind it to corrupt.
+        let _guard = SPEAKING
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some((sound, volume)) = tone {
+            crate::audio::play_blocking(&sound, volume);
+        }
+        for line in lines {
+            if let Err(e) = imp::speak_blocking(&line) {
+                log::warn!("speech failed: {e}");
+                // One dead engine will be dead for the rest of them too.
+                break;
+            }
         }
     });
 }
 
-/// The browser speaks asynchronously on its own, so there is no thread to spawn — and no thread to
-/// spawn with, since wasm32 has no `std::thread`.
-#[cfg(target_arch = "wasm32")]
+/// Speak `text` aloud, if the platform can. Returns immediately.
+///
+/// Goes through [`announce`], so a chase position update waits for a warning to finish rather
+/// than interrupting it.
 pub fn speak(text: &str) {
-    if let Err(e) = imp::speak_blocking(text) {
-        log::warn!("speech failed: {e}");
+    announce(None, vec![text.to_string()]);
+}
+
+/// The tone, then the words. The browser queues utterances itself, so the only thing to arrange
+/// is that the first one does not start underneath the tone.
+///
+// ponytail: no lock on the web. A second announcement's tone can overlap the tail of the first,
+// which needs an outstanding-count to fix; the browser build is not the one anyone chases with.
+#[cfg(target_arch = "wasm32")]
+pub fn announce(tone: Option<(crate::settings::AlertSound, f32)>, lines: Vec<String>) {
+    if tone.is_none() && lines.is_empty() {
+        return;
     }
+    let wait = tone
+        .map(|(sound, volume)| {
+            crate::audio::play(&sound, volume);
+            crate::audio::duration_ms(&sound)
+        })
+        .unwrap_or(0);
+    wasm_bindgen_futures::spawn_local(async move {
+        crate::fonts::sleep_ms(wait).await;
+        for line in lines {
+            if let Err(e) = imp::speak_blocking(&line) {
+                log::warn!("speech failed: {e}");
+                break;
+            }
+        }
+    });
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -192,6 +244,87 @@ mod imp {
         synth.speak(&utter);
         Ok(())
     }
+}
+
+/// What is wrong with the configured Piper binary, once anything is known to be.
+///
+/// `(binary probed, problem)`. Keyed by path so editing the field re-probes, and written by a real
+/// synthesis run too — what actually happened beats what `--help` implied.
+#[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
+static PROBE: std::sync::Mutex<Option<(String, Option<String>)>> = std::sync::Mutex::new(None);
+
+/// The nudge for a machine with a voice selected and no engine to speak it.
+///
+/// Named for Arch on purpose: `extra/piper` is a GTK mouse-configuration tool that installs
+/// `/usr/bin/piper`, so "install piper" is advice that leads to a program for setting DPI on a
+/// gaming mouse. The text-to-speech one is in the AUR.
+#[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
+pub const NOT_FOUND: &str = "Piper is not installed — on Arch: `yay -S piper-tts-bin` \
+                            (not `extra/piper`, which is a mouse tool). Or point the field above \
+                            at the binary.";
+
+#[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
+fn set_piper_problem(problem: Option<String>) {
+    let bin = PIPER.read().map(|g| g.0.clone()).unwrap_or_default();
+    if let Ok(mut g) = PROBE.lock() {
+        *g = Some((bin, problem));
+    }
+}
+
+/// What Settings should warn about, or `None` while all is well or not yet known.
+///
+/// The first call for a given binary starts a probe on a background thread and returns `None`
+/// until it lands: this is read every frame, and forking a process per frame to answer it would
+/// be worse than the problem.
+#[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
+pub fn piper_problem() -> Option<String> {
+    let bin = PIPER.read().map(|g| g.0.clone()).unwrap_or_default();
+    let mut guard = PROBE.lock().ok()?;
+    if let Some((probed, problem)) = guard.as_ref() {
+        if *probed == bin {
+            return problem.clone();
+        }
+    }
+    // Claim the slot before spawning, so a UI redrawing at 60 Hz starts one probe, not sixty.
+    *guard = Some((bin.clone(), None));
+    drop(guard);
+    std::thread::spawn(move || {
+        let exe = if bin.is_empty() { "piper" } else { &bin };
+        let mut cmd = std::process::Command::new(exe);
+        crate::platform::no_window(&mut cmd);
+        let problem = match cmd.arg("--help").output() {
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Some(NOT_FOUND.to_string()),
+            Err(e) => Some(format!("{exe}: {e}")),
+            // `--model` is what tells the synthesizer from the mouse tool, which also answers
+            // `--help` and also mentions its own name in the output.
+            Ok(out) => {
+                let text = String::from_utf8_lossy(&out.stdout).to_lowercase()
+                    + &String::from_utf8_lossy(&out.stderr).to_lowercase();
+                (!text.contains("--model")).then(|| {
+                    format!("`{exe}` is not the text-to-speech Piper — it takes no `--model`.")
+                })
+            }
+        };
+        set_piper_problem(problem);
+    });
+    None
+}
+
+/// How loud a spoken warning is. Piper's own output has no volume of its own, and speech that is
+/// louder than the tone that introduced it is a jump-scare.
+#[cfg(not(target_arch = "wasm32"))]
+static VOLUME: std::sync::atomic::AtomicU32 =
+    std::sync::atomic::AtomicU32::new(1.0_f32.to_bits());
+
+/// Tell the speech path how loud to be. Takes the same slider the alert tones use.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn set_volume(v: f32) {
+    VOLUME.store(v.clamp(0.0, 1.0).to_bits(), std::sync::atomic::Ordering::Relaxed);
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn speech_volume() -> f32 {
+    f32::from_bits(VOLUME.load(std::sync::atomic::Ordering::Relaxed))
 }
 
 #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
@@ -283,8 +416,12 @@ mod imp {
             .spawn()
         {
             Ok(c) => c,
-            // Not installed is the common case, and it is not a failure worth a warning.
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            // Not installed is the common case, and it is not a failure worth a warning — but it
+            // is worth saying so in Settings, where the user asked for this voice.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                super::set_piper_problem(Some(super::NOT_FOUND.to_string()));
+                return Ok(false);
+            }
             Err(e) => return Err(format!("spawn {bin}: {e}")),
         };
         child
@@ -295,9 +432,18 @@ mod imp {
             .map_err(|e| e.to_string())?;
         let out = child.wait_with_output().map_err(|e| e.to_string())?;
         if !out.status.success() || out.stdout.is_empty() {
+            // The likeliest cause on Arch is the wrong `piper`: `extra/piper` is a mouse
+            // configuration tool that installs the same binary name.
+            super::set_piper_problem(Some(format!(
+                "{bin} exited {} with no audio — is this the text-to-speech piper?",
+                out.status
+            )));
             return Err(format!("piper exited {}", out.status));
         }
-        crate::audio::play_wav(out.stdout);
+        super::set_piper_problem(None);
+        // Blocking: this call is already inside `announce`'s one thread, and the next line of the
+        // warning must not start until this one has been heard.
+        crate::audio::play_wav_blocking(out.stdout, super::speech_volume());
         Ok(true)
     }
 }

--- a/crates/hookecho/src/speech.rs
+++ b/crates/hookecho/src/speech.rs
@@ -327,7 +327,9 @@ pub fn set_volume(v: f32) {
 #[cfg(target_arch = "wasm32")]
 pub fn set_volume(_v: f32) {}
 
-#[cfg(not(target_arch = "wasm32"))]
+/// Only the desktop arm plays its own audio; Android hands the words to TextToSpeech, which owns
+/// the level itself.
+#[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
 fn speech_volume() -> f32 {
     f32::from_bits(VOLUME.load(std::sync::atomic::Ordering::Relaxed))
 }

--- a/crates/hookecho/src/speech.rs
+++ b/crates/hookecho/src/speech.rs
@@ -322,6 +322,11 @@ pub fn set_volume(v: f32) {
     VOLUME.store(v.clamp(0.0, 1.0).to_bits(), std::sync::atomic::Ordering::Relaxed);
 }
 
+/// The browser mixes speech itself and `SpeechSynthesisUtterance` carries its own volume, so
+/// there is nothing here to set. A stub rather than a `cfg` at every call site.
+#[cfg(target_arch = "wasm32")]
+pub fn set_volume(_v: f32) {}
+
 #[cfg(not(target_arch = "wasm32"))]
 fn speech_volume() -> f32 {
     f32::from_bits(VOLUME.load(std::sync::atomic::Ordering::Relaxed))

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -1324,6 +1324,9 @@ fn piper_row(ui: &mut egui::Ui, settings: &mut Settings) {
         crate::speech::set_piper(&settings.piper_path, &settings.piper_voice);
     }
     // Only once a voice is chosen: until then Piper is off on purpose and there is nothing wrong.
+    // Android speaks through its own TextToSpeech and has no Piper to diagnose — and the runtime
+    // `if !cfg!(android)` at the call site still compiles this body, so the gate has to be here.
+    #[cfg(not(target_os = "android"))]
     if !settings.piper_voice.is_empty() {
         if let Some(problem) = crate::speech::piper_problem() {
             ui.colored_label(ui.visuals().warn_fg_color, problem);

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -1232,10 +1232,20 @@ fn alerts_tab(ui: &mut egui::Ui, settings: &mut Settings) {
     ui.strong("Spoken warnings");
     ui.checkbox(&mut settings.speak_warnings, "Read new warnings aloud")
         .on_hover_text(
-            "Speaks the event, area and expiry through the system speech engine \u{2014} for when \
-             your eyes are on the road",
+            "The tone first, then the words: which counties, the towns in the path, where it sits \
+             from your saved place, and what to do \u{2014} for when your eyes are on the road",
         );
-    ui.weak("Linux needs spd-say or espeak installed; Android uses its built-in voice.");
+    ui.weak("Piper below is the good voice; without it Linux uses spd-say or espeak, macOS and \
+             Windows their own, Android its own.");
+    // Hearing it once beats reading three settings and waiting for weather to find out that the
+    // engine was never installed.
+    if ui
+        .button("\u{1f50a} Speak a test warning")
+        .on_hover_text("Plays the emergency tone and reads a made-up tornado warning")
+        .clicked()
+    {
+        speak_test(settings);
+    }
     #[cfg(not(target_arch = "wasm32"))]
     if !cfg!(target_os = "android") {
         piper_row(ui, settings);
@@ -1254,6 +1264,33 @@ fn alerts_tab(ui: &mut egui::Ui, settings: &mut Settings) {
     );
     ui.checkbox(&mut settings.lightning_alarm, "Lightning within ~15 km of a saved location")
         .on_hover_text("Chime + push when CG lightning strikes near a marker. Requires the Lightning layer (National) to be on.");
+}
+
+/// Speak a warning that never happened, through the whole chain the real ones use.
+///
+/// Deliberately the escalated path: the emergency tone and a catastrophic tornado warning, which
+/// is the one worth knowing works. The home marker's name is borrowed so the relation clause
+/// sounds like it will on the night.
+fn speak_test(settings: &Settings) {
+    let home = settings
+        .markers
+        .iter()
+        .find(|m| m.home)
+        .or_else(|| settings.markers.first())
+        .map(|m| m.name.as_str())
+        .unwrap_or("Home");
+    crate::speech::set_volume(settings.alert_volume);
+    // Imperial, because the demo is an Oklahoma tornado warning. Real ones follow the pane's
+    // radar network, which Settings has no pane to ask.
+    let script = wxdata::spoken::warning_script(
+        &wxdata::spoken::demo_alert(),
+        &wxdata::spoken::relation(home, 19.3, Some(45.0), false),
+        "7 15 PM",
+    );
+    let tone = settings
+        .alert_sound
+        .then(|| (settings.emergency_sound.clone(), settings.alert_volume));
+    crate::speech::announce(tone, vec![script]);
 }
 
 /// Piper: the local neural voice, and the one download this app ever offers.
@@ -1285,6 +1322,12 @@ fn piper_row(ui: &mut egui::Ui, settings: &mut Settings) {
     });
     if edited {
         crate::speech::set_piper(&settings.piper_path, &settings.piper_voice);
+    }
+    // Only once a voice is chosen: until then Piper is off on purpose and there is nothing wrong.
+    if !settings.piper_voice.is_empty() {
+        if let Some(problem) = crate::speech::piper_problem() {
+            ui.colored_label(ui.visuals().warn_fg_color, problem);
+        }
     }
     // The picker downloads; the field above is what actually gets spoken with. Picking a voice
     // that is already on disk switches to it without touching the network.

--- a/crates/wxdata/src/spoken.rs
+++ b/crates/wxdata/src/spoken.rs
@@ -119,13 +119,356 @@ pub fn expand(text: &str) -> String {
     out
 }
 
-/// The sentence spoken when a warning arrives: hazard, place, motion, then the expiry.
+/// Two-letter region codes as they arrive in an `areaDesc` tail, and how to say them.
 ///
-/// `place` is the watched location the warning hit, or the alert's own area when it hit none.
-/// `until` is the already-formatted clock time, or empty.
-pub fn warning_script(a: &AlertInfo, place: &str, until: &str) -> String {
+/// US states plus the territories NWS issues for, and the Canadian provinces ECCC does. A code
+/// that is not here is not a region, and the whole area string is then passed through untouched —
+/// MeteoAlarm sends `"Bayern"`, and a marine zone sends prose.
+const REGIONS: &[(&str, &str)] = &[
+    ("AL", "Alabama"),
+    ("AK", "Alaska"),
+    ("AZ", "Arizona"),
+    ("AR", "Arkansas"),
+    ("CA", "California"),
+    ("CO", "Colorado"),
+    ("CT", "Connecticut"),
+    ("DE", "Delaware"),
+    ("DC", "the District of Columbia"),
+    ("FL", "Florida"),
+    ("GA", "Georgia"),
+    ("HI", "Hawaii"),
+    ("ID", "Idaho"),
+    ("IL", "Illinois"),
+    ("IN", "Indiana"),
+    ("IA", "Iowa"),
+    ("KS", "Kansas"),
+    ("KY", "Kentucky"),
+    ("LA", "Louisiana"),
+    ("ME", "Maine"),
+    ("MD", "Maryland"),
+    ("MA", "Massachusetts"),
+    ("MI", "Michigan"),
+    ("MN", "Minnesota"),
+    ("MS", "Mississippi"),
+    ("MO", "Missouri"),
+    ("MT", "Montana"),
+    ("NE", "Nebraska"),
+    ("NV", "Nevada"),
+    ("NH", "New Hampshire"),
+    ("NJ", "New Jersey"),
+    ("NM", "New Mexico"),
+    ("NY", "New York"),
+    ("NC", "North Carolina"),
+    ("ND", "North Dakota"),
+    ("OH", "Ohio"),
+    ("OK", "Oklahoma"),
+    ("OR", "Oregon"),
+    ("PA", "Pennsylvania"),
+    ("RI", "Rhode Island"),
+    ("SC", "South Carolina"),
+    ("SD", "South Dakota"),
+    ("TN", "Tennessee"),
+    ("TX", "Texas"),
+    ("UT", "Utah"),
+    ("VT", "Vermont"),
+    ("VA", "Virginia"),
+    ("WA", "Washington"),
+    ("WV", "West Virginia"),
+    ("WI", "Wisconsin"),
+    ("WY", "Wyoming"),
+    ("PR", "Puerto Rico"),
+    ("VI", "the Virgin Islands"),
+    ("GU", "Guam"),
+    ("AS", "American Samoa"),
+    ("MP", "the Northern Mariana Islands"),
+    ("AB", "Alberta"),
+    ("BC", "British Columbia"),
+    ("MB", "Manitoba"),
+    ("NB", "New Brunswick"),
+    ("NL", "Newfoundland and Labrador"),
+    ("NS", "Nova Scotia"),
+    ("NT", "the Northwest Territories"),
+    ("NU", "Nunavut"),
+    ("ON", "Ontario"),
+    ("PE", "Prince Edward Island"),
+    ("QC", "Quebec"),
+    ("SK", "Saskatchewan"),
+    ("YT", "Yukon"),
+];
+
+/// Codes whose divisions are not counties. Louisiana has parishes; Alaska has boroughs and census
+/// areas, which `areaDesc` already spells out; DC and the Canadian provinces have neither.
+const NOT_COUNTY: &[&str] = &[
+    "AK", "DC", "AB", "BC", "MB", "NB", "NL", "NS", "NT", "NU", "ON", "PE", "QC", "SK", "YT",
+];
+
+/// At most this many county names before the rest become "and N more". Past four the listener has
+/// stopped counting and the sentence is still going.
+const MAX_AREAS: usize = 4;
+
+/// At most this many towns. The NWS list runs to twenty on a big polygon.
+const MAX_CITIES: usize = 5;
+
+/// Turn an `areaDesc` into something worth hearing: `"Cleveland, OK; McClain, OK"` becomes
+/// `"Cleveland County and McClain County, Oklahoma"`.
+///
+/// The state is said once per run of counties that share it, because saying "Oklahoma" after every
+/// name is how a list stops being a list. A name that already carries its own kind (Parish, City,
+/// Borough) keeps it and gains nothing.
+///
+/// Anything that is not a `Name, XX` list is returned as written, only [`expand`]ed: MeteoAlarm
+/// sends a German region and NWS sends marine prose, and inventing "County" for either is worse
+/// than reading it plainly.
+pub fn spoken_area(area: &str) -> String {
+    let mut parts: Vec<(String, &'static str)> = Vec::new();
+    for raw in area.split(';') {
+        let part = raw.trim();
+        if part.is_empty() {
+            continue;
+        }
+        // The tail is the last comma group, and only a known two-letter code counts.
+        let Some((name, code)) = part.rsplit_once(", ") else {
+            return expand(area);
+        };
+        let Some((_, region)) = REGIONS.iter().find(|(c, _)| *c == code.trim()) else {
+            return expand(area);
+        };
+        let name = name.trim();
+        if name.is_empty() {
+            return expand(area);
+        }
+        parts.push((with_kind(name, code.trim()), region));
+    }
+    if parts.is_empty() {
+        return expand(area);
+    }
+    let more = parts.len().saturating_sub(MAX_AREAS);
+    parts.truncate(MAX_AREAS);
+
+    // Group runs that share a region so the region is spoken once, at the end of its run.
+    let mut out = String::new();
+    let mut i = 0;
+    while i < parts.len() {
+        let region = parts[i].1;
+        let mut names: Vec<&str> = Vec::new();
+        while i < parts.len() && parts[i].1 == region {
+            names.push(&parts[i].0);
+            i += 1;
+        }
+        if !out.is_empty() {
+            out.push_str("; ");
+        }
+        out.push_str(&join_and(&names));
+        out.push_str(", ");
+        out.push_str(region);
+    }
+    if more > 0 {
+        out.push_str(&format!(" and {more} more"));
+    }
+    out
+}
+
+/// `"Cleveland"` in Oklahoma is a county; in Louisiana it would be a parish; in Ontario it is just
+/// a place. A name that already says what it is keeps its own word.
+fn with_kind(name: &str, code: &str) -> String {
+    let already = ["County", "Parish", "Borough", "City", "Municipality", "Census Area", "Island"]
+        .iter()
+        .any(|k| name.ends_with(k));
+    if already || NOT_COUNTY.contains(&code) {
+        name.to_string()
+    } else if code == "LA" {
+        format!("{name} Parish")
+    } else {
+        format!("{name} County")
+    }
+}
+
+/// `["a", "b", "c"]` -> `"a, b and c"`. No serial comma: this is read aloud, not printed.
+fn join_and(items: &[&str]) -> String {
+    match items.split_last() {
+        None => String::new(),
+        Some((last, [])) => (*last).to_string(),
+        Some((last, head)) => format!("{} and {last}", head.join(", ")),
+    }
+}
+
+/// The towns in the path, from the block every NWS warning carries:
+///
+/// ```text
+/// Locations impacted include...
+/// Canton, Salem, Columbiana, Boardman, Alliance, Louisville, Sebring,
+/// Minerva, Waynesburg and East Sparta.
+/// ```
+///
+/// Matched on a line ending in `include...` — the wording differs between a severe thunderstorm
+/// warning and a flash flood one, but the three dots do not. The list is wrapped at whatever
+/// column the office's software chose, so it is unwrapped before splitting, and it ends at the
+/// blank line.
+pub fn cities(description: &str) -> Vec<String> {
+    let mut lines = description.lines();
+    // `include...` may be followed by trailing spaces; nothing else follows it on the line.
+    if !lines.any(|l| l.trim_end().to_ascii_lowercase().ends_with("include...")) {
+        return Vec::new();
+    }
+    let block: Vec<&str> = lines
+        .take_while(|l| !l.trim().is_empty())
+        .map(|l| l.trim())
+        .collect();
+    if block.is_empty() {
+        return Vec::new();
+    }
+    let joined = block.join(" ");
+    let joined = joined.trim().trim_end_matches('.');
+    joined
+        .split(',')
+        // A serial "and" arrives with or without the comma before it, so both are split here.
+        .flat_map(|p| p.split(" and "))
+        .map(|p| p.trim().trim_start_matches("and ").trim())
+        .filter(|p| !p.is_empty())
+        .take(MAX_CITIES)
+        .map(|p| p.to_string())
+        .collect()
+}
+
+/// What the office told people to do, short enough to still be playing when it matters.
+///
+/// The first paragraph of `instruction` is the call to action; anything after it is background
+/// ("Continuous cloud to ground lightning is occurring…"). Offices write the urgent ones in
+/// capitals, which a synthesizer spells out letter by letter, so a shouted sentence is lowered
+/// back to a spoken one.
+pub fn call_to_action(instruction: &str) -> String {
+    let para: Vec<&str> = instruction
+        .lines()
+        .map(|l| l.trim())
+        .take_while(|l| !l.is_empty())
+        .collect();
+    if para.is_empty() {
+        return String::new();
+    }
+    let text = para.join(" ");
+    let mut out = String::new();
+    let mut sentence = String::new();
+    let mut taken = 0;
+    for c in text.chars() {
+        sentence.push(c);
+        if !matches!(c, '.' | '!' | '?') {
+            continue;
+        }
+        let s = unshout(sentence.trim());
+        if out.len() + s.len() + 1 > 160 && !out.is_empty() {
+            return out;
+        }
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        out.push_str(&s);
+        sentence.clear();
+        taken += 1;
+        if taken == 2 {
+            return out;
+        }
+    }
+    // A final fragment with no full stop still counts, so long as it fits.
+    let s = unshout(sentence.trim());
+    if !s.is_empty() && out.len() + s.len() < 160 {
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        out.push_str(&s);
+    }
+    out
+}
+
+/// `"TAKE COVER NOW!"` → `"Take cover now!"`. A sentence with any lower case in it is left alone,
+/// so an ordinary sentence containing an abbreviation is untouched.
+fn unshout(s: &str) -> String {
+    if s.chars().any(|c| c.is_ascii_lowercase()) {
+        return s.to_string();
+    }
+    capitalize(&s.to_lowercase())
+}
+
+/// Where the warning sits relative to a place the listener actually knows.
+///
+/// `bearing_deg` is the direction from the place to the warning, which is the one a listener can
+/// act on. Zero distance is not "0 miles from Home" — it is the polygon sitting on top of it.
+pub fn relation(name: &str, km: f64, bearing_deg: Option<f32>, metric: bool) -> String {
+    if name.is_empty() {
+        return String::new();
+    }
+    if km <= 0.05 {
+        return format!("covering {name}");
+    }
+    match bearing_deg {
+        Some(b) => format!(
+            "{} {} of {name}",
+            spoken_distance(km, metric),
+            spoken_compass(b)
+        ),
+        None => format!("{} from {name}", spoken_distance(km, metric)),
+    }
+}
+
+/// Spelled out, not abbreviated: a synthesizer reading "km" says "kay em".
+fn spoken_distance(km: f64, metric: bool) -> String {
+    let (n, unit) = if metric {
+        (km.round() as i32, "kilometer")
+    } else {
+        ((km * 0.621_371).round() as i32, "mile")
+    };
+    if n == 1 {
+        format!("1 {unit}")
+    } else {
+        format!("{n} {unit}s")
+    }
+}
+
+/// A warning that never happened, for hearing what a real one will sound like.
+///
+/// Settings speaks this so the whole chain — tone, engine, voice, script — can be checked without
+/// waiting for weather, and the tests read the same fixture so the button and the assertions can
+/// never drift apart.
+pub fn demo_alert() -> AlertInfo {
+    AlertInfo {
+        id: "urn:hookecho:demo".into(),
+        event: "Tornado Warning".into(),
+        headline: String::new(),
+        area: "Cleveland, OK; McClain, OK".into(),
+        description: "At 7 02 PM, a confirmed tornado was located near Norman.\n\n\
+                      Locations impacted include...\n\
+                      Norman, Moore, and Noble."
+            .into(),
+        instruction: "TAKE COVER NOW! Move to a basement or an interior room on the lowest floor \
+                      of a sturdy building.\n\nAvoid windows."
+            .into(),
+        expires: None,
+        max_hail_in: Some(1.75),
+        max_wind: None,
+        tornado_detection: Some("OBSERVED".into()),
+        damage_threat: Some("CATASTROPHIC".into()),
+        source: None,
+        motion: Some(crate::overlay::StormMotion {
+            deg: 225.0,
+            kt: 40.0,
+            points: vec![],
+        }),
+        vtec: None,
+    }
+}
+
+/// The sentence spoken when a warning arrives.
+///
+/// Order is what a listener can act on, soonest first: what it is, where it is relative to them,
+/// which counties it covers, the towns in its path, how it is moving, and what to do about it.
+/// The tone that precedes this says a warning exists; every word here says something the tone
+/// could not.
+///
+/// `relation` is how the warning sits against a watched place ("covering Home", "12 miles
+/// northeast of Home"), or empty when it hit none. It used to be a banner fragment, which is why
+/// the voice once said "Tornado warning for covers Home".
+pub fn warning_script(a: &AlertInfo, relation: &str, until: &str) -> String {
     let mut s = String::new();
-    // Lead with the escalated wording when there is any — "Tornado emergency" first, not fourth.
+    // Lead with the escalated wording when there is any -- "Tornado emergency" first, not fourth.
     let lead = a
         .damage_threat
         .as_deref()
@@ -133,9 +476,24 @@ pub fn warning_script(a: &AlertInfo, place: &str, until: &str) -> String {
         .map(|t| format!("{} {}", expand(t).to_lowercase(), a.event.to_lowercase()))
         .unwrap_or_else(|| a.event.to_lowercase());
     s.push_str(&capitalize(&lead));
-    if !place.is_empty() {
+    if !relation.is_empty() {
+        s.push(' ');
+        s.push_str(&expand(relation));
+    }
+    let area = spoken_area(&a.area);
+    if !area.is_empty() {
+        // The comma only earns its place once something already follows the hazard.
+        if !relation.is_empty() {
+            s.push(',');
+        }
         s.push_str(" for ");
-        s.push_str(&expand(place));
+        s.push_str(&area);
+    }
+    let cities = cities(&a.description);
+    if !cities.is_empty() {
+        let refs: Vec<&str> = cities.iter().map(String::as_str).collect();
+        s.push_str(", including ");
+        s.push_str(&join_and(&refs));
     }
     if let Some(m) = &a.motion {
         // `deg` is the FROM bearing as issued; the heading it travels toward is the other way,
@@ -157,6 +515,11 @@ pub fn warning_script(a: &AlertInfo, place: &str, until: &str) -> String {
         s.push_str(until);
     }
     s.push('.');
+    let cta = call_to_action(&a.instruction);
+    if !cta.is_empty() {
+        s.push(' ');
+        s.push_str(&expand(&cta));
+    }
     s
 }
 
@@ -172,14 +535,9 @@ pub fn position_script(
     moving_toward_deg: Option<f32>,
     metric: bool,
 ) -> String {
-    // Spelled out, not abbreviated: a synthesizer reading "km" says "kay em".
-    let (n, unit) = if metric {
-        (km.round() as i32, "kilometers")
-    } else {
-        ((km * 0.621_371).round() as i32, "miles")
-    };
     let mut s = format!(
-        "{name} is {n} {unit} to your {}",
+        "{name} is {} to your {}",
+        spoken_distance(km, metric),
         spoken_compass(bearing_deg)
     );
     if let Some(d) = moving_toward_deg {
@@ -200,39 +558,17 @@ fn capitalize(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::overlay::StormMotion;
-
-    fn tor() -> AlertInfo {
-        AlertInfo {
-            id: "urn:x".into(),
-            event: "Tornado Warning".into(),
-            headline: String::new(),
-            area: "Cleveland County".into(),
-            description: String::new(),
-            instruction: String::new(),
-            expires: None,
-            max_hail_in: None,
-            max_wind: None,
-            tornado_detection: Some("OBSERVED".into()),
-            damage_threat: Some("CATASTROPHIC".into()),
-            source: None,
-            motion: Some(StormMotion {
-                deg: 225.0, // from the southwest, so travelling northeast
-                kt: 40.0,
-                points: vec![],
-            }),
-            vtec: None,
-        }
-    }
 
     #[test]
     fn the_hazard_place_and_heading_come_first() {
-        let s = warning_script(&tor(), "Home", "7 15 PM");
-        assert!(
-            s.starts_with("Catastrophic tornado warning for Home, moving northeast at 46 miles"),
-            "{s}"
+        let s = warning_script(&demo_alert(), "covering Home", "7 15 PM");
+        assert_eq!(
+            s,
+            "Catastrophic tornado warning covering Home, for Cleveland County and McClain County, \
+             Oklahoma, including Norman, Moore and Noble, moving northeast at 46 miles per hour, \
+             hail to 1.75 inch, until 7 15 PM. Take cover now! Move to a basement or an interior \
+             room on the lowest floor of a sturdy building."
         );
-        assert!(s.ends_with("until 7 15 PM."), "{s}");
     }
 
     #[test]
@@ -247,14 +583,98 @@ mod tests {
 
     #[test]
     fn a_plain_warning_still_reads_cleanly() {
-        let mut a = tor();
+        let mut a = demo_alert();
+        a.area = "Cleveland County".into();
         a.damage_threat = None;
         a.motion = None;
-        a.max_hail_in = Some(1.75);
+        a.description = String::new();
+        a.instruction = String::new();
         assert_eq!(
             warning_script(&a, "", ""),
-            "Tornado warning, hail to 1.75 inch."
+            "Tornado warning for Cleveland County, hail to 1.75 inch."
         );
+    }
+
+    #[test]
+    fn counties_gain_their_kind_and_the_state_is_said_once() {
+        assert_eq!(
+            spoken_area("Cleveland, OK; McClain, OK"),
+            "Cleveland County and McClain County, Oklahoma"
+        );
+        // Louisiana has parishes, and a name that already says what it is keeps its own word.
+        assert_eq!(spoken_area("Orleans, LA"), "Orleans Parish, Louisiana");
+        assert_eq!(
+            spoken_area("St. Louis City, MO"),
+            "St. Louis City, Missouri"
+        );
+        // Two states: each run names its own, rather than one trailing state for both.
+        assert_eq!(
+            spoken_area("Cowley, KS; Kay, OK"),
+            "Cowley County, Kansas; Kay County, Oklahoma"
+        );
+        // Canada has no counties to invent.
+        assert_eq!(
+            spoken_area("Ottawa North - Kanata - Orléans, ON"),
+            "Ottawa North - Kanata - Orléans, Ontario"
+        );
+        // Not a `Name, XX` list at all: read it as written rather than guess.
+        assert_eq!(spoken_area("Bayern"), "Bayern");
+        assert_eq!(
+            spoken_area("Coastal waters from Fenwick Island DE to Chincoteague VA"),
+            "Coastal waters from Fenwick Island DE to Chincoteague VA"
+        );
+    }
+
+    #[test]
+    fn a_long_county_list_stops_being_a_list() {
+        assert_eq!(
+            spoken_area("A, OK; B, OK; C, OK; D, OK; E, OK; F, OK"),
+            "A County, B County, C County and D County, Oklahoma and 2 more"
+        );
+    }
+
+    #[test]
+    fn the_towns_are_read_off_the_wrapped_block() {
+        // Verbatim shape of a real product: the list is wrapped at the office's column and ends
+        // at the blank line, and the serial "and" arrives with a comma in front of it.
+        let d = "IMPACT...Expect damage to trees and power lines.\n\n\
+                 Locations impacted include...\n\
+                 Canton, Salem, Columbiana, Boardman, Alliance, Louisville, Sebring,\n\
+                 Minerva, Waynesburg, and Maximo.\n\n\
+                 HAIL...1.00 IN";
+        assert_eq!(
+            cities(d),
+            ["Canton", "Salem", "Columbiana", "Boardman", "Alliance"]
+        );
+        assert!(cities("No such block here.").is_empty());
+    }
+
+    #[test]
+    fn the_call_to_action_is_two_sentences_and_never_shouted() {
+        let i = "TAKE COVER NOW! Move to a basement or an interior room on the lowest floor of a \
+                 sturdy building.\n\nContinuous cloud to ground lightning is occurring.";
+        let s = call_to_action(i);
+        assert!(s.starts_with("Take cover now!"), "{s}");
+        // The second paragraph is background, not an instruction.
+        assert!(!s.contains("lightning"), "{s}");
+        assert!(s.len() <= 160, "{} chars: {s}", s.len());
+        assert_eq!(call_to_action(""), "");
+    }
+
+    #[test]
+    fn a_relation_says_which_side_of_you_it_is_on() {
+        assert_eq!(relation("Home", 0.0, Some(45.0), false), "covering Home");
+        assert_eq!(
+            relation("Home", 19.3, Some(45.0), false),
+            "12 miles northeast of Home"
+        );
+        assert_eq!(
+            relation("Home", 19.3, None, true),
+            "19 kilometers from Home"
+        );
+        // One is one, not "1 miles".
+        assert_eq!(relation("Home", 1.61, None, false), "1 mile from Home");
+        assert_eq!(relation("", 5.0, None, false), "");
     }
 
     #[test]

--- a/scripts/web/build.sh
+++ b/scripts/web/build.sh
@@ -116,7 +116,7 @@ gz_bytes="$(gzip -9 -c "web/dist/hookecho_bg-$wasm_hash.wasm" | wc -c)"
 #
 # Raised deliberately for the offline chase packs (IndexedDB via web-sys) — the one budget raise
 # the R18 batch reserved for itself.
-budget="${HOOKECHO_WASM_BUDGET:-4060000}"
+budget="${HOOKECHO_WASM_BUDGET:-4066000}"
 printf 'wasm: %s raw, %s gzipped (budget %s)\n' \
   "$(stat -c%s "web/dist/hookecho_bg-$wasm_hash.wasm")" "$gz_bytes" "$budget"
 if [ "$gz_bytes" -gt "$budget" ]; then


### PR DESCRIPTION
## What

Spoken warnings become the default and start carrying the information a tone cannot: which counties (state spoken in full), the towns in the path, how far and which way the warning lies from a place you saved, and the office's call to action. The tone now plays *before* the words instead of on top of them, and one announcement finishes before the next begins.

## Why

The feature already existed but said the wrong thing on the path that matters most. When a warning covered a saved marker, `detect_new_warnings` passed the *banner fragment* into the speech script, so the voice said:

> "Tornado warning for covers Home."

The counties were sitting in `AlertInfo.area` and the towns in `AlertInfo.description` at that exact moment, and both were discarded. With no marker at all it read the raw `areaDesc`, so "Cleveland, OK" came out as a name followed by "okay".

Meanwhile the tone and the voice each opened their own output stream on their own detached thread. The EAS tone therefore played over the opening words of the warning it was announcing, and a squall line that warned four counties in a single fetch pass produced four voices talking simultaneously. None of it was intelligible, which is the opposite of what an alert is for.

After:

> "Catastrophic tornado warning 12 miles northeast of Home, for Cleveland County and McClain County, Oklahoma, including Norman, Moore and Noble, moving northeast at 46 miles per hour, hail to 1.75 inch, until 7 15 PM. Take cover now! Move to a basement or an interior room on the lowest floor of a sturdy building."

## How

**`wxdata::spoken`** gains four pure helpers, all tested:

- `spoken_area` — `"Cleveland, OK; McClain, OK"` → `"Cleveland County and McClain County, Oklahoma"`. The state is said once per run of counties sharing it. Louisiana gets parishes; Alaska, DC and the Canadian provinces get nothing appended; a name already ending in County/Parish/City keeps its own word. Anything that is not a `Name, XX` list — MeteoAlarm's `"Bayern"`, a marine zone's prose — is read as written. Inventing "County" for a German region is worse than reading it plainly.
- `cities` — reads the `Locations impacted include...` block. Matched on the three dots rather than the wording, because a flash flood warning phrases it differently (`Some locations that will experience flash flooding include...`). The list is unwrapped before splitting, since the issuing office's software wraps it at whatever column it likes, and the serial "and" arrives with or without a comma in front of it.
- `call_to_action` — first paragraph of the instruction, two sentences and 160 characters at most. Anything after the first paragraph is background ("Continuous cloud to ground lightning is occurring…"), not an instruction. A shouted sentence is lowered first: every synthesizer spells `TAKE COVER NOW!` out letter by letter.
- `relation` — replaces the banner fragment. Units spelled out, because `fmt_distance`'s "12 mi" is read as "twelve em eye". `spoken_distance` is now shared with `position_script`, which had the same four lines.

**Audio sequencing.** `speech::announce(tone, lines)` owns one thread and one process-wide lock for the whole sequence: tone to completion, then each line in order. `speak` becomes `announce(None, vec![text])`, so the chase position update joins the same queue for free rather than cutting into a tornado warning. `audio::play` splits into `play_blocking` plus its spawning wrapper; `play_wav` becomes `play_wav_blocking` and now takes a volume, since Piper's output was the one sound in the app ignoring the slider and arrived louder than the tone introducing it.

Serializing behind a lock made an existing bug matter: `Sink::sleep_until_end` is a channel receive with no timeout that never returns if the device disappears mid-stream. Unplug a USB headset and that thread was gone for the life of the process — survivable when each playback owned a throwaway thread, fatal once one thread gates every later warning. Both players now drain with a deadline and log if they hit it.

The web build has no threads to lock, so it waits the tone out by the clock (`audio::duration_ms`) and lets the browser queue the utterances. Noted as a `ponytail:` ceiling: a second announcement's tone can still overlap the first's tail there.

**`detect_new_warnings`** collects scripts through the pass and announces once at the end. The polygon centroid is hoisted out of the rule loop because the bearing needs it too — same arithmetic, computed once instead of once per matching rule.

**Settings** flips `speak_warnings` to on and adds a "Speak a test warning" button that runs the entire chain on the same `demo_alert` fixture the tests assert against, so the button and the assertions cannot drift. There is also a warning label when a voice is configured and Piper cannot run it, which has to name the distribution: on Arch `extra/piper` is a GTK **mouse-configuration tool** that installs `/usr/bin/piper`, so "install piper" hands you a program for setting the DPI on a gaming mouse. The probe runs `--help` once per binary path on a background thread and looks for `--model` to tell them apart; a real synthesis run overwrites the verdict with what actually happened.

## Two behaviour changes worth calling out

- **The voice now honours quiet hours** for non-urgent warnings. It never did — only the tone did — so a 3 a.m. warning too minor to chime for still read itself out in the dark. Escalated warnings still go past quiet hours, exactly as the tone always has.
- **`speak_warnings` defaults to on.** Existing installs are unaffected: every field is written on save, so a settings file storing `false` keeps it. `default_true` only covers files written before the field existed.

## Measured wasm

Measured in CI, not locally. Local and CI do not gzip to the same number even with `wasm-opt` installed — the first attempt at this PR failed the budget because I trusted a local reading that was ~5.8 KB optimistic.

| | gzipped |
|---|---|
| `main` (CI) | 4,054,422 |
| this branch (CI) | 4,061,576 |
| delta | +7,154 |
| budget | 4,060,000 → **4,066,000** |

The growth is the 69-row region table, the four string helpers and the demo fixture. The budget is raised by the measured growth plus the headroom it already had, not to a round number. **No new dependencies.**

## Verification actually run

- `cargo test -p wxdata spoken` — 9 pass, including the two updated script assertions and one test per new helper. The `cities` test uses the verbatim wrapped block from a live NWS product fetched today (Canton/Salem/Columbiana, Oxford comma included).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test --workspace` — clean (360 + 339 + the rest, 0 failures).
- `RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check --target wasm32-unknown-unknown -p hookecho --lib` — clean.
- `./scripts/shots/shoot.sh check` — passed.
- `./scripts/web/build.sh` — under budget, numbers above.
- End to end on this box: rendered the demo script and fed it to `espeak-ng`, which synthesized 21 seconds of audio from it. The exact string is the one quoted at the top of this PR.

## Not verified, and what is left

- **Piper itself is not installed here**, so the neural path is unexercised on this box. `yay -S piper-tts-bin` then Settings ▸ Alerts ▸ pick a voice ▸ Download ▸ "Use this voice" ▸ "Speak a test warning" is the check. The espeak fallback is what ran above.
- The `piper-tts` 1.5 AUR package is the Python rewrite; whether it still streams WAV to stdout under `--output_file -` is unconfirmed. `piper-tts-bin` is the C++ build this code targets.
- Android's background `AlertService` (Kotlin) still never speaks — only the in-app path does. Separate feature.
- Towns are read in the order NWS lists them, not nearest-first: sorting them would need town coordinates there is no table for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

