### PR TITLE
Show the StormDesk dashboard on the homepage

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -96,14 +96,14 @@ const jsonld = {
       <picture>
         <source
           type="image/webp"
-          srcset="/shots/stormdesk-wide-800.webp 800w, /shots/stormdesk-wide-1600.webp 1600w"
+          srcset="/shots/stormdesk-dashboard-800.webp 800w, /shots/stormdesk-dashboard-1200.webp 1200w"
           sizes="(max-width: 760px) calc(100vw - 2.5rem), 55vw"
         />
         <img
-          src="/shots/stormdesk-wide-1600.webp"
-          alt="StormDesk showing a personal weather dashboard with HookEcho radar"
-          width="1600"
-          height="900"
+          src="/shots/stormdesk-dashboard-1200.webp"
+          alt="StormDesk Desk tab showing current conditions and the local forecast"
+          width="1200"
+          height="675"
           loading="lazy"
         />
       </picture>


### PR DESCRIPTION
Replace the radar image in the homepage StormDesk card with the Desk-tab screenshot and matching accessible text.

- `npm test` — 5 passed
- `npm run build` — 381 pages built