### PR TITLE
fix(performance): do not mistake idle heartbeats for slow frames

### DIFF
--- a/crates/hookecho/src/ui/motion.rs
+++ b/crates/hookecho/src/ui/motion.rs
@@ -72,7 +72,9 @@ pub fn reduced() -> bool {
 /// start. Sustained badness is the thing worth reacting to.
 pub fn frame(ctx: &egui::Context, user_reduce: bool) {
     USER_OFF.store(user_reduce, Ordering::Relaxed);
-    let dt = ctx.input(|i| i.unstable_dt);
+    // `stable_dt` substitutes the predicted frame interval after reactive-mode sleep. The raw
+    // delta counts an idle 100 ms heartbeat as a slow frame and degrades a perfectly idle app.
+    let dt = ctx.input(|i| i.stable_dt);
     let (slow, changed) = ctx.data_mut(|d| {
         let id = egui::Id::new("visual_quality_guard");
         let mut guard: Guard = d.get_temp(id).unwrap_or_default();


### PR DESCRIPTION
## What

- measure the adaptive performance guard with egui's stable frame delta
- ignore reactive-mode idle heartbeats while preserving real slow-frame detection

## Why

The browser's normal 100 ms idle heartbeat was counted as a slow rendered frame, so an untouched app could incorrectly show “Visual quality reduced.” `stable_dt` already substitutes the predicted frame interval after reactive sleep and is the correct shared measurement.

## Wasm size

- before: 4,062,737 bytes gzipped
- after: 4,062,470 bytes gzipped
- delta: -267 bytes
- budget: unchanged at 4,067,000 bytes

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check --target wasm32-unknown-unknown -p hookecho --lib`
- `./scripts/shots/shoot.sh check`
- `PATH="$HOME/.cargo/bin:$PATH" ./scripts/web/build.sh`
- browser idle test: no reduced-quality chip after six seconds untouched
- browser 20× CPU throttle: guard engaged; after throttle removal and 340 fast frames, guard recovered

🤖 Generated with [Claude Code](https://claude.com/claude-code)
