### PR TITLE
Keep radar labels visible across zoom tile transitions

### DIFF
--- a/crates/hookecho/src/render/mod.rs
+++ b/crates/hookecho/src/render/mod.rs
@@ -1635,12 +1635,19 @@ impl egui_wgpu::CallbackTrait for MapCallback {
 
 /// Keep cached geography visible while a new zoom level loads. Coarse tiles draw first,
 /// then finer fallbacks, then the requested tiles so current detail always wins.
-fn vector_draw_tiles(visible: &[TileId], resident: impl Iterator<Item = TileId>) -> Vec<TileId> {
+pub(crate) fn vector_draw_tiles(visible: &[TileId], resident: impl Iterator<Item = TileId>) -> Vec<TileId> {
     let resident: Vec<_> = resident.collect();
     let mut fallback = Vec::new();
     // ponytail: bounded tile-cache scan; add a spatial index only if the cache grows substantially.
     for &(z, x, y) in visible {
         if resident.contains(&(z, x, y)) {
+            continue;
+        }
+        // Prefer the nearest ancestor instead of stacking every cached zoom level.
+        if let Some(parent) = resident.iter().copied().filter(|&(rz, rx, ry)| {
+            rz < z && (x >> (z - rz), y >> (z - rz)) == (rx, ry)
+        }).max_by_key(|id| id.0) {
+            fallback.push(parent);
             continue;
         }
         for &(rz, rx, ry) in &resident {
@@ -1670,6 +1677,8 @@ mod vector_fallback_tests {
         let child = (5, 6, 10);
         let sibling = (5, 7, 10);
         let far = (5, 20, 20);
+        let grandparent = (3, 1, 2);
+        assert_eq!(vector_draw_tiles(&[child], [grandparent, parent].into_iter()), vec![parent]);
         assert_eq!(vector_draw_tiles(&[child], [parent, far].into_iter()), vec![parent]);
         assert_eq!(vector_draw_tiles(&[parent], [child, far].into_iter()), vec![child]);
         assert_eq!(vector_draw_tiles(&[child, sibling], [parent, child].into_iter()), vec![parent, child]);

--- a/crates/hookecho/src/render/mod.rs
+++ b/crates/hookecho/src/render/mod.rs
@@ -1648,15 +1648,9 @@ pub(crate) fn vector_draw_tiles(visible: &[TileId], resident: impl Iterator<Item
             rz < z && (x >> (z - rz), y >> (z - rz)) == (rx, ry)
         }).max_by_key(|id| id.0) {
             fallback.push(parent);
-            continue;
         }
         for &(rz, rx, ry) in &resident {
-            let overlaps = if rz <= z {
-                (x >> (z - rz), y >> (z - rz)) == (rx, ry)
-            } else {
-                (rx >> (rz - z), ry >> (rz - z)) == (x, y)
-            };
-            if overlaps {
+            if rz > z && (rx >> (rz - z), ry >> (rz - z)) == (x, y) {
                 fallback.push((rz, rx, ry));
             }
         }

--- a/crates/hookecho/src/vector_tiles.rs
+++ b/crates/hookecho/src/vector_tiles.rs
@@ -1158,7 +1158,27 @@ impl VectorTileManager {
 
     /// Labels for the given visible tile ids (for the egui text pass).
     pub fn labels_for<'a>(&'a self, ids: impl Iterator<Item = &'a TileId>) -> Vec<&'a PlaceLabel> {
-        ids.filter_map(|id| self.labels.get(id)).flatten().collect()
+        let mut labels = Vec::new();
+        for &id in ids {
+            // The GPU retains cached geography while a new detail level loads. Use the same
+            // fallback for names/shields; looking up only exact ids blanked every label at once.
+            let sources = crate::render::vector_draw_tiles(&[id], self.labels.keys().copied());
+            let n = (1u32 << id.0) as f32;
+            for source in &sources {
+                if let Some(tile_labels) = self.labels.get(source) {
+                    labels.extend(tile_labels.iter().filter(|l| {
+                        ((l.world[0] * n).floor() as u32, (l.world[1] * n).floor() as u32)
+                            == (id.1, id.2)
+                            && !sources.iter().any(|&(z, x, y)| {
+                                let n = (1u32 << z) as f32;
+                                z > source.0 && ((l.world[0] * n).floor() as u32,
+                                    (l.world[1] * n).floor() as u32) == (x, y)
+                            })
+                    }));
+                }
+            }
+        }
+        labels
     }
 }
 
@@ -1192,6 +1212,28 @@ mod tests {
             template_requested: false,
             template_failed: None,
         }
+    }
+
+    #[tokio::test]
+    async fn labels_follow_cached_geography_through_zoom_and_partial_loads() {
+        let mut manager = test_manager();
+        let parent = (4, 3, 5);
+        let child = (5, 6, 10);
+        let sibling = (5, 7, 10);
+        let label = |name: &str, x| PlaceLabel {
+            name: name.into(), world: [x, 10.5 / 32.0], city: true,
+            rank: 1, shield: RoadShield::None, min_zoom: 0.0,
+        };
+        manager.labels.insert(parent, vec![label("old left", 6.5 / 32.0), label("right", 7.5 / 32.0)]);
+        assert_eq!(manager.labels_for([&child, &sibling].into_iter()).len(), 2,
+            "zoom-in must retain names before child tiles arrive");
+        manager.labels.insert(child, vec![label("new left", 6.5 / 32.0)]);
+        let names: Vec<_> = manager.labels_for([&child, &sibling].into_iter())
+            .into_iter().map(|l| l.name.as_str()).collect();
+        assert_eq!(names, ["new left", "right"], "partial loads must not duplicate or erase neighbors");
+        manager.labels.remove(&parent);
+        assert_eq!(manager.labels_for([&parent].into_iter())[0].name, "new left",
+            "zoom-out retains child labels while its parent loads");
     }
 
     #[test]


### PR DESCRIPTION
City names and route shields disappeared together when zoom requested a new tile level: geography used cached fallback tiles, but label lookup required exact tile IDs. Use the same cached tile selection for labels and limit each fallback to its requested region, allowing incoming tiles to replace their own labels without erasing neighbors or duplicating covered labels. Prefer the nearest cached ancestor over stacking every older level.

Validation: 384 library tests passed, including zoom-in, zoom-out, and partially loaded label coverage; clippy passed. A fresh browser cache retained city names and shields across the previously blank transition. Optimized web build passed its bundle budget.
