### PR TITLE
feat(speech): let emergencies jump the queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Install wasm-bindgen-cli
-        run: cargo install wasm-bindgen-cli --locked
+        run: |
+          version="$(sed -n '/^name = "wasm-bindgen"$/,/^$/s/^version = "\(.*\)"/\1/p' Cargo.lock)"
+          cargo install wasm-bindgen-cli --version "$version" --locked
 
       # Without this, build.sh skips wasm-opt with a warning and the size gate measures a bundle
       # nobody ships.

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -33,7 +33,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Install wasm-bindgen-cli
-        run: cargo install wasm-bindgen-cli --locked
+        run: |
+          version="$(sed -n '/^name = "wasm-bindgen"$/,/^$/s/^version = "\(.*\)"/\1/p' Cargo.lock)"
+          cargo install wasm-bindgen-cli --version "$version" --locked
 
       # build.sh runs wasm-opt when it is on PATH and warns when it is not; the deployed bundle
       # should always be the optimized one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ The rolling `latest` release tracks `main` and is not listed here.
   Every cue used to open its own audio stream on its own thread, so the alert
   tone played over the opening words and a squall line warning four counties
   in one refresh produced four voices at once.
+- An emergency now runs immediately after the sentence already being spoken,
+  discarding queued ordinary warnings and chase updates. Warnings delivered
+  together are spoken from highest to lowest escalation.
 - Spoken warnings honour quiet hours the way the tone always has. Escalated
   warnings still go past it. The voice previously ignored quiet hours
   entirely.

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -4451,9 +4451,9 @@ impl HookEchoApp {
         let mut max_esc = 0u8; // highest escalation among newly-seen warnings this pass
         // Collected, not spoken here: the tone has to play first, and it plays once for the whole
         // pass rather than once per warning.
-        let mut to_speak: Vec<String> = Vec::new();
-                               // Only banner warnings within the selected radar's coverage — a warning covering a saved
-                               // location still banners + pushes regardless (that's a watched place, not the viewed site).
+        let mut to_speak: Vec<(u8, String)> = Vec::new();
+        // Only banner warnings within the selected radar's coverage — a warning covering a saved
+        // location still banners + pushes regardless (that's a watched place, not the viewed site).
         let site_box = self.active_site_bounds(250.0);
         for f in feats {
             if f.kind != overlay::FeatureKind::Warning {
@@ -4636,7 +4636,7 @@ impl HookEchoApp {
                         .unwrap_or_default();
                     // Hazard, then where it sits against a place you know, then the counties, the
                     // towns in its path and what to do — see `wxdata::spoken`.
-                    to_speak.push(wxdata::spoken::warning_script(a, &relation, &until));
+                    to_speak.push((esc, wxdata::spoken::warning_script(a, &relation, &until)));
                 }
                 if notify_ok && self.settings.ntfy_snapshot {
                     // Newest wins: one picture per pass, of whatever last warned.
@@ -4673,8 +4673,17 @@ impl HookEchoApp {
                 // The voice tracks the same slider the tones do; Piper's output has no level of
                 // its own, so without this the words arrived louder than the tone.
                 crate::speech::set_volume(self.settings.alert_volume);
-                // One announcement for the whole pass: tone, then every new warning in turn.
-                crate::speech::announce(tone, to_speak);
+                // One announcement for the whole pass: highest escalation first, then the rest.
+                to_speak.sort_by_key(|(esc, _)| std::cmp::Reverse(*esc));
+                crate::speech::announce(
+                    if urgent {
+                        crate::speech::Priority::Emergency
+                    } else {
+                        crate::speech::Priority::Warning
+                    },
+                    tone,
+                    to_speak.into_iter().map(|(_, line)| line).collect(),
+                );
             }
         }
     }

--- a/crates/hookecho/src/platform.rs
+++ b/crates/hookecho/src/platform.rs
@@ -1312,7 +1312,19 @@ mod android_tts {
         let deadline = wxdata::clock::Instant::now() + Duration::from_secs(6);
         loop {
             match try_speak(text) {
-                Ok(true) => return Ok(()),
+                Ok(true) => {
+                    // `speak` only queues. The cross-platform speech worker needs this call to
+                    // finish at the utterance boundary so an emergency can run next.
+                    std::thread::sleep(Duration::from_millis(20));
+                    let speech_deadline = wxdata::clock::Instant::now() + Duration::from_secs(120);
+                    while is_speaking().map_err(|e| format!("{e:?}"))? {
+                        if wxdata::clock::Instant::now() >= speech_deadline {
+                            return Err("TTS utterance did not finish".into());
+                        }
+                        std::thread::sleep(Duration::from_millis(50));
+                    }
+                    return Ok(());
+                }
                 Ok(false) => {
                     if wxdata::clock::Instant::now() >= deadline {
                         return Err("TTS engine never became ready".into());
@@ -1367,6 +1379,18 @@ mod android_tts {
                 Err(e)
             }
         }
+    }
+
+    fn is_speaking() -> jni::errors::Result<bool> {
+        let Some(app) = super::android::app() else {
+            return Ok(false);
+        };
+        let Some(tts) = TTS.get() else {
+            return Ok(false);
+        };
+        let vm = unsafe { jni::JavaVM::from_raw(app.vm_as_ptr() as *mut jni::sys::JavaVM) }?;
+        let mut env = vm.attach_current_thread()?;
+        env.call_method(tts.as_obj(), "isSpeaking", "()Z", &[])?.z()
     }
 }
 

--- a/crates/hookecho/src/speech.rs
+++ b/crates/hookecho/src/speech.rs
@@ -5,7 +5,7 @@
 //! one is configured, otherwise the platform's own synthesizer.
 //!
 //! Chasing is an eyes-on-the-road activity: a warning you have to read is a warning you read at
-//! the wrong moment. Every call is fire-and-forget on a background thread and every failure is
+//! the wrong moment. Every call is fire-and-forget on one background worker and every failure is
 //! logged and dropped — a machine with no speech engine is a normal machine, not a broken one.
 
 /// Piper binary and voice model, as configured. Empty binary means "look on PATH"; empty voice
@@ -157,41 +157,155 @@ pub fn take_voice_request() -> Option<String> {
     WANT_VOICE.lock().ok().and_then(|mut g| g.take())
 }
 
-/// Held for the length of one announcement, so the next one waits its turn.
-///
-/// Before this, every cue opened its own output stream on its own thread: the tone played over
-/// the first word, and a squall line that warned four counties in one fetch pass had four voices
-/// talking at once. None of it was audible and all of it was alarming.
-#[cfg(not(target_arch = "wasm32"))]
-static SPEAKING: std::sync::Mutex<()> = std::sync::Mutex::new(());
+/// Internal urgency of queued speech. Only an emergency may discard anything already waiting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Priority {
+    Background,
+    Warning,
+    Emergency,
+}
 
-/// The tone, then the words — one announcement at a time.
-///
-/// Returns immediately; everything happens on one detached thread that holds [`SPEAKING`] for the
-/// whole sequence. `tone` is `None` when the user has alert sounds off, and `lines` is empty when
-/// they have speech off, so a run with both is a no-op rather than a silent thread.
-#[cfg(not(target_arch = "wasm32"))]
-pub fn announce(tone: Option<(crate::settings::AlertSound, f32)>, lines: Vec<String>) {
-    if tone.is_none() && lines.is_empty() {
-        return;
+struct SpeechJob {
+    priority: Priority,
+    tone: Option<(crate::settings::AlertSound, f32)>,
+    lines: Vec<String>,
+}
+
+impl SpeechJob {
+    fn new(
+        priority: Priority,
+        tone: Option<(crate::settings::AlertSound, f32)>,
+        lines: Vec<String>,
+    ) -> Self {
+        Self {
+            priority,
+            tone,
+            lines: lines
+                .into_iter()
+                .flat_map(|line| split_sentences(&line))
+                .collect(),
+        }
     }
-    std::thread::spawn(move || {
-        // A panic elsewhere in the audio path must not silence every later warning, so a poisoned
-        // lock is taken anyway — there is no shared state behind it to corrupt.
-        let _guard = SPEAKING
+
+    fn is_empty(&self) -> bool {
+        self.tone.is_none() && self.lines.is_empty()
+    }
+}
+
+/// Break generated scripts at sentence endings so an emergency never waits behind a whole
+/// multi-sentence warning after the voice reaches a natural stopping point.
+fn split_sentences(text: &str) -> Vec<String> {
+    let bytes = text.as_bytes();
+    let mut out = Vec::new();
+    let mut start = 0;
+    for (i, b) in bytes.iter().enumerate() {
+        if matches!(b, b'.' | b'!' | b'?') && bytes.get(i + 1).is_none_or(u8::is_ascii_whitespace) {
+            let sentence = text[start..=i].trim();
+            if !sentence.is_empty() {
+                out.push(sentence.to_string());
+            }
+            start = i + 1;
+        }
+    }
+    let tail = text[start..].trim();
+    if !tail.is_empty() {
+        out.push(tail.to_string());
+    }
+    out
+}
+
+fn enqueue(queue: &mut std::collections::VecDeque<SpeechJob>, job: SpeechJob) {
+    if job.priority == Priority::Emergency {
+        queue.retain(|queued| queued.priority == Priority::Emergency);
+    }
+    queue.push_back(job);
+}
+
+fn emergency_waiting(queue: &std::collections::VecDeque<SpeechJob>) -> bool {
+    queue.iter().any(|job| job.priority == Priority::Emergency)
+}
+
+fn should_preempt(current: Priority, queue: &std::collections::VecDeque<SpeechJob>) -> bool {
+    current != Priority::Emergency && emergency_waiting(queue)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+struct SpeechQueue {
+    jobs: std::sync::Mutex<std::collections::VecDeque<SpeechJob>>,
+    ready: std::sync::Condvar,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn speech_queue() -> &'static std::sync::Arc<SpeechQueue> {
+    static QUEUE: std::sync::OnceLock<std::sync::Arc<SpeechQueue>> = std::sync::OnceLock::new();
+    QUEUE.get_or_init(|| {
+        let queue = std::sync::Arc::new(SpeechQueue {
+            jobs: std::sync::Mutex::new(std::collections::VecDeque::new()),
+            ready: std::sync::Condvar::new(),
+        });
+        let worker = std::sync::Arc::clone(&queue);
+        std::thread::spawn(move || speech_worker(&worker));
+        queue
+    })
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn speech_worker(queue: &SpeechQueue) {
+    loop {
+        let mut jobs = queue
+            .jobs
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        if let Some((sound, volume)) = tone {
+        while jobs.is_empty() {
+            jobs = queue
+                .ready
+                .wait(jobs)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+        let job = jobs.pop_front().expect("queue was not empty");
+        drop(jobs);
+
+        if let Some((sound, volume)) = job.tone {
             crate::audio::play_blocking(&sound, volume);
         }
-        for line in lines {
+        for line in job.lines {
+            let jobs = queue
+                .jobs
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let preempt = should_preempt(job.priority, &jobs);
+            drop(jobs);
+            if preempt {
+                break;
+            }
             if let Err(e) = imp::speak_blocking(&line) {
                 log::warn!("speech failed: {e}");
-                // One dead engine will be dead for the rest of them too.
                 break;
             }
         }
-    });
+    }
+}
+
+/// The tone, then the words — one announcement at a time.
+///
+/// Returns immediately; one process-wide worker owns the queue and all platform speech calls.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn announce(
+    priority: Priority,
+    tone: Option<(crate::settings::AlertSound, f32)>,
+    lines: Vec<String>,
+) {
+    let job = SpeechJob::new(priority, tone, lines);
+    if job.is_empty() {
+        return;
+    }
+    let queue = speech_queue();
+    let mut jobs = queue
+        .jobs
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    enqueue(&mut jobs, job);
+    queue.ready.notify_one();
 }
 
 /// Speak `text` aloud, if the platform can. Returns immediately.
@@ -199,34 +313,82 @@ pub fn announce(tone: Option<(crate::settings::AlertSound, f32)>, lines: Vec<Str
 /// Goes through [`announce`], so a chase position update waits for a warning to finish rather
 /// than interrupting it.
 pub fn speak(text: &str) {
-    announce(None, vec![text.to_string()]);
+    announce(Priority::Background, None, vec![text.to_string()]);
 }
 
-/// The tone, then the words. The browser queues utterances itself, so the only thing to arrange
-/// is that the first one does not start underneath the tone.
-///
-// ponytail: no lock on the web. A second announcement's tone can overlap the tail of the first,
-// which needs an outstanding-count to fix; the browser build is not the one anyone chases with.
 #[cfg(target_arch = "wasm32")]
-pub fn announce(tone: Option<(crate::settings::AlertSound, f32)>, lines: Vec<String>) {
-    if tone.is_none() && lines.is_empty() {
+#[derive(Default)]
+struct WebQueue {
+    jobs: std::collections::VecDeque<SpeechJob>,
+    running: bool,
+}
+
+#[cfg(target_arch = "wasm32")]
+std::thread_local! {
+    static WEB_QUEUE: std::cell::RefCell<WebQueue> = std::cell::RefCell::new(WebQueue::default());
+}
+
+/// The same single FIFO on the browser's one thread. Only one utterance is handed to
+/// `speechSynthesis` at a time, so its `speaking` state is the completion signal and the next
+/// sentence is a preemption boundary.
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn announce(
+    priority: Priority,
+    tone: Option<(crate::settings::AlertSound, f32)>,
+    lines: Vec<String>,
+) {
+    let job = SpeechJob::new(priority, tone, lines);
+    if job.is_empty() {
         return;
     }
-    let wait = tone
-        .map(|(sound, volume)| {
-            crate::audio::play(&sound, volume);
-            crate::audio::duration_ms(&sound)
-        })
-        .unwrap_or(0);
-    wasm_bindgen_futures::spawn_local(async move {
-        crate::fonts::sleep_ms(wait).await;
-        for line in lines {
+    let start = WEB_QUEUE.with(|queue| {
+        let mut queue = queue.borrow_mut();
+        enqueue(&mut queue.jobs, job);
+        if queue.running {
+            false
+        } else {
+            queue.running = true;
+            true
+        }
+    });
+    if start {
+        wasm_bindgen_futures::spawn_local(web_speech_worker());
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn web_speech_worker() {
+    loop {
+        let Some(job) = WEB_QUEUE.with(|queue| queue.borrow_mut().jobs.pop_front()) else {
+            WEB_QUEUE.with(|queue| queue.borrow_mut().running = false);
+            return;
+        };
+        if let Some((sound, volume)) = &job.tone {
+            crate::audio::play(sound, *volume);
+            crate::fonts::sleep_ms(crate::audio::duration_ms(sound)).await;
+        }
+        for line in job.lines {
+            let preempt =
+                WEB_QUEUE.with(|queue| should_preempt(job.priority, &queue.borrow().jobs));
+            if preempt {
+                break;
+            }
             if let Err(e) = imp::speak_blocking(&line) {
                 log::warn!("speech failed: {e}");
                 break;
             }
+            // Let the browser start the queued utterance before observing its state.
+            crate::fonts::sleep_ms(20).await;
+            let mut polls = 0;
+            while imp::is_speaking() && polls < 4_800 {
+                crate::fonts::sleep_ms(25).await;
+                polls += 1;
+            }
+            if polls == 4_800 {
+                log::warn!("browser speech did not finish after 120 seconds");
+            }
         }
-    });
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -243,6 +405,12 @@ mod imp {
             .map_err(|_| "utterance failed")?;
         synth.speak(&utter);
         Ok(())
+    }
+
+    pub fn is_speaking() -> bool {
+        web_sys::window()
+            .and_then(|w| w.speech_synthesis().ok())
+            .is_some_and(|s| s.speaking())
     }
 }
 
@@ -478,6 +646,44 @@ mod imp {
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
+
+    fn job(priority: Priority, text: &str) -> SpeechJob {
+        SpeechJob::new(priority, None, vec![text.to_string()])
+    }
+
+    #[test]
+    fn an_emergency_discards_pending_lower_priority_speech() {
+        let mut queue = std::collections::VecDeque::new();
+        enqueue(&mut queue, job(Priority::Background, "chase update"));
+        enqueue(&mut queue, job(Priority::Warning, "ordinary warning"));
+        enqueue(&mut queue, job(Priority::Emergency, "tornado emergency"));
+
+        assert_eq!(queue.len(), 1);
+        assert_eq!(queue.front().unwrap().priority, Priority::Emergency);
+        assert!(emergency_waiting(&queue));
+        assert!(should_preempt(Priority::Warning, &queue));
+        assert!(should_preempt(Priority::Background, &queue));
+        assert!(!should_preempt(Priority::Emergency, &queue));
+    }
+
+    #[test]
+    fn ordinary_speech_stays_fifo_and_scripts_split_at_sentences() {
+        let mut queue = std::collections::VecDeque::new();
+        enqueue(&mut queue, job(Priority::Background, "first"));
+        enqueue(
+            &mut queue,
+            job(
+                Priority::Warning,
+                "Hail to 1.75 inches. Take cover now! Stay there?",
+            ),
+        );
+
+        assert_eq!(queue.pop_front().unwrap().priority, Priority::Background);
+        assert_eq!(
+            queue.pop_front().unwrap().lines,
+            ["Hail to 1.75 inches.", "Take cover now!", "Stay there?"]
+        );
+    }
 
     /// The repository layout is derived from the id rather than listed, so the derivation is the
     /// thing that can be wrong. Every id in [`VOICES`] was checked live when it was added.

--- a/crates/hookecho/src/ui/settings_window.rs
+++ b/crates/hookecho/src/ui/settings_window.rs
@@ -1290,7 +1290,7 @@ fn speak_test(settings: &Settings) {
     let tone = settings
         .alert_sound
         .then(|| (settings.emergency_sound.clone(), settings.alert_volume));
-    crate::speech::announce(tone, vec![script]);
+    crate::speech::announce(crate::speech::Priority::Emergency, tone, vec![script]);
 }
 
 /// Piper: the local neural voice, and the one download this app ever offers.


### PR DESCRIPTION
## What
- Add Background, Warning, and Emergency speech priorities.
- Replace per-call serialization with one FIFO worker on desktop and Android and one browser state machine on wasm.
- Let the current sentence finish, then make a waiting emergency discard queued ordinary warning and chase speech and run next.
- Split scripts into sentence-sized utterances and sort warnings received together by escalation.
- Wait for Android TextToSpeech.isSpeaking and browser speechSynthesis.speaking before crossing an utterance boundary.
- Preserve tone-before-voice ordering and existing quiet-hour behavior.
- Pin the wasm-bindgen CLI used by CI and Demo to the version in Cargo.lock; #301 exposed that installing latest made all web bundles fail on schema drift.

## Why
A long ordinary warning or chase update could make a tornado emergency wait through every queued announcement. The old desktop lock serialized whole scripts, while Android and the browser only queued speech and returned without a usable preemption boundary.

The workflow pin is required to test and deploy this code: the crate is locked to 0.2.126 while the unpinned runner installed CLI 0.2.128.

## Wasm size
- Before: 4,056,713 bytes gzipped
- After: 4,061,794 bytes gzipped
- Delta: +5,081 bytes
- Budget: 4,066,000 bytes (unchanged)
- The workflow-only follow-up has no bundle effect.

## Verification
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- RUSTFLAGS=--cfg getrandom_backend=wasm_js cargo check --target wasm32-unknown-unknown -p hookecho --lib
- ./scripts/shots/shoot.sh check
- PATH=$HOME/.cargo/bin:$PATH ./scripts/web/build.sh
- Confirmed the lockfile extractor returns wasm-bindgen 0.2.126.
- Added queue tests for FIFO ordering, sentence splitting, emergency purging, and emergency preemption boundaries.
- A local Android cross-check was attempted; this host has the Rust target but no Android NDK compiler, so the dedicated GitHub Android job is the cross-platform compile proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
