### PR TITLE
Move browser radar basemap work off the input thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2592,6 +2592,7 @@ dependencies = [
  "nexrad-model",
  "notify-rust",
  "percent-encoding",
+ "postcard",
  "puffin",
  "puffin_http",
  "reqwest 0.12.28",

--- a/crates/hookecho/Cargo.toml
+++ b/crates/hookecho/Cargo.toml
@@ -27,6 +27,7 @@ winresource = "0.1"
 profiling = ["dep:puffin", "dep:puffin_http"]
 
 [dependencies]
+postcard = { version = "1", features = ["alloc"] }
 wxdata = { path = "../wxdata" }
 puffin = { version = "0.20", optional = true }
 puffin_http = { version = "0.17", optional = true }

--- a/crates/hookecho/src/basemap_style.rs
+++ b/crates/hookecho/src/basemap_style.rs
@@ -15,7 +15,7 @@ const fn rgb(hex: u32) -> [u8; 4] {
 /// This used to be a bare `dark: bool`. It is an enum because the hybrid satellite basemap needs
 /// a third look — roads and boundaries only, no land or water fills — drawn *over* raster imagery
 /// rather than instead of it.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub enum Palette {
     #[default]
     Dark,

--- a/crates/hookecho/src/lib.rs
+++ b/crates/hookecho/src/lib.rs
@@ -195,6 +195,13 @@ pub fn assemble_live_chunks(framed: Vec<u8>) -> Result<Vec<u8>, wasm_bindgen::Js
     wxdata::live::assemble_and_encode(&framed).map_err(|e| e.to_string().into())
 }
 
+/// Worker export: decode and triangulate a basemap tile without blocking map input.
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen::prelude::wasm_bindgen]
+pub fn tessellate_vector_tile(payload: Vec<u8>) -> Result<Vec<u8>, wasm_bindgen::JsValue> {
+    vector_tiles::build_worker_tile(&payload).map_err(|e| e.to_string().into())
+}
+
 /// Web entry point, called from `web/index.html` with the id of a `<canvas>`.
 ///
 /// Same `HookEchoApp` as every other platform — eframe's `WebRunner` takes the identical creation

