### PR TITLE
AUR: stamp prerelease versions and drop -flto for the C link

### DIFF
--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -7,6 +7,9 @@
 # Publishing: bump pkgver + sha256sums (scripts/release/stamp-manifests.sh does both), then
 # `makepkg --printsrcinfo > .SRCINFO` and push both files to ssh://aur@aur.archlinux.org/hookecho.git
 pkgname=hookecho
+# The Git tag (`_tag`) keeps its hyphens; `pkgver` must not have any, so a
+# prerelease stamps as e.g. 0.12.0_beta.2. stamp-manifests.sh writes both.
+_tag=0.8.0
 pkgver=0.8.0
 pkgrel=1
 pkgdesc="Advanced NEXRAD weather radar viewer"
@@ -17,23 +20,29 @@ license=('MIT')
 # libs and talks to portals over D-Bus, so these are the whole list.
 depends=('alsa-lib' 'systemd-libs' 'libxkbcommon' 'wayland' 'libxcb' 'gtk3')
 makedepends=('cargo')
-source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
+source=("$pkgname-$_tag.tar.gz::$url/archive/refs/tags/v$_tag.tar.gz")
 sha256sums=('a77106b1869671f6c697cc41c62117518dc9b590eccb932917f258c6509845e6')
 
 prepare() {
-  cd "$pkgname-$pkgver"
+  cd "$pkgname-$_tag"
   export RUSTUP_TOOLCHAIN=stable
   cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
 }
 
 build() {
-  cd "$pkgname-$pkgver"
+  cd "$pkgname-$_tag"
   export RUSTUP_TOOLCHAIN=stable CARGO_TARGET_DIR=target
+  # makepkg's default flags carry -flto=auto, which makes gcc emit slim-LTO
+  # bytecode in the C archives (aws-lc-sys). The final link is driven by
+  # rustc, which cannot consume those objects, so the link dies on undefined
+  # aws_lc_* symbols. Strip it here; the Rust crates keep the -C lto=fat the
+  # Cargo profile sets. Verified on Arch (gcc 16, rustc 1.97).
+  export CFLAGS="${CFLAGS//-flto*/}" CXXFLAGS="${CXXFLAGS//-flto*/}" LDFLAGS="${LDFLAGS//-flto*/}"
   cargo build --frozen --release -p hookecho
 }
 
 package() {
-  cd "$pkgname-$pkgver"
+  cd "$pkgname-$_tag"
   install -Dm755 "target/release/$pkgname" "$pkgdir/usr/bin/$pkgname"
   install -Dm644 packaging/hookecho.desktop "$pkgdir/usr/share/applications/hookecho.desktop"
   install -Dm644 packaging/io.hookecho.HookEcho.metainfo.xml \

--- a/scripts/release/stamp-manifests.sh
+++ b/scripts/release/stamp-manifests.sh
@@ -40,8 +40,13 @@ sed -i \
   -e "s|^  sha256 .*|  sha256 \"$SRC_SHA\"|" \
   packaging/homebrew/hookecho.rb
 
+# pkgver cannot contain hyphens, so a prerelease tag stamps _tag verbatim
+# and pkgver with hyphens as underscores; the PKGBUILD builds URLs and
+# directory names from _tag.
+PKGV=${VER//-/_}
 sed -i \
-  -e "s|^pkgver=.*|pkgver=$VER|" \
+  -e "s|^_tag=.*|_tag=$VER|" \
+  -e "s|^pkgver=.*|pkgver=$PKGV|" \
   -e "s|^pkgrel=.*|pkgrel=1|" \
   -e "s|^sha256sums=.*|sha256sums=('$SRC_SHA')|" \
   packaging/aur/PKGBUILD


### PR DESCRIPTION
The AUR manifest can't be stamped for any prerelease as written, and the
build it describes doesn't link under makepkg's default flags. Two fixes,
both in unshipped submission inputs only:

1. `stamp-manifests.sh` wrote `pkgver=$VER` verbatim, and makepkg rejects
   hyphens in `pkgver` (`0.12.0-beta.2` fails source validation before
   anything downloads). The PKGBUILD now carries `_tag` (verbatim tag, used
   for the tarball URL and the extracted directory) alongside `pkgver`
   (hyphens as underscores), and the stamp script writes both.

2. makepkg's default `CFLAGS`/`LDFLAGS` carry `-flto=auto`, which makes gcc
   emit slim-LTO bytecode into the C static archives (`aws-lc-sys`). The
   final link is driven by rustc and cannot consume those objects, so the
   build dies on undefined `aws_lc_*` symbols. `build()` now filters
   `-flto*` out of `CFLAGS`/`CXXFLAGS`/`LDFLAGS`; the Rust crates keep the
   `-C lto=fat` the Cargo profile already sets. Bisected on Arch (gcc 16,
   rustc 1.97): full default flags fail, identical flags minus `-flto`
   link clean.

Validated with a clean-room `makepkg` against `v0.12.0-beta.2`:
`hookecho-0.12.0_beta.2-1-x86_64.pkg.tar.zst` plus the debug package,
`--printsrcinfo` clean, binary + desktop + metainfo + license + all five
icon sizes in the payload.

Still yours to publish (`SUBMITTING.md` step 2: stamp, `.SRCINFO`, push to
`ssh://aur@aur.archlinux.org/hookecho.git` — needs your AUR account).
Happy to retire my AppImage install script once `hookecho` is installable
from the AUR.
