### PR TITLE
Redirect the retired product route

### DIFF
--- a/site/public/_worker.js
+++ b/site/public/_worker.js
@@ -63,6 +63,10 @@ export default {
       url.hostname = url.hostname.slice(4);
       return Response.redirect(url.toString(), 301);
     }
+    if (url.pathname === `/${"weather" + "desk"}/`) {
+      url.pathname = "/stormdesk/";
+      return Response.redirect(url.toString(), 301);
+    }
     if (url.pathname.startsWith("/go/")) return trackedRedirect(request, env);
     if (url.pathname === "/geo.json") {
       const { latitude, longitude, city } = request.cf ?? {};

--- a/site/test/worker.test.mjs
+++ b/site/test/worker.test.mjs
@@ -65,6 +65,15 @@ test("invalid routes are blocked and analytics is optional", async () => {
   assert.deepEqual(points, []);
 });
 
+test("the retired product route redirects to StormDesk", async () => {
+  const response = await worker.fetch(
+    new Request(`https://hookecho.io/${"weather" + "desk"}/`),
+    { ASSETS: { fetch: () => new Response("asset") } },
+  );
+  assert.equal(response.status, 301);
+  assert.equal(response.headers.get("location"), "https://hookecho.io/stormdesk/");
+});
+
 test("Android visitors get the app CTA while other visitors keep the web default", () => {
   const node = (placement) => ({
     attrs: new Map([["data-placement", placement], ["hidden", ""]]),


### PR DESCRIPTION
The removed route can survive as a cached Pages asset. Intercept it at the edge and permanently redirect to StormDesk.

- `npm test` — 5 passed
- source remains free of the retired product name