### PR TITLE
fix: refresh the StormDesk dashboard image

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -96,11 +96,11 @@ const jsonld = {
       <picture>
         <source
           type="image/webp"
-          srcset="/shots/stormdesk-dashboard-800.webp 800w, /shots/stormdesk-dashboard-1200.webp 1200w"
+          srcset="/shots/stormdesk-dashboard-800.webp?v=4074903 800w, /shots/stormdesk-dashboard-1200.webp?v=4074903 1200w"
           sizes="(max-width: 760px) calc(100vw - 2.5rem), 55vw"
         />
         <img
-          src="/shots/stormdesk-dashboard-1200.webp"
+          src="/shots/stormdesk-dashboard-1200.webp?v=4074903"
           alt="StormDesk Desk tab showing current conditions and the local forecast"
           width="1200"
           height="675"

--- a/site/src/pages/stormdesk/index.astro
+++ b/site/src/pages/stormdesk/index.astro
@@ -83,11 +83,11 @@ const jsonld = {
       <picture class="hero-shot">
         <source
           type="image/webp"
-          srcset="/shots/stormdesk-dashboard-800.webp 800w, /shots/stormdesk-dashboard-1200.webp 1200w"
+          srcset="/shots/stormdesk-dashboard-800.webp?v=4074903 800w, /shots/stormdesk-dashboard-1200.webp?v=4074903 1200w"
           sizes="(max-width: 760px) calc(100vw - 2.5rem), 52vw"
         />
         <img
-          src="/shots/stormdesk-dashboard-1200.webp"
+          src="/shots/stormdesk-dashboard-1200.webp?v=4074903"
           alt="StormDesk dashboard showing current station readings, forecasts and weather charts"
           width="1200"
           height="675"


### PR DESCRIPTION
## Summary
- version the StormDesk dashboard image URL on the homepage
- apply the same cache bust on the StormDesk landing page

## Test
- npm run build
- generated pages reference the versioned assets