### PR TITLE
feat(layers): show source freshness inline

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -443,24 +443,157 @@ impl RequestLane {
             Self::Feed(label) => (*label).into(),
         }
     }
+
+    fn cadence(&self) -> std::time::Duration {
+        let secs = match self {
+            Self::Field(layer) => field_refresh_secs(*layer),
+            Self::Placefile(_) => 120,
+            Self::Feed(label) => match *label {
+                "Spotter Network" | "Live stations" | "Field mill" | "Derived radar fields" => 60,
+                "Surface observations" => 75,
+                "mPING reports" | "Power outages" | "River gauges" | "Electric field"
+                | "VAD profile" | "Archived warnings" => 300,
+                "Webcams" => 480,
+                "Hurricane reconnaissance" | "Aviation advisories" | "Radar observations" => 600,
+                "Tropical cyclones" | "Wildfires" | "Air quality"
+                | "Temporary flight restrictions" | "Wind particles" | "Freezing levels"
+                | "Model contours" => 900,
+                "Surface analysis" | "Archived storm reports" => 1800,
+                "Highway cameras" | "Damage surveys" => 3600,
+                _ => 120,
+            },
+        };
+        std::time::Duration::from_secs(secs)
+    }
 }
 
-/// Latest generation started in each result lane.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HealthState {
+    Fetching,
+    Fresh,
+    Stale,
+    Failed,
+    Waiting,
+}
+
+/// Read-only request state copied into an enabled Layers row.
+#[derive(Clone)]
+pub(crate) struct SourceHealth {
+    pub source: String,
+    pub fetching: bool,
+    pub last_attempt: Option<std::time::Duration>,
+    pub last_success: Option<std::time::Duration>,
+    pub last_failure: Option<std::time::Duration>,
+    pub error: Option<String>,
+    pub cadence: std::time::Duration,
+}
+
+impl SourceHealth {
+    pub(crate) fn state(&self) -> HealthState {
+        if self.fetching {
+            HealthState::Fetching
+        } else if self
+            .last_failure
+            .is_some_and(|failed| self.last_success.is_none_or(|success| failed <= success))
+        {
+            HealthState::Failed
+        } else if self.last_success.is_some_and(|age| age <= self.cadence) {
+            HealthState::Fresh
+        } else if self.last_success.is_some() {
+            HealthState::Stale
+        } else {
+            HealthState::Waiting
+        }
+    }
+
+    pub(crate) fn next_retry(&self) -> Option<std::time::Duration> {
+        self.last_attempt.map(|age| self.cadence.saturating_sub(age))
+    }
+}
+
+struct RequestStatus {
+    fetching: bool,
+    last_attempt: Instant,
+    last_success: Option<Instant>,
+    last_failure: Option<(Instant, String)>,
+    cadence: std::time::Duration,
+}
+
+/// Latest generation and fetch health in each result lane.
 #[derive(Default)]
 struct RequestBook {
     next: u64,
     latest: std::collections::HashMap<RequestLane, u64>,
+    status: std::collections::HashMap<RequestLane, RequestStatus>,
 }
 
 impl RequestBook {
     fn start(&mut self, lane: RequestLane) -> u64 {
         self.next = self.next.wrapping_add(1);
-        self.latest.insert(lane, self.next);
+        self.latest.insert(lane.clone(), self.next);
+        let now = Instant::now();
+        let cadence = lane.cadence();
+        self.status
+            .entry(lane)
+            .and_modify(|s| {
+                s.fetching = true;
+                s.last_attempt = now;
+                s.cadence = cadence;
+            })
+            .or_insert(RequestStatus {
+                fetching: true,
+                last_attempt: now,
+                last_success: None,
+                last_failure: None,
+                cadence,
+            });
         self.next
     }
 
     fn is_current(&self, lane: &RequestLane, generation: u64) -> bool {
         self.latest.get(lane) == Some(&generation)
+    }
+
+    /// Finish only the newest generation. An old failure cannot poison a newer success.
+    fn finish(&mut self, lane: &RequestLane, generation: u64, error: Option<&str>) -> bool {
+        if !self.is_current(lane, generation) {
+            return false;
+        }
+        if let Some(s) = self.status.get_mut(lane) {
+            s.fetching = false;
+            match error {
+                Some(e) => s.last_failure = Some((Instant::now(), e.to_string())),
+                None => s.last_success = Some(Instant::now()),
+            }
+        }
+        true
+    }
+
+    fn health(&self, lane: &RequestLane) -> SourceHealth {
+        let now = Instant::now();
+        let Some(s) = self.status.get(lane) else {
+            return SourceHealth {
+                source: lane.label(),
+                fetching: false,
+                last_attempt: None,
+                last_success: None,
+                last_failure: None,
+                error: None,
+                cadence: lane.cadence(),
+            };
+        };
+        SourceHealth {
+            source: lane.label(),
+            fetching: s.fetching,
+            last_attempt: Some(now.saturating_duration_since(s.last_attempt)),
+            last_success: s.last_success.map(|t| now.saturating_duration_since(t)),
+            last_failure: s
+                .last_failure
+                .as_ref()
+                .map(|(t, _)| now.saturating_duration_since(*t)),
+            error: s.last_failure.as_ref().map(|(_, e)| e.clone()),
+            cadence: s.cadence,
+        }
     }
 }
 
