### PR TITLE
feat(chase): connect gpsd at launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The rolling `latest` release tracks `main` and is not listed here.
 
 ## Unreleased
 
+### GPS connects itself
+
+- **Connect GPS at launch** (Chase tab; `gps_autoconnect` in settings.json)
+  opens the gpsd stream every start on desktop, so a receiver on the dash no
+  longer needs the connect button clicked every morning. Turning autoconnect
+  on connects at once; Disconnect GPS turns it off again. Android and the
+  web keep the click, since there it is a permission prompt.
+
 ### Warnings say where, and what to do
 
 - Spoken warnings are on by default and now say something the tone cannot.

--- a/crates/hookecho/src/app.rs
+++ b/crates/hookecho/src/app.rs
@@ -3721,6 +3721,11 @@ impl HookEchoApp {
         // `update` picks them up a moment later, once there is radar on screen.
         #[cfg(not(target_arch = "wasm32"))]
         app.fetch_overlays(&cc.egui_ctx.clone());
+        // The receiver on the dash does not need a click every morning.
+        #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
+        if app.settings.gps_autoconnect {
+            app.connect_gpsd();
+        }
         app
     }
 
@@ -5787,6 +5792,21 @@ impl HookEchoApp {
                     });
                 });
             });
+    }
+
+    /// Open the gpsd stream and enter chase mode. Shared by the Chase tab's connect button,
+    /// the launch-time autoconnect, and the toggle that turns autoconnect on. A daemon that is
+    /// not there just logs; chase mode stays manual.
+    #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
+    fn connect_gpsd(&mut self) {
+        match crate::gps::spawn() {
+            Some(rx) => {
+                log::info!("gpsd: connected on localhost:2947, chase mode on");
+                self.gps_rx = Some(rx);
+                self.chase_mode = true;
+            }
+            None => log::warn!("gpsd: not reachable on localhost:2947"),
+        }
     }
 
     /// Chase-mode follow-me: when the tracked position changes, hand the active pane off to the
@@ -14220,6 +14240,19 @@ impl HookEchoApp {
                     }
                     if ui.button("Disconnect GPS").clicked() {
                         self.gps_rx = None;
+                        // A deliberate disconnect is also a "not at launch, either".
+                        self.settings.gps_autoconnect = false;
+                    }
+                }
+                // Desktop only: gpsd is a daemon that is either there or not, so connecting at
+                // launch costs nothing and asks nobody. The permission platforms keep the click.
+                #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
+                {
+                    let was = self.settings.gps_autoconnect;
+                    toggle(ui, &mut self.settings.gps_autoconnect, "Connect GPS at launch")
+                        .on_hover_text("Connect to the local gpsd every time HookEcho starts");
+                    if self.settings.gps_autoconnect && !was && self.gps_rx.is_none() {
+                        self.connect_gpsd();
                     }
                 }
                 // Position sharing: the phone in the field and the desktop at home showing each other

--- a/crates/hookecho/src/settings.rs
+++ b/crates/hookecho/src/settings.rs
@@ -411,6 +411,12 @@ pub struct Settings {
     /// "my location". Nothing is written to the saved markers and nothing is shared.
     #[serde(default)]
     pub alert_follow_gps: bool,
+    /// Connect to the local gpsd at launch and stay in chase mode. The Chase tab's connect
+    /// button was never remembered, so a laptop with a receiver on the dash had to be clicked
+    /// back into following itself every start. Desktop only: Android and the web ask for a
+    /// permission instead, and launch is the wrong moment to ask.
+    #[serde(default)]
+    pub gps_autoconnect: bool,
     /// Quiet hours: between `quiet_start_hour` and `quiet_end_hour` (local, 24h), alert sounds
     /// and pushes are held back. Escalated warnings — Tornado Emergency, PDS, destructive — go
     /// through anyway: the whole point of the tier is that it is worth waking up for.
@@ -1151,6 +1157,7 @@ impl Default for Settings {
             battery_saver: false,
             ntfy_snapshot: false,
             alert_follow_gps: false,
+            gps_autoconnect: false,
             quiet_hours: false,
             quiet_start_hour: default_quiet_start(),
             quiet_end_hour: default_quiet_end(),
@@ -1685,6 +1692,7 @@ mod tests {
             battery_saver: false,
             ntfy_snapshot: false,
             alert_follow_gps: false,
+            gps_autoconnect: false,
             quiet_hours: false,
             quiet_start_hour: 22,
             quiet_end_hour: 7,

--- a/docs/technical-reference.md
+++ b/docs/technical-reference.md
@@ -398,7 +398,9 @@ clearing a cache costs the next fetch and nothing else.
 - **Chase mode**: live GPS (gpsd on desktop, the system location service on
   Android) drawn as a blue dot on the radar, a storm-relative HUD with closest
   approach and escape bearing, and offline "chase packs" of pre-downloaded
-  basemap tiles.
+  basemap tiles. On desktop, **Connect GPS at launch** (Chase tab, or
+  `gps_autoconnect` in settings.json) opens the gpsd stream every start, so a
+  receiver on the dash needs no click; Disconnect GPS turns it back off.
 - **Position sharing**: opt in and every HookEcho on the same network sees
   everyone else's dot, no account and no configuration (UDP broadcast on
   :41777). For devices that aren't on one network — the phone chasing on


### PR DESCRIPTION
The Chase tab's "Connect GPS (gpsd)" is a click that is never remembered:
`gps_rx` is runtime state only, so a laptop with a receiver permanently on
the dash has to be clicked back into chase mode every single start. Found
building [omarchy-chase](https://github.com/joshuaswarren/omarchy-chase),
where a chase session launches HookEcho with gpsd already running — and
then still needs a human to press the button.

This adds **Connect GPS at launch** (`gps_autoconnect` in settings.json,
default off):

- On desktop, when set, `HookEchoApp::new` opens the gpsd stream after the
  overlays fetch, exactly as the button would. A gpsd that is not there
  logs one warning and chase mode stays manual — same as the button.
- The toggle sits under the connect/disconnect controls in the Chase tab.
  Turning it on connects immediately; **Disconnect GPS** also turns it off,
  since a deliberate disconnect is also "not at launch, either".
- Android and the web keep the click: there it is a permission prompt, and
  launch is the wrong moment to ask. The toggle is `cfg`'d away on both.
- One `connect_gpsd()` now serves the button, the toggle, and startup.

Persistence rides the existing `settings != saved` autosave, so no new save
path. Docs: technical-reference chase-mode bullet and a CHANGELOG entry.

Gate: `cargo clippy -p hookecho --all-targets -- -D warnings` clean;
`cargo fmt --check` clean on the touched files (the one diff it reports is
in `app/chrome/permalink.rs`, untouched here).

Verified on Omarchy (Arch) against a running gpsd: with the setting on, the
app logs `gpsd: connected on localhost:2947, chase mode on` at startup with
no click, and holds the :2947 session (`ss -tnp`). That log line is new
too, so a headless run has a receipt for the connection.