--- a/crates/hookecho/src/render/mod.rs
+++ b/crates/hookecho/src/render/mod.rs
@@ -296,7 +296,7 @@ pub struct MrmsUpload {
 
 /// A tessellated vertex for the vector overlay layer.
 #[repr(C)]
-#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable, serde::Serialize, serde::Deserialize)]
 pub struct OverlayVertex {
     pub world: [f32; 2],
     pub color: [f32; 4],

--- a/crates/hookecho/src/rt.rs
+++ b/crates/hookecho/src/rt.rs
@@ -56,8 +56,8 @@ impl Spawner {
     /// There is no thread pool to move work to, so "blocking" work runs on the main thread.
     ///
     // ponytail: wasm spawn_blocking is spawn_local on the main thread; the ceiling is jank on big
-    // CPU work. The one thing big enough to hurt — Level 2 decode — took that upgrade already and
-    // runs in a worker (`wxdata::wasm_worker`); everything else still lands here.
+    // CPU work. Radar decoding and vector-tile tessellation use the existing Web Worker bridge
+    // (`wxdata::wasm_worker`); remaining callers still land here.
     pub fn spawn_blocking<F>(&self, f: F)
     where
         F: FnOnce() + 'static,

--- a/crates/hookecho/src/vector_tiles.rs
+++ b/crates/hookecho/src/vector_tiles.rs
@@ -59,7 +59,7 @@ enum StrokePass {
     Road,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum RoadShield {
     None,
     Interstate,
@@ -69,7 +69,7 @@ pub enum RoadShield {
 }
 
 /// A map label to draw with the egui painter (never appears in GPU/headless PNGs).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct PlaceLabel {
     pub world: [f32; 2],
     pub name: String,
@@ -796,11 +796,23 @@ const TILE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 /// hundreds of requests a second. Same number, same reason, as the raster manager's.
 const RETRY_AFTER: std::time::Duration = std::time::Duration::from_secs(5);
 
+#[derive(serde::Serialize, serde::Deserialize)]
 struct FetchedVector {
     id: TileId,
     vertices: Vec<OverlayVertex>,
     indices: Vec<u32>,
     labels: Vec<PlaceLabel>,
+}
+
+// Reuse the radar worker and its transferred buffers: no additional worker or WASM heap.
+#[cfg(any(target_arch = "wasm32", test))]
+type VectorJob = (Vec<u8>, TileId, basemap_style::Palette, f64, crate::settings::Theme);
+
+#[cfg(any(target_arch = "wasm32", test))]
+pub(crate) fn build_worker_tile(payload: &[u8]) -> Result<Vec<u8>, postcard::Error> {
+    let (bytes, id, palette, zoom, theme): VectorJob = postcard::from_bytes(payload)?;
+    let (vertices, indices, labels) = build_tile_with_theme(&bytes, id, palette, zoom, theme);
+    postcard::to_allocvec(&FetchedVector { id, vertices, indices, labels })
 }
 
 /// Async vector-tile manager for the GUI (mirrors [`crate::tiles::TileManager`]).
@@ -1021,6 +1033,7 @@ impl VectorTileManager {
             let tx = self.tx.clone();
             let id = v.id;
             let ctx = self.ctx.clone();
+            #[cfg(not(target_arch = "wasm32"))]
             let blocking = self.spawner.clone();
             let inflight = self.inflight.clone();
             self.inflight.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -1041,21 +1054,32 @@ impl VectorTileManager {
                     }
                     return;
                 };
-                // gunzip + lyon tessellation is the heaviest CPU in the app after the volume
-                // decode; running it on the async worker starves every other fetch.
-                blocking.spawn_blocking(move || {
-                    let (vertices, indices, labels) =
-                        build_tile_with_theme(&bytes, id, palette, tess_zoom, theme);
-                    let _ = tx.send((generation, Ok(FetchedVector {
-                        id,
-                        vertices,
-                        indices,
-                        labels,
-                    })));
+                let finish = move |result| {
+                    let _ = tx.send((generation, result));
                     inflight.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
-                    if let Some(ctx) = ctx {
-                        ctx.request_repaint();
-                    }
+                    if let Some(ctx) = ctx { ctx.request_repaint(); }
+                };
+                #[cfg(target_arch = "wasm32")]
+                {
+                    let payload = postcard::to_allocvec(&(bytes, id, palette, tess_zoom, theme));
+                    let result = match payload {
+                        Ok(payload) => {
+                            let encoded = match wxdata::wasm_worker::tessellate_vector(payload.clone()).await {
+                                Ok(encoded) => Some(encoded),
+                                Err(wxdata::wasm_worker::Error::Unavailable) => build_worker_tile(&payload).ok(),
+                                Err(e) => { log::warn!("vector tile worker: {e}"); None }
+                            };
+                            encoded.and_then(|data| postcard::from_bytes::<FetchedVector>(&data).ok())
+                                .filter(|tile| tile.id == id).ok_or(id)
+                        }
+                        Err(_) => Err(id),
+                    };
+                    finish(result);
+                }
+                #[cfg(not(target_arch = "wasm32"))]
+                blocking.spawn_blocking(move || {
+                    let (vertices, indices, labels) = build_tile_with_theme(&bytes, id, palette, tess_zoom, theme);
+                    finish(Ok(FetchedVector { id, vertices, indices, labels }));
                 });
             });
         }
@@ -1209,6 +1233,22 @@ mod tests {
             template_requested: false,
             template_failed: None,
         }
+    }
+
+    #[test]
+    fn worker_tile_matches_inline_geometry_and_rejects_invalid_jobs() {
+        let id = (8, 65, 95);
+        let palette = basemap_style::Palette::Dark;
+        let theme = crate::settings::Theme::Dark;
+        let payload = postcard::to_allocvec(&(vec![] as Vec<u8>, id, palette, 8.0, theme)).unwrap();
+        let encoded = build_worker_tile(&payload).unwrap();
+        let result: FetchedVector = postcard::from_bytes(&encoded).unwrap();
+        let (vertices, indices, labels) = build_tile_with_theme(&[], id, palette, 8.0, theme);
+        assert_eq!(result.id, id);
+        assert_eq!(bytemuck::cast_slice::<_, u8>(&result.vertices), bytemuck::cast_slice::<_, u8>(&vertices));
+        assert_eq!(result.indices, indices);
+        assert_eq!(result.labels.len(), labels.len());
+        assert!(build_worker_tile(b"not a tile job").is_err());
     }
 
     #[tokio::test]

--- a/crates/wxdata/src/wasm_worker.rs
+++ b/crates/wxdata/src/wasm_worker.rs
@@ -44,6 +44,11 @@ pub async fn assemble_chunks(framed: Vec<u8>) -> Result<Vec<u8>, Error> {
     call("assemble", framed).await
 }
 
+/// Build a vector basemap tile off the thread handling map input.
+pub async fn tessellate_vector(payload: Vec<u8>) -> Result<Vec<u8>, Error> {
+    call("vector", payload).await
+}
+
 /// Run one job on the worker. `op` names the export it should call.
 async fn call(op: &str, bytes: Vec<u8>) -> Result<Vec<u8>, Error> {
     let global = js_sys::global();

--- a/scripts/web/build.sh
+++ b/scripts/web/build.sh
@@ -89,7 +89,7 @@ sed \
 # a worker the browser never bothers to install.
 font_shell=""
 for f in web/dist/font-*.ttf; do font_shell="$font_shell,\"/${f#web/}\""; done
-shell_json="[\"/\",\"/dist/hookecho-$glue_hash.js\",\"/dist/hookecho_bg-$wasm_hash.wasm\",\"/decode-worker.js\",\"/decode-bridge.js\",\"/manifest.webmanifest\",\"/icon-192.png\",\"/icon-512.png\"$font_shell]"
+shell_json="[\"/\",\"/dist/hookecho-$glue_hash.js\",\"/dist/hookecho_bg-$wasm_hash.wasm\",\"/decode-worker.js?v=vector-tiles\",\"/decode-bridge.js\",\"/manifest.webmanifest\",\"/icon-192.png\",\"/icon-512.png\"$font_shell]"
 sed \
   -e "s#__SHELL__#$shell_json#" \
   -e "s#__VERSION__#\"$glue_hash-$wasm_hash\"#" \
@@ -116,8 +116,8 @@ gz_bytes="$(gzip -9 -c "web/dist/hookecho_bg-$wasm_hash.wasm" | wc -c)"
 #
 # Raised deliberately for the offline chase packs (IndexedDB via web-sys) and the detailed dark
 # street-map labels shipped in the default view.
-# Map recovery, responsive timeline and shared-view fixes: CI measured 4,075,695 bytes.
-budget="${HOOKECHO_WASM_BUDGET:-4080000}"
+# Vector-tile worker serialization adds ~2.4 KB gzip while moving tessellation off the UI thread.
+budget="${HOOKECHO_WASM_BUDGET:-4085000}"
 printf 'wasm: %s raw, %s gzipped (budget %s)\n' \
   "$(stat -c%s "web/dist/hookecho_bg-$wasm_hash.wasm")" "$gz_bytes" "$budget"
 if [ "$gz_bytes" -gt "$budget" ]; then

--- a/web/decode-bridge.test.mjs
+++ b/web/decode-bridge.test.mjs
@@ -91,3 +91,10 @@ test("no workers at all means every job decodes inline", async () => {
   });
   await assert.rejects(() => bridge(new Uint8Array([1]), "decode"), /worker unavailable/);
 });
+
+test("vector tile jobs preserve their operation and transferred payload", async () => {
+  const { bridge, spawned } = harness([[{ ok: new Uint8Array([7]).buffer }]]);
+  assert.deepEqual([...await bridge(new Uint8Array([3, 4]), "vector")], [7]);
+  assert.equal(spawned[0].jobs[0].op, "vector");
+  assert.deepEqual([...new Uint8Array(spawned[0].jobs[0].bytes)], [3, 4]);
+});

--- a/web/decode-worker.js
+++ b/web/decode-worker.js
@@ -42,7 +42,8 @@ self.onmessage = async (e) => {
   const { id, bytes, op } = msg;
   try {
     const wasm = await ready;
-    const run = op === "assemble" ? wasm.assemble_live_chunks : wasm.decode_archive2;
+    const run = op === "vector" ? wasm.tessellate_vector_tile
+      : op === "assemble" ? wasm.assemble_live_chunks : wasm.decode_archive2;
     const out = run(new Uint8Array(bytes));
     // Transfer rather than copy: a decoded volume is tens of MB and the worker is done with it.
     self.postMessage({ id, ok: out.buffer }, [out.buffer]);

--- a/web/index.src.html
+++ b/web/index.src.html
@@ -96,7 +96,7 @@
       // the spawn as a callback so its failure path can be tested without a browser.
       globalThis.__decodeVolume = makeBridge({
         spawnWorker: () => {
-          const w = new Worker(new URL("./decode-worker.js", import.meta.url), { type: "module" });
+          const w = new Worker(new URL("./decode-worker.js?v=vector-tiles", import.meta.url), { type: "module" });
           w.postMessage({ module, glue: glueUrl });
           return w;
         },


### PR DESCRIPTION
Radar zoom in StormDesk remained glitchy after preserving cached basemap tiles. In WebAssembly, Spawner::spawn_blocking schedules work on the UI thread, so vector tile decoding and lyon tessellation could still block input as tiles arrived.

Route browser vector tiles through the existing radar Web Worker, sharing its compiled WASM module and failure handling. Transfer serialized jobs/results, preserve generation checks and native background execution, and retain inline fallback only when workers are unavailable. Version the worker URL and precache entry so an existing service worker cannot return the old dispatcher.

Validation: 383 library tests passed (9 ignored), six worker bridge tests passed, Clippy passed with warnings denied, and optimized browser build passed. Browser instrumentation confirmed 66 completed vector worker jobs with zero errors and continued radar playback. Sample zoom-in frames stayed around 17 ms; reverse zoom still showed one 67 ms frame, so this is not a universal frame-time guarantee. The serialized worker interface adds approximately 2.4 KB gzip; the bundle budget increases by 5 KB to accommodate it.
