### PR TITLE
Fix radar startup crash in WebGL browsers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,7 @@ jobs:
           python3 -m http.server 8080 --directory web &
           for _ in $(seq 1 30); do curl -sf http://127.0.0.1:8080/ >/dev/null && break; sleep 1; done
           node scripts/web/smoke.mjs http://127.0.0.1:8080/
+          node scripts/web/smoke.mjs http://127.0.0.1:8080/ --webgl
 
   # Golden-image test for the wgpu radar pipeline. Runs on the software rasterizer
   # (mesa lavapipe) via HOOKECHO_GPU_FALLBACK=1 so the render is deterministic across

--- a/crates/hookecho/src/render/mod.rs
+++ b/crates/hookecho/src/render/mod.rs
@@ -382,6 +382,8 @@ struct CameraUniform {
     scale: [f32; 2],
     world_per_pixel: f32,
     road_scale: f32,
+    // WebGL uniform bindings must occupy a multiple of 16 bytes.
+    _pad: [f32; 2],
 }
 
 struct TileGpu {
@@ -1261,6 +1263,7 @@ impl RenderResources {
                 road_scale: crate::basemap_style::road_scale(
                     -(256.0 * cb.world_per_pixel as f64).log2(),
                 ) as f32,
+                _pad: [0.0; 2],
             }),
         );
         if let Some(r) = &cb.radar_upload {

--- a/crates/hookecho/src/shaders/overlay.wgsl
+++ b/crates/hookecho/src/shaders/overlay.wgsl
@@ -6,6 +6,7 @@ struct Camera {
     scale: vec2<f32>,
     world_per_pixel: f32,
     road_scale: f32,
+    _pad: vec2<f32>,
 };
 
 @group(0) @binding(0) var<uniform> camera: Camera;

--- a/scripts/web/smoke.mjs
+++ b/scripts/web/smoke.mjs
@@ -13,6 +13,7 @@ import puppeteer from "puppeteer";
 const args = process.argv.slice(2);
 // Only meaningful against a deployed origin, where `/proxy/` is real and volumes actually arrive.
 const expectLoop = args.includes("--expect-loop");
+const webgl = args.includes("--webgl");
 const url = args.find((a) => !a.startsWith("--")) ?? "http://127.0.0.1:8080/";
 const errors = [];
 
@@ -33,6 +34,12 @@ const browser = await puppeteer.launch({
   ],
 });
 const page = await browser.newPage();
+if (webgl) {
+  // Exercise the fallback used by browsers without WebGPU, including uniform alignment rules.
+  await page.evaluateOnNewDocument(() => {
+    Object.defineProperty(navigator, "gpu", { value: undefined });
+  });
+}
 page.on("pageerror", (e) => errors.push(`page error: ${e.message}`));
 let loopStarted = false;
 page.on("console", (m) => {


### PR DESCRIPTION
The radar crashed at startup in WebGL browsers after the screen-space stroke change expanded CameraUniform from 16 to 24 bytes. WebGPU accepted it; WebGL rejects uniform types whose size is not a multiple of 16. Reproduced the exact overlay_pipeline validation panic and “HookEcho stopped: RuntimeError: unreachable” by disabling WebGPU.

Pad both the Rust camera buffer and WGSL camera type to 32 bytes. Add an explicit --webgl smoke mode and run it alongside the normal CI browser startup check.

Validation: GPU stroke regression passed; smoke script syntax checked. Optimized WASM build passed. Forced-WebGL browser check now starts successfully on the same adapter that reproduced the panic, with the map rendered and the live radar stream started.
