### PR TITLE
Fix radar zoom stutter and basemap flashing

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -2920,7 +2920,7 @@ pub struct HookEchoApp {
     /// When the user last did anything — the input the idle heartbeat listens for. Also what
     /// "a gesture is in progress" is read from.
     last_input: Instant,
-    /// A pointer or finger is down this frame. Read once at the top of `ui`, because the overlay
+    /// A drag, touch, scroll or pinch is active this frame. Read at the top of `ui`, because the overlay
     /// tessellation asks it before any pane has drawn.
     gesture_live: bool,
     /// Perf readout state: whether `HOOKECHO_PERF=1` asked for the window, the frame count and
@@ -14914,8 +14914,14 @@ pub(crate) fn to_upload(
     }
 }
 
-/// Whether the overlay geometry should be re-tessellated this frame.
-///
+/// Include inertial scrolling and trackpad pinches, which do not hold a pointer down.
+fn map_gesture_live(i: &egui::InputState) -> bool {
+    i.pointer.any_down()
+        || i.any_touches()
+        || i.smooth_scroll_delta != egui::Vec2::ZERO
+        || (i.zoom_delta() - 1.0).abs() > f32::EPSILON
+}
+
 /// A zoom-bucket crossing waits for the gesture to end; new geometry does not.
 fn should_retess(gesture_live: bool, geometry_changed: bool, bucket_changed: bool) -> bool {
     geometry_changed || (bucket_changed && !gesture_live)
@@ -15522,7 +15528,7 @@ impl eframe::App for HookEchoApp {
         // force one refresh rather than making the user wait out the poll interval.
         self.frame_nr = self.frame_nr.wrapping_add(1);
         wxdata::stats::bump(wxdata::stats::Counter::FramesDrawn);
-        self.gesture_live = ctx.input(|i| i.pointer.any_down() || i.any_touches());
+        self.gesture_live = ctx.input(map_gesture_live);
         #[cfg(not(target_arch = "wasm32"))]
         self.perf.tick(ctx);
         #[cfg(debug_assertions)]
@@ -17259,9 +17265,10 @@ impl eframe::App for HookEchoApp {
                     .vtiles
                     .set_style(style.vector_palette().unwrap_or_default());
                 clear_vector |= self.vtiles.set_theme(self.settings.theme);
-                clear_vector |= self
-                    .vtiles
-                    .note_zoom(self.views[self.active.min(n - 1)].camera.zoom);
+                self.vtiles.note_zoom(
+                    self.views[self.active.min(n - 1)].camera.zoom,
+                    self.gesture_live,
+                );
             }
             self.last_viewport = rects
                 .get(self.active)
@@ -17701,6 +17708,22 @@ mod field_lut_tests {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn wheel_and_trackpad_zoom_count_as_live_gestures() {
+        let mut input = egui::InputState::default();
+        assert!(!super::map_gesture_live(&input));
+        input.smooth_scroll_delta = egui::vec2(0.0, 0.25);
+        assert!(super::map_gesture_live(&input), "include the smoothed wheel tail");
+        let ctx = egui::Context::default();
+        let raw = egui::RawInput {
+            events: vec![egui::Event::Zoom(1.1)],
+            ..Default::default()
+        };
+        let _ = ctx.run_ui(raw, |ui| {
+            assert!(ui.input(super::map_gesture_live), "trackpad pinch without a button");
+        });
+    }
 
     /// New geometry appears when it lands; a zoom-bucket crossing waits for the finger to lift,
     /// so a pinch across three buckets tessellates once instead of three times.

--- a/crates/hookecho/src/render/mod.rs
+++ b/crates/hookecho/src/render/mod.rs
@@ -1627,8 +1627,8 @@ impl egui_wgpu::CallbackTrait for MapCallback {
 /// Keep cached geography visible while a new zoom level loads. Coarse tiles draw first,
 /// then finer fallbacks, then the requested tiles so current detail always wins.
 fn vector_draw_tiles(visible: &[TileId], resident: impl Iterator<Item = TileId>) -> Vec<TileId> {
-    let resident: std::collections::BTreeSet<_> = resident.collect();
-    let mut fallback = std::collections::BTreeSet::new();
+    let resident: Vec<_> = resident.collect();
+    let mut fallback = Vec::new();
     // ponytail: bounded tile-cache scan; add a spatial index only if the cache grows substantially.
     for &(z, x, y) in visible {
         if resident.contains(&(z, x, y)) {
@@ -1641,11 +1641,14 @@ fn vector_draw_tiles(visible: &[TileId], resident: impl Iterator<Item = TileId>)
                 (rx >> (rz - z), ry >> (rz - z)) == (x, y)
             };
             if overlaps {
-                fallback.insert((rz, rx, ry));
+                fallback.push((rz, rx, ry));
             }
         }
     }
-    fallback.into_iter().chain(visible.iter().copied().filter(|id| resident.contains(id))).collect()
+    fallback.sort_unstable();
+    fallback.dedup();
+    fallback.extend(visible.iter().copied().filter(|id| resident.contains(id)));
+    fallback
 }
 
 #[cfg(test)]

--- a/crates/hookecho/src/render/mod.rs
+++ b/crates/hookecho/src/render/mod.rs
@@ -1242,6 +1242,7 @@ impl RenderResources {
         );
         let quads = (self.panes.get(&cb.pane).map(|p| p.quads_key) != Some(Some(quads_key)))
             .then(|| self.tile_verts(cb));
+        let visible_vector = vector_draw_tiles(&cb.visible_vector, self.vector_tiles.keys().copied());
         let overlay_present = self.overlay.is_some();
 
         let pane = self.pane_mut(device, cb.pane);
@@ -1276,7 +1277,7 @@ impl RenderResources {
             pane.frame_visible = visible;
             pane.quads_key = Some(quads_key);
         }
-        pane.frame_visible_vector = cb.visible_vector.clone();
+        pane.frame_visible_vector = visible_vector;
         pane.vector_over_raster = cb.vector_over_raster;
         pane.frame_draw_radar = cb.draw_radar && pane.radar.is_some();
         pane.frame_draw_overlay = cb.draw_overlay && overlay_present;
@@ -1620,6 +1621,48 @@ impl egui_wgpu::CallbackTrait for MapCallback {
         crate::prof_scope!("render paint");
         let res: &RenderResources = resources.get().unwrap();
         res.record_pane(self.pane, pass);
+    }
+}
+
+/// Keep cached geography visible while a new zoom level loads. Coarse tiles draw first,
+/// then finer fallbacks, then the requested tiles so current detail always wins.
+fn vector_draw_tiles(visible: &[TileId], resident: impl Iterator<Item = TileId>) -> Vec<TileId> {
+    let resident: std::collections::BTreeSet<_> = resident.collect();
+    let mut fallback = std::collections::BTreeSet::new();
+    // ponytail: bounded tile-cache scan; add a spatial index only if the cache grows substantially.
+    for &(z, x, y) in visible {
+        if resident.contains(&(z, x, y)) {
+            continue;
+        }
+        for &(rz, rx, ry) in &resident {
+            let overlaps = if rz <= z {
+                (x >> (z - rz), y >> (z - rz)) == (rx, ry)
+            } else {
+                (rx >> (rz - z), ry >> (rz - z)) == (x, y)
+            };
+            if overlaps {
+                fallback.insert((rz, rx, ry));
+            }
+        }
+    }
+    fallback.into_iter().chain(visible.iter().copied().filter(|id| resident.contains(id))).collect()
+}
+
+#[cfg(test)]
+mod vector_fallback_tests {
+    use super::vector_draw_tiles;
+
+    #[test]
+    fn zooming_both_ways_keeps_cached_tiles_and_current_detail_wins() {
+        let parent = (4, 3, 5);
+        let child = (5, 6, 10);
+        let sibling = (5, 7, 10);
+        let far = (5, 20, 20);
+        assert_eq!(vector_draw_tiles(&[child], [parent, far].into_iter()), vec![parent]);
+        assert_eq!(vector_draw_tiles(&[parent], [child, far].into_iter()), vec![child]);
+        assert_eq!(vector_draw_tiles(&[child, sibling], [parent, child].into_iter()), vec![parent, child]);
+        assert_eq!(vector_draw_tiles(&[child], [parent, child].into_iter()), vec![child]);
+        assert!(vector_draw_tiles(&[child], [far].into_iter()).is_empty());
     }
 }
 

--- a/crates/hookecho/src/vector_tiles.rs
+++ b/crates/hookecho/src/vector_tiles.rs
@@ -819,7 +819,7 @@ pub struct VectorTileManager {
     requested: HashSet<TileId>,
     /// Tessellated tiles live on the GPU; this mirrors them so the oldest can be dropped. A
     /// HashSet here meant a long pan grew vertex buffers until the style changed.
-    uploaded: LruCache<TileId, ()>,
+    uploaded: LruCache<TileId, u64>,
     /// Ids the LRU pushed out, handed to the renderer to free.
     vevicted: Vec<TileId>,
     labels: HashMap<TileId, Vec<PlaceLabel>>,
@@ -916,13 +916,16 @@ impl VectorTileManager {
         true
     }
 
-    /// Note the current camera zoom (drives stroke widths). Returns true (clear GPU cache) only
-    /// when overzooming past the max tile level, where tile ids stop changing but widths must.
-    pub fn note_zoom(&mut self, cam_zoom: f64) -> bool {
+    /// Refresh stroke widths after zooming settles, keeping resident tiles until replacements land.
+    pub fn note_zoom(&mut self, cam_zoom: f64, gesture_live: bool) {
+        if gesture_live {
+            self.zoom_settled = None;
+            return;
+        }
         let tz = cam_zoom.round() as i32;
         if tz == self.tess_zoom {
             self.zoom_settled = None;
-            return false;
+            return;
         }
         // Mid-pinch this fires at every integer step, and each one throws away the whole vector
         // basemap and re-tessellates it — the worst possible moment. Wait for the zoom to hold
@@ -932,10 +935,10 @@ impl VectorTileManager {
             .get_or_insert_with(|| (tz, wxdata::clock::Instant::now()));
         if settled.0 != tz {
             self.zoom_settled = Some((tz, wxdata::clock::Instant::now()));
-            return false;
+            return;
         }
         if settled.1.elapsed() < std::time::Duration::from_millis(700) {
-            return false;
+            return;
         }
         self.zoom_settled = None;
         self.tess_zoom = tz;
@@ -949,10 +952,7 @@ impl VectorTileManager {
         self.render_generation += 1;
         self.requested.clear();
         self.failed.clear();
-        self.uploaded.clear();
-        self.labels.clear();
-        self.label_gen += 1;
-        true
+        // Keep the GPU tiles and labels visible; drain_ready replaces each tile in place.
     }
 
     pub fn visible(&self, cam: &Camera, viewport_px: (f32, f32)) -> Vec<VisibleTile> {
@@ -1117,8 +1117,11 @@ impl VectorTileManager {
                     continue;
                 }
             };
-            match self.uploaded.push(f.id, ()) {
-                Some((id, _)) if id == f.id => continue, // already resident
+            if self.uploaded.peek(&f.id) == Some(&generation) {
+                continue; // already resident at this generation
+            }
+            match self.uploaded.push(f.id, generation) {
+                Some((id, _)) if id == f.id => {} // refreshed in place
                 Some((id, _)) => {
                     self.requested.remove(&id);
                     self.labels.remove(&id);
@@ -1206,6 +1209,34 @@ mod tests {
             template_requested: false,
             template_failed: None,
         }
+    }
+
+    #[tokio::test]
+    async fn zoom_refresh_keeps_tiles_until_their_replacements_arrive() {
+        let mut manager = test_manager();
+        let id = (6, 14, 25);
+        manager.uploaded.put(id, 0);
+        manager.labels.insert(id, vec![]);
+        manager.requested.insert(id);
+        let settled = wxdata::clock::Instant::now() - std::time::Duration::from_secs(1);
+        manager.zoom_settled = Some((9, settled));
+        manager.note_zoom(9.0, true);
+        assert_eq!(manager.render_generation, 0, "no rebuild while zooming");
+        assert!(manager.zoom_settled.is_none());
+        manager.zoom_settled = Some((9, settled));
+        manager.note_zoom(9.0, false);
+        assert_eq!(manager.render_generation, 1);
+        assert!(manager.uploaded.contains(&id), "keep the visible GPU tile");
+        assert!(manager.labels.contains_key(&id), "keep its labels too");
+        assert!(!manager.requested.contains(&id), "allow a replacement fetch");
+        for _ in 0..2 {
+            manager.tx.send((1, Ok(FetchedVector {
+                id, vertices: vec![], indices: vec![], labels: vec![],
+            }))).unwrap();
+        }
+        assert_eq!(manager.drain_ready().len(), 1, "replace once, ignore duplicates");
+        assert_eq!(manager.uploaded.peek(&id), Some(&1));
+        assert!(manager.take_evicted().is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Zooming the radar embedded in StormDesk could rebuild overlays during wheel/trackpad input, clear the street map before refreshed tiles arrived, and show gaps when crossing tile zoom levels.

Recognize scroll inertia and trackpad pinch as active gestures, defer zoom-dependent tessellation until input settles, and retain resident vector tiles and labels while refreshed tiles replace them in place. Draw cached parent/child tiles behind missing zoom-level tiles until current detail arrives. Generation checks still reject obsolete results and duplicate uploads.

Validation: 382 HookEcho library tests passed (9 ignored); native Clippy passed with warnings denied. Regression tests cover wheel/pinch input, tile replacement without cache eviction, and map coverage during zoom in/out.
