### PR TITLE
fix(spoken): five glitches found reviewing #298

### DIFF
--- a/crates/hookecho/src/speech.rs
+++ b/crates/hookecho/src/speech.rs
@@ -258,10 +258,16 @@ static PROBE: std::sync::Mutex<Option<(String, Option<String>)>> = std::sync::Mu
 /// Named for Arch on purpose: `extra/piper` is a GTK mouse-configuration tool that installs
 /// `/usr/bin/piper`, so "install piper" is advice that leads to a program for setting DPI on a
 /// gaming mouse. The text-to-speech one is in the AUR.
-#[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
+#[cfg(target_os = "linux")]
 pub const NOT_FOUND: &str = "Piper is not installed — on Arch: `yay -S piper-tts-bin` \
                             (not `extra/piper`, which is a mouse tool). Or point the field above \
                             at the binary.";
+
+/// The same nudge where there is no package manager to name.
+#[cfg(not(any(target_os = "linux", target_os = "android", target_arch = "wasm32")))]
+pub const NOT_FOUND: &str = "Piper is not installed — download piper-tts from \
+                            github.com/rhasspy/piper/releases and point the field above at the \
+                            binary.";
 
 #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
 fn set_piper_problem(problem: Option<String>) {
@@ -403,7 +409,13 @@ mod imp {
             .read()
             .map(|g| g.clone())
             .map_err(|_| "piper config poisoned")?;
-        if voice.is_empty() || !std::path::Path::new(&voice).exists() {
+        if voice.is_empty() {
+            return Ok(false);
+        }
+        if !std::path::Path::new(&voice).exists() {
+            // Configured and gone: a cleaned cache, a moved data directory. Without this the
+            // fallback voice takes over and nothing says why the good one stopped.
+            super::set_piper_problem(Some(format!("voice model not found: {voice}")));
             return Ok(false);
         }
         let bin = if bin.is_empty() {

--- a/crates/wxdata/src/spoken.rs
+++ b/crates/wxdata/src/spoken.rs
@@ -197,9 +197,11 @@ const REGIONS: &[(&str, &str)] = &[
 ];
 
 /// Codes whose divisions are not counties. Louisiana has parishes; Alaska has boroughs and census
-/// areas, which `areaDesc` already spells out; DC and the Canadian provinces have neither.
+/// areas, which `areaDesc` already spells out; DC, the territories (Puerto Rico has municipios,
+/// the islands have districts) and the Canadian provinces have neither.
 const NOT_COUNTY: &[&str] = &[
-    "AK", "DC", "AB", "BC", "MB", "NB", "NL", "NS", "NT", "NU", "ON", "PE", "QC", "SK", "YT",
+    "AK", "DC", "PR", "VI", "GU", "AS", "MP", "AB", "BC", "MB", "NB", "NL", "NS", "NT", "NU", "ON",
+    "PE", "QC", "SK", "YT",
 ];
 
 /// At most this many county names before the rest become "and N more". Past four the listener has
@@ -305,20 +307,24 @@ fn join_and(items: &[&str]) -> String {
 /// column the office's software chose, so it is unwrapped before splitting, and it ends at the
 /// blank line.
 pub fn cities(description: &str) -> Vec<String> {
+    const KEY: &str = "include...";
     let mut lines = description.lines();
-    // `include...` may be followed by trailing spaces; nothing else follows it on the line.
-    if !lines.any(|l| l.trim_end().to_ascii_lowercase().ends_with("include...")) {
+    // Whatever follows the key on its own line is the start of the list. Usually nothing — the
+    // list begins on the next line — but an office that puts the first town on the same line
+    // used to get no towns read at all.
+    let Some(first) = lines.find_map(|l| {
+        let at = l.to_ascii_lowercase().find(KEY)?;
+        Some(l[at + KEY.len()..].trim())
+    }) else {
         return Vec::new();
-    }
-    let block: Vec<&str> = lines
-        .take_while(|l| !l.trim().is_empty())
-        .map(|l| l.trim())
-        .collect();
-    if block.is_empty() {
-        return Vec::new();
-    }
+    };
+    let mut block: Vec<&str> = vec![first];
+    block.extend(lines.take_while(|l| !l.trim().is_empty()).map(|l| l.trim()));
     let joined = block.join(" ");
     let joined = joined.trim().trim_end_matches('.');
+    if joined.is_empty() {
+        return Vec::new();
+    }
     joined
         .split(',')
         // A serial "and" arrives with or without the comma before it, so both are split here.
@@ -477,8 +483,10 @@ pub fn warning_script(a: &AlertInfo, relation: &str, until: &str) -> String {
         .unwrap_or_else(|| a.event.to_lowercase());
     s.push_str(&capitalize(&lead));
     if !relation.is_empty() {
+        // Not expanded: every word here is ours except the marker's name, and a marker called
+        // "NW Farm" or "HQ" is a name, not shorthand. `expand` turned "IN" into "inch".
         s.push(' ');
-        s.push_str(&expand(relation));
+        s.push_str(relation);
     }
     let area = spoken_area(&a.area);
     if !area.is_empty() {
@@ -582,6 +590,18 @@ mod tests {
     }
 
     #[test]
+    fn a_marker_name_is_a_name_not_shorthand() {
+        let mut a = demo_alert();
+        a.description = String::new();
+        a.instruction = String::new();
+        a.motion = None;
+        a.max_hail_in = None;
+        a.damage_threat = None;
+        let s = warning_script(&a, "covering NW Farm", "");
+        assert!(s.starts_with("Tornado warning covering NW Farm, for "), "{s}");
+    }
+
+    #[test]
     fn a_plain_warning_still_reads_cleanly() {
         let mut a = demo_alert();
         a.area = "Cleveland County".into();
@@ -617,6 +637,8 @@ mod tests {
             spoken_area("Ottawa North - Kanata - Orléans, ON"),
             "Ottawa North - Kanata - Orléans, Ontario"
         );
+        // Puerto Rico has municipios. "San Juan County" is a place in Utah.
+        assert_eq!(spoken_area("San Juan, PR"), "San Juan, Puerto Rico");
         // Not a `Name, XX` list at all: read it as written rather than guess.
         assert_eq!(spoken_area("Bayern"), "Bayern");
         assert_eq!(
@@ -647,6 +669,12 @@ mod tests {
             ["Canton", "Salem", "Columbiana", "Boardman", "Alliance"]
         );
         assert!(cities("No such block here.").is_empty());
+        // The first town on the same line as the key, which used to read as no towns at all.
+        assert_eq!(
+            cities("Locations impacted include... Norman, Moore\nand Noble.\n\nHAIL...1 IN"),
+            ["Norman", "Moore", "Noble"]
+        );
+        assert!(cities("Locations impacted include...\n\nNothing listed.").is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## What

Five bugs found by reading #298 back after it merged. All in code that PR added; none reachable by the tests it shipped with.

## The bugs

1. **Marker names were being "expanded" as NWS shorthand.** `warning_script` ran `expand()` over the relation clause. That clause is entirely our own words plus the marker's name, so a marker called "NW Farm" was read as "northwest Farm" and one called "IN" as "inch". The clause is no longer expanded. The area and the call to action still are — those come from the office and carry real shorthand like `MPH` and `TSTM`.

2. **An inline town list read as no towns.** `cities` matched only a line *ending* in `include...`. An office that puts the first town on the same line as the key got nothing. The key is now found anywhere on the line and whatever follows it begins the list.

3. **Territories gained counties.** Puerto Rico, the Virgin Islands, Guam, American Samoa and the Northern Marianas were getting "County" appended. Puerto Rico has municipios and the islands have districts. "San Juan County" is a place in Utah.

4. **A vanished voice file failed silently.** A configured `.onnx` that was gone — cleaned cache, moved data directory — fell back to espeak with no explanation. The missing path is now the problem Settings shows.

5. **Windows and macOS users were told to run `yay`.** The Arch-specific hint stays on Linux, where the `extra/piper` mouse-tool collision lives. Everything else points at the piper releases page.

## Verification actually run

- `cargo test -p wxdata spoken` — 10 pass (one new test for the marker-name case, two new assertions for the inline list and the empty block, one for Puerto Rico).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test --workspace` — 722 pass, 0 fail.
- `RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check --target wasm32-unknown-unknown -p hookecho --lib` — clean.
- `./scripts/shots/shoot.sh check` — passed.
- `./scripts/web/build.sh` — local 4,056,715 gz against the 4,066,000 budget. CI's number runs ~5.8 KB higher than local and is the one that counts; the changes here are a handful of string literals, well inside the margin.

No new dependencies. No budget change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
