### PR TITLE
Fix radar road swelling and delayed zoom redraws

### DIFF
--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -11364,6 +11364,7 @@ impl HookEchoApp {
             pane: idx as u32,
             camera_center: center,
             camera_scale: scale,
+            world_per_pixel: cam.world_per_pixel() as f32,
             new_tiles,
             visible,
             basemap_key: pane_style.key(),
@@ -17265,10 +17266,6 @@ impl eframe::App for HookEchoApp {
                     .vtiles
                     .set_style(style.vector_palette().unwrap_or_default());
                 clear_vector |= self.vtiles.set_theme(self.settings.theme);
-                self.vtiles.note_zoom(
-                    self.views[self.active.min(n - 1)].camera.zoom,
-                    self.gesture_live,
-                );
             }
             self.last_viewport = rects
                 .get(self.active)

--- a/crates/hookecho/src/headless.rs
+++ b/crates/hookecho/src/headless.rs
@@ -464,6 +464,7 @@ pub fn run(
         pane: 0,
         camera_center: center,
         camera_scale: scale,
+        world_per_pixel: camera.world_per_pixel() as f32,
         new_tiles,
         visible,
         basemap_key: basemap.key(),
@@ -519,6 +520,7 @@ pub fn run_multipane(site: &str, out_a: &str, out_b: &str) -> anyhow::Result<()>
             pane,
             camera_center: center,
             camera_scale: scale,
+            world_per_pixel: cam.world_per_pixel() as f32,
             basemap_key: 0,
             vector_over_raster: false,
             new_tiles: Vec::new(),
@@ -1184,6 +1186,7 @@ pub fn run_live(out_path: &str, site: &str, moment: Moment) -> anyhow::Result<()
         pane: 0,
         camera_center: center,
         camera_scale: scale,
+        world_per_pixel: camera.world_per_pixel() as f32,
         basemap_key: 0,
         vector_over_raster: false,
         new_tiles: Vec::new(),
@@ -1269,6 +1272,7 @@ pub fn run_placefile(path: &str, out_path: &str) -> anyhow::Result<()> {
         pane: 0,
         camera_center: center,
         camera_scale: scale,
+        world_per_pixel: camera.world_per_pixel() as f32,
         basemap_key: 0,
         vector_over_raster: false,
         new_tiles: Vec::new(),
@@ -1331,6 +1335,7 @@ pub fn run_overlay(out_path: &str) -> anyhow::Result<()> {
         pane: 0,
         camera_center: center,
         camera_scale: scale,
+        world_per_pixel: camera.world_per_pixel() as f32,
         basemap_key: 0,
         vector_over_raster: false,
         new_tiles,
@@ -1453,6 +1458,7 @@ pub fn run_mrms(out_path: &str) -> anyhow::Result<()> {
         pane: 0,
         camera_center: center,
         camera_scale: scale,
+        world_per_pixel: camera.world_per_pixel() as f32,
         basemap_key: 0,
         vector_over_raster: false,
         new_tiles,
@@ -1510,6 +1516,7 @@ pub fn run_lightning(out_path: &str) -> anyhow::Result<()> {
         pane: 0,
         camera_center: center,
         camera_scale: scale,
+        world_per_pixel: camera.world_per_pixel() as f32,
         basemap_key: 0,
         vector_over_raster: false,
         new_tiles,
@@ -1583,6 +1590,7 @@ pub fn run_field(slug: &str, out_path: &str) -> anyhow::Result<()> {
         pane: 0,
         camera_center: center,
         camera_scale: scale,
+        world_per_pixel: camera.world_per_pixel() as f32,
         basemap_key: 0,
         vector_over_raster: false,
         new_tiles,
@@ -1685,6 +1693,7 @@ pub fn run_global(model: &str, slug: &str, out_path: &str) -> anyhow::Result<()>
         pane: 0,
         camera_center: center,
         camera_scale: scale,
+        world_per_pixel: camera.world_per_pixel() as f32,
         basemap_key: 0,
         vector_over_raster: false,
         new_tiles,
@@ -1801,6 +1810,7 @@ pub fn run_diff(slug: &str, out_path: &str) -> anyhow::Result<()> {
         pane: 0,
         camera_center: center,
         camera_scale: scale,
+        world_per_pixel: camera.world_per_pixel() as f32,
         basemap_key: 0,
         vector_over_raster: false,
         new_tiles,
@@ -2126,6 +2136,7 @@ pub fn run_l3grid(kind: &str, site: &str, out_path: &str) -> anyhow::Result<()> 
         pane: 0,
         camera_center: center,
         camera_scale: scale,
+        world_per_pixel: camera.world_per_pixel() as f32,
         basemap_key: 0,
         vector_over_raster: false,
         new_tiles,
@@ -2201,6 +2212,7 @@ pub fn run_env(slug: &str, out_path: &str) -> anyhow::Result<()> {
         pane: 0,
         camera_center: center,
         camera_scale: scale,
+        world_per_pixel: camera.world_per_pixel() as f32,
         basemap_key: 0,
         vector_over_raster: false,
         new_tiles,
@@ -2385,6 +2397,7 @@ pub fn run_hrrr_layer(
         pane: 0,
         camera_center: center,
         camera_scale: scale,
+        world_per_pixel: camera.world_per_pixel() as f32,
         basemap_key: 0,
         vector_over_raster: false,
         new_tiles,
@@ -2423,6 +2436,7 @@ fn render_field_png(
         pane: 0,
         camera_center: center,
         camera_scale: scale,
+        world_per_pixel: camera.world_per_pixel() as f32,
         basemap_key: 0,
         vector_over_raster: false,
         new_tiles,
@@ -3197,6 +3211,7 @@ mod golden_tests {
                 pane: 0,
                 camera_center: center,
                 camera_scale: scale,
+                world_per_pixel: camera.world_per_pixel() as f32,
                 basemap_key: 0,
                 vector_over_raster: false,
                 new_tiles: Vec::new(),
@@ -3232,6 +3247,65 @@ mod golden_tests {
         assert_eq!(quads, 1, "a still camera keeps its tile quads");
     }
 
+
+    #[test]
+    #[ignore = "gpu"]
+    fn gpu_stroke_width_survives_zoom_without_reupload() {
+        use crate::render::{OverlayUpload, OverlayVertex};
+        let mut camera = Camera::at_lonlat(-97.0, 35.0, 7.0);
+        let (center, scale) = camera.world_to_clip_uniform((200.0, 200.0));
+        let mut cb = MapCallback {
+            pane: 0,
+            camera_center: center,
+            camera_scale: scale,
+            world_per_pixel: camera.world_per_pixel() as f32,
+            basemap_key: 0,
+            vector_over_raster: false,
+            new_tiles: Vec::new(),
+            visible: Vec::new(),
+            radar_upload: None,
+            draw_radar: false,
+            overlay_upload: None,
+            draw_overlay: true,
+            field_uploads: Vec::new(),
+            field_draws: Vec::new(),
+            clear_tiles: false,
+            drop_tiles: Vec::new(),
+            drop_fields: Vec::new(),
+            new_vector_tiles: Vec::new(),
+            visible_vector: Vec::new(),
+            clear_vector: false,
+            drop_vector_tiles: Vec::new(),
+            wind_upload: None,
+            wind: None,
+        };
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let (device, queue, _) = init_gpu(&rt).expect("no wgpu adapter");
+        let format = wgpu::TextureFormat::Rgba8UnormSrgb;
+        let mut res = RenderResources::new(&device, format);
+        let target = new_target(&device, format, 200);
+        let view = target.create_view(&Default::default());
+        cb.overlay_upload = Some(OverlayUpload {
+            vertices: [(-0.02, -2.0), (0.02, -2.0), (0.02, 2.0), (-0.02, 2.0)]
+                .into_iter().map(|(x, y)| OverlayVertex {
+                    world: [center[0] + x, center[1]], color: [1.0; 4], offset: [0.0, y, 0.0],
+                }).collect(),
+            indices: vec![0, 1, 2, 0, 2, 3],
+        });
+        for zoom in [7.0, 9.25, 6.5, 12.0] {
+            camera.zoom = zoom;
+            let (center, scale) = camera.world_to_clip_uniform((200.0, 200.0));
+            cb.camera_center = center;
+            cb.camera_scale = scale;
+            cb.world_per_pixel = camera.world_per_pixel() as f32;
+            res.render_once(&device, &queue, &view, &cb, wgpu::Color::BLACK);
+            cb.overlay_upload = None;
+            let pixels = read_target(&device, &queue, &target, 200);
+            let width = (0..200).filter(|&y| pixels[(y * 200 + 100) * 4] > 200).count();
+            assert_eq!(width, 4, "stroke changed width at zoom {zoom}");
+        }
+    }
+
     /// Golden-image test for the radar render pipeline. Run with
     /// `HOOKECHO_GPU_FALLBACK=1 cargo test -p hookecho -- --ignored gpu` so the
     /// software (lavapipe) adapter is used — the golden is authored under lavapipe.
@@ -3247,6 +3321,7 @@ mod golden_tests {
             pane: 0,
             camera_center: center,
             camera_scale: scale,
+            world_per_pixel: camera.world_per_pixel() as f32,
             basemap_key: 0,
             vector_over_raster: false,
             new_tiles: Vec::new(),

--- a/crates/hookecho/src/overlay_build.rs
+++ b/crates/hookecho/src/overlay_build.rs
@@ -76,6 +76,7 @@ pub fn build_with_theme(
             &path,
             &fill_opts,
             &mut BuffersBuilder::new(&mut buf, |v: FillVertex| OverlayVertex {
+                offset: [0.0; 3],
                 world: [v.position().x, v.position().y],
                 color: fill,
             }),
@@ -84,6 +85,7 @@ pub fn build_with_theme(
             &path,
             &stroke_opts,
             &mut BuffersBuilder::new(&mut buf, |v: StrokeVertex| OverlayVertex {
+                offset: [0.0; 3],
                 world: [v.position().x, v.position().y],
                 color: stroke,
             }),
@@ -162,6 +164,7 @@ pub fn append_placefiles_with_theme(
                     &path,
                     &opts,
                     &mut BuffersBuilder::new(&mut buf, |v: StrokeVertex| OverlayVertex {
+                        offset: [0.0; 3],
                         world: [v.position().x, v.position().y],
                         color: stroke,
                     }),
@@ -191,6 +194,7 @@ pub fn append_placefiles_with_theme(
                     &path,
                     &opts,
                     &mut BuffersBuilder::new(&mut buf, |v: FillVertex| OverlayVertex {
+                        offset: [0.0; 3],
                         world: [v.position().x, v.position().y],
                         color: fill,
                     }),
@@ -204,6 +208,7 @@ pub fn append_placefiles_with_theme(
                 for (p, c) in verts {
                     let (wx, wy) = project(*p);
                     geom.vertices.push(OverlayVertex {
+                        offset: [0.0; 3],
                         world: [wx as f32, wy as f32],
                         color: color(*c),
                     });
@@ -228,6 +233,7 @@ pub fn append_placefiles_with_theme(
                 for (p, _uv) in verts {
                     let (wx, wy) = project(*p);
                     geom.vertices.push(OverlayVertex {
+                        offset: [0.0; 3],
                         world: [wx as f32, wy as f32],
                         color: col,
                     });

--- a/crates/hookecho/src/render/mod.rs
+++ b/crates/hookecho/src/render/mod.rs
@@ -300,6 +300,8 @@ pub struct MrmsUpload {
 pub struct OverlayVertex {
     pub world: [f32; 2],
     pub color: [f32; 4],
+    /// XY: screen-pixel stroke extrusion. Z: apply the road width scale (0 or 1).
+    pub offset: [f32; 3],
 }
 
 /// Pre-tessellated overlay geometry to upload this frame.
@@ -321,6 +323,7 @@ pub struct MapCallback {
     pub pane: u32,
     pub camera_center: [f32; 2],
     pub camera_scale: [f32; 2],
+    pub world_per_pixel: f32,
     pub new_tiles: Vec<PendingTile>,
     pub visible: Vec<VisibleTile>,
     /// Which basemap style this pane draws ([`crate::tiles::BasemapStyle::key`]).
@@ -377,6 +380,8 @@ struct RadarVertex {
 struct CameraUniform {
     center: [f32; 2],
     scale: [f32; 2],
+    world_per_pixel: f32,
+    road_scale: f32,
 }
 
 struct TileGpu {
@@ -488,7 +493,7 @@ impl RenderResources {
                 ty: wgpu::BindingType::Buffer {
                     ty: wgpu::BufferBindingType::Uniform,
                     has_dynamic_offset: false,
-                    min_binding_size: NonZeroU64::new(16),
+                    min_binding_size: NonZeroU64::new(std::mem::size_of::<CameraUniform>() as u64),
                 },
                 count: None,
             }],
@@ -724,7 +729,7 @@ impl RenderResources {
                 buffers: &[wgpu::VertexBufferLayout {
                     array_stride: std::mem::size_of::<OverlayVertex>() as u64,
                     step_mode: wgpu::VertexStepMode::Vertex,
-                    attributes: &wgpu::vertex_attr_array![0 => Float32x2, 1 => Float32x4],
+                    attributes: &wgpu::vertex_attr_array![0 => Float32x2, 1 => Float32x4, 2 => Float32x3],
                 }],
             },
             fragment: Some(wgpu::FragmentState {
@@ -1252,6 +1257,10 @@ impl RenderResources {
             bytemuck::bytes_of(&CameraUniform {
                 center: cb.camera_center,
                 scale: cb.camera_scale,
+                world_per_pixel: cb.world_per_pixel,
+                road_scale: crate::basemap_style::road_scale(
+                    -(256.0 * cb.world_per_pixel as f64).log2(),
+                ) as f32,
             }),
         );
         if let Some(r) = &cb.radar_upload {

--- a/crates/hookecho/src/shaders/overlay.wgsl
+++ b/crates/hookecho/src/shaders/overlay.wgsl
@@ -4,6 +4,8 @@
 struct Camera {
     center: vec2<f32>,
     scale: vec2<f32>,
+    world_per_pixel: f32,
+    road_scale: f32,
 };
 
 @group(0) @binding(0) var<uniform> camera: Camera;
@@ -11,6 +13,7 @@ struct Camera {
 struct VsIn {
     @location(0) world: vec2<f32>,
     @location(1) color: vec4<f32>,
+    @location(2) offset: vec3<f32>,
 };
 struct VsOut {
     @builtin(position) clip: vec4<f32>,
@@ -20,7 +23,9 @@ struct VsOut {
 @vertex
 fn vs_main(in: VsIn) -> VsOut {
     var out: VsOut;
-    let p = (in.world - camera.center) * camera.scale;
+    let p = (in.world - camera.center) * camera.scale
+        + in.offset.xy * mix(1.0, camera.road_scale, in.offset.z)
+        * camera.world_per_pixel * camera.scale;
     out.clip = vec4<f32>(p, 0.0, 1.0);
     out.color = in.color;
     return out;

--- a/crates/hookecho/src/vector_tiles.rs
+++ b/crates/hookecho/src/vector_tiles.rs
@@ -215,18 +215,22 @@ pub fn build_tile_with_theme(
         let base = verts.len() as u32;
         verts.extend_from_slice(&[
             OverlayVertex {
+                offset: [0.0; 3],
                 world: [x0 as f32, y0 as f32],
                 color: bg,
             },
             OverlayVertex {
+                offset: [0.0; 3],
                 world: [x1 as f32, y0 as f32],
                 color: bg,
             },
             OverlayVertex {
+                offset: [0.0; 3],
                 world: [x1 as f32, y1 as f32],
                 color: bg,
             },
             OverlayVertex {
+                offset: [0.0; 3],
                 world: [x0 as f32, y1 as f32],
                 color: bg,
             },
@@ -293,6 +297,7 @@ pub fn build_tile_with_theme(
                 &mut BuffersBuilder::new(&mut buf, |v: FillVertex| {
                     let p = v.position();
                     OverlayVertex {
+                        offset: [0.0; 3],
                         world: [
                             ((txf + p.x as f64) / n) as f32,
                             ((tyf + p.y as f64) / n) as f32,
@@ -328,12 +333,7 @@ pub fn build_tile_with_theme(
             let Some((c, wpx)) = styled else {
                 continue;
             };
-            let road_scale = if *layer == "transportation" {
-                basemap_style::road_scale(tess_zoom)
-            } else {
-                1.0
-            };
-            let w = (wpx as f64 * px_to_tile * theme_scale as f64 * road_scale) as f32;
+            let w = (wpx as f64 * px_to_tile * theme_scale as f64) as f32;
             let mut b = Path::builder();
             let mut any = false;
             match &f.geometry {
@@ -364,8 +364,13 @@ pub fn build_tile_with_theme(
                 &path,
                 &opts,
                 &mut BuffersBuilder::new(&mut buf, |v: StrokeVertex| {
-                    let p = v.position();
+                    // Keep the centerline geographic; expand its edges in screen pixels on the GPU.
+                    let p = v.position_on_path();
+                    let normal = v.normal();
+                    let half_px = (w as f64 / px_to_tile * 0.5) as f32;
                     OverlayVertex {
+                        offset: [normal.x * half_px, normal.y * half_px,
+                            if *layer == "transportation" { 1.0 } else { 0.0 }],
                         world: [
                             ((txf + p.x as f64) / n) as f32,
                             ((tyf + p.y as f64) / n) as f32,
@@ -839,9 +844,6 @@ pub struct VectorTileManager {
     label_gen: u64,
     palette: basemap_style::Palette,
     theme: crate::settings::Theme,
-    tess_zoom: i32,
-    /// Candidate new tessellation zoom and when it was first seen — see [`Self::note_zoom`].
-    zoom_settled: Option<(i32, wxdata::clock::Instant)>,
     cache_root: Option<PathBuf>,
     template: Option<String>,
     template_tx: Sender<Option<String>>,
@@ -879,8 +881,6 @@ impl VectorTileManager {
             label_gen: 0,
             palette: basemap_style::Palette::Dark,
             theme: crate::settings::Theme::Dark,
-            tess_zoom: 7,
-            zoom_settled: None,
             cache_root,
             template: None,
             template_tx,
@@ -928,45 +928,6 @@ impl VectorTileManager {
         true
     }
 
-    /// Refresh stroke widths after zooming settles, keeping resident tiles until replacements land.
-    pub fn note_zoom(&mut self, cam_zoom: f64, gesture_live: bool) {
-        if gesture_live {
-            self.zoom_settled = None;
-            return;
-        }
-        let tz = cam_zoom.round() as i32;
-        if tz == self.tess_zoom {
-            self.zoom_settled = None;
-            return;
-        }
-        // Mid-pinch this fires at every integer step, and each one throws away the whole vector
-        // basemap and re-tessellates it — the worst possible moment. Wait for the zoom to hold
-        // still before acting on it.
-        let settled = *self
-            .zoom_settled
-            .get_or_insert_with(|| (tz, wxdata::clock::Instant::now()));
-        if settled.0 != tz {
-            self.zoom_settled = Some((tz, wxdata::clock::Instant::now()));
-            return;
-        }
-        if settled.1.elapsed() < std::time::Duration::from_millis(700) {
-            return;
-        }
-        self.zoom_settled = None;
-        self.tess_zoom = tz;
-        // Every resident tile was tessellated for the *old* zoom, and stroke widths are baked in
-        // at tessellation. This used to re-tessellate only when overzooming past the deepest tile
-        // level, on the theory that below that the tile ids change anyway and the new tiles pick
-        // up the new width. They do — but the tiles already on screen do not, and a jump straight
-        // to z12 from the z7 the manager starts at left roads roughly thirty times too wide until
-        // something else happened to clear them. The 700 ms settle above is what makes doing this
-        // unconditionally affordable.
-        self.render_generation += 1;
-        self.requested.clear();
-        self.failed.clear();
-        // Keep the GPU tiles and labels visible; drain_ready replaces each tile in place.
-    }
-
     pub fn visible(&self, cam: &Camera, viewport_px: (f32, f32)) -> Vec<VisibleTile> {
         tile_cover(cam, viewport_px, MAX_VECTOR_Z, label_detail_bias(cam.zoom))
     }
@@ -1006,7 +967,6 @@ impl VectorTileManager {
         let generation = self.render_generation;
         let palette = self.palette;
         let theme = self.theme;
-        let tess_zoom = self.tess_zoom as f64;
         for v in visible {
             // Same reason the raster manager caps itself: a pan at low zoom asks for a screenful
             // at once, and without a ceiling they all leave together and answer together.
@@ -1024,6 +984,7 @@ impl VectorTileManager {
                 continue;
             }
             let (z, x, y) = v.id;
+            let tess_zoom = z as f64;
             let url = fill_template(&template, z, x, y);
             let path = self
                 .cache_root
@@ -1224,8 +1185,6 @@ mod tests {
             label_gen: 0,
             palette: basemap_style::Palette::Dark,
             theme: crate::settings::Theme::Dark,
-            tess_zoom: 7,
-            zoom_settled: None,
             cache_root: None,
             template: None,
             template_tx,
@@ -1252,23 +1211,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn zoom_refresh_keeps_tiles_until_their_replacements_arrive() {
+    async fn replacement_tiles_upload_once() {
         let mut manager = test_manager();
         let id = (6, 14, 25);
         manager.uploaded.put(id, 0);
         manager.labels.insert(id, vec![]);
         manager.requested.insert(id);
-        let settled = wxdata::clock::Instant::now() - std::time::Duration::from_secs(1);
-        manager.zoom_settled = Some((9, settled));
-        manager.note_zoom(9.0, true);
-        assert_eq!(manager.render_generation, 0, "no rebuild while zooming");
-        assert!(manager.zoom_settled.is_none());
-        manager.zoom_settled = Some((9, settled));
-        manager.note_zoom(9.0, false);
-        assert_eq!(manager.render_generation, 1);
-        assert!(manager.uploaded.contains(&id), "keep the visible GPU tile");
-        assert!(manager.labels.contains_key(&id), "keep its labels too");
-        assert!(!manager.requested.contains(&id), "allow a replacement fetch");
+        manager.render_generation = 1;
         for _ in 0..2 {
             manager.tx.send((1, Ok(FetchedVector {
                 id, vertices: vec![], indices: vec![], labels: vec![],


### PR DESCRIPTION
Radar zoom made roads swell with the map, then snap back tile by tile after the 700 ms rebuild. Store basemap centerlines in world coordinates and extrude their edges in screen pixels in the shader. Road styling follows the current camera continuously, including cached tiles and separate panes. Remove the zoom-triggered tile rebuild.

Validation: 383 library tests passed; the new GPU regression passed on the local adapter across zooms 7, 9.25, 6.5, and 12 without geometry re-upload; clippy passed. Optimized web build passed its bundle budget. Browser verification in the StormDesk iframe covered zoom out, zoom in, and reversal with the final build; road edges no longer balloon and reset after the gesture. Cold, uncached map areas still fill as their tiles load.
