### PR TITLE
Stop radar zoom snapping back to its own permalink

### DIFF
--- a/crates/hookecho/src/app/chrome/permalink.rs
+++ b/crates/hookecho/src/app/chrome/permalink.rs
@@ -43,8 +43,12 @@ impl HookEchoApp {
             // The rest of the URL is left exactly as it is — the recovery reload's `?relaunched`
             // lives in the query, and stamping over it would spend the retry it is tracking.
             if let Ok(h) = win.history() {
-                let _ = h.replace_state_with_url(&wasm_bindgen::JsValue::NULL, "", Some(&frag));
-                *last = Some(frag);
+                if h.replace_state_with_url(&wasm_bindgen::JsValue::NULL, "", Some(&frag)).is_ok() {
+                    // This is our own camera snapshot, not an incoming navigation. Otherwise
+                    // apply_goto_hash replays this stale zoom on its next one-second poll.
+                    self.last_goto_hash = Some(frag.clone());
+                    *last = Some(frag);
+                }
             }
         }
     }


### PR DESCRIPTION
Zooming was repeatedly pulled back by the app's own permalink. The writer saved a camera snapshot every 750 ms; the one-second incoming-link poll treated that snapshot as a new command and reapplied its older, rounded zoom. Mark successful URL writes as already handled by the incoming-link reader. Failed writes do not update either remembered value.

Validation: optimized WASM build passed (4,082,934 bytes gzip). In the browser, identical 30-step zoom-in sequences from zoom 8 reached approximately 9.4 on production versus 10.1 during input and 10.2 after settling with the fix. The corrected camera remained at its final zoom after input stopped. Incoming fragment navigation was also checked separately.