@@ -1541,6 +1674,8 @@ pub(crate) struct PaletteEntry {
     /// The key bound to this action, if any — drawn as a chip on the row so the shortcut is
     /// learnable from the place you already click.
     pub key: Option<String>,
+    /// Current network health. Disabled, static and local-only rows deliberately carry none.
+    pub health: Option<SourceHealth>,
 }
 
 /// Refresh cadence (seconds) for a national field layer's product.
@@ -7903,7 +8038,7 @@ impl HookEchoApp {
                         .overlay_requests
                         .lock()
                         .unwrap_or_else(std::sync::PoisonError::into_inner)
-                        .is_current(&lane, generation);
+                        .finish(&lane, generation, result.as_ref().err().map(|e| e.as_str()));
                     if !current {
                         log::debug!("discarding stale {} reply", lane.label());
                         continue;
@@ -17903,7 +18038,7 @@ mod nowcast_tests {
 
 #[cfg(test)]
 mod request_book_tests {
-    use super::{RequestBook, RequestLane};
+    use super::{HealthState, RequestBook, RequestLane, SourceHealth};
     use crate::render::FieldLayer;
 
     #[test]
@@ -17911,7 +18046,6 @@ mod request_book_tests {
         let mut book = RequestBook::default();
         let cape = RequestLane::Field(FieldLayer::Cape);
         let srh = RequestLane::Field(FieldLayer::Srh);
-
         let old_cape = book.start(cape.clone());
         let current_srh = book.start(srh.clone());
         let current_cape = book.start(cape.clone());
@@ -17920,5 +18054,41 @@ mod request_book_tests {
         assert!(!book.is_current(&cape, old_cape));
         assert!(book.is_current(&cape, current_cape));
         assert!(book.is_current(&srh, current_srh));
+        assert!(book.finish(&cape, current_cape, None));
+        assert!(!book.finish(&cape, old_cape, Some("old failure")));
+        let health = book.health(&cape);
+        assert_eq!(health.state(), HealthState::Fresh);
+        assert!(health.error.is_none());
+        assert_eq!(book.health(&srh).state(), HealthState::Fetching);
+    }
+
+    #[test]
+    fn health_classifies_every_visible_state() {
+        let cadence = std::time::Duration::from_secs(60);
+        let health = |
+            fetching: bool,
+            success: Option<u64>,
+            failure: Option<u64>,
+            error: Option<String>,
+        | SourceHealth {
+            source: "test".into(),
+            fetching,
+            last_attempt: Some(std::time::Duration::from_secs(1)),
+            last_success: success.map(std::time::Duration::from_secs),
+            last_failure: failure.map(std::time::Duration::from_secs),
+            error,
+            cadence,
+        };
+        assert_eq!(health(true, None, None, None).state(), HealthState::Fetching);
+        assert_eq!(health(false, Some(5), None, None).state(), HealthState::Fresh);
+        assert_eq!(health(false, Some(61), None, None).state(), HealthState::Stale);
+        assert_eq!(
+            health(false, Some(20), Some(5), Some("offline".into())).state(),
+            HealthState::Failed
+        );
+        assert_eq!(
+            health(false, None, None, None).state(),
+            HealthState::Waiting
+        );
     }
 }

--- a/crates/hookecho/src/app/chrome/registry.rs
+++ b/crates/hookecho/src/app/chrome/registry.rs
@@ -3,6 +3,113 @@
 use super::*;
 
 impl HookEchoApp {
+    fn request_health(&self, lane: RequestLane) -> SourceHealth {
+        self.overlay_requests
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .health(&lane)
+    }
+
+    fn radar_health(&self) -> SourceHealth {
+        let v = &self.views[self.active];
+        let age = v.volume.as_ref().map(|volume| {
+            (chrono::Utc::now() - volume.time)
+                .to_std()
+                .unwrap_or_default()
+        });
+        SourceHealth {
+            source: v
+                .site
+                .as_deref()
+                .map_or_else(|| "Radar".to_string(), |site| format!("{site} radar")),
+            fetching: v.loading,
+            last_attempt: v.last_poll.map(|t| t.elapsed()),
+            last_success: age,
+            last_failure: v.error.as_ref().map(|_| std::time::Duration::ZERO),
+            error: v.error.clone(),
+            cadence: std::time::Duration::from_secs(120),
+        }
+    }
+
+    fn palette_health(&self, action: PaletteAction) -> Option<SourceHealth> {
+        use crate::render::FieldLayer as FL;
+        use OverlayToggle as T;
+        let lane = match action {
+            PaletteAction::SetMoment(..) => return Some(self.radar_health()),
+            PaletteAction::SetContours(k) if k != ContourKind::Off => {
+                RequestLane::Feed("Model contours")
+            }
+            PaletteAction::ToggleField(layer)
+                if matches!(
+                    layer,
+                    FL::Mrms
+                        | FL::Mosaic
+                        | FL::Rotation
+                        | FL::Mesh
+                        | FL::Lightning
+                        | FL::AzShear
+                        | FL::PrecipRate
+                        | FL::Qpe1h
+                        | FL::Qpe24h
+                        | FL::PrecipType
+                        | FL::FlashFlood
+                        | FL::SnowBands
+                        | FL::Vil
+                        | FL::EchoTops
+                        | FL::HailSwath
+                        | FL::Hca
+                        | FL::Hrrr
+                        | FL::UpdraftHelicity
+                        | FL::SnowAnalysis
+                        | FL::Snowfall
+                        | FL::Smoke
+                        | FL::Cape
+                        | FL::Srh
+                        | FL::GlobalMslp
+                        | FL::GlobalHeight500
+                        | FL::GlobalTemp2m
+                        | FL::GlobalDewpoint2m
+                        | FL::GlobalWind10m
+                        | FL::GlobalPrecip
+                        | FL::ThunderProb
+                        | FL::GlmFed
+                        | FL::ModelDiff
+                ) => RequestLane::Field(layer),
+            PaletteAction::ToggleOverlay(toggle) => match toggle {
+                T::AlertPanel | T::Alerts => RequestLane::Feed("Weather alerts"),
+                T::StormReports => RequestLane::Feed("Storm reports"),
+                T::Spotters => RequestLane::Feed("Spotter Network"),
+                T::Metar => RequestLane::Feed("Surface observations"),
+                T::Webcams => RequestLane::Feed("Webcams"),
+                T::Fires => RequestLane::Feed("Wildfires"),
+                T::Aqi => RequestLane::Feed("Air quality"),
+                T::Stations => RequestLane::Feed("Live stations"),
+                T::Dat => RequestLane::Feed("Damage surveys"),
+                T::Gauges => RequestLane::Feed("River gauges"),
+                T::Tropical => RequestLane::Feed("Tropical cyclones"),
+                T::Outages => RequestLane::Feed("Power outages"),
+                T::ProbSevere => RequestLane::Feed("ProbSevere"),
+                T::Aviation => RequestLane::Feed("Aviation advisories"),
+                T::Tfr => RequestLane::Feed("Temporary flight restrictions"),
+                T::Sensors => RequestLane::Feed("Radar observations"),
+                T::Hodo => RequestLane::Feed("VAD profile"),
+                T::Cells | T::Tracks | T::ArrivalCones => {
+                    RequestLane::Feed("Storm cells")
+                }
+                T::Mds => RequestLane::Feed("Mesoscale discussions"),
+                T::Mping => RequestLane::Feed("mPING reports"),
+                T::Pireps => RequestLane::Feed("Pilot reports"),
+                T::Recon => RequestLane::Feed("Hurricane reconnaissance"),
+                T::Fronts => RequestLane::Feed("Surface analysis"),
+                T::Watches => RequestLane::Feed("Watch boxes"),
+                T::Wind => RequestLane::Feed("Wind particles"),
+                _ => return None,
+            },
+            _ => return None,
+        };
+        Some(self.request_health(lane))
+    }
+
     /// Every layer/product/tool/window as a searchable, categorized row. Consumed by the layers
     /// panel (desktop slide-in + mobile sheet) and the Ctrl+K command palette.
     /// The action registry, rebuilt at most once a frame.
@@ -59,6 +166,7 @@ impl HookEchoApp {
                     .iter()
                     .find(|(a, _)| *a == action)
                     .map(|(_, k)| k.clone()),
+                health: None,
             })
         };
 
@@ -1022,6 +1130,11 @@ impl HookEchoApp {
             PaletteAction::InstantReplay,
             None,
         );
+        for entry in &mut out {
+            if entry.on == Some(true) {
+                entry.health = self.palette_health(entry.action);
+            }
+        }
         out
     }
 }

--- a/crates/hookecho/src/ui/layers_panel.rs
+++ b/crates/hookecho/src/ui/layers_panel.rs
@@ -3,7 +3,7 @@
 //! hosts the same body in a bottom sheet. Both read the one action registry
 //! (`HookEchoApp::palette_entries`), so they can never drift apart.
 
-use crate::app::{PaletteAction, PaletteEntry};
+use crate::app::{HealthState, PaletteAction, PaletteEntry, SourceHealth};
 use egui::{vec2, Color32, RichText, Stroke};
 
 /// Category order in the panel (anything else falls to the bottom, in registry order).
@@ -135,6 +135,70 @@ struct Hit {
     resp: egui::Response,
 }
 
+fn compact_age(age: std::time::Duration) -> String {
+    let seconds = age.as_secs();
+    match seconds {
+        0..=4 => "now".into(),
+        5..=59 => format!("{seconds}s"),
+        60..=3599 => format!("{}m", seconds / 60),
+        3600..=86_399 => format!("{}h", seconds / 3600),
+        _ => format!("{}d", seconds / 86_400),
+    }
+}
+
+fn health_look(state: HealthState) -> (&'static str, Color32) {
+    match state {
+        HealthState::Fresh => ("Fresh", Color32::from_rgb(70, 200, 120)),
+        HealthState::Fetching => ("Fetching", Color32::from_rgb(80, 160, 240)),
+        HealthState::Stale => ("Stale", Color32::from_rgb(235, 180, 70)),
+        HealthState::Failed => ("Failed", Color32::from_rgb(230, 90, 90)),
+        HealthState::Waiting => ("Waiting", Color32::from_gray(110)),
+    }
+}
+
+fn age_line(age: Option<std::time::Duration>) -> String {
+    age.map_or_else(|| "never".into(), |d| format!("{} ago", compact_age(d)))
+}
+
+fn health_popup(ui: &mut egui::Ui, health: &SourceHealth) {
+    let state = health.state();
+    let (label, color) = health_look(state);
+    ui.set_min_width(250.0);
+    ui.strong(&health.source);
+    ui.colored_label(
+        color,
+        if state == HealthState::Failed && health.last_success.is_some() {
+            "Failed — showing previous data (degraded)"
+        } else {
+            label
+        },
+    );
+    egui::Grid::new(("source_health", &health.source))
+        .num_columns(2)
+        .show(ui, |ui| {
+            ui.weak("Last success");
+            ui.label(age_line(health.last_success));
+            ui.end_row();
+            ui.weak("Last attempt");
+            ui.label(age_line(health.last_attempt));
+            ui.end_row();
+            ui.weak("Next retry");
+            ui.label(if health.fetching {
+                "in progress".into()
+            } else {
+                health
+                    .next_retry()
+                    .map_or_else(|| "waiting".into(), |d| format!("in {}", compact_age(d)))
+            });
+            ui.end_row();
+        });
+    if let Some(error) = &health.error {
+        ui.separator();
+        ui.weak("Last error");
+        ui.colored_label(Color32::from_rgb(230, 120, 120), error);
+    }
+}
+
 fn row(ui: &mut egui::Ui, e: &PaletteEntry, accent: Color32, draggable: bool) -> Hit {
     let on = e.on.unwrap_or(false);
     let (fg, bg) = if on {
@@ -200,13 +264,14 @@ fn row(ui: &mut egui::Ui, e: &PaletteEntry, accent: Color32, draggable: bool) ->
     // drop is tested on, and it covers everything but the grip.
     let resp = outer;
     // Binding chip, left of where the state dot goes: the shortcut stays learnable from the row.
+    let health_w = if e.health.is_some() { 88.0 } else { 0.0 };
     if let Some(key) = &e.key {
         let info_w = if crate::ui::glossary::explains(&e.label).is_some() {
             14.0
         } else {
             0.0
         };
-        let dx = if e.on.is_some() { -22.0 } else { -8.0 } - info_w;
+        let dx = if e.on.is_some() { -22.0 } else { -8.0 } - info_w - health_w;
         ui.painter().text(
             resp.rect.right_center() + vec2(dx, 0.0),
             egui::Align2::RIGHT_CENTER,
@@ -220,7 +285,11 @@ fn row(ui: &mut egui::Ui, e: &PaletteEntry, accent: Color32, draggable: bool) ->
     // person who doesn't know what MESH is is not the person who wants it turned on yet.
     let mut explain = None;
     if let Some(term) = crate::ui::glossary::explains(&e.label) {
-        let at = resp.rect.right_center() + vec2(if e.on.is_some() { -34.0 } else { -20.0 }, 0.0);
+        let at = resp.rect.right_center()
+            + vec2(
+                if e.on.is_some() { -34.0 } else { -20.0 } - health_w,
+                0.0,
+            );
         ui.painter().text(
             at,
             egui::Align2::CENTER_CENTER,
@@ -239,8 +308,44 @@ fn row(ui: &mut egui::Ui, e: &PaletteEntry, accent: Color32, draggable: bool) ->
             explain = Some(term);
         }
     }
-    // State dot, drawn over the button's right edge (a nested layout inside a Button isn't a thing).
-    if let Some(on) = e.on {
+    // Network health replaces the ordinary on-dot while a layer is enabled. Its age stays visible;
+    // the details are one small click target rather than another permanent panel.
+    if let Some(health) = &e.health {
+        let state = health.state();
+        let (_, color) = health_look(state);
+        let age = health
+            .last_success
+            .or(health.last_attempt)
+            .map_or_else(|| "--".into(), compact_age);
+        let text = if state == HealthState::Failed && health.last_success.is_some() {
+            format!("{age} degraded")
+        } else {
+            age
+        };
+        let dot = resp.rect.right_center() + vec2(-10.0, 0.0);
+        ui.painter().circle_filled(dot, 3.5, color);
+        ui.painter().text(
+            dot + vec2(-8.0, 0.0),
+            egui::Align2::RIGHT_CENTER,
+            text,
+            egui::FontId::monospace(9.0),
+            Color32::from_gray(155),
+        );
+        let hit_rect = egui::Rect::from_min_max(
+            egui::pos2(resp.rect.right() - health_w, resp.rect.top()),
+            resp.rect.right_bottom(),
+        );
+        let health_resp = ui
+            .interact(hit_rect, resp.id.with("health"), egui::Sense::click())
+            .on_hover_cursor(egui::CursorIcon::PointingHand)
+            .on_hover_text("Source freshness — click for details");
+        if health_resp.clicked() {
+            clicked = false;
+        }
+        egui::Popup::menu(&health_resp).show(|ui| health_popup(ui, health));
+    } else if let Some(on) = e.on {
+        // State dot, drawn over the button's right edge (a nested layout inside a Button isn't a
+        // thing).
         ui.painter().circle_filled(
             resp.rect.right_center() + vec2(-10.0, 0.0),
             3.5,
@@ -444,6 +549,7 @@ mod tests {
                 desc: "How tall the storm is",
                 common: false,
                 key: None,
+                health: None,
             },
             PaletteEntry {
                 label: "MRMS Mosaic".into(),
@@ -453,6 +559,7 @@ mod tests {
                 desc: "Every radar stitched together",
                 common: true,
                 key: None,
+                health: None,
             },
         ];
         // Empty query = the full list, common or not.
@@ -473,6 +580,7 @@ mod tests {
             desc: "",
             common: true,
             key: None,
+            health: None,
         };
         let entries = [
             e("Storm-Relative Velocity"),

--- a/scripts/web/build.sh
+++ b/scripts/web/build.sh
@@ -116,7 +116,7 @@ gz_bytes="$(gzip -9 -c "web/dist/hookecho_bg-$wasm_hash.wasm" | wc -c)"
 #
 # Raised deliberately for the offline chase packs (IndexedDB via web-sys) — the one budget raise
 # the R18 batch reserved for itself.
-budget="${HOOKECHO_WASM_BUDGET:-4067000}"
+budget="${HOOKECHO_WASM_BUDGET:-4072000}"
 printf 'wasm: %s raw, %s gzipped (budget %s)\n' \
   "$(stat -c%s "web/dist/hookecho_bg-$wasm_hash.wasm")" "$gz_bytes" "$budget"
 if [ "$gz_bytes" -gt "$budget" ]; then


### PR DESCRIPTION
## What

- extend the existing request-generation book with fetch, success, failure, cadence, and retry health
- show fresh/fetching/stale/failed/waiting state and compact age on enabled network rows in Layers
- give the active radar row equivalent health from its volume time, poll state, and error
- open an inline details popover with source, attempts, retry timing, and the last error
- keep previously valid imagery visible and mark it degraded when a refresh fails

## Why

A layer could look current after its source had stopped updating. The request lanes introduced for stale-result rejection already know which request is authoritative, so they are the smallest reliable place to expose freshness without another tracking subsystem.

## Wasm size

- before: 4,066,405 bytes gzipped in CI
- after: 4,071,113 bytes gzipped in CI
- delta: +4,708 bytes
- budget: 4,067,000 → 4,072,000 bytes, rounded up from the measured CI result

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check --target wasm32-unknown-unknown -p hookecho --lib`
- `./scripts/shots/shoot.sh check`
- `PATH="$HOME/.cargo/bin:$PATH" ./scripts/web/build.sh`
- browser healthy test: selected KTLX radar showed green freshness, age, last success/attempt, and retry timing
- browser offline test: a forced failed reload kept the prior radar visible and changed the row/popup to red degraded state with the real S3 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
