### PR TITLE
fix: preserve Windows settings and bound background work

### DIFF
--- a/crates/hookecho/Cargo.toml
+++ b/crates/hookecho/Cargo.toml
@@ -143,7 +143,7 @@ wgpu = { version = "29", default-features = false, features = ["vulkan", "gles"]
 [target.'cfg(target_os = "windows")'.dependencies]
 wgpu = { version = "29", default-features = false, features = ["dx12", "vulkan"] }
 # Already in the graph via winit; named here for `AttachConsole` and the `CREATE_NO_WINDOW` flag.
-windows-sys = { version = "0.61", features = ["Win32_System_Console"] }
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem", "Win32_System_Console"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 wgpu = { version = "29", default-features = false, features = ["metal"] }

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -5877,8 +5877,9 @@ impl HookEchoApp {
         // failures are logged rather than surfaced — a dead relay must not break chase mode.
         let tx = share.sender();
         let id = share.id.clone();
+        let client = self.http.clone();
         self.spawner.spawn(async move {
-            let client = reqwest::Client::new();
+            let timeout = std::time::Duration::from_secs(Self::SHARE_SECS - 2);
             let body = match serde_json::to_string(&me) {
                 Ok(b) => b,
                 Err(e) => {
@@ -5890,24 +5891,36 @@ impl HookEchoApp {
                 .post(&relay)
                 .header("content-type", "application/json")
                 .body(body)
+                .timeout(timeout)
                 .send()
                 .await
+                .and_then(reqwest::Response::error_for_status)
             {
                 log::warn!("share relay post failed: {e}");
                 return;
             }
-            match client.get(&relay).send().await {
-                Ok(r) => match r.text().await.map_err(|e| e.to_string()).and_then(|t| {
-                    serde_json::from_str::<Vec<crate::share::Peer>>(&t).map_err(|e| e.to_string())
-                }) {
-                    Ok(list) => {
-                        for p in list.into_iter().filter(|p| p.id != id) {
-                            let _ = tx.send(p);
-                        }
+            let response = match client
+                .get(&relay)
+                .timeout(timeout)
+                .send()
+                .await
+                .and_then(reqwest::Response::error_for_status)
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    log::warn!("share relay get failed: {e}");
+                    return;
+                }
+            };
+            match response.text().await.map_err(|e| e.to_string()).and_then(|t| {
+                serde_json::from_str::<Vec<crate::share::Peer>>(&t).map_err(|e| e.to_string())
+            }) {
+                Ok(list) => {
+                    for p in list.into_iter().filter(|p| p.id != id) {
+                        let _ = tx.send(p);
                     }
-                    Err(e) => log::warn!("share relay list unreadable: {e}"),
-                },
-                Err(e) => log::warn!("share relay get failed: {e}"),
+                }
+                Err(e) => log::warn!("share relay list unreadable: {e}"),
             }
         });
     }
@@ -6721,7 +6734,7 @@ impl HookEchoApp {
         // Dark and Light pack the same vector tiles (the `.pbf` cache is palette-agnostic), so
         // resolving `Auto` either way gives the same pack.
         let style = self.views[self.active].basemap.resolve(true);
-        let packable = if style.is_raster() {
+        let packable = !cfg!(target_arch = "wasm32") && if style.is_raster() {
             self.tiles.packable(style)
         } else if matches!(style, BasemapStyle::Dark | BasemapStyle::Light) {
             self.vtiles.packable()
@@ -6784,6 +6797,7 @@ impl HookEchoApp {
     }
 
     /// Kick off an offline chase-pack download of the current view's basemap tiles (4 workers).
+    #[cfg(not(target_arch = "wasm32"))]
     fn start_chasepack(&mut self) {
         use crate::tiles::BasemapStyle;
         if self.chasepack.is_some() {
@@ -6838,7 +6852,6 @@ impl HookEchoApp {
         let total = jobs.len() as u64;
         let (tx, rx) = std::sync::mpsc::channel();
         let cancel = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-        #[cfg(not(target_arch = "wasm32"))]
         crate::tiles::start_pack_download(self._rt.handle(), jobs, cancel.clone(), tx);
         self.chasepack = Some(ChasePack {
             rx,
@@ -6864,6 +6877,7 @@ impl HookEchoApp {
         if actions.instant_replay {
             self.instant_replay();
         }
+        #[cfg(not(target_arch = "wasm32"))]
         if actions.download_chasepack {
             self.start_chasepack();
         }
@@ -7008,7 +7022,11 @@ impl HookEchoApp {
             // Offline chase pack: pre-cache this view's basemap tiles so it renders with no signal.
             ui.separator();
             if !chasepack.packable {
-                ui.weak("Offline pack: pick a raster or vector basemap");
+                if cfg!(target_arch = "wasm32") {
+                    ui.weak("Offline packs are available in the desktop and Android apps");
+                } else {
+                    ui.weak("Offline pack: pick a raster or vector basemap");
+                }
             } else {
                 ui.weak(format!(
                     "Offline pack: {} tiles ≈ {:.0} MB (z{}–{}, current view)",

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -1406,12 +1406,59 @@ pub fn atomic_write(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()>
     let mut f = std::fs::File::create(&tmp)?;
     f.write_all(bytes)?;
     f.sync_all()?;
-    std::fs::rename(&tmp, path)
+    replace_file(&tmp, path)
+}
+
+#[cfg(not(target_os = "windows"))]
+fn replace_file(from: &std::path::Path, to: &std::path::Path) -> std::io::Result<()> {
+    std::fs::rename(from, to)
+}
+
+#[cfg(target_os = "windows")]
+fn replace_file(from: &std::path::Path, to: &std::path::Path) -> std::io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+
+    let from: Vec<u16> = from.as_os_str().encode_wide().chain(Some(0)).collect();
+    let to: Vec<u16> = to.as_os_str().encode_wide().chain(Some(0)).collect();
+    // `std::fs::rename` does not replace an existing file on Windows. Settings are rewritten
+    // throughout a session, so the first save worked and every later one quietly failed.
+    let ok = unsafe {
+        MoveFileExW(
+            from.as_ptr(),
+            to.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if ok == 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn atomic_write_replaces_an_existing_file() {
+        let dir = std::env::temp_dir().join(format!(
+            "hookecho-atomic-write-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("settings.json");
+
+        atomic_write(&path, b"first").unwrap();
+        atomic_write(&path, b"second").unwrap();
+
+        assert_eq!(std::fs::read(&path).unwrap(), b"second");
+        std::fs::remove_dir_all(dir).unwrap();
+    }
 
     #[test]
     fn rules_are_absent_from_old_settings_and_start_disabled() {


### PR DESCRIPTION
## What

- Replace settings and token files atomically on Windows with `MoveFileExW(..., REPLACE_EXISTING | WRITE_THROUGH)`, using the already-present `windows-sys` dependency.
- Give chase-sharing relay POST/GET requests an 8-second abort deadline, reuse the app HTTP client, and reject non-success statuses.
- Stop presenting the desktop-only offline-pack downloader as functional on wasm; the web UI now explains where packs are available instead of starting a permanent 0% job.

## Why

`std::fs::rename` does not replace an existing destination on Windows. The first settings save could succeed, then every later save quietly failed. A dead sharing relay could also accumulate a new pair of stuck tasks every ten seconds. Finally, the wasm build compiled the offline-pack UI but no downloader, so its button created progress that could never complete.

## Wasm size

Measured with `scripts/web/build.sh` on the same checkout/toolchain:

- before: 4,056,715 bytes gzipped
- after: 4,053,832 bytes gzipped
- change: -2,883 bytes
- budget: 4,066,000 bytes (unchanged)

## Verification actually run

- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (723 passed, 0 failed)
- `RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check --target wasm32-unknown-unknown -p hookecho --lib`
- `./scripts/shots/shoot.sh check`
- `PATH="$HOME/.cargo/bin:$PATH" ./scripts/web/build.sh`
- Added `atomic_write_replaces_an_existing_file`; GitHub's native Windows run exercises the platform replacement path.
- Local Windows cross-check was attempted, but this Linux host lacks `x86_64-w64-mingw32-gcc`; it stopped in `aws-lc-sys` before compiling HookEcho. The `MoveFileExW` signature and flags were checked against the installed `windows-sys 0.61.2` bindings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)